### PR TITLE
fix(NODE-4095): hard to use findOne with filter

### DIFF
--- a/src/collection.ts
+++ b/src/collection.ts
@@ -693,8 +693,8 @@ export class Collection<TSchema extends Document = Document> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   findOne(): Promise<WithId<TSchema> | null>;
-  findOne(callback: Callback<WithId<TSchema> | null>): void;
   findOne(filter: Filter<TSchema>): Promise<WithId<TSchema> | null>;
+  findOne(callback: Callback<WithId<TSchema> | null>): void;
   findOne(filter: Filter<TSchema>, callback: Callback<WithId<TSchema> | null>): void;
   findOne(filter: Filter<TSchema>, options: FindOptions): Promise<WithId<TSchema> | null>;
   findOne(
@@ -705,8 +705,8 @@ export class Collection<TSchema extends Document = Document> {
 
   // allow an override of the schema.
   findOne<T = TSchema>(): Promise<T | null>;
-  findOne<T = TSchema>(callback: Callback<T | null>): void;
   findOne<T = TSchema>(filter: Filter<TSchema>): Promise<T | null>;
+  findOne<T = TSchema>(callback: Callback<T | null>): void;
   findOne<T = TSchema>(filter: Filter<TSchema>, options?: FindOptions): Promise<T | null>;
   findOne<T = TSchema>(
     filter: Filter<TSchema>,


### PR DESCRIPTION
https://www.mongodb.com/community/forums/t/mongodb-4-1-4-with-typescript-findone-syntax-error-type-void-is-not-assignable-to-type-dbuser-undefined-ts-2322/131533

### Description
Fix of https://jira.mongodb.org/browse/NODE-4095

#### What is changing?
Reorders single parameter overloads of findOne to pick the `Filter` one in generic consumer code

##### Is there new documentation needed for these changes?
no

#### What is the motivation for this change?

The JIRA issue (and community ticket) outlines scenairos that imho should work

### Double check the following

- [X] Ran `npm run check:lint` script
- [X] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [X] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] Changes are covered by tests
- [X] New TODOs have a related JIRA ticket
