### PR TITLE
test(NODE-3719,NODE-3543): fix unified runner to not pass uri opts in object and unskip lb tests

### DIFF
--- a/test/integration/load-balancers/load_balancers.spec.test.js
+++ b/test/integration/load-balancers/load_balancers.spec.test.js
@@ -7,13 +7,12 @@ const SKIP = [
   // Verified they use the same connection but the Node implementation executes
   // a getMore before the killCursors even though the stream is immediately
   // closed.
-  // TODO: should we implement and reference a node specific integration test for this?
+  // TODO(NODE-3970): implement and reference a node specific integration test for this
   'change streams pin to a connection',
 
-  // NOTE: The following three tests are skipped pending a decision made on DRIVERS-1847, since
-  //       pinning the connection on any getMore error is very awkward in node and likely results
-  //       in sub-optimal pinning.
-  // TODO(DRIVERS-1847)
+  // TODO(DRIVERS-1847): The following three tests are skipped pending a decision made on DRIVERS-1847,
+  // since pinning the connection on any getMore error is very awkward in node and likely results
+  // in sub-optimal pinning.
   'pinned connections are not returned after an network error during getMore',
   'pinned connections are not returned to the pool after a non-network error on getMore',
   'stale errors are ignored',

--- a/test/integration/load-balancers/load_balancers.spec.test.js
+++ b/test/integration/load-balancers/load_balancers.spec.test.js
@@ -7,21 +7,20 @@ const SKIP = [
   // Verified they use the same connection but the Node implementation executes
   // a getMore before the killCursors even though the stream is immediately
   // closed.
+  // TODO: should we implement and reference a node specific integration test for this?
   'change streams pin to a connection',
-  'errors during the initial connection hello are ignore',
 
   // NOTE: The following three tests are skipped pending a decision made on DRIVERS-1847, since
   //       pinning the connection on any getMore error is very awkward in node and likely results
   //       in sub-optimal pinning.
+  // TODO(DRIVERS-1847)
   'pinned connections are not returned after an network error during getMore',
   'pinned connections are not returned to the pool after a non-network error on getMore',
   'stale errors are ignored',
-  // NOTE: The driver correctly fails these 2 tests in non LB mode for server versions greater than 3.4.
-  // In versions that are 3.4 or less an error still occurs but a different one (connection closes).
-  // TODO(NODE-3543): fix the path-ing that will produce errors for older servers
-  'operations against non-load balanced clusters fail if URI contains loadBalanced=true',
-  'operations against non-load balanced clusters succeed if URI contains loadBalanced=false',
 
+  // This test is skipped because it assumes drivers attempt connections on the first operation,
+  // but Node has a connect() method that is called before the first operation is ever run.
+  // TODO(NODE-2149): Refactor connect()
   'errors during the initial connection hello are ignored',
 
   ...(process.env.SERVERLESS

--- a/test/tools/unified-spec-runner/entities.ts
+++ b/test/tools/unified-spec-runner/entities.ts
@@ -101,7 +101,6 @@ export class UnifiedMongoClient extends MongoClient {
   constructor(uri: string, description: ClientEntity) {
     super(uri, {
       monitorCommands: true,
-      ...description.uriOptions,
       ...getEnvironmentalOptions(),
       ...(description.serverApi ? { serverApi: description.serverApi } : {})
     });


### PR DESCRIPTION
### Description
NODE-3719, NODE-3543

#### What is changing?
Fixed the unified runner to not pass in URI options as an object, since that behavior is incorrect for URI-only options (like `loadBalanced`, and since they are already included in the generated URI string anyway.

##### Is there new documentation needed for these changes?
N/A

#### What is the motivation for this change?
Spec compliance review

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
