### PR TITLE
chore: fix csfle imports and bump version

### DIFF
--- a/.evergreen/run-bson-ext-test.sh
+++ b/.evergreen/run-bson-ext-test.sh
@@ -23,7 +23,7 @@ fi
 # run tests
 echo "Running $AUTH tests over $SSL, connecting to $MONGODB_URI"
 
-npm install mongodb-client-encryption@">=2.0.0-beta.3"
+npm install mongodb-client-encryption@">=2.0.0-beta.4"
 npm install bson-ext
 
 export MONGODB_API_VERSION=${MONGODB_API_VERSION}

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -48,6 +48,6 @@ else
   . $DRIVERS_TOOLS/.evergreen/csfle/set-temp-creds.sh
 fi
 
-npm install mongodb-client-encryption@">=2.0.0-beta.3"
+npm install mongodb-client-encryption@">=2.0.0-beta.4"
 
 AUTH=$AUTH SINGLE_MONGOS_LB_URI=${SINGLE_MONGOS_LB_URI} MULTI_MONGOS_LB_URI=${MULTI_MONGOS_LB_URI} MONGODB_API_VERSION=${MONGODB_API_VERSION} MONGODB_UNIFIED_TOPOLOGY=${UNIFIED} MONGODB_URI=${MONGODB_URI} LOAD_BALANCER=${LOAD_BALANCER} npm run ${TEST_NPM_SCRIPT}

--- a/test/integration/client-side-encryption/client_side_encryption.prose.deadlock.js
+++ b/test/integration/client-side-encryption/client_side_encryption.prose.deadlock.js
@@ -2,7 +2,7 @@
 
 const BSON = require('bson');
 const { expect } = require('chai');
-const { dropCollection } = require('../../integration/shared');
+const { dropCollection } = require('../shared');
 const util = require('util');
 const fs = require('fs');
 const path = require('path');

--- a/test/integration/client-side-encryption/client_side_encryption.prose.test.js
+++ b/test/integration/client-side-encryption/client_side_encryption.prose.test.js
@@ -51,7 +51,7 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
   const keyVaultCollName = 'datakeys';
   const keyVaultNamespace = `${keyVaultDbName}.${keyVaultCollName}`;
 
-  const shared = require('../../integration/shared');
+  const shared = require('../shared');
   const dropCollection = shared.dropCollection;
   const APMEventCollector = shared.APMEventCollector;
 


### PR DESCRIPTION
### Description

Updates mongodb-client-encryption to beta 4 and fixes shared imports in csfle tests.

#### What is changing?

Updates mongodb-client-encryption to beta 4 and fixes shared imports in csfle tests.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-3777

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
