### PR TITLE
test(NODE-3885): update spec tests to remove legacy language

### DIFF
--- a/test/spec/retryable-writes/insertOne-serverErrors.json
+++ b/test/spec/retryable-writes/insertOne-serverErrors.json
@@ -118,7 +118,7 @@
       }
     },
     {
-      "description": "InsertOne succeeds after NotMaster",
+      "description": "InsertOne succeeds after NotWritablePrimary",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -167,7 +167,7 @@
       }
     },
     {
-      "description": "InsertOne succeeds after NotMasterOrSecondary",
+      "description": "InsertOne succeeds after NotPrimaryOrSecondary",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -216,7 +216,7 @@
       }
     },
     {
-      "description": "InsertOne succeeds after NotMasterNoSlaveOk",
+      "description": "InsertOne succeeds after NotPrimaryNoSecondaryOk",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {

--- a/test/spec/retryable-writes/insertOne-serverErrors.yml
+++ b/test/spec/retryable-writes/insertOne-serverErrors.yml
@@ -56,7 +56,7 @@ tests:
                     - { _id: 1, x: 11 }
                     - { _id: 2, x: 22 }
     -
-        description: "InsertOne succeeds after NotMaster"
+        description: "InsertOne succeeds after NotWritablePrimary"
         failPoint:
             configureFailPoint: failCommand
             mode: { times: 1 }
@@ -78,7 +78,7 @@ tests:
                     - { _id: 2, x: 22 }
                     - { _id: 3, x: 33 }
     -
-        description: "InsertOne succeeds after NotMasterOrSecondary"
+        description: "InsertOne succeeds after NotPrimaryOrSecondary"
         failPoint:
             configureFailPoint: failCommand
             mode: { times: 1 }
@@ -100,7 +100,7 @@ tests:
                     - { _id: 2, x: 22 }
                     - { _id: 3, x: 33 }
     -
-        description: "InsertOne succeeds after NotMasterNoSlaveOk"
+        description: "InsertOne succeeds after NotPrimaryNoSecondaryOk"
         failPoint:
             configureFailPoint: failCommand
             mode: { times: 1 }

--- a/test/spec/transactions-convenient-api/commit-retry.json
+++ b/test/spec/transactions-convenient-api/commit-retry.json
@@ -293,7 +293,7 @@
       }
     },
     {
-      "description": "commit is retried after commitTransaction UnknownTransactionCommitResult (NotMaster)",
+      "description": "commit is retried after commitTransaction UnknownTransactionCommitResult (NotWritablePrimary)",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {

--- a/test/spec/transactions-convenient-api/commit-retry.yml
+++ b/test/spec/transactions-convenient-api/commit-retry.yml
@@ -185,13 +185,13 @@ tests:
         data:
           - { _id: 1 }
   -
-    description: commit is retried after commitTransaction UnknownTransactionCommitResult (NotMaster)
+    description: commit is retried after commitTransaction UnknownTransactionCommitResult (NotWritablePrimary)
     failPoint:
       configureFailPoint: failCommand
       mode: { times: 2 }
       data:
           failCommands: ["commitTransaction"]
-          errorCode: 10107 # NotMaster
+          errorCode: 10107 # NotWritablePrimary
           errorLabels: ["RetryableWriteError"] # SPEC-1565
           closeConnection: false
     operations:

--- a/test/spec/transactions/legacy/error-labels.json
+++ b/test/spec/transactions/legacy/error-labels.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "description": "NotMaster errors contain transient label",
+      "description": "NotWritablePrimary errors contain transient label",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {

--- a/test/spec/transactions/legacy/error-labels.yml
+++ b/test/spec/transactions/legacy/error-labels.yml
@@ -68,14 +68,14 @@ tests:
       collection:
         data: []
 
-  - description: NotMaster errors contain transient label
+  - description: NotWritablePrimary errors contain transient label
 
     failPoint:
       configureFailPoint: failCommand
       mode: { times: 1 }
       data:
           failCommands: ["insert"]
-          errorCode: 10107  # NotMaster
+          errorCode: 10107  # NotWritablePrimary
 
     operations:
       - name: startTransaction

--- a/test/spec/transactions/legacy/mongos-recovery-token.json
+++ b/test/spec/transactions/legacy/mongos-recovery-token.json
@@ -307,7 +307,8 @@
               "data": {
                 "failCommands": [
                   "commitTransaction",
-                  "isMaster"
+                  "isMaster",
+                  "hello"
                 ],
                 "closeConnection": true
               }

--- a/test/spec/transactions/legacy/mongos-recovery-token.yml
+++ b/test/spec/transactions/legacy/mongos-recovery-token.yml
@@ -196,7 +196,7 @@ tests:
         result:
           insertedId: 1
       # Enable the fail point only on the Mongos that session0 is pinned to.
-      # Fail isMaster to prevent the heartbeat requested directly after the
+      # Fail hello/legacy hello to prevent the heartbeat requested directly after the
       # retryable commit error from racing with server selection for the retry.
       # Note: times: 7 is slightly artbitrary but it accounts for one failed
       # commit and some SDAM heartbeats. A test runner will have multiple
@@ -210,7 +210,7 @@ tests:
             configureFailPoint: failCommand
             mode: { times: 7 }
             data:
-              failCommands: ["commitTransaction", "isMaster"]
+              failCommands: ["commitTransaction", "isMaster", "hello"]
               closeConnection: true
       # The first commitTransaction sees a retryable connection error due to
       # the fail point and also fails on the server. The retry attempt on a
@@ -218,7 +218,7 @@ tests:
       # because the transaction was aborted. Note that the retry attempt should
       # not select the original mongos because that server's SDAM state is
       # reset by the connection error, heartbeatFrequencyMS is high, and
-      # subsequent isMaster heartbeats should fail.
+      # subsequent heartbeats should fail.
       - name: commitTransaction
         object: session0
         result:

--- a/test/spec/transactions/legacy/pin-mongos.json
+++ b/test/spec/transactions/legacy/pin-mongos.json
@@ -1107,7 +1107,8 @@
               "data": {
                 "failCommands": [
                   "insert",
-                  "isMaster"
+                  "isMaster",
+                  "hello"
                 ],
                 "closeConnection": true
               }

--- a/test/spec/transactions/legacy/pin-mongos.yml
+++ b/test/spec/transactions/legacy/pin-mongos.yml
@@ -464,7 +464,7 @@ tests:
         result:
           insertedId: 3
       # Enable the fail point only on the Mongos that session0 is pinned to.
-      # Fail isMaster to prevent the heartbeat requested directly after the
+      # Fail hello/legacy hello to prevent the heartbeat requested directly after the
       # insert error from racing with server selection for the commit.
       # Note: times: 7 is slightly artbitrary but it accounts for one failed
       # insert and some SDAM heartbeats. A test runner will have multiple
@@ -478,7 +478,7 @@ tests:
             configureFailPoint: failCommand
             mode: { times: 7 }
             data:
-              failCommands: ["insert", "isMaster"]
+              failCommands: ["insert", "isMaster", "hello"]
               closeConnection: true
       - name: insertOne
         object: collection
@@ -498,7 +498,7 @@ tests:
       #
       # Note that the commit attempt should not select the original mongos
       # because that server's SDAM state is reset by the connection error,
-      # heartbeatFrequencyMS is high, and subsequent isMaster heartbeats
+      # heartbeatFrequencyMS is high, and subsequent heartbeats
       # should fail.
       - name: commitTransaction
         object: session0

--- a/test/spec/transactions/legacy/retryable-abort.json
+++ b/test/spec/transactions/legacy/retryable-abort.json
@@ -402,7 +402,7 @@
       }
     },
     {
-      "description": "abortTransaction succeeds after NotMaster",
+      "description": "abortTransaction succeeds after NotWritablePrimary",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -506,7 +506,7 @@
       }
     },
     {
-      "description": "abortTransaction succeeds after NotMasterOrSecondary",
+      "description": "abortTransaction succeeds after NotPrimaryOrSecondary",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -610,7 +610,7 @@
       }
     },
     {
-      "description": "abortTransaction succeeds after NotMasterNoSlaveOk",
+      "description": "abortTransaction succeeds after NotPrimaryNoSecondaryOk",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {

--- a/test/spec/transactions/legacy/retryable-abort.yml
+++ b/test/spec/transactions/legacy/retryable-abort.yml
@@ -266,7 +266,7 @@ tests:
       collection:
         data: []
 
-  - description: abortTransaction succeeds after NotMaster
+  - description: abortTransaction succeeds after NotWritablePrimary
 
     failPoint:
       configureFailPoint: failCommand
@@ -334,7 +334,7 @@ tests:
       collection:
         data: []
 
-  - description: abortTransaction succeeds after NotMasterOrSecondary
+  - description: abortTransaction succeeds after NotPrimaryOrSecondary
 
     failPoint:
       configureFailPoint: failCommand
@@ -402,7 +402,7 @@ tests:
       collection:
         data: []
 
-  - description: abortTransaction succeeds after NotMasterNoSlaveOk
+  - description: abortTransaction succeeds after NotPrimaryNoSecondaryOk
 
     failPoint:
       configureFailPoint: failCommand

--- a/test/spec/transactions/legacy/retryable-commit.json
+++ b/test/spec/transactions/legacy/retryable-commit.json
@@ -624,7 +624,7 @@
       }
     },
     {
-      "description": "commitTransaction succeeds after NotMaster",
+      "description": "commitTransaction succeeds after NotWritablePrimary",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -735,7 +735,7 @@
       }
     },
     {
-      "description": "commitTransaction succeeds after NotMasterOrSecondary",
+      "description": "commitTransaction succeeds after NotPrimaryOrSecondary",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -846,7 +846,7 @@
       }
     },
     {
-      "description": "commitTransaction succeeds after NotMasterNoSlaveOk",
+      "description": "commitTransaction succeeds after NotPrimaryNoSecondaryOk",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {

--- a/test/spec/transactions/legacy/retryable-commit.yml
+++ b/test/spec/transactions/legacy/retryable-commit.yml
@@ -385,7 +385,7 @@ tests:
         data:
           - _id: 1
 
-  - description: commitTransaction succeeds after NotMaster
+  - description: commitTransaction succeeds after NotWritablePrimary
 
     failPoint:
       configureFailPoint: failCommand
@@ -455,7 +455,7 @@ tests:
         data:
           - _id: 1
 
-  - description: commitTransaction succeeds after NotMasterOrSecondary
+  - description: commitTransaction succeeds after NotPrimaryOrSecondary
 
     failPoint:
       configureFailPoint: failCommand
@@ -525,7 +525,7 @@ tests:
         data:
           - _id: 1
 
-  - description: commitTransaction succeeds after NotMasterNoSlaveOk
+  - description: commitTransaction succeeds after NotPrimaryNoSecondaryOk
 
     failPoint:
       configureFailPoint: failCommand


### PR DESCRIPTION
### Description

#### What is changing?

Removes the last of the legacy language (that isn't required for tests)

#### What is the motivation for this change?

Wrap up the effort to remove the deprecated terms.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
