### PR TITLE
test(NODE-3860): improve skipReason reporting for disabled 'auth' tests

### DIFF
--- a/test/integration/causal-consistency/causal_consistency.prose.test.js
+++ b/test/integration/causal-consistency/causal_consistency.prose.test.js
@@ -10,7 +10,7 @@ const ignoredCommands = [LEGACY_HELLO_COMMAND, 'endSessions'];
 const test = { commands: { started: [], succeeded: [] } };
 
 // TODO(NODE-3882) - properly implement all prose tests and add missing cases 1, 8, 9, 11, 12
-describe.only('Causal Consistency - prose tests', function () {
+describe('Causal Consistency - prose tests', function () {
   before(function () {
     return setupDatabase(this.configuration);
   });

--- a/test/integration/causal-consistency/causal_consistency.prose.test.js
+++ b/test/integration/causal-consistency/causal_consistency.prose.test.js
@@ -16,13 +16,15 @@ describe('Causal Consistency - prose tests', function () {
   });
 
   beforeEach(
-    testSkipBrokenAuthTestBeforeEachHook([
-      '2. The first read in a causally consistent session must not send afterClusterTime to the server',
-      '3. The first read or write on a ClientSession should update the operationTime of the ClientSession, even if there is an error',
-      'case: second operation is findOne',
-      'case: successful insert',
-      '6. A read operation in a ClientSession that is not causally consistent should not include the afterClusterTime parameter in the command sent to the server'
-    ])
+    testSkipBrokenAuthTestBeforeEachHook({
+      skippedTests: [
+        '2. The first read in a causally consistent session must not send afterClusterTime to the server',
+        '3. The first read or write on a ClientSession should update the operationTime of the ClientSession, even if there is an error',
+        'case: second operation is findOne',
+        'case: successful insert',
+        '6. A read operation in a ClientSession that is not causally consistent should not include the afterClusterTime parameter in the command sent to the server'
+      ]
+    })
   );
 
   beforeEach(function () {

--- a/test/integration/causal-consistency/causal_consistency.prose.test.js
+++ b/test/integration/causal-consistency/causal_consistency.prose.test.js
@@ -19,7 +19,7 @@ describe('Causal Consistency - prose tests', function () {
     testSkipBrokenAuthTestBeforeEachHook({
       skippedTests: [
         '2. The first read in a causally consistent session must not send afterClusterTime to the server',
-        '3. The first read or write on a ClientSession should update the operationTime of the ClientSession, even if there is an error',
+        'case: successful read with causal consistency',
         'case: second operation is findOne',
         'case: successful insert',
         '6. A read operation in a ClientSession that is not causally consistent should not include the afterClusterTime parameter in the command sent to the server'

--- a/test/integration/causal-consistency/causal_consistency.prose.test.js
+++ b/test/integration/causal-consistency/causal_consistency.prose.test.js
@@ -64,8 +64,6 @@ describe('Causal Consistency - prose tests', function () {
         const session = test.client.startSession({ causalConsistency: true });
         const db = test.client.db(this.configuration.db);
 
-        console.error(this.currentTest);
-        console.error(this.configuration);
         return db
           .collection('causal_test')
           .findOne({}, { session: session })

--- a/test/integration/causal-consistency/causal_consistency.prose.test.js
+++ b/test/integration/causal-consistency/causal_consistency.prose.test.js
@@ -4,7 +4,7 @@ const { LEGACY_HELLO_COMMAND } = require('../../../src/constants');
 
 const { setupDatabase } = require('../shared');
 const { expect } = require('chai');
-const { testSkipBrokenAuthTestBeforeEachHook } = require('../../tools/runner/hooks/configuration');
+const { skipBrokenAuthTestBeforeEachHook } = require('../../tools/runner/hooks/configuration');
 
 const ignoredCommands = [LEGACY_HELLO_COMMAND, 'endSessions'];
 const test = { commands: { started: [], succeeded: [] } };
@@ -16,7 +16,7 @@ describe('Causal Consistency - prose tests', function () {
   });
 
   beforeEach(
-    testSkipBrokenAuthTestBeforeEachHook({
+    skipBrokenAuthTestBeforeEachHook({
       skippedTests: [
         '2. The first read in a causally consistent session must not send afterClusterTime to the server',
         'case: successful read with causal consistency',

--- a/test/integration/causal-consistency/causal_consistency.prose.test.js
+++ b/test/integration/causal-consistency/causal_consistency.prose.test.js
@@ -42,7 +42,7 @@ describe('Causal Consistency - prose tests', function () {
   });
 
   afterEach(() => {
-    return test.client.close();
+    return test.client ? test.client.close() : Promise.resolve();
   });
 
   it(

--- a/test/integration/causal-consistency/causal_consistency.prose.test.js
+++ b/test/integration/causal-consistency/causal_consistency.prose.test.js
@@ -4,15 +4,26 @@ const { LEGACY_HELLO_COMMAND } = require('../../../src/constants');
 
 const { setupDatabase } = require('../shared');
 const { expect } = require('chai');
+const { testSkipBrokenAuthTestBeforeEachHook } = require('../../tools/runner/hooks/configuration');
 
 const ignoredCommands = [LEGACY_HELLO_COMMAND, 'endSessions'];
 const test = { commands: { started: [], succeeded: [] } };
 
 // TODO(NODE-3882) - properly implement all prose tests and add missing cases 1, 8, 9, 11, 12
-describe('Causal Consistency - prose tests', function () {
+describe.only('Causal Consistency - prose tests', function () {
   before(function () {
     return setupDatabase(this.configuration);
   });
+
+  beforeEach(
+    testSkipBrokenAuthTestBeforeEachHook([
+      '2. The first read in a causally consistent session must not send afterClusterTime to the server',
+      '3. The first read or write on a ClientSession should update the operationTime of the ClientSession, even if there is an error',
+      'case: second operation is findOne',
+      'case: successful insert',
+      '6. A read operation in a ClientSession that is not causally consistent should not include the afterClusterTime parameter in the command sent to the server'
+    ])
+  );
 
   beforeEach(function () {
     test.commands = { started: [], succeeded: [] };
@@ -42,16 +53,17 @@ describe('Causal Consistency - prose tests', function () {
      */
     {
       metadata: {
-        requires: { topology: ['replicaset', 'sharded'], auth: 'disabled' },
+        requires: { topology: ['replicaset', 'sharded'] },
         // Skipping session leak tests b/c these are explicit sessions
-        sessions: { skipLeakTests: true },
-        skipReason: 'TODO: NODE-3891 - fix tests broken when AUTH enabled'
+        sessions: { skipLeakTests: true }
       },
 
       test: function () {
         const session = test.client.startSession({ causalConsistency: true });
         const db = test.client.db(this.configuration.db);
 
+        console.error(this.currentTest);
+        console.error(this.configuration);
         return db
           .collection('causal_test')
           .findOne({}, { session: session })
@@ -81,10 +93,9 @@ describe('Causal Consistency - prose tests', function () {
 
       it('case: successful read with causal consistency', {
         metadata: {
-          requires: { topology: ['replicaset', 'sharded'], auth: 'disabled' },
+          requires: { topology: ['replicaset', 'sharded'] },
           // Skipping session leak tests b/c these are explicit sessions
-          sessions: { skipLeakTests: true },
-          skipReason: 'TODO: NODE-3891 - fix tests broken when AUTH enabled'
+          sessions: { skipLeakTests: true }
         },
 
         test: function () {
@@ -120,10 +131,9 @@ describe('Causal Consistency - prose tests', function () {
     () => {
       it('case: second operation is findOne', {
         metadata: {
-          requires: { topology: ['replicaset', 'sharded'], auth: 'disabled' },
+          requires: { topology: ['replicaset', 'sharded'] },
           // Skipping session leak tests b/c these are explicit sessions
-          sessions: { skipLeakTests: true },
-          skipReason: 'TODO: NODE-3891 - fix tests broken when AUTH enabled'
+          sessions: { skipLeakTests: true }
         },
 
         test: function () {
@@ -166,10 +176,9 @@ describe('Causal Consistency - prose tests', function () {
     () => {
       it('case: successful insert', {
         metadata: {
-          requires: { topology: ['replicaset', 'sharded'], auth: 'disabled' },
+          requires: { topology: ['replicaset', 'sharded'] },
           // Skipping session leak tests b/c these are explicit sessions
-          sessions: { skipLeakTests: true },
-          skipReason: 'TODO: NODE-3891 - fix tests broken when AUTH enabled'
+          sessions: { skipLeakTests: true }
         },
 
         test: function () {
@@ -207,10 +216,9 @@ describe('Causal Consistency - prose tests', function () {
      */
     {
       metadata: {
-        requires: { topology: ['replicaset', 'sharded'], auth: 'disabled' },
+        requires: { topology: ['replicaset', 'sharded'] },
         // Skipping session leak tests b/c these are explicit sessions
-        sessions: { skipLeakTests: true },
-        skipReason: 'TODO: NODE-3891 - fix tests broken when AUTH enabled'
+        sessions: { skipLeakTests: true }
       },
 
       test: function () {

--- a/test/integration/change-streams/change_stream.test.js
+++ b/test/integration/change-streams/change_stream.test.js
@@ -11,7 +11,7 @@ const { Long, ReadPreference, MongoNetworkError } = require('../../../src');
 
 const crypto = require('crypto');
 const { isHello } = require('../../../src/utils');
-const { testSkipBrokenAuthTestBeforeEachHook } = require('../../tools/runner/hooks/configuration');
+const { skipBrokenAuthTestBeforeEachHook } = require('../../tools/runner/hooks/configuration');
 
 function withChangeStream(dbName, collectionName, callback) {
   if (arguments.length === 1) {
@@ -1255,7 +1255,7 @@ describe('Change Streams', function () {
     }
 
     beforeEach(
-      testSkipBrokenAuthTestBeforeEachHook({
+      skipBrokenAuthTestBeforeEachHook({
         skippedTests: ['when invoked using eventEmitter API']
       })
     );

--- a/test/integration/change-streams/change_stream.test.js
+++ b/test/integration/change-streams/change_stream.test.js
@@ -11,6 +11,7 @@ const { Long, ReadPreference, MongoNetworkError } = require('../../../src');
 
 const crypto = require('crypto');
 const { isHello } = require('../../../src/utils');
+const { testSkipBrokenAuthTestBeforeEachHook } = require('../../tools/runner/hooks/configuration');
 
 function withChangeStream(dbName, collectionName, callback) {
   if (arguments.length === 1) {
@@ -1253,6 +1254,8 @@ describe('Change Streams', function () {
       return coll.insertOne({ c: 3 });
     }
 
+    beforeEach(testSkipBrokenAuthTestBeforeEachHook(['when invoked using eventEmitter API']));
+
     beforeEach(function () {
       client = this.configuration.newClient();
       return client.connect().then(_client => {
@@ -1334,8 +1337,7 @@ describe('Change Streams', function () {
 
     it('when invoked using eventEmitter API', {
       metadata: {
-        requires: { topology: 'replicaset', mongodb: '>=3.6', auth: 'disabled' },
-        skipReason: 'TODO: NODE-3891 - fix tests broken when AUTH enabled'
+        requires: { topology: 'replicaset', mongodb: '>=3.6', auth: 'disabled' }
       },
       test: function (done) {
         let closed = false;

--- a/test/integration/change-streams/change_stream.test.js
+++ b/test/integration/change-streams/change_stream.test.js
@@ -1254,7 +1254,11 @@ describe('Change Streams', function () {
       return coll.insertOne({ c: 3 });
     }
 
-    beforeEach(testSkipBrokenAuthTestBeforeEachHook(['when invoked using eventEmitter API']));
+    beforeEach(
+      testSkipBrokenAuthTestBeforeEachHook({
+        skippedTests: ['when invoked using eventEmitter API']
+      })
+    );
 
     beforeEach(function () {
       client = this.configuration.newClient();

--- a/test/integration/connection-monitoring-and-pooling/connection.test.js
+++ b/test/integration/connection-monitoring-and-pooling/connection.test.js
@@ -8,11 +8,11 @@ const { setupDatabase, withClient, assert: test } = require('../shared');
 const { ns, HostAddress } = require('../../../src/utils');
 const { LEGACY_HELLO_COMMAND } = require('../../../src/constants');
 const { Topology } = require('../../../src/sdam/topology');
-const { testSkipBrokenAuthTestBeforeEachHook } = require('../../tools/runner/hooks/configuration');
+const { skipBrokenAuthTestBeforeEachHook } = require('../../tools/runner/hooks/configuration');
 
 describe('Connection', function () {
   beforeEach(
-    testSkipBrokenAuthTestBeforeEachHook({
+    skipBrokenAuthTestBeforeEachHook({
       skippedTests: [
         'should support calling back multiple times on exhaust commands',
         'should correctly connect to server using domain socket'

--- a/test/integration/connection-monitoring-and-pooling/connection.test.js
+++ b/test/integration/connection-monitoring-and-pooling/connection.test.js
@@ -12,10 +12,12 @@ const { testSkipBrokenAuthTestBeforeEachHook } = require('../../tools/runner/hoo
 
 describe('Connection', function () {
   beforeEach(
-    testSkipBrokenAuthTestBeforeEachHook([
-      'should support calling back multiple times on exhaust commands',
-      'should correctly connect to server using domain socket'
-    ])
+    testSkipBrokenAuthTestBeforeEachHook({
+      skippedTests: [
+        'should support calling back multiple times on exhaust commands',
+        'should correctly connect to server using domain socket'
+      ]
+    })
   );
 
   before(function () {

--- a/test/integration/connection-monitoring-and-pooling/connection.test.js
+++ b/test/integration/connection-monitoring-and-pooling/connection.test.js
@@ -8,8 +8,16 @@ const { setupDatabase, withClient, assert: test } = require('../shared');
 const { ns, HostAddress } = require('../../../src/utils');
 const { LEGACY_HELLO_COMMAND } = require('../../../src/constants');
 const { Topology } = require('../../../src/sdam/topology');
+const { testSkipBrokenAuthTestBeforeEachHook } = require('../../tools/runner/hooks/configuration');
 
 describe('Connection', function () {
+  beforeEach(
+    testSkipBrokenAuthTestBeforeEachHook([
+      'should support calling back multiple times on exhaust commands',
+      'should correctly connect to server using domain socket'
+    ])
+  );
+
   before(function () {
     return setupDatabase(this.configuration);
   });
@@ -89,8 +97,7 @@ describe('Connection', function () {
 
     it('should support calling back multiple times on exhaust commands', {
       metadata: {
-        requires: { apiVersion: false, mongodb: '>=4.2.0', topology: ['single'], auth: 'disabled' },
-        skipReason: 'TODO: NODE-3891 - fix tests broken when AUTH enabled'
+        requires: { apiVersion: false, mongodb: '>=4.2.0', topology: ['single'] }
       },
       test: function (done) {
         const namespace = ns(`${this.configuration.db}.$cmd`);
@@ -200,8 +207,7 @@ describe('Connection', function () {
 
     it('should correctly connect to server using domain socket', {
       metadata: {
-        requires: { topology: 'single', os: '!win32', auth: 'disabled' },
-        skipReason: 'TODO: NODE-3891 - fix tests broken when AUTH enabled'
+        requires: { topology: 'single', os: '!win32' }
       },
 
       test: function (done) {

--- a/test/integration/connections-survive-step-down/connections_survive_step_down.prose.test.js
+++ b/test/integration/connections-survive-step-down/connections_survive_step_down.prose.test.js
@@ -35,13 +35,15 @@ maybeDescribe('Connections survive primary step down - prose', function () {
   let collection;
 
   beforeEach(
-    testSkipBrokenAuthTestBeforeEachHook([
-      'getMore iteration',
-      'Not Primary - Keep Connection Pool',
-      'Not Primary - Reset Connection Pool',
-      'Shutdown in progress - Reset Connection Pool',
-      'Interrupted at shutdown - Reset Connection Pool'
-    ])
+    testSkipBrokenAuthTestBeforeEachHook({
+      skippedTests: [
+        'getMore iteration',
+        'Not Primary - Keep Connection Pool',
+        'Not Primary - Reset Connection Pool',
+        'Shutdown in progress - Reset Connection Pool',
+        'Interrupted at shutdown - Reset Connection Pool'
+      ]
+    })
   );
 
   beforeEach(function () {

--- a/test/integration/connections-survive-step-down/connections_survive_step_down.prose.test.js
+++ b/test/integration/connections-survive-step-down/connections_survive_step_down.prose.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { expect } = require('chai');
-const { testSkipBrokenAuthTestBeforeEachHook } = require('../../tools/runner/hooks/configuration');
+const { skipBrokenAuthTestBeforeEachHook } = require('../../tools/runner/hooks/configuration');
 
 function ignoreNsNotFound(err) {
   if (!err.message.match(/ns not found/)) {
@@ -35,7 +35,7 @@ maybeDescribe('Connections survive primary step down - prose', function () {
   let collection;
 
   beforeEach(
-    testSkipBrokenAuthTestBeforeEachHook({
+    skipBrokenAuthTestBeforeEachHook({
       skippedTests: [
         'getMore iteration',
         'Not Primary - Keep Connection Pool',

--- a/test/integration/connections-survive-step-down/connections_survive_step_down.prose.test.js
+++ b/test/integration/connections-survive-step-down/connections_survive_step_down.prose.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { expect } = require('chai');
+const { testSkipBrokenAuthTestBeforeEachHook } = require('../../tools/runner/hooks/configuration');
 
 function ignoreNsNotFound(err) {
   if (!err.message.match(/ns not found/)) {
@@ -32,6 +33,16 @@ maybeDescribe('Connections survive primary step down - prose', function () {
   let checkClient;
   let db;
   let collection;
+
+  beforeEach(
+    testSkipBrokenAuthTestBeforeEachHook([
+      'getMore iteration',
+      'Not Primary - Keep Connection Pool',
+      'Not Primary - Reset Connection Pool',
+      'Shutdown in progress - Reset Connection Pool',
+      'Interrupted at shutdown - Reset Connection Pool'
+    ])
+  );
 
   beforeEach(function () {
     const clientOptions = {
@@ -73,8 +84,7 @@ maybeDescribe('Connections survive primary step down - prose', function () {
 
   it('getMore iteration', {
     metadata: {
-      requires: { mongodb: '>=4.2.0', topology: 'replicaset', auth: 'disabled' },
-      skipReason: 'TODO: NODE-3891 - fix tests broken when AUTH enabled'
+      requires: { mongodb: '>=4.2.0', topology: 'replicaset' }
     },
 
     test: function () {
@@ -142,8 +152,7 @@ maybeDescribe('Connections survive primary step down - prose', function () {
 
   it('Not Primary - Keep Connection Pool', {
     metadata: {
-      requires: { mongodb: '>=4.2.0', topology: 'replicaset', auth: 'disabled' },
-      skipReason: 'TODO: NODE-3891 - fix tests broken when AUTH enabled'
+      requires: { mongodb: '>=4.2.0', topology: 'replicaset' }
     },
     test: function () {
       return runStepownScenario(10107, expectPoolWasNotCleared);
@@ -152,8 +161,7 @@ maybeDescribe('Connections survive primary step down - prose', function () {
 
   it('Not Primary - Reset Connection Pool', {
     metadata: {
-      requires: { mongodb: '4.0.x', topology: 'replicaset', auth: 'disabled' },
-      skipReason: 'TODO: NODE-3891 - fix tests broken when AUTH enabled'
+      requires: { mongodb: '4.0.x', topology: 'replicaset' }
     },
     test: function () {
       return runStepownScenario(10107, expectPoolWasCleared);
@@ -162,8 +170,7 @@ maybeDescribe('Connections survive primary step down - prose', function () {
 
   it('Shutdown in progress - Reset Connection Pool', {
     metadata: {
-      requires: { mongodb: '>=4.0.0', topology: 'replicaset', auth: 'disabled' },
-      skipReason: 'TODO: NODE-3891 - fix tests broken when AUTH enabled'
+      requires: { mongodb: '>=4.0.0', topology: 'replicaset' }
     },
     test: function () {
       return runStepownScenario(91, expectPoolWasCleared);
@@ -172,8 +179,7 @@ maybeDescribe('Connections survive primary step down - prose', function () {
 
   it('Interrupted at shutdown - Reset Connection Pool', {
     metadata: {
-      requires: { mongodb: '>=4.0.0', topology: 'replicaset', auth: 'disabled' },
-      skipReason: 'TODO: NODE-3891 - fix tests broken when AUTH enabled'
+      requires: { mongodb: '>=4.0.0', topology: 'replicaset' }
     },
     test: function () {
       return runStepownScenario(11600, expectPoolWasCleared);

--- a/test/integration/connections-survive-step-down/connections_survive_step_down.prose.test.js
+++ b/test/integration/connections-survive-step-down/connections_survive_step_down.prose.test.js
@@ -80,7 +80,7 @@ maybeDescribe('Connections survive primary step down - prose', function () {
   afterEach(function () {
     return Promise.all(deferred.map(d => d())).then(() => {
       deferred = [];
-      return Promise.all([client.close(), checkClient.close()]);
+      return Promise.all([client, checkClient].filter(x => !!x).map(client => client.close()));
     });
   });
 

--- a/test/integration/node-specific/operation_example.test.js
+++ b/test/integration/node-specific/operation_example.test.js
@@ -5,7 +5,7 @@ const { Topology } = require('../../../src/sdam/topology');
 const { Code, ObjectId, ReturnDocument } = require('../../../src');
 
 const chai = require('chai');
-const { testSkipBrokenAuthTestBeforeEachHook } = require('../../tools/runner/hooks/configuration');
+const { skipBrokenAuthTestBeforeEachHook } = require('../../tools/runner/hooks/configuration');
 
 const expect = chai.expect;
 chai.use(require('chai-subset'));
@@ -16,7 +16,7 @@ describe('Operation Examples', function () {
   });
 
   beforeEach(
-    testSkipBrokenAuthTestBeforeEachHook({
+    skipBrokenAuthTestBeforeEachHook({
       skippedTests: [
         'Should correctly connect to a replicaset',
         'Should connect to mongos proxies using connectiong string'

--- a/test/integration/node-specific/operation_example.test.js
+++ b/test/integration/node-specific/operation_example.test.js
@@ -16,10 +16,12 @@ describe('Operation Examples', function () {
   });
 
   beforeEach(
-    testSkipBrokenAuthTestBeforeEachHook([
-      'Should correctly connect to a replicaset',
-      'Should connect to mongos proxies using connectiong string'
-    ])
+    testSkipBrokenAuthTestBeforeEachHook({
+      skippedTests: [
+        'Should correctly connect to a replicaset',
+        'Should connect to mongos proxies using connectiong string'
+      ]
+    })
   );
 
   /**************************************************************************

--- a/test/integration/node-specific/operation_example.test.js
+++ b/test/integration/node-specific/operation_example.test.js
@@ -5,6 +5,7 @@ const { Topology } = require('../../../src/sdam/topology');
 const { Code, ObjectId, ReturnDocument } = require('../../../src');
 
 const chai = require('chai');
+const { testSkipBrokenAuthTestBeforeEachHook } = require('../../tools/runner/hooks/configuration');
 
 const expect = chai.expect;
 chai.use(require('chai-subset'));
@@ -13,6 +14,13 @@ describe('Operation Examples', function () {
   before(function () {
     return setupDatabase(this.configuration, ['integration_tests_2']);
   });
+
+  beforeEach(
+    testSkipBrokenAuthTestBeforeEachHook([
+      'Should correctly connect to a replicaset',
+      'Should connect to mongos proxies using connectiong string'
+    ])
+  );
 
   /**************************************************************************
    *
@@ -5488,8 +5496,7 @@ describe('Operation Examples', function () {
    */
   it('Should correctly connect to a replicaset', {
     metadata: {
-      requires: { topology: 'replicaset', auth: 'disabled' },
-      skipReason: 'TODO: NODE-3891 - fix tests broken when AUTH enabled'
+      requires: { topology: 'replicaset' }
     },
 
     test: function (done) {
@@ -5544,8 +5551,7 @@ describe('Operation Examples', function () {
    */
   it('Should connect to mongos proxies using connectiong string', {
     metadata: {
-      requires: { topology: 'sharded', auth: 'disabled' },
-      skipReason: 'TODO: NODE-3891 - fix tests broken when AUTH enabled'
+      requires: { topology: 'sharded' }
     },
 
     test: function (done) {

--- a/test/integration/node-specific/operation_promises_example.test.js
+++ b/test/integration/node-specific/operation_promises_example.test.js
@@ -6,7 +6,7 @@ const { enumToString } = require('../../../src/utils');
 const { ProfilingLevel } = require('../../../src/operations/set_profiling_level');
 const { Code, ReturnDocument } = require('../../../src');
 const { expect } = require('chai');
-const { testSkipBrokenAuthTestBeforeEachHook } = require('../../tools/runner/hooks/configuration');
+const { skipBrokenAuthTestBeforeEachHook } = require('../../tools/runner/hooks/configuration');
 
 describe('Operation (Promises)', function () {
   before(function () {
@@ -14,7 +14,7 @@ describe('Operation (Promises)', function () {
   });
 
   beforeEach(
-    testSkipBrokenAuthTestBeforeEachHook({
+    skipBrokenAuthTestBeforeEachHook({
       skippedTests: [
         'Should correctly connect to a replicaset',
         'Should connect to mongos proxies using connectiong string With Promises',

--- a/test/integration/node-specific/operation_promises_example.test.js
+++ b/test/integration/node-specific/operation_promises_example.test.js
@@ -17,7 +17,8 @@ describe('Operation (Promises)', function () {
     testSkipBrokenAuthTestBeforeEachHook({
       skippedTests: [
         'Should correctly connect to a replicaset',
-        'Should connect to mongos proxies using connectiong string With Promises'
+        'Should connect to mongos proxies using connectiong string With Promises',
+        'Should correctly connect to a replicaset With Promises'
       ]
     })
   );

--- a/test/integration/node-specific/operation_promises_example.test.js
+++ b/test/integration/node-specific/operation_promises_example.test.js
@@ -6,11 +6,19 @@ const { enumToString } = require('../../../src/utils');
 const { ProfilingLevel } = require('../../../src/operations/set_profiling_level');
 const { Code, ReturnDocument } = require('../../../src');
 const { expect } = require('chai');
+const { testSkipBrokenAuthTestBeforeEachHook } = require('../../tools/runner/hooks/configuration');
 
 describe('Operation (Promises)', function () {
   before(function () {
     return setupDatabase(this.configuration, ['integration_tests_2', 'hr', 'reporting']);
   });
+
+  beforeEach(
+    testSkipBrokenAuthTestBeforeEachHook([
+      'Should correctly connect to a replicaset',
+      'Should connect to mongos proxies using connectiong string With Promises'
+    ])
+  );
 
   /**************************************************************************
    *
@@ -4016,8 +4024,7 @@ describe('Operation (Promises)', function () {
    */
   it('Should correctly connect to a replicaset With Promises', {
     metadata: {
-      requires: { topology: 'replicaset', auth: 'disabled' },
-      skipReason: 'TODO: NODE-3891 - fix tests broken when AUTH enabled'
+      requires: { topology: 'replicaset' }
     },
 
     test: function () {
@@ -4064,8 +4071,7 @@ describe('Operation (Promises)', function () {
    */
   it('Should connect to mongos proxies using connectiong string With Promises', {
     metadata: {
-      requires: { topology: 'sharded', auth: 'disabled' },
-      skipReason: 'TODO: NODE-3891 - fix tests broken when AUTH enabled'
+      requires: { topology: 'sharded' }
     },
 
     test: function () {

--- a/test/integration/node-specific/operation_promises_example.test.js
+++ b/test/integration/node-specific/operation_promises_example.test.js
@@ -14,10 +14,12 @@ describe('Operation (Promises)', function () {
   });
 
   beforeEach(
-    testSkipBrokenAuthTestBeforeEachHook([
-      'Should correctly connect to a replicaset',
-      'Should connect to mongos proxies using connectiong string With Promises'
-    ])
+    testSkipBrokenAuthTestBeforeEachHook({
+      skippedTests: [
+        'Should correctly connect to a replicaset',
+        'Should connect to mongos proxies using connectiong string With Promises'
+      ]
+    })
   );
 
   /**************************************************************************

--- a/test/tools/reporter/mongodb_reporter.js
+++ b/test/tools/reporter/mongodb_reporter.js
@@ -233,11 +233,6 @@ class MongoDBMochaReporter extends mocha.reporters.Spec {
    */
   pending(test) {
     if (REPORT_TO_STDIO) console.log(chalk.cyan(`↬ ${test.fullTitle()}`));
-    if (test.metadata && test.metadata.skipReason && typeof test.metadata.skipReason === 'string') {
-      console.log(
-        chalk.cyan(`${'  '.repeat(test.titlePath().length + 1)}↬ ${test.metadata.skipReason}`)
-      );
-    }
     if (typeof test.skipReason === 'string') {
       console.log(chalk.cyan(`${'  '.repeat(test.titlePath().length + 1)}↬ ${test.skipReason}`));
     }

--- a/test/tools/runner/hooks/configuration.js
+++ b/test/tools/runner/hooks/configuration.js
@@ -89,7 +89,7 @@ const testSkipBeforeEachHook = async function () {
 };
 
 // TODO: NODE-3891 - fix tests that are broken with auth enabled and remove this hook
-const testSkipBrokenAuthTestBeforeEachHook = function ({ skippedTests } = { skippedTests: [] }) {
+const skipBrokenAuthTestBeforeEachHook = function ({ skippedTests } = { skippedTests: [] }) {
   return function () {
     if (process.env.AUTH === 'auth' && skippedTests.includes(this.currentTest.title)) {
       this.currentTest.skipReason = 'TODO: NODE-3891 - fix tests broken when AUTH enabled';
@@ -163,5 +163,5 @@ module.exports = {
     beforeEach: [testSkipBeforeEachHook],
     afterAll: [cleanUpMocksAfterHook]
   },
-  testSkipBrokenAuthTestBeforeEachHook
+  skipBrokenAuthTestBeforeEachHook
 };

--- a/test/tools/runner/hooks/configuration.js
+++ b/test/tools/runner/hooks/configuration.js
@@ -88,6 +88,15 @@ const testSkipBeforeEachHook = async function () {
   }
 };
 
+const testSkipBrokenAuthTestBeforeEachHook = function (skippedTests = []) {
+  return function () {
+    if (process.env.AUTH === 'auth' && skippedTests.includes(this.currentTest.title)) {
+      this.currentTest.skipReason = 'TODO: NODE-3891 - fix tests broken when AUTH enabled';
+      this.skip();
+    }
+  };
+};
+
 const testConfigBeforeHook = async function () {
   const client = new MongoClient(loadBalanced ? SINGLE_MONGOS_LB_URI : MONGODB_URI, {
     ...getEnvironmentalOptions()
@@ -152,5 +161,6 @@ module.exports = {
     beforeAll: [beforeAllPluginImports, testConfigBeforeHook],
     beforeEach: [testSkipBeforeEachHook],
     afterAll: [cleanUpMocksAfterHook]
-  }
+  },
+  testSkipBrokenAuthTestBeforeEachHook
 };

--- a/test/tools/runner/hooks/configuration.js
+++ b/test/tools/runner/hooks/configuration.js
@@ -88,7 +88,8 @@ const testSkipBeforeEachHook = async function () {
   }
 };
 
-const testSkipBrokenAuthTestBeforeEachHook = function (skippedTests = []) {
+// TODO: NODE-3891 - fix tests that are broken with auth enabled and remove this hook
+const testSkipBrokenAuthTestBeforeEachHook = function ({ skippedTests } = { skippedTests: [] }) {
   return function () {
     if (process.env.AUTH === 'auth' && skippedTests.includes(this.currentTest.title)) {
       this.currentTest.skipReason = 'TODO: NODE-3891 - fix tests broken when AUTH enabled';

--- a/test/tools/utils.js
+++ b/test/tools/utils.js
@@ -252,7 +252,7 @@ function removeAuthFromConnectionString(connectionString) {
     return connectionString;
   }
 
-  return connectionString.slice(0, start + 2) + connectionString.slice(end + 1);
+  return connectionString.slice(0, start) + connectionString.slice(end + 1);
 }
 
 function extractAuthFromConnectionString(connectionString) {

--- a/test/tools/utils.js
+++ b/test/tools/utils.js
@@ -241,7 +241,12 @@ function getIndicesOfAuthInUrl(connectionString) {
 }
 
 function removeAuthFromConnectionString(connectionString) {
-  const { start, end } = getIndicesOfAuthInUrl(connectionString);
+  const indices = getIndicesOfAuthInUrl(connectionString);
+  if (!indices) {
+    return connectionString;
+  }
+
+  const { start, end } = indices;
 
   if (start === -1 || end === -1) {
     return connectionString;


### PR DESCRIPTION
### Description

#### What is changing?

This PR cleans up the `skipReason` logic added in https://github.com/mongodb/node-mongodb-native/pull/3121.  By including the skipReason and the filter status `auth: disabled` in the metadata for tests that fail because `auth` was enabled, in cases where the test would not have run due to other requirements, we report the skip reason being that `auth` was enabled rather than the actual skip reason for the test.

This PR also fixes the broken AWS tests.

##### Is there new documentation needed for these changes?

No.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
