### PR TITLE
fix(NODE-3917): Throw an error when directConnection is set with multiple hosts

### DIFF
--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -468,6 +468,10 @@ export function parseOptions(
     }
   }
 
+  if (mongoOptions.directConnection && mongoOptions.hosts.length !== 1) {
+    throw new MongoParseError('directConnection option requires exactly one host');
+  }
+
   if (
     !mongoOptions.proxyHost &&
     (mongoOptions.proxyPort || mongoOptions.proxyUsername || mongoOptions.proxyPassword)

--- a/test/spec/uri-options/connection-options.json
+++ b/test/spec/uri-options/connection-options.json
@@ -135,7 +135,8 @@
       "valid": false,
       "warning": false,
       "hosts": null,
-      "auth": null
+      "auth": null,
+      "options": {}
     },
     {
       "description": "directConnection=false",
@@ -180,6 +181,18 @@
       }
     },
     {
+      "description": "loadBalanced=true with directConnection=false",
+      "uri": "mongodb://example.com/?loadBalanced=true&directConnection=false",
+      "valid": true,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {
+        "loadBalanced": true,
+        "directConnection": false
+      }
+    },
+    {
       "description": "loadBalanced=false",
       "uri": "mongodb://example.com/?loadBalanced=false",
       "valid": true,
@@ -211,15 +224,6 @@
     {
       "description": "loadBalanced=true with directConnection=true causes an error",
       "uri": "mongodb://example.com/?loadBalanced=true&directConnection=true",
-      "valid": false,
-      "warning": false,
-      "hosts": null,
-      "auth": null,
-      "options": {}
-    },
-    {
-      "description": "loadBalanced=true with directConnection=false causes an error",
-      "uri": "mongodb://example.com/?loadBalanced=true&directConnection=false",
       "valid": false,
       "warning": false,
       "hosts": null,

--- a/test/spec/uri-options/connection-options.yml
+++ b/test/spec/uri-options/connection-options.yml
@@ -64,7 +64,7 @@ tests:
         hosts: ~
         auth: ~
         options: {}
-    - 
+    -
         description: "Invalid retryWrites causes a warning"
         uri: "mongodb://example.com/?retryWrites=invalid"
         valid: true
@@ -104,7 +104,6 @@ tests:
         hosts: ~
         auth: ~
         options: {}
-
     -
       description: directConnection=true
       uri: "mongodb://example.com/?directConnection=true"
@@ -121,6 +120,7 @@ tests:
       warning: false
       hosts: ~
       auth: ~
+      options: {}
     -
       description: directConnection=false
       uri: "mongodb://example.com/?directConnection=false"
@@ -157,6 +157,16 @@ tests:
       options:
           loadBalanced: true
     -
+      description: loadBalanced=true with directConnection=false
+      uri: "mongodb://example.com/?loadBalanced=true&directConnection=false"
+      valid: true
+      warning: false
+      hosts: ~
+      auth: ~
+      options:
+          loadBalanced: true
+          directConnection: false
+    -
       description: loadBalanced=false
       uri: "mongodb://example.com/?loadBalanced=false"
       valid: true
@@ -184,14 +194,6 @@ tests:
     -
       description: loadBalanced=true with directConnection=true causes an error
       uri: "mongodb://example.com/?loadBalanced=true&directConnection=true"
-      valid: false
-      warning: false
-      hosts: ~
-      auth: ~
-      options: {}
-    -
-      description: loadBalanced=true with directConnection=false causes an error
-      uri: "mongodb://example.com/?loadBalanced=true&directConnection=false"
       valid: false
       warning: false
       hosts: ~

--- a/test/unit/assorted/uri_options.spec.test.ts
+++ b/test/unit/assorted/uri_options.spec.test.ts
@@ -7,10 +7,6 @@ describe('URI option spec tests', function () {
   const suites = loadSpecTests('uri-options');
 
   const skipTests = [
-    // TODO(NODE-3917): Fix directConnection and loadBalanced option validation
-    'directConnection=true with multiple seeds',
-    'loadBalanced=true with directConnection=false causes an error',
-
     // Skipped because this does not apply to Node
     'Valid options specific to single-threaded drivers are parsed correctly',
 

--- a/test/unit/assorted/uri_options.spec.test.ts
+++ b/test/unit/assorted/uri_options.spec.test.ts
@@ -32,7 +32,7 @@ describe('URI option spec tests', function () {
     'Too high zlibCompressionLevel causes a warning',
     'Too low zlibCompressionLevel causes a warning',
 
-    // TODO(NODE-3917): Fix directConnection and loadBalanced option validation
+    // TODO(NODE-3989): Fix legacy boolean parsing
     'Invalid loadBalanced value'
   ];
 

--- a/test/unit/connection_string.test.ts
+++ b/test/unit/connection_string.test.ts
@@ -157,6 +157,19 @@ describe('Connection String', function () {
     expect(options.replicaSet).to.equal('123abc');
   });
 
+  context('when directionConnection is set', () => {
+    it('sets directConnection successfully when there is one host', () => {
+      const options = parseOptions('mongodb://localhost:27027/?directConnection=true');
+      expect(options.directConnection).to.be.true;
+    });
+
+    it('throws when directConnection is true and there is more than one host', () => {
+      expect(() =>
+        parseOptions('mongodb://localhost:27027,localhost:27018/?directConnection=true')
+      ).to.throw(MongoParseError, 'directConnection option requires exactly one host');
+    });
+  });
+
   context('when both tls and ssl options are provided', function () {
     context('when the options are provided in the URI', function () {
       context('when the options are equal', function () {


### PR DESCRIPTION
### Description

#### What is changing?

This PR updates the URI parsing logic to throw an error when the `directConnection` option is set with more than one host.

##### Is there new documentation needed for these changes?

No, I don't think so.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
