### PR TITLE
fix(NODE-4074): ensure getTopology doesn't throw synchronously

### DIFF
--- a/src/admin.ts
+++ b/src/admin.ts
@@ -14,7 +14,7 @@ import {
   ValidateCollectionOperation,
   ValidateCollectionOptions
 } from './operations/validate_collection';
-import { Callback, getTopology } from './utils';
+import type { Callback } from './utils';
 
 /** @internal */
 export interface AdminPrivate {
@@ -83,7 +83,7 @@ export class Admin {
     options = Object.assign({ dbName: 'admin' }, options);
 
     return executeOperation(
-      getTopology(this.s.db),
+      this.s.db,
       new RunCommandOperation(this.s.db, command, options),
       callback
     );
@@ -207,7 +207,7 @@ export class Admin {
     options = Object.assign({ dbName: 'admin' }, options);
 
     return executeOperation(
-      getTopology(this.s.db),
+      this.s.db,
       new AddUserOperation(this.s.db, username, password, options),
       callback
     );
@@ -233,7 +233,7 @@ export class Admin {
     options = Object.assign({ dbName: 'admin' }, options);
 
     return executeOperation(
-      getTopology(this.s.db),
+      this.s.db,
       new RemoveUserOperation(this.s.db, username, options),
       callback
     );
@@ -263,7 +263,7 @@ export class Admin {
     options = options ?? {};
 
     return executeOperation(
-      getTopology(this.s.db),
+      this.s.db,
       new ValidateCollectionOperation(this, collectionName, options),
       callback
     );
@@ -286,11 +286,7 @@ export class Admin {
     if (typeof options === 'function') (callback = options), (options = {});
     options = options ?? {};
 
-    return executeOperation(
-      getTopology(this.s.db),
-      new ListDatabasesOperation(this.s.db, options),
-      callback
-    );
+    return executeOperation(this.s.db, new ListDatabasesOperation(this.s.db, options), callback);
   }
 
   /**

--- a/src/bulk/common.ts
+++ b/src/bulk/common.ts
@@ -655,19 +655,19 @@ function executeCommands(
   try {
     if (isInsertBatch(batch)) {
       executeOperation(
-        bulkOperation.s.topology,
+        bulkOperation.s.collection,
         new InsertOperation(bulkOperation.s.namespace, batch.operations, finalOptions),
         resultHandler
       );
     } else if (isUpdateBatch(batch)) {
       executeOperation(
-        bulkOperation.s.topology,
+        bulkOperation.s.collection,
         new UpdateOperation(bulkOperation.s.namespace, batch.operations, finalOptions),
         resultHandler
       );
     } else if (isDeleteBatch(batch)) {
       executeOperation(
-        bulkOperation.s.topology,
+        bulkOperation.s.collection,
         new DeleteOperation(bulkOperation.s.namespace, batch.operations, finalOptions),
         resultHandler
       );
@@ -1285,7 +1285,7 @@ export abstract class BulkOperationBase {
     const finalOptions = { ...this.s.options, ...options };
     const operation = new BulkWriteShimOperation(this, finalOptions);
 
-    return executeOperation(this.s.topology, operation, callback);
+    return executeOperation(this.s.collection, operation, callback);
   }
 
   /**

--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -503,7 +503,7 @@ export class ChangeStreamCursor<TSchema extends Document = Document> extends Abs
       session
     });
 
-    executeOperation(this.topology, aggregateOperation, (err, response) => {
+    executeOperation(session, aggregateOperation, (err, response) => {
       if (err || response == null) {
         return callback(err);
       }

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -296,7 +296,7 @@ export class Collection<TSchema extends Document = Document> {
     }
 
     return executeOperation(
-      getTopology(this),
+      this,
       new InsertOneOperation(
         this as TODO_NODE_3286,
         doc,
@@ -338,7 +338,7 @@ export class Collection<TSchema extends Document = Document> {
     options = options ? Object.assign({}, options) : { ordered: true };
 
     return executeOperation(
-      getTopology(this),
+      this,
       new InsertManyOperation(
         this as TODO_NODE_3286,
         docs,
@@ -406,7 +406,7 @@ export class Collection<TSchema extends Document = Document> {
     }
 
     return executeOperation(
-      getTopology(this),
+      this,
       new BulkWriteOperation(
         this as TODO_NODE_3286,
         operations as TODO_NODE_3286,
@@ -453,7 +453,7 @@ export class Collection<TSchema extends Document = Document> {
     if (typeof options === 'function') (callback = options), (options = {});
 
     return executeOperation(
-      getTopology(this),
+      this,
       new UpdateOneOperation(
         this as TODO_NODE_3286,
         filter,
@@ -501,7 +501,7 @@ export class Collection<TSchema extends Document = Document> {
     if (typeof options === 'function') (callback = options), (options = {});
 
     return executeOperation(
-      getTopology(this),
+      this,
       new ReplaceOneOperation(
         this as TODO_NODE_3286,
         filter,
@@ -549,7 +549,7 @@ export class Collection<TSchema extends Document = Document> {
     if (typeof options === 'function') (callback = options), (options = {});
 
     return executeOperation(
-      getTopology(this),
+      this,
       new UpdateManyOperation(
         this as TODO_NODE_3286,
         filter,
@@ -583,7 +583,7 @@ export class Collection<TSchema extends Document = Document> {
     if (typeof options === 'function') (callback = options), (options = {});
 
     return executeOperation(
-      getTopology(this),
+      this,
       new DeleteOneOperation(this as TODO_NODE_3286, filter, resolveOptions(this, options)),
       callback
     );
@@ -623,7 +623,7 @@ export class Collection<TSchema extends Document = Document> {
     }
 
     return executeOperation(
-      getTopology(this),
+      this,
       new DeleteManyOperation(this as TODO_NODE_3286, filter, resolveOptions(this, options)),
       callback
     );
@@ -652,7 +652,7 @@ export class Collection<TSchema extends Document = Document> {
 
     // Intentionally, we do not inherit options from parent for this operation.
     return executeOperation(
-      getTopology(this),
+      this,
       new RenameOperation(this as TODO_NODE_3286, newName, {
         ...options,
         readPreference: ReadPreference.PRIMARY
@@ -679,7 +679,7 @@ export class Collection<TSchema extends Document = Document> {
     options = options ?? {};
 
     return executeOperation(
-      getTopology(this),
+      this,
       new DropCollectionOperation(this.s.db, this.collectionName, options),
       callback
     );
@@ -783,7 +783,7 @@ export class Collection<TSchema extends Document = Document> {
     if (typeof options === 'function') (callback = options), (options = {});
 
     return executeOperation(
-      getTopology(this),
+      this,
       new OptionsOperation(this as TODO_NODE_3286, resolveOptions(this, options)),
       callback
     );
@@ -806,7 +806,7 @@ export class Collection<TSchema extends Document = Document> {
     if (typeof options === 'function') (callback = options), (options = {});
 
     return executeOperation(
-      getTopology(this),
+      this,
       new IsCappedOperation(this as TODO_NODE_3286, resolveOptions(this, options)),
       callback
     );
@@ -857,7 +857,7 @@ export class Collection<TSchema extends Document = Document> {
     if (typeof options === 'function') (callback = options), (options = {});
 
     return executeOperation(
-      getTopology(this),
+      this,
       new CreateIndexOperation(
         this as TODO_NODE_3286,
         this.collectionName,
@@ -918,7 +918,7 @@ export class Collection<TSchema extends Document = Document> {
     if (typeof options.maxTimeMS !== 'number') delete options.maxTimeMS;
 
     return executeOperation(
-      getTopology(this),
+      this,
       new CreateIndexesOperation(
         this as TODO_NODE_3286,
         this.collectionName,
@@ -952,7 +952,7 @@ export class Collection<TSchema extends Document = Document> {
     options.readPreference = ReadPreference.primary;
 
     return executeOperation(
-      getTopology(this),
+      this,
       new DropIndexOperation(this as TODO_NODE_3286, indexName, options),
       callback
     );
@@ -975,7 +975,7 @@ export class Collection<TSchema extends Document = Document> {
     if (typeof options === 'function') (callback = options), (options = {});
 
     return executeOperation(
-      getTopology(this),
+      this,
       new DropIndexesOperation(this as TODO_NODE_3286, resolveOptions(this, options)),
       callback
     );
@@ -1013,7 +1013,7 @@ export class Collection<TSchema extends Document = Document> {
     if (typeof options === 'function') (callback = options), (options = {});
 
     return executeOperation(
-      getTopology(this),
+      this,
       new IndexExistsOperation(this as TODO_NODE_3286, indexes, resolveOptions(this, options)),
       callback
     );
@@ -1036,7 +1036,7 @@ export class Collection<TSchema extends Document = Document> {
     if (typeof options === 'function') (callback = options), (options = {});
 
     return executeOperation(
-      getTopology(this),
+      this,
       new IndexInformationOperation(this.s.db, this.collectionName, resolveOptions(this, options)),
       callback
     );
@@ -1058,7 +1058,7 @@ export class Collection<TSchema extends Document = Document> {
   ): Promise<number> | void {
     if (typeof options === 'function') (callback = options), (options = {});
     return executeOperation(
-      getTopology(this),
+      this,
       new EstimatedDocumentCountOperation(this as TODO_NODE_3286, resolveOptions(this, options)),
       callback
     );
@@ -1118,7 +1118,7 @@ export class Collection<TSchema extends Document = Document> {
 
     filter ??= {};
     return executeOperation(
-      getTopology(this),
+      this,
       new CountDocumentsOperation(
         this as TODO_NODE_3286,
         filter as Document,
@@ -1193,7 +1193,7 @@ export class Collection<TSchema extends Document = Document> {
 
     filter ??= {};
     return executeOperation(
-      getTopology(this),
+      this,
       new DistinctOperation(
         this as TODO_NODE_3286,
         key as TODO_NODE_3286,
@@ -1221,7 +1221,7 @@ export class Collection<TSchema extends Document = Document> {
     if (typeof options === 'function') (callback = options), (options = {});
 
     return executeOperation(
-      getTopology(this),
+      this,
       new IndexesOperation(this as TODO_NODE_3286, resolveOptions(this, options)),
       callback
     );
@@ -1245,7 +1245,7 @@ export class Collection<TSchema extends Document = Document> {
     options = options ?? {};
 
     return executeOperation(
-      getTopology(this),
+      this,
       new CollStatsOperation(this as TODO_NODE_3286, options),
       callback
     );
@@ -1277,7 +1277,7 @@ export class Collection<TSchema extends Document = Document> {
     if (typeof options === 'function') (callback = options), (options = {});
 
     return executeOperation(
-      getTopology(this),
+      this,
       new FindOneAndDeleteOperation(
         this as TODO_NODE_3286,
         filter,
@@ -1324,7 +1324,7 @@ export class Collection<TSchema extends Document = Document> {
     if (typeof options === 'function') (callback = options), (options = {});
 
     return executeOperation(
-      getTopology(this),
+      this,
       new FindOneAndReplaceOperation(
         this as TODO_NODE_3286,
         filter,
@@ -1372,7 +1372,7 @@ export class Collection<TSchema extends Document = Document> {
     if (typeof options === 'function') (callback = options), (options = {});
 
     return executeOperation(
-      getTopology(this),
+      this,
       new FindOneAndUpdateOperation(
         this as TODO_NODE_3286,
         filter,
@@ -1495,7 +1495,7 @@ export class Collection<TSchema extends Document = Document> {
     }
 
     return executeOperation(
-      getTopology(this),
+      this,
       new MapReduceOperation(
         this as TODO_NODE_3286,
         map,
@@ -1636,7 +1636,7 @@ export class Collection<TSchema extends Document = Document> {
 
     filter ??= {};
     return executeOperation(
-      getTopology(this),
+      this,
       new CountOperation(
         MongoDBNamespace.fromString(this.namespace),
         filter,

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -618,7 +618,7 @@ export abstract class AbstractCursor<
       batchSize
     });
 
-    executeOperation(this.topology, getMoreOperation, callback);
+    executeOperation(this, getMoreOperation, callback);
   }
 }
 

--- a/src/cursor/aggregation_cursor.ts
+++ b/src/cursor/aggregation_cursor.ts
@@ -68,7 +68,7 @@ export class AggregationCursor<TSchema = Document> extends AbstractCursor<TSchem
       session
     });
 
-    executeOperation(this.topology, aggregateOperation, (err, response) => {
+    executeOperation(this, aggregateOperation, (err, response) => {
       if (err || response == null) return callback(err);
 
       // TODO: NODE-2882
@@ -88,7 +88,7 @@ export class AggregationCursor<TSchema = Document> extends AbstractCursor<TSchem
     if (verbosity == null) verbosity = true;
 
     return executeOperation(
-      this.topology,
+      this,
       new AggregateOperation(this.namespace, this[kPipeline], {
         ...this[kOptions], // NOTE: order matters here, we may need to refine this
         ...this.cursorOptions,

--- a/src/cursor/find_cursor.ts
+++ b/src/cursor/find_cursor.ts
@@ -75,7 +75,7 @@ export class FindCursor<TSchema = Document> extends AbstractCursor<TSchema> {
       session
     });
 
-    executeOperation(this.topology, findOperation, (err, response) => {
+    executeOperation(this, findOperation, (err, response) => {
       if (err || response == null) return callback(err);
 
       // TODO: We only need this for legacy queries that do not support `limit`, maybe
@@ -143,7 +143,7 @@ export class FindCursor<TSchema = Document> extends AbstractCursor<TSchema> {
     options = options ?? {};
 
     return executeOperation(
-      this.topology,
+      this,
       new CountOperation(this.namespace, this[kFilter], {
         ...this[kBuiltOptions], // NOTE: order matters here, we may need to refine this
         ...this.cursorOptions,
@@ -165,7 +165,7 @@ export class FindCursor<TSchema = Document> extends AbstractCursor<TSchema> {
     if (verbosity == null) verbosity = true;
 
     return executeOperation(
-      this.topology,
+      this,
       new FindOperation(undefined, this.namespace, this[kFilter], {
         ...this[kBuiltOptions], // NOTE: order matters here, we may need to refine this
         ...this.cursorOptions,

--- a/src/db.ts
+++ b/src/db.ts
@@ -711,7 +711,7 @@ export class Db {
    * @deprecated This function is deprecated and will be removed in the next major version.
    */
   unref(): void {
-    this.unref();
+    getTopology(this).unref();
   }
 
   /**

--- a/src/db.ts
+++ b/src/db.ts
@@ -258,7 +258,7 @@ export class Db {
     if (typeof options === 'function') (callback = options), (options = {});
 
     return executeOperation(
-      getTopology(this),
+      this,
       new CreateCollectionOperation(this, name, resolveOptions(this, options)) as TODO_NODE_3286,
       callback
     ) as TODO_NODE_3286;
@@ -286,11 +286,7 @@ export class Db {
     if (typeof options === 'function') (callback = options), (options = {});
 
     // Intentionally, we do not inherit options from parent for this operation.
-    return executeOperation(
-      getTopology(this),
-      new RunCommandOperation(this, command, options ?? {}),
-      callback
-    );
+    return executeOperation(this, new RunCommandOperation(this, command, options ?? {}), callback);
   }
 
   /**
@@ -359,7 +355,7 @@ export class Db {
   ): Promise<Document> | void {
     if (typeof options === 'function') (callback = options), (options = {});
     return executeOperation(
-      getTopology(this),
+      this,
       new DbStatsOperation(this, resolveOptions(this, options)),
       callback
     );
@@ -438,7 +434,7 @@ export class Db {
     options.new_collection = true;
 
     return executeOperation(
-      getTopology(this),
+      this,
       new RenameOperation(
         this.collection<TSchema>(fromCollection) as TODO_NODE_3286,
         toCollection,
@@ -467,7 +463,7 @@ export class Db {
     if (typeof options === 'function') (callback = options), (options = {});
 
     return executeOperation(
-      getTopology(this),
+      this,
       new DropCollectionOperation(this, name, resolveOptions(this, options)),
       callback
     );
@@ -490,7 +486,7 @@ export class Db {
     if (typeof options === 'function') (callback = options), (options = {});
 
     return executeOperation(
-      getTopology(this),
+      this,
       new DropDatabaseOperation(this, resolveOptions(this, options)),
       callback
     );
@@ -513,7 +509,7 @@ export class Db {
     if (typeof options === 'function') (callback = options), (options = {});
 
     return executeOperation(
-      getTopology(this),
+      this,
       new CollectionsOperation(this, resolveOptions(this, options)),
       callback
     );
@@ -549,7 +545,7 @@ export class Db {
     if (typeof options === 'function') (callback = options), (options = {});
 
     return executeOperation(
-      getTopology(this),
+      this,
       new CreateIndexOperation(this, name, indexSpec, resolveOptions(this, options)),
       callback
     );
@@ -595,7 +591,7 @@ export class Db {
     }
 
     return executeOperation(
-      getTopology(this),
+      this,
       new AddUserOperation(this, username, password, resolveOptions(this, options)),
       callback
     );
@@ -620,7 +616,7 @@ export class Db {
     if (typeof options === 'function') (callback = options), (options = {});
 
     return executeOperation(
-      getTopology(this),
+      this,
       new RemoveUserOperation(this, username, resolveOptions(this, options)),
       callback
     );
@@ -652,7 +648,7 @@ export class Db {
     if (typeof options === 'function') (callback = options), (options = {});
 
     return executeOperation(
-      getTopology(this),
+      this,
       new SetProfilingLevelOperation(this, level, resolveOptions(this, options)),
       callback
     );
@@ -675,7 +671,7 @@ export class Db {
     if (typeof options === 'function') (callback = options), (options = {});
 
     return executeOperation(
-      getTopology(this),
+      this,
       new ProfilingLevelOperation(this, resolveOptions(this, options)),
       callback
     );
@@ -704,7 +700,7 @@ export class Db {
     if (typeof options === 'function') (callback = options), (options = {});
 
     return executeOperation(
-      getTopology(this),
+      this,
       new IndexInformationOperation(this, name, resolveOptions(this, options)),
       callback
     );
@@ -715,7 +711,7 @@ export class Db {
    * @deprecated This function is deprecated and will be removed in the next major version.
    */
   unref(): void {
-    getTopology(this).unref();
+    this.unref();
   }
 
   /**

--- a/src/operations/add_user.ts
+++ b/src/operations/add_user.ts
@@ -79,7 +79,14 @@ export class AddUserOperation extends CommandOperation<Document> {
       roles = Array.isArray(options.roles) ? options.roles : [options.roles];
     }
 
-    const digestPassword = getTopology(db).lastHello().maxWireVersion >= 7;
+    let topology;
+    try {
+      topology = getTopology(db);
+    } catch (error) {
+      return callback(error);
+    }
+
+    const digestPassword = topology.lastHello().maxWireVersion >= 7;
 
     let userPassword = password;
 

--- a/src/operations/common_functions.ts
+++ b/src/operations/common_functions.ts
@@ -40,8 +40,15 @@ export function indexInformation(
   // If we specified full information
   const full = options.full == null ? false : options.full;
 
+  let topology;
+  try {
+    topology = getTopology(db);
+  } catch (error) {
+    return callback(error);
+  }
+
   // Did the user destroy the topology
-  if (getTopology(db).isDestroyed()) return callback(new MongoTopologyClosedError());
+  if (topology.isDestroyed()) return callback(new MongoTopologyClosedError());
   // Process all the results from the index command and collection
   function processResults(indexes: any) {
     // Contains all the information

--- a/src/operations/execute_operation.ts
+++ b/src/operations/execute_operation.ts
@@ -65,29 +65,25 @@ export interface ExecutionResult {
  */
 export function executeOperation<
   T extends AbstractOperation<TResult>,
-  TResult = ResultTypeFromOperation<T>,
-  TSchema = Document
->(topology: Topology | TopologyProvider<TSchema>, operation: T): Promise<TResult>;
+  TResult = ResultTypeFromOperation<T>
+>(topologyProvider: Topology | TopologyProvider, operation: T): Promise<TResult>;
 export function executeOperation<
   T extends AbstractOperation<TResult>,
-  TResult = ResultTypeFromOperation<T>,
-  TSchema = Document
->(topology: Topology | TopologyProvider<TSchema>, operation: T, callback: Callback<TResult>): void;
+  TResult = ResultTypeFromOperation<T>
+>(topologyProvider: Topology | TopologyProvider, operation: T, callback: Callback<TResult>): void;
 export function executeOperation<
   T extends AbstractOperation<TResult>,
-  TResult = ResultTypeFromOperation<T>,
-  TSchema = Document
+  TResult = ResultTypeFromOperation<T>
 >(
-  topology: Topology | TopologyProvider<TSchema>,
+  topologyProvider: Topology | TopologyProvider,
   operation: T,
   callback?: Callback<TResult>
 ): Promise<TResult> | void;
 export function executeOperation<
   T extends AbstractOperation<TResult>,
-  TResult = ResultTypeFromOperation<T>,
-  TSchema = Document
+  TResult = ResultTypeFromOperation<T>
 >(
-  topology: Topology | TopologyProvider<TSchema>,
+  topologyProvider: Topology | TopologyProvider,
   operation: T,
   callback?: Callback<TResult>
 ): Promise<TResult> | void {
@@ -97,8 +93,10 @@ export function executeOperation<
   }
 
   return maybePromise(callback, callback => {
+    let topology: Topology | TopologyProvider;
     try {
-      topology = topology instanceof Topology ? topology : getTopology(topology);
+      topology =
+        topologyProvider instanceof Topology ? topologyProvider : getTopology(topologyProvider);
     } catch (error) {
       return callback(error);
     }
@@ -106,7 +104,7 @@ export function executeOperation<
       return topology.selectServer(ReadPreference.primaryPreferred, {}, err => {
         if (err) return callback(err);
 
-        executeOperation<T, TResult, TSchema>(topology, operation, callback);
+        executeOperation<T, TResult>(topology, operation, callback);
       });
     }
 

--- a/src/operations/execute_operation.ts
+++ b/src/operations/execute_operation.ts
@@ -19,9 +19,15 @@ import {
   secondaryWritableServerSelector,
   ServerSelector
 } from '../sdam/server_selection';
-import type { Topology } from '../sdam/topology';
+import { Topology } from '../sdam/topology';
 import type { ClientSession } from '../sessions';
-import { Callback, maybePromise, supportsRetryableWrites } from '../utils';
+import {
+  Callback,
+  getTopology,
+  maybePromise,
+  supportsRetryableWrites,
+  TopologyProvider
+} from '../utils';
 import { AbstractOperation, Aspect } from './operation';
 
 const MMAPv1_RETRY_WRITES_ERROR_CODE = MONGODB_ERROR_CODES.IllegalOperation;
@@ -59,31 +65,48 @@ export interface ExecutionResult {
  */
 export function executeOperation<
   T extends AbstractOperation<TResult>,
-  TResult = ResultTypeFromOperation<T>
->(topology: Topology, operation: T): Promise<TResult>;
+  TResult = ResultTypeFromOperation<T>,
+  TSchema = Document
+>(topology: Topology | TopologyProvider<TSchema>, operation: T): Promise<TResult>;
 export function executeOperation<
   T extends AbstractOperation<TResult>,
-  TResult = ResultTypeFromOperation<T>
->(topology: Topology, operation: T, callback: Callback<TResult>): void;
+  TResult = ResultTypeFromOperation<T>,
+  TSchema = Document
+>(topology: Topology | TopologyProvider<TSchema>, operation: T, callback: Callback<TResult>): void;
 export function executeOperation<
   T extends AbstractOperation<TResult>,
-  TResult = ResultTypeFromOperation<T>
->(topology: Topology, operation: T, callback?: Callback<TResult>): Promise<TResult> | void;
+  TResult = ResultTypeFromOperation<T>,
+  TSchema = Document
+>(
+  topology: Topology | TopologyProvider<TSchema>,
+  operation: T,
+  callback?: Callback<TResult>
+): Promise<TResult> | void;
 export function executeOperation<
   T extends AbstractOperation<TResult>,
-  TResult = ResultTypeFromOperation<T>
->(topology: Topology, operation: T, callback?: Callback<TResult>): Promise<TResult> | void {
+  TResult = ResultTypeFromOperation<T>,
+  TSchema = Document
+>(
+  topology: Topology | TopologyProvider<TSchema>,
+  operation: T,
+  callback?: Callback<TResult>
+): Promise<TResult> | void {
   if (!(operation instanceof AbstractOperation)) {
     // TODO(NODE-3483): Extend MongoRuntimeError
     throw new MongoRuntimeError('This method requires a valid operation instance');
   }
 
   return maybePromise(callback, callback => {
+    try {
+      topology = topology instanceof Topology ? topology : getTopology(topology);
+    } catch (error) {
+      return callback(error);
+    }
     if (topology.shouldCheckForSessionSupport()) {
       return topology.selectServer(ReadPreference.primaryPreferred, {}, err => {
         if (err) return callback(err);
 
-        executeOperation<T, TResult>(topology, operation, callback);
+        executeOperation<T, TResult, TSchema>(topology, operation, callback);
       });
     }
 

--- a/src/operations/execute_operation.ts
+++ b/src/operations/execute_operation.ts
@@ -19,7 +19,7 @@ import {
   secondaryWritableServerSelector,
   ServerSelector
 } from '../sdam/server_selection';
-import { Topology } from '../sdam/topology';
+import type { Topology } from '../sdam/topology';
 import type { ClientSession } from '../sessions';
 import {
   Callback,
@@ -66,16 +66,16 @@ export interface ExecutionResult {
 export function executeOperation<
   T extends AbstractOperation<TResult>,
   TResult = ResultTypeFromOperation<T>
->(topologyProvider: Topology | TopologyProvider, operation: T): Promise<TResult>;
+>(topologyProvider: TopologyProvider, operation: T): Promise<TResult>;
 export function executeOperation<
   T extends AbstractOperation<TResult>,
   TResult = ResultTypeFromOperation<T>
->(topologyProvider: Topology | TopologyProvider, operation: T, callback: Callback<TResult>): void;
+>(topologyProvider: TopologyProvider, operation: T, callback: Callback<TResult>): void;
 export function executeOperation<
   T extends AbstractOperation<TResult>,
   TResult = ResultTypeFromOperation<T>
 >(
-  topologyProvider: Topology | TopologyProvider,
+  topologyProvider: TopologyProvider,
   operation: T,
   callback?: Callback<TResult>
 ): Promise<TResult> | void;
@@ -83,7 +83,7 @@ export function executeOperation<
   T extends AbstractOperation<TResult>,
   TResult = ResultTypeFromOperation<T>
 >(
-  topologyProvider: Topology | TopologyProvider,
+  topologyProvider: TopologyProvider,
   operation: T,
   callback?: Callback<TResult>
 ): Promise<TResult> | void {
@@ -93,10 +93,9 @@ export function executeOperation<
   }
 
   return maybePromise(callback, callback => {
-    let topology: Topology | TopologyProvider;
+    let topology: Topology;
     try {
-      topology =
-        topologyProvider instanceof Topology ? topologyProvider : getTopology(topologyProvider);
+      topology = getTopology(topologyProvider);
     } catch (error) {
       return callback(error);
     }
@@ -104,7 +103,7 @@ export function executeOperation<
       return topology.selectServer(ReadPreference.primaryPreferred, {}, err => {
         if (err) return callback(err);
 
-        executeOperation<T, TResult>(topology, operation, callback);
+        executeOperation<T, TResult>(topologyProvider, operation, callback);
       });
     }
 

--- a/src/operations/indexes.ts
+++ b/src/operations/indexes.ts
@@ -453,7 +453,7 @@ export class ListIndexesCursor extends AbstractCursor {
       session
     });
 
-    executeOperation(getTopology(this.parent), operation, (err, response) => {
+    executeOperation(this.parent, operation, (err, response) => {
       if (err || response == null) return callback(err);
 
       // TODO: NODE-2882

--- a/src/operations/list_collections.ts
+++ b/src/operations/list_collections.ts
@@ -157,7 +157,7 @@ export class ListCollectionsCursor<
       session
     });
 
-    executeOperation(getTopology(this.parent), operation, (err, response) => {
+    executeOperation(this.parent, operation, (err, response) => {
       if (err || response == null) return callback(err);
 
       // TODO: NODE-2882

--- a/src/operations/map_reduce.ts
+++ b/src/operations/map_reduce.ts
@@ -1,7 +1,6 @@
 import type { ObjectId } from '../bson';
 import { Code, Document } from '../bson';
 import type { Collection } from '../collection';
-import { Db } from '../db';
 import { MongoCompatibilityError, MongoServerError } from '../error';
 import { ReadPreference, ReadPreferenceMode } from '../read_preference';
 import type { Server } from '../sdam/server';
@@ -210,9 +209,7 @@ export class MapReduceOperation extends CommandOperation<Document | Document[]> 
       if (result.result != null && typeof result.result === 'object') {
         const doc = result.result;
         // Return a collection from another db
-        collection = new Db(coll.s.db.s.client, doc.db, coll.s.db.s.options).collection(
-          doc.collection
-        );
+        collection = coll.s.db.s.client.db(doc.db, coll.s.db.s.options).collection(doc.collection);
       } else {
         // Create a collection object that wraps the result collection
         collection = coll.s.db.collection(result.result);

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -757,7 +757,7 @@ function endTransaction(
 
   // send the command
   executeOperation(
-    session.topology,
+    session,
     new RunAdminCommandOperation(undefined, command, {
       session,
       readPreference: ReadPreference.primary,
@@ -781,7 +781,7 @@ function endTransaction(
         }
 
         return executeOperation(
-          session.topology,
+          session,
           new RunAdminCommandOperation(undefined, command, {
             session,
             readPreference: ReadPreference.primary,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -329,14 +329,15 @@ export function decorateWithExplain(command: Document, explain: Explain): Docume
 /**
  * @internal
  */
-export type TopologyProvider<T> = MongoClient | Db | Collection<T>;
+export type TopologyProvider = MongoClient | Db | Collection<any>;
 
 /**
  * A helper function to get the topology from a given provider. Throws
  * if the topology cannot be found.
+ * @throws MongoNotConnectedError
  * @internal
  */
-export function getTopology<T>(provider: TopologyProvider<T>): Topology {
+export function getTopology(provider: TopologyProvider): Topology {
   if (`topology` in provider && provider.topology) {
     return provider.topology;
   } else if ('client' in provider.s && provider.s.client.topology) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -327,6 +327,11 @@ export function decorateWithExplain(command: Document, explain: Explain): Docume
 }
 
 /**
+ * @internal
+ */
+export type TopologyProvider<T> = MongoClient | Db | Collection<T>;
+
+/**
  * A helper function to get the topology from a given provider. Throws
  * if the topology cannot be found.
  * @internal

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -336,7 +336,7 @@ export type TopologyProvider<T> = MongoClient | Db | Collection<T>;
  * if the topology cannot be found.
  * @internal
  */
-export function getTopology<T>(provider: MongoClient | Db | Collection<T>): Topology {
+export function getTopology<T>(provider: TopologyProvider<T>): Topology {
   if (`topology` in provider && provider.topology) {
     return provider.topology;
   } else if ('client' in provider.s && provider.s.client.topology) {

--- a/test/integration/connection-monitoring-and-pooling/connection.test.js
+++ b/test/integration/connection-monitoring-and-pooling/connection.test.js
@@ -1,6 +1,10 @@
 'use strict';
 
-const { ServerHeartbeatStartedEvent, MongoClient } = require('../../../src');
+const {
+  ServerHeartbeatStartedEvent,
+  MongoClient,
+  MongoNotConnectedError
+} = require('../../../src');
 const { Connection } = require('../../../src/cmap/connection');
 const { connect } = require('../../../src/cmap/connect');
 const { expect } = require('chai');
@@ -456,7 +460,7 @@ describe('Connection', function () {
       const client = this.configuration.newClient();
       const collection = client.db('shouldCorrectlyFailOnRetry').collection('test');
       collection.insertOne({ a: 2 }, err => {
-        expect(err).to.match(/must be connected/);
+        expect(err).to.be.instanceof(MongoNotConnectedError);
         done();
       });
     });
@@ -465,11 +469,8 @@ describe('Connection', function () {
       const client = this.configuration.newClient();
       const collection = client.db('shouldCorrectlyFailOnRetry').collection('test');
 
-      try {
-        await collection.insertOne({ a: 2 });
-      } catch (err) {
-        expect(err).to.match(/must be connected/);
-      }
+      const err = await collection.insertOne({ a: 2 }).catch(err => err);
+      expect(err).to.be.instanceof(MongoNotConnectedError);
     });
 
     it(
@@ -484,7 +485,7 @@ describe('Connection', function () {
             expect(err).to.not.exist;
 
             collection.insertOne({ a: 2 }, err => {
-              expect(err).to.match(/must be connected/);
+              expect(err).to.be.instanceof(MongoNotConnectedError);
               done();
             });
           });
@@ -498,11 +499,8 @@ describe('Connection', function () {
       await collection.insertOne({ a: 1 });
       await client.close(true);
 
-      try {
-        await collection.insertOne({ a: 2 });
-      } catch (err) {
-        expect(err).to.match(/must be connected/);
-      }
+      const err = await collection.insertOne({ a: 2 }).catch(err => err);
+      expect(err).to.be.instanceof(MongoNotConnectedError);
     });
   });
 });

--- a/test/integration/connection-monitoring-and-pooling/connection.test.js
+++ b/test/integration/connection-monitoring-and-pooling/connection.test.js
@@ -452,7 +452,7 @@ describe('Connection', function () {
       })
     );
 
-    it.only('throws when attempting an operation if the client is not connected', function (done) {
+    it('throws when attempting an operation if the client is not connected', function (done) {
       const client = this.configuration.newClient();
       const collection = client.db('shouldCorrectlyFailOnRetry').collection('test');
       collection.insertOne({ a: 2 }, err => {
@@ -461,7 +461,7 @@ describe('Connection', function () {
       });
     });
 
-    it.only('throws when attempting an operation if the client is not connected (promises)', async function () {
+    it('throws when attempting an operation if the client is not connected (promises)', async function () {
       const client = this.configuration.newClient();
       const collection = client.db('shouldCorrectlyFailOnRetry').collection('test');
 
@@ -472,7 +472,7 @@ describe('Connection', function () {
       }
     });
 
-    it.only(
+    it(
       'should correctly fail on retry when client has been closed',
       withClient(function (client, done) {
         const collection = client.db('shouldCorrectlyFailOnRetry').collection('test');
@@ -492,7 +492,7 @@ describe('Connection', function () {
       })
     );
 
-    it.only('should correctly fail on retry when client has been closed (promises)', async function () {
+    it('should correctly fail on retry when client has been closed (promises)', async function () {
       const client = await this.configuration.newClient().connect();
       const collection = client.db('shouldCorrectlyFailOnRetry').collection('test');
       await collection.insertOne({ a: 1 });


### PR DESCRIPTION
### Description

This PR is a re-do of the work done by Daniel Lando (original PR: https://github.com/mongodb/node-mongodb-native/pull/3170).  I messed up the rebase and accidentally removed all changes.

#### What is changing?

All uses of `getTopology` that are used in an asynchronous manner now catch any errors thrown and pass the error along to the appropriate callback.

- All calls to `getTopology` that were used in conjunction with `executeOperation` were moved into `executeOperation`
- Tests were added to ensure we're handling the errors appropriately with both callbacks and promises
- Two other uses of `getTopology` (`indexInformation` and `AddUserOperation.execute`) were calling getTopology in an asynchronous context, so these two uses now handle the potential error thrown from `getTopology`.
- `getTopology` was enhanced to take other topology providers that are used throughout the driver

##### Is there new documentation needed for these changes?

Nope! 

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
