### PR TITLE
fix(NODE-4129): constrain `watch` type parameter to extend `ChangeStream` type parameter

### DIFF
--- a/src/collection.ts
+++ b/src/collection.ts
@@ -1422,7 +1422,7 @@ export class Collection<TSchema extends Document = Document> {
    * @param pipeline - An array of {@link https://docs.mongodb.com/manual/reference/operator/aggregation-pipeline/|aggregation pipeline stages} through which to pass change stream documents. This allows for filtering (using $match) and manipulating the change stream documents.
    * @param options - Optional settings for the command
    */
-  watch<TLocal = TSchema>(
+  watch<TLocal extends Document = TSchema>(
     pipeline: Document[] = [],
     options: ChangeStreamOptions = {}
   ): ChangeStream<TLocal> {

--- a/src/db.ts
+++ b/src/db.ts
@@ -722,7 +722,7 @@ export class Db {
    * @param pipeline - An array of {@link https://docs.mongodb.com/manual/reference/operator/aggregation-pipeline/|aggregation pipeline stages} through which to pass change stream documents. This allows for filtering (using $match) and manipulating the change stream documents.
    * @param options - Optional settings for the command
    */
-  watch<TSchema = Document>(
+  watch<TSchema extends Document = Document>(
     pipeline: Document[] = [],
     options: ChangeStreamOptions = {}
   ): ChangeStream<TSchema> {

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -590,7 +590,7 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> {
    * @param pipeline - An array of {@link https://docs.mongodb.com/manual/reference/operator/aggregation-pipeline/|aggregation pipeline stages} through which to pass change stream documents. This allows for filtering (using $match) and manipulating the change stream documents.
    * @param options - Optional settings for the command
    */
-  watch<TSchema = Document>(
+  watch<TSchema extends Document = Document>(
     pipeline: Document[] = [],
     options: ChangeStreamOptions = {}
   ): ChangeStream<TSchema> {


### PR DESCRIPTION

### Description

#### What is changing?
Constrain `watch` type parameter to same constraint as `ChangeStream`

##### Is there new documentation needed for these changes?
Not

#### What is the motivation for this change?

Starting with https://github.com/microsoft/TypeScript/pull/48366 we'll no longer be able to assign an unconstraint type parameter to a constraint one.

Constraining the type is required to pass https://github.com/DefinitelyTyped/DefinitelyTyped/pull/59560

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
