### PR TITLE
fix(NODE-4069): remove 'default' from options for fullDocument field in change stream options

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -166,7 +166,6 @@ export type {
 export type { OrderedBulkOperation } from './bulk/ordered';
 export type { UnorderedBulkOperation } from './bulk/unordered';
 export type {
-  ChangeStream,
   ChangeStreamCursor,
   ChangeStreamCursorOptions,
   ChangeStreamDocument,
@@ -178,6 +177,7 @@ export type {
   ResumeToken,
   UpdateDescription
 } from './change_stream';
+export { ChangeStream } from './change_stream';
 export type {
   AuthMechanismProperties,
   MongoCredentials,


### PR DESCRIPTION
### Description

#### What is changing?

This PR removes the default value of `'default'` for the `fullDocument` field in the ChangeStreamOptions.

This PR also adds tests to options that are set in the `createChangeStreamCursor` method.  It seemed too out of scope to write tests to fully test the constructor, but at the very least I could add tests for options that were set in the ChangeStreamCursor constructor from this method.

##### Is there new documentation needed for these changes?
No.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
