### PR TITLE
fix: Filter query root operators support for partials

### DIFF
--- a/src/mongo_types.ts
+++ b/src/mongo_types.ts
@@ -65,13 +65,15 @@ export type EnhancedOmit<TRecordOrUnion, KeyUnion> = string extends keyof TRecor
 export type WithoutId<TSchema> = Omit<TSchema, '_id'>;
 
 /** A MongoDB filter can be some portion of the schema or a set of operators @public */
-export type Filter<TSchema> =
+export type Filter<TSchema> = (
   | Partial<TSchema>
-  | ({
+  | {
       [Property in Join<NestedPaths<WithId<TSchema>>, '.'>]?: Condition<
         PropertyType<WithId<TSchema>, Property>
       >;
-    } & RootFilterOperators<WithId<TSchema>>);
+    }
+) &
+  RootFilterOperators<WithId<TSchema>>;
 
 /** @public */
 export type Condition<T> = AlternativeType<T> | FilterOperators<AlternativeType<T>>;

--- a/test/types/community/collection/findX-recursive-types.test-d.ts
+++ b/test/types/community/collection/findX-recursive-types.test-d.ts
@@ -1,6 +1,6 @@
 import { expectError } from 'tsd';
 
-import type { Collection } from '../../../../src';
+import type { Collection, Filter } from '../../../../src';
 
 /**
  * mutually recursive types are not supported and will not get type safety

--- a/test/types/community/collection/findX.test-d.ts
+++ b/test/types/community/collection/findX.test-d.ts
@@ -313,6 +313,16 @@ const fooObj: Foo = {
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const fooFilter: Filter<Foo> = fooObj;
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const fooFilterBuiltNow: Filter<Foo> = {
+  a: 'foo',
+  $or: [{ a: 'bar' }]
+};
+
+const fooFilterBuiltLater: Filter<Foo> = {};
+fooFilterBuiltLater.a = 'foo';
+fooFilterBuiltLater.$or = [{ a: 'bar' }];
+
 // Specifically test that arrays can be included as a part of an object
 //  ensuring that a bug reported in https://jira.mongodb.org/browse/NODE-3856 is addressed
 interface FooWithArray {


### PR DESCRIPTION
### Description

A change was introduced in https://github.com/mongodb/node-mongodb-native/pull/3102 in v4.3.1 regarding the new `Filter` type, which throws new errors for filter objects with root operators created dynamically.

#### What is changing?

I moved the `RootFilterOperators<WithId<TSchema>>` outside of the union inside the `Filter<TSchema>`.

This fixes the use case below, but it does break 3 lines in the find recursive test. I would love some help from @baileympearson, since you were the one to work on the recursive support.

##### Is there new documentation needed for these changes?

No.

#### What is the motivation for this change?

```ts
// this works in v4.3.1
const fooFilterBuiltNow: Filter<Foo> = {
  a: 'foo',
  $or: [{ a: 'bar' }]
};

const fooFilterBuiltLater: Filter<Foo> = {};
fooFilterBuiltLater.a = 'foo';
// this throws a TS error in v4.3.1
fooFilterBuiltLater.$or = [{ a: 'bar' }];
```
### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket