### PR TITLE
docs: update build script to pin version of typedoc

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -56,7 +56,7 @@
           <div> Return to Docs Homepage </div>
         </a>
       </div>
-      <div class="col-md-2" id="mongodbNodelogo"></div>
+      <img class="col-md-2" id="mongodbNodelogo" src="s/img/node.png" alt="MongoDB Node Logo"></div>
     </div>
     </div>
   </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -68,13 +68,6 @@
 </div>
 
 
-  <div class="alert alert-info" role="alert">
-  Note: This documentation is for versions of the Node.js driver up to 3.6 only.
-  For documentation of newer versions of the driver,
-  <a href="https://docs.mongodb.com/drivers/node">click here</a>.
-</div>
-
-
   
   <div class="container" id="mainContent">
     <div class="row">

--- a/docs/index.html
+++ b/docs/index.html
@@ -347,21 +347,6 @@ This will download the MongoDB driver and add a dependency entry in your `packag
         </tr>
       
         <tr>
-          <th class="not-supported">3.x Core Driver</th>
-          <td>
-
-            
-              <a href="./core" class="reference">Reference</a>
-            
-
-            &#124; 
-
-            <a href="./core/api">API</a>
-
-          </td>
-        </tr>
-      
-        <tr>
           <th class="not-supported">2.2 Driver</th>
           <td>
 

--- a/docs/s/css/frontpage.css
+++ b/docs/s/css/frontpage.css
@@ -232,10 +232,7 @@ input.gsc-search-button[title], input.gsc-search-button:hover[title], input.gsc-
 }
 
 #mongodbNodelogo {
-  background-image: url("../img/node.png");
-  background-position: left top;
-  background-repeat: no-repeat;
-  width: 83px;
+  width: fit-content;
   height: 150px;
 }
 

--- a/docs/versions.json
+++ b/docs/versions.json
@@ -43,8 +43,5 @@
     },
     {
         "version": "2.2"
-    },
-    {
-        "version": "core"
     }
 ]

--- a/etc/docs/build.ts
+++ b/etc/docs/build.ts
@@ -24,7 +24,7 @@ const RELEASES_JSON_FILE = './template/static/versions.json';
 
 const copyGeneratedDocsToDocsFolder = () => exec(`cp -R temp/. ../../docs/.`);
 const removeTempDirectory = () => exec('rm -rf temp');
-const installDependencies = () => exec('npm i --no-save --legacy-peer-deps typedoc');
+const installDependencies = () => exec('npm i --no-save --legacy-peer-deps typedoc@0.22.13');
 const buildDocs = ({ tag }: VersionSchema) => {
   const revision = tag === LATEST_TAG ? 'main' : `v${tag}.0`;
   return exec(`npm run build:typedoc -- --gitRevision ${revision}`);

--- a/etc/docs/preview.ts
+++ b/etc/docs/preview.ts
@@ -13,6 +13,8 @@ app.use((req, res, next) => {
 app.use(express.static('docs'));
 app.use('/node-mongodb-native', express.static('docs'));
 
+app.get('*', (req, res) => res.redirect('404.html'));
+
 app.listen(8080, () => {
   log('listening on port 8080');
 });

--- a/etc/docs/template/data/releases.toml
+++ b/etc/docs/template/data/releases.toml
@@ -100,13 +100,6 @@ api = "./3.0/api"
 tag = "3.0"
 
 [[versions]]
-version = "3.x Core Driver"
-status = "not-supported"
-docs = "./core"
-api = "./core/api"
-tag = "3.-1"
-
-[[versions]]
 version = "2.2 Driver"
 status = "not-supported"
 docs = "./2.2"

--- a/etc/docs/template/layouts/404.html
+++ b/etc/docs/template/layouts/404.html
@@ -24,7 +24,7 @@
           <div> Return to Docs Homepage </div>
         </a>
       </div>
-      <div class="col-md-2" id="mongodbNodelogo"></div>
+      <img class="col-md-2" id="mongodbNodelogo" src="s/img/node.png" alt="MongoDB Node Logo"></div>
     </div>
     </div>
   </div>

--- a/etc/docs/template/layouts/index.html
+++ b/etc/docs/template/layouts/index.html
@@ -16,8 +16,6 @@
 
   {{ partial "hero.html" . }}
 
-  {{ partial "banners/new_version.html" . }}
-
   <!-- Main content -->
   <div class="container" id="mainContent">
     <div class="row">

--- a/etc/docs/template/layouts/partials/banners/new_version.html
+++ b/etc/docs/template/layouts/partials/banners/new_version.html
@@ -1,5 +1,0 @@
-<div class="alert alert-info" role="alert">
-  Note: This documentation is for versions of the Node.js driver up to 3.6 only.
-  For documentation of newer versions of the driver,
-  <a href="{{.Site.Params.ReferenceDocsUrl}}">click here</a>.
-</div>

--- a/etc/docs/template/static/s/css/frontpage.css
+++ b/etc/docs/template/static/s/css/frontpage.css
@@ -232,10 +232,7 @@ input.gsc-search-button[title], input.gsc-search-button:hover[title], input.gsc-
 }
 
 #mongodbNodelogo {
-  background-image: url("../img/node.png");
-  background-position: left top;
-  background-repeat: no-repeat;
-  width: 83px;
+  width: fit-content;
   height: 150px;
 }
 

--- a/etc/docs/template/static/versions.json
+++ b/etc/docs/template/static/versions.json
@@ -43,8 +43,5 @@
     },
     {
         "version": "2.2"
-    },
-    {
-        "version": "core"
     }
 ]

--- a/etc/docs/utils.ts
+++ b/etc/docs/utils.ts
@@ -89,10 +89,6 @@ export function customSemverCompare(a: string, b: string) {
   if ([a, b].includes('next')) {
     return a === 'next' ? -1 : 1;
   }
-  // put legacy 3x driver version at the end of the list
-  if ([a, b].includes('core')) {
-    return a === 'core' ? 1 : -1;
-  }
 
   const [majorA, minorA] = a.split('.').map(Number);
   const [majorB, minorB] = b.split('.').map(Number);


### PR DESCRIPTION
### Description

#### What is changing?

- Remove legacy 3x driver links
- Pin typedoc version
- Remove the version 3.6 banner from the index.html
