### PR TITLE
feat(NODE-4085): add typings for csfle shared library option support

### DIFF
--- a/src/deps.ts
+++ b/src/deps.ts
@@ -295,6 +295,16 @@ export interface AutoEncryptionOptions {
     mongocryptdSpawnPath?: string;
     /** Command line arguments to use when auto-spawning a mongocryptd */
     mongocryptdSpawnArgs?: string[];
+    /**
+     * Full path to a CSFLE shared library to be used (instead of mongocryptd)
+     * @experimental
+     */
+    csflePath?: string;
+    /**
+     * Search paths for a CSFLE shared library to be used (instead of mongocryptd)
+     * @experimental
+     */
+    csfleSearchPaths?: string[];
   };
   proxyOptions?: ProxyOptions;
   /** The TLS options to use connecting to the KMS provider */
@@ -315,4 +325,5 @@ export interface AutoEncrypter {
   teardown(force: boolean, callback: Callback): void;
   encrypt(ns: string, cmd: Document, options: any, callback: Callback<Document>): void;
   decrypt(cmd: Document, options: any, callback: Callback<Document>): void;
+  readonly csfleVersionInfo: { version: bigint; versionStr: string } | null;
 }


### PR DESCRIPTION
Typings for (the current state of) https://github.com/mongodb/libmongocrypt/pull/265.

### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
