### PR TITLE
test(NODE-4057): update dns discovery tests

### DIFF
--- a/test/integration/initial-dns-seedlist-discovery/initial_dns_seedlist_discovery.spec.test.ts
+++ b/test/integration/initial-dns-seedlist-discovery/initial_dns_seedlist_discovery.spec.test.ts
@@ -18,7 +18,9 @@ function makeTest(test, topology) {
   });
 
   it(test.comment, async function () {
-    return this.skip(); // FIXME(NODE-3757): These tests require specific environment setups, also the error cases need better assertions
+    this.test.skipReason =
+      'TODO(NODE-3757): These tests require specific environment setups, also the error cases need better assertions';
+    return this.skip();
     if (topology === 'replica-set' && this.configuration.topologyType !== 'ReplicaSetWithPrimary') {
       return this.skip();
     }

--- a/test/spec/initial-dns-seedlist-discovery/load-balanced/loadBalanced-directConnection.json
+++ b/test/spec/initial-dns-seedlist-discovery/load-balanced/loadBalanced-directConnection.json
@@ -1,10 +1,10 @@
 {
-  "uri": "mongodb+srv://test20.test.build.10gen.cc/?directConnection=false",
+  "uri": "mongodb+srv://test24.test.build.10gen.cc/?directConnection=false",
   "seeds": [
-    "localhost.test.build.10gen.cc:27017"
+    "localhost.test.build.10gen.cc:8000"
   ],
   "hosts": [
-    "localhost.test.build.10gen.cc:27017"
+    "localhost.test.build.10gen.cc:8000"
   ],
   "options": {
     "loadBalanced": true,

--- a/test/spec/initial-dns-seedlist-discovery/load-balanced/loadBalanced-directConnection.yml
+++ b/test/spec/initial-dns-seedlist-discovery/load-balanced/loadBalanced-directConnection.yml
@@ -1,12 +1,12 @@
-# The TXT record for test20.test.build.10gen.cc contains loadBalanced=true.
+# The TXT record for test24.test.build.10gen.cc contains loadBalanced=true.
 # DRIVERS-1721 introduced this test as passing.
-uri: "mongodb+srv://test20.test.build.10gen.cc/?directConnection=false"
+uri: "mongodb+srv://test24.test.build.10gen.cc/?directConnection=false"
 seeds:
-    - localhost.test.build.10gen.cc:27017
+    - localhost.test.build.10gen.cc:8000
 hosts:
     # In LB mode, the driver does not do server discovery, so the hostname does
-    # not get resolved to localhost:27017.
-    - localhost.test.build.10gen.cc:27017
+    # not get resolved to localhost:8000.
+    - localhost.test.build.10gen.cc:8000
 options:
     loadBalanced: true
     ssl: true

--- a/test/spec/initial-dns-seedlist-discovery/load-balanced/loadBalanced-replicaSet-errors.json
+++ b/test/spec/initial-dns-seedlist-discovery/load-balanced/loadBalanced-replicaSet-errors.json
@@ -1,5 +1,5 @@
 {
-  "uri": "mongodb+srv://test20.test.build.10gen.cc/?replicaSet=replset",
+  "uri": "mongodb+srv://test24.test.build.10gen.cc/?replicaSet=replset",
   "seeds": [],
   "hosts": [],
   "error": true,

--- a/test/spec/initial-dns-seedlist-discovery/load-balanced/loadBalanced-replicaSet-errors.yml
+++ b/test/spec/initial-dns-seedlist-discovery/load-balanced/loadBalanced-replicaSet-errors.yml
@@ -1,5 +1,5 @@
-# The TXT record for test20.test.build.10gen.cc contains loadBalanced=true.
-uri: "mongodb+srv://test20.test.build.10gen.cc/?replicaSet=replset"
+# The TXT record for test24.test.build.10gen.cc contains loadBalanced=true.
+uri: "mongodb+srv://test24.test.build.10gen.cc/?replicaSet=replset"
 seeds: []
 hosts: []
 error: true

--- a/test/spec/initial-dns-seedlist-discovery/load-balanced/loadBalanced-true-txt.json
+++ b/test/spec/initial-dns-seedlist-discovery/load-balanced/loadBalanced-true-txt.json
@@ -1,10 +1,10 @@
 {
-  "uri": "mongodb+srv://test20.test.build.10gen.cc/",
+  "uri": "mongodb+srv://test24.test.build.10gen.cc/",
   "seeds": [
-    "localhost.test.build.10gen.cc:27017"
+    "localhost.test.build.10gen.cc:8000"
   ],
   "hosts": [
-    "localhost.test.build.10gen.cc:27017"
+    "localhost.test.build.10gen.cc:8000"
   ],
   "options": {
     "loadBalanced": true,

--- a/test/spec/initial-dns-seedlist-discovery/load-balanced/loadBalanced-true-txt.yml
+++ b/test/spec/initial-dns-seedlist-discovery/load-balanced/loadBalanced-true-txt.yml
@@ -1,10 +1,10 @@
-uri: "mongodb+srv://test20.test.build.10gen.cc/"
+uri: "mongodb+srv://test24.test.build.10gen.cc/"
 seeds:
-    - localhost.test.build.10gen.cc:27017
+    - localhost.test.build.10gen.cc:8000
 hosts:
     # In LB mode, the driver does not do server discovery, so the hostname does
-    # not get resolved to localhost:27017.
-    - localhost.test.build.10gen.cc:27017
+    # not get resolved to localhost:8000.
+    - localhost.test.build.10gen.cc:8000
 options:
     loadBalanced: true
     ssl: true

--- a/test/spec/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-conflicts_with_loadBalanced-true-txt.json
+++ b/test/spec/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-conflicts_with_loadBalanced-true-txt.json
@@ -1,5 +1,5 @@
 {
-  "uri": "mongodb+srv://test20.test.build.10gen.cc/?srvMaxHosts=1",
+  "uri": "mongodb+srv://test24.test.build.10gen.cc/?srvMaxHosts=1",
   "seeds": [],
   "hosts": [],
   "error": true,

--- a/test/spec/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-conflicts_with_loadBalanced-true-txt.yml
+++ b/test/spec/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-conflicts_with_loadBalanced-true-txt.yml
@@ -1,4 +1,4 @@
-uri: "mongodb+srv://test20.test.build.10gen.cc/?srvMaxHosts=1"
+uri: "mongodb+srv://test24.test.build.10gen.cc/?srvMaxHosts=1"
 seeds: []
 hosts: []
 error: true

--- a/test/spec/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-zero-txt.json
+++ b/test/spec/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-zero-txt.json
@@ -1,10 +1,10 @@
 {
-  "uri": "mongodb+srv://test20.test.build.10gen.cc/?srvMaxHosts=0",
+  "uri": "mongodb+srv://test24.test.build.10gen.cc/?srvMaxHosts=0",
   "seeds": [
-    "localhost.test.build.10gen.cc:27017"
+    "localhost.test.build.10gen.cc:8000"
   ],
   "hosts": [
-    "localhost.test.build.10gen.cc:27017"
+    "localhost.test.build.10gen.cc:8000"
   ],
   "options": {
     "loadBalanced": true,

--- a/test/spec/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-zero-txt.yml
+++ b/test/spec/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-zero-txt.yml
@@ -1,9 +1,9 @@
 # loadBalanced=true (TXT) is permitted because srvMaxHosts is non-positive
-uri: "mongodb+srv://test20.test.build.10gen.cc/?srvMaxHosts=0"
+uri: "mongodb+srv://test24.test.build.10gen.cc/?srvMaxHosts=0"
 seeds:
-    - localhost.test.build.10gen.cc:27017
+    - localhost.test.build.10gen.cc:8000
 hosts:
-    - localhost.test.build.10gen.cc:27017
+    - localhost.test.build.10gen.cc:8000
 options:
     loadBalanced: true
     srvMaxHosts: 0

--- a/test/spec/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-zero.json
+++ b/test/spec/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-zero.json
@@ -1,10 +1,10 @@
 {
-  "uri": "mongodb+srv://test3.test.build.10gen.cc/?loadBalanced=true&srvMaxHosts=0",
+  "uri": "mongodb+srv://test23.test.build.10gen.cc/?loadBalanced=true&srvMaxHosts=0",
   "seeds": [
-    "localhost.test.build.10gen.cc:27017"
+    "localhost.test.build.10gen.cc:8000"
   ],
   "hosts": [
-    "localhost.test.build.10gen.cc:27017"
+    "localhost.test.build.10gen.cc:8000"
   ],
   "options": {
     "loadBalanced": true,

--- a/test/spec/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-zero.yml
+++ b/test/spec/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-zero.yml
@@ -1,9 +1,9 @@
 # loadBalanced=true is permitted because srvMaxHosts is non-positive
-uri: "mongodb+srv://test3.test.build.10gen.cc/?loadBalanced=true&srvMaxHosts=0"
+uri: "mongodb+srv://test23.test.build.10gen.cc/?loadBalanced=true&srvMaxHosts=0"
 seeds:
-    - localhost.test.build.10gen.cc:27017
+    - localhost.test.build.10gen.cc:8000
 hosts:
-    - localhost.test.build.10gen.cc:27017
+    - localhost.test.build.10gen.cc:8000
 options:
     loadBalanced: true
     srvMaxHosts: 0


### PR DESCRIPTION
### Description

Updates the spec tests to verify DRIVERS-2224, which corrects the test cases for testing srv records in a load balancer environment.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

DRIVERS-2224/NODE-4057

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
