### PR TITLE
chore(NODE-4075): add docs generation workflow

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   build:
 
-    # prevent subsequent commits from trigger the job multiple times
+    # prevent subsequent commits from triggering the job multiple times
     concurrency:
       group: ci-${{ github.ref }}
       cancel-in-progress: true
@@ -25,15 +25,14 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
-    - name: Install and Build Docs
+    - name: Install Dependencies
       run: |
         npm ci
-
         sudo apt-get install hugo
-        hugo version
-        npm run build:docs -- --yes
-    - name: Create Pull Request
+    - name: Build Docs
+      run: npm run build:docs -- --yes
+    - name: Open Pull Request
       uses: peter-evans/create-pull-request@v4
       with:
         title: 'docs: generate docs from latest main'
-        delete: true
+        delete-branch: true

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -1,0 +1,39 @@
+name: Build and commit docs
+
+on:
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  build:
+
+    # prevent subsequent commits from trigger the job multiple times
+    concurrency:
+      group: ci-${{ github.ref }}
+      cancel-in-progress: true
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup NodeJS
+      uses: actions/setup-node@v3
+      with:
+        node-version: 16.x
+        cache: 'npm'
+    - name: Install and Build Docs
+      run: |
+        npm ci
+
+        sudo apt-get install hugo
+        hugo version
+        npm run build:docs -- --yes
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v4
+      with:
+        title: 'docs: generate docs from latest main'
+        delete: true


### PR DESCRIPTION
### Description

Adds a github action to generate docs automatically off of commits to main and open a PR with the changes.

##### Is there new documentation needed for these changes?
No.

##### Notes

Some notes

- If multiple changes come in before we merge the docs PR into main, the github action will automatically add the changes to the existing PR as to not create a duplicate PR.
- We don't pin a version of Hugo (our static site generator).  I don't think this is an issue because Hugo is widely used.  We've already been version hopping - the docs build in 4.5.0 used version 0.96 instead of 0.30 without issues.
- You can view the generated PR on my fork ([here](https://github.com/baileympearson/node-mongodb-native)).  It currently contains changes from two commits, including a change to a public interface (`ChangeStreamOptions`).

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
