### PR TITLE
fix(NODE-4133): array field NestedPaths return type

### DIFF
--- a/src/mongo_types.ts
+++ b/src/mongo_types.ts
@@ -515,7 +515,7 @@ export type NestedPaths<Type> = Type extends
           ArrayType extends Type
           ? [Key] // we have a recursive array union
           : // child is an array, but it's not a recursive array
-            [Key, ...NestedPaths<Type[Key]>]
+            [Key] | [Key, ...NestedPaths<Type[Key]>]
         : // child is not structured the same as the parent
           [Key, ...NestedPaths<Type[Key]>];
     }[Extract<keyof Type, string>]

--- a/src/mongo_types.ts
+++ b/src/mongo_types.ts
@@ -496,7 +496,7 @@ export type NestedPaths<Type> = Type extends
   | { _bsontype: string }
   ? []
   : Type extends ReadonlyArray<infer ArrayType>
-  ? [number, ...NestedPaths<ArrayType>]
+  ? [] | [number, ...NestedPaths<ArrayType>]
   : Type extends Map<string, any>
   ? [string]
   : // eslint-disable-next-line @typescript-eslint/ban-types
@@ -515,7 +515,7 @@ export type NestedPaths<Type> = Type extends
           ArrayType extends Type
           ? [Key] // we have a recursive array union
           : // child is an array, but it's not a recursive array
-            [Key] | [Key, ...NestedPaths<Type[Key]>]
+            [Key, ...NestedPaths<Type[Key]>]
         : // child is not structured the same as the parent
           [Key, ...NestedPaths<Type[Key]>];
     }[Extract<keyof Type, string>]

--- a/test/types/community/collection/filterQuery.test-d.ts
+++ b/test/types/community/collection/filterQuery.test-d.ts
@@ -204,6 +204,14 @@ expectNotType<Filter<PetModel>>({ 'playmates.0.name': 123 });
 expectNotType<Filter<PetModel>>({ 'laps.foo': 'string' });
 expectNotType<Filter<PetModel>>({ 'treats.0': 123 });
 
+/// it should not accept wrong types for nested document array fields
+expectError<Filter<PetModel>>({
+  treats: {
+    $elemMatch: true
+  }
+});
+expectError<Filter<PetModel>>({ treats: 123 });
+
 // Nested arrays aren't checked
 expectNotType<Filter<PetModel>>({ 'meta.deep.nestedArray.0': 'not a number' });
 


### PR DESCRIPTION
### Description

#### What is changing?
before:
![image](https://user-images.githubusercontent.com/33797740/160789024-b234d80f-d63b-4230-b7a9-8f043eb30b9c.png)
after: 
![image](https://user-images.githubusercontent.com/33797740/160789059-8559e3b2-ee6b-4a1b-af1d-202d8ec89b1e.png)

##### Is there new documentation needed for these changes?
not need

#### What is the motivation for this change?
a tsc build error occurred for our specific requirements, after locating the cause several times, I think it is good for everyone, so fix it

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
