### PR TITLE
fix(NODE-3813): unexpected type conversion of read preference tags

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -59,6 +59,17 @@
       "global"
     ],
     "@typescript-eslint/no-explicit-any": "off",
+    "no-restricted-imports": [
+      "error",
+      {
+        "paths": [
+          {
+            "name": ".",
+            "message": "Please import directly from the relevant file instead."
+          }
+        ]
+      }
+    ],
     "no-restricted-syntax": [
       "error",
       {

--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -204,11 +204,22 @@ function getUint(name: string, value: unknown): number {
   return parsedValue;
 }
 
-
 function toArray<T>(value: T): T[];
 function toArray<T>(value: T[]): T[];
 function toArray<T>(value: T | T[]): T[] {
   return Array.isArray(value) ? value : [value];
+}
+
+function parseType(value: string): number | boolean | string {
+  try {
+    return getBoolean('', value);
+  } catch {
+    try {
+      return getInt('', value);
+    } catch {
+      return value;
+    }
+  }
 }
 
 function toRecord(value: string): Record<string, any> {
@@ -219,18 +230,7 @@ function toRecord(value: string): Record<string, any> {
     if (value == null) {
       throw new MongoParseError('Cannot have undefined values in key value pairs');
     }
-    try {
-      // try to get a boolean
-      record[key] = getBoolean('', value);
-    } catch {
-      try {
-        // try to get a number
-        record[key] = getInt('', value);
-      } catch {
-        // keep value as a string
-        record[key] = value;
-      }
-    }
+    record[key] = value;
   }
   return record;
 }
@@ -632,7 +632,9 @@ export const OPTIONS = {
     target: 'credentials',
     transform({ options, values: [value] }): MongoCredentials {
       if (typeof value === 'string') {
-        value = toRecord(value);
+        value = Object.fromEntries(
+          Object.entries(toRecord(value)).map(([key, value]) => [key, parseType(value)])
+        );
       }
       if (!isRecord(value)) {
         throw new MongoParseError('AuthMechanismProperties must be an object');

--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -224,7 +224,7 @@ function toArray<T>(value: OneOrMore<T>): T[] {
   return Array.isArray(value) ? value : [value];
 }
 
-function* parseObjectString(value: string) {
+function* entriesFromString(value: string) {
   const keyValuePairs = value.split(',');
   for (const keyValue of keyValuePairs) {
     const [key, value] = keyValue.split(':');
@@ -244,7 +244,7 @@ function* parseAuthMechanismParameters(stringValue: string) {
     'AWS_SESSION_TOKEN'
   ];
 
-  for (const [key, value] of parseObjectString(stringValue)) {
+  for (const [key, value] of entriesFromString(stringValue)) {
     if (validKeys.includes(key)) {
       if (key === 'CANONICALIZE_HOST_NAME') {
         yield [key, getBoolean(key, value)];
@@ -986,7 +986,7 @@ export const OPTIONS = {
       for (const tag of values) {
         const readPreferenceTag: TagSet = Object.create(null);
         if (typeof tag === 'string') {
-          for (const [k, v] of parseObjectString(tag)) {
+          for (const [k, v] of entriesFromString(tag)) {
             readPreferenceTag[k] = v;
           }
         }

--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -3,7 +3,6 @@ import * as fs from 'fs';
 import ConnectionString from 'mongodb-connection-string-url';
 import { URLSearchParams } from 'url';
 
-import type { OneOrMore } from '.';
 import type { Document } from './bson';
 import { MongoCredentials } from './cmap/auth/mongo_credentials';
 import { AUTH_MECHS_AUTH_SRC_EXTERNAL, AuthMechanism } from './cmap/auth/providers';
@@ -20,6 +19,7 @@ import {
   ServerApi,
   ServerApiVersion
 } from './mongo_client';
+import type { OneOrMore } from './mongo_types';
 import { PromiseProvider } from './promise_provider';
 import { ReadConcern, ReadConcernLevel } from './read_concern';
 import { ReadPreference, ReadPreferenceMode } from './read_preference';

--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -28,7 +28,7 @@ import {
   AnyOptions,
   Callback,
   DEFAULT_PK_FACTORY,
-  emitWarning,
+  emitWarningOnce,
   HostAddress,
   isRecord,
   makeClientMetadata,
@@ -187,7 +187,7 @@ function getBoolean(name: string, value: unknown): boolean {
   const valueString = String(value).toLowerCase();
   if (TRUTHS.has(valueString)) {
     if (valueString !== 'true') {
-      emitWarning(
+      emitWarningOnce(
         `deprecated value for ${name} : ${valueString} - please update to ${name} : true instead`
       );
     }
@@ -195,7 +195,7 @@ function getBoolean(name: string, value: unknown): boolean {
   }
   if (FALSEHOODS.has(valueString)) {
     if (valueString !== 'false') {
-      emitWarning(
+      emitWarningOnce(
         `deprecated value for ${name} : ${valueString} - please update to ${name} : false instead`
       );
     }

--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -28,6 +28,7 @@ import {
   AnyOptions,
   Callback,
   DEFAULT_PK_FACTORY,
+  emitWarning,
   emitWarningOnce,
   HostAddress,
   isRecord,
@@ -640,19 +641,21 @@ export const OPTIONS = {
           'AWS_SESSION_TOKEN'
         ];
 
-        const properties = Object.create(null);
+        const mechanismProperties = Object.create(null);
 
         for (const [key, _value] of entriesFromString(value)) {
           if (validKeys.includes(key)) {
             if (key === 'CANONICALIZE_HOST_NAME') {
-              properties[key] = getBoolean(key, _value);
+              mechanismProperties[key] = getBoolean(key, _value);
             } else {
-              properties[key] = _value;
+              mechanismProperties[key] = _value;
             }
           }
         }
 
-        value = properties;
+        return MongoCredentials.merge(options.credentials, {
+          mechanismProperties
+        });
       }
       if (!isRecord(value)) {
         throw new MongoParseError('AuthMechanismProperties must be an object');

--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -326,7 +326,9 @@ export function parseOptions(
   for (const key of allKeys) {
     const values = [];
     if (objectOptions.has(key)) {
-      const options = [objectOptions.get(key)].flat();
+      const options = Array.isArray(objectOptions.get(key))
+        ? objectOptions.get(key)
+        : [objectOptions.get(key)];
       values.push(...options);
     }
     if (urlOptions.has(key)) {
@@ -334,7 +336,9 @@ export function parseOptions(
       values.push(...options);
     }
     if (DEFAULT_OPTIONS.has(key)) {
-      const options = [DEFAULT_OPTIONS.get(key)].flat();
+      const options = Array.isArray(DEFAULT_OPTIONS.get(key))
+        ? DEFAULT_OPTIONS.get(key)
+        : [DEFAULT_OPTIONS.get(key)];
       values.push(...options);
     }
     allOptions.set(key, values);

--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import ConnectionString from 'mongodb-connection-string-url';
 import { URLSearchParams } from 'url';
 
+import type { OneOrMore } from '.';
 import type { Document } from './bson';
 import { MongoCredentials } from './cmap/auth/mongo_credentials';
 import { AUTH_MECHS_AUTH_SRC_EXTERNAL, AuthMechanism } from './cmap/auth/providers';
@@ -204,9 +205,8 @@ function getUint(name: string, value: unknown): number {
   return parsedValue;
 }
 
-function toArray<T>(value: T): T[];
-function toArray<T>(value: T[]): T[];
-function toArray<T>(value: T | T[]): T[] {
+/** Wrap a single value in an array if the value is not an array */
+function toArray<T>(value: OneOrMore<T>): T[] {
   return Array.isArray(value) ? value : [value];
 }
 

--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -632,24 +632,15 @@ export const OPTIONS = {
   },
   authMechanismProperties: {
     target: 'credentials',
-    transform({ options, values: [value] }): MongoCredentials {
-      if (typeof value === 'string') {
-        const validKeys = [
-          'SERVICE_NAME',
-          'SERVICE_REALM',
-          'CANONICALIZE_HOST_NAME',
-          'AWS_SESSION_TOKEN'
-        ];
-
+    transform({ options, values: [optionValue] }): MongoCredentials {
+      if (typeof optionValue === 'string') {
         const mechanismProperties = Object.create(null);
 
-        for (const [key, _value] of entriesFromString(value)) {
-          if (validKeys.includes(key)) {
-            if (key === 'CANONICALIZE_HOST_NAME') {
-              mechanismProperties[key] = getBoolean(key, _value);
-            } else {
-              mechanismProperties[key] = _value;
-            }
+        for (const [key, value] of entriesFromString(optionValue)) {
+          try {
+            mechanismProperties[key] = getBoolean(key, value);
+          } catch {
+            mechanismProperties[key] = value;
           }
         }
 
@@ -657,10 +648,10 @@ export const OPTIONS = {
           mechanismProperties
         });
       }
-      if (!isRecord(value)) {
+      if (!isRecord(optionValue)) {
         throw new MongoParseError('AuthMechanismProperties must be an object');
       }
-      return MongoCredentials.merge(options.credentials, { mechanismProperties: value });
+      return MongoCredentials.merge(options.credentials, { mechanismProperties: optionValue });
     }
   },
   authSource: {

--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -204,6 +204,13 @@ function getUint(name: string, value: unknown): number {
   return parsedValue;
 }
 
+
+function toArray<T>(value: T): T[];
+function toArray<T>(value: T[]): T[];
+function toArray<T>(value: T | T[]): T[] {
+  return Array.isArray(value) ? value : [value];
+}
+
 function toRecord(value: string): Record<string, any> {
   const record = Object.create(null);
   const keyValuePairs = value.split(',');
@@ -324,23 +331,11 @@ export function parseOptions(
   ]);
 
   for (const key of allKeys) {
-    const values = [];
-    if (objectOptions.has(key)) {
-      const options = Array.isArray(objectOptions.get(key))
-        ? objectOptions.get(key)
-        : [objectOptions.get(key)];
-      values.push(...options);
-    }
-    if (urlOptions.has(key)) {
-      const options = urlOptions.get(key) ?? [];
-      values.push(...options);
-    }
-    if (DEFAULT_OPTIONS.has(key)) {
-      const options = Array.isArray(DEFAULT_OPTIONS.get(key))
-        ? DEFAULT_OPTIONS.get(key)
-        : [DEFAULT_OPTIONS.get(key)];
-      values.push(...options);
-    }
+    const values = [objectOptions, urlOptions, DEFAULT_OPTIONS].flatMap(optionsObject => {
+      const options = optionsObject.get(key) ?? [];
+      return toArray(options);
+    });
+
     allOptions.set(key, values);
   }
 

--- a/test/tools/uri_spec_runner.ts
+++ b/test/tools/uri_spec_runner.ts
@@ -221,6 +221,12 @@ export function executeUriValidationTest(
           .to.have.nested.property(expectedProp)
           .deep.equal(optionValue);
         break;
+      case 'maxStalenessSeconds':
+        expectedProp = 'readPreference.maxStalenessSeconds';
+        expect(options, `${errorMessage} ${optionKey} -> ${expectedProp}`)
+          .to.have.nested.property(expectedProp)
+          .deep.equal(optionValue);
+        break;
 
       //** WRITE CONCERN OPTIONS **/
       case 'w':

--- a/test/unit/assorted/uri_options.spec.test.ts
+++ b/test/unit/assorted/uri_options.spec.test.ts
@@ -28,10 +28,7 @@ describe('URI option spec tests', function () {
     'tlsDisableCertificateRevocationCheck can be set to true',
     'tlsDisableCertificateRevocationCheck can be set to false',
     'tlsDisableOCSPEndpointCheck can be set to true',
-    'tlsDisableOCSPEndpointCheck can be set to false',
-
-    // TODO(NODE-3813): read preference tag issue: parsing rack:1 as rack:true
-    'Valid read preference options are parsed correctly'
+    'tlsDisableOCSPEndpointCheck can be set to false'
   ];
 
   const testsThatDoNotThrowOnWarn = [
@@ -60,6 +57,7 @@ describe('URI option spec tests', function () {
 
       for (const test of suite.tests) {
         it(`${test.description}`, function () {
+          console.error(test);
           if (skipTests.includes(test.description)) {
             return this.skip();
           }

--- a/test/unit/assorted/uri_options.spec.test.ts
+++ b/test/unit/assorted/uri_options.spec.test.ts
@@ -57,7 +57,6 @@ describe('URI option spec tests', function () {
 
       for (const test of suite.tests) {
         it(`${test.description}`, function () {
-          console.error(test);
           if (skipTests.includes(test.description)) {
             return this.skip();
           }

--- a/test/unit/connection_string.test.ts
+++ b/test/unit/connection_string.test.ts
@@ -46,11 +46,20 @@ describe('Connection String', function () {
     expect(options.hosts[0].port).to.equal(27017);
   });
 
-  it('should parse multiple readPreferenceTags', function () {
-    const options = parseOptions(
-      'mongodb://hostname?readPreferenceTags=bar:foo&readPreferenceTags=baz:bar'
-    );
-    expect(options.readPreference.tags).to.deep.equal([{ bar: 'foo' }, { baz: 'bar' }]);
+  context('readPreferenceTags', function () {
+    it('should parse multiple readPreferenceTags when passed in the uri', () => {
+      const options = parseOptions(
+        'mongodb://hostname?readPreferenceTags=bar:foo&readPreferenceTags=baz:bar'
+      );
+      expect(options.readPreference.tags).to.deep.equal([{ bar: 'foo' }, { baz: 'bar' }]);
+    });
+
+    it('should parse multiple readPreferenceTags when passed in options object', () => {
+      const options = parseOptions('mongodb://hostname?', {
+        readPreferenceTags: [{ bar: 'foo' }, { baz: 'bar' }]
+      });
+      expect(options.readPreference.tags).to.deep.equal([{ bar: 'foo' }, { baz: 'bar' }]);
+    });
   });
 
   it('should parse boolean values', function () {


### PR DESCRIPTION
### Description

#### What is changing?

This PR does two things:
- fixes options parsing for arrays of options.
- refactors how we parse key-value pairs of options for a particular option.  In particular, it removes logic from parsing `readPreference` that was converting string values to native JS types, causing spec tests to fail

##### Is there new documentation needed for these changes?

No.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
