### PR TITLE
chore(NODE-3971) options as the first argument of `collection.watch()`

### DIFF
--- a/src/collection.ts
+++ b/src/collection.ts
@@ -1422,8 +1422,13 @@ export class Collection<TSchema extends Document = Document> {
    * @param pipeline - An array of {@link https://docs.mongodb.com/manual/reference/operator/aggregation-pipeline/|aggregation pipeline stages} through which to pass change stream documents. This allows for filtering (using $match) and manipulating the change stream documents.
    * @param options - Optional settings for the command
    */
+  watch<TLocal = TSchema>(options?: ChangeStreamOptions): ChangeStream<TLocal>;
   watch<TLocal = TSchema>(
-    pipeline: Document[] = [],
+    pipeline?: Document[],
+    options?: ChangeStreamOptions
+  ): ChangeStream<TLocal>;
+  watch<TLocal = TSchema>(
+    pipeline: Document[] | ChangeStreamOptions = [],
     options: ChangeStreamOptions = {}
   ): ChangeStream<TLocal> {
     // Allow optionally not specifying a pipeline


### PR DESCRIPTION
### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

We're currently allowed to pass either a `pipeline` or `options` to
`collection.watch()` as the first argument.

However, the TypeScript definitions don't reflect this. This change adds
method overloads that allow for passing the options as the only argument
as well as passing it as a second argument.

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
