### PR TITLE
test: failing aws test should not check for region

### DIFF
--- a/test/integration/client-side-encryption/client_side_encryption.prose.test.js
+++ b/test/integration/client-side-encryption/client_side_encryption.prose.test.js
@@ -931,11 +931,8 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
         },
         succeed: false,
         errorValidator: err => {
-          //    Expect this to fail with an exception with a message containing the string: "us-east-1"
-          expect(err)
-            .to.be.an.instanceOf(Error)
-            .and.to.have.property('message')
-            .that.matches(/us-east-1/);
+          // TODO(NODE-4162): aws region test should only check if an error is thrown
+          expect(err).to.be.an.instanceOf(Error);
         }
       },
       {


### PR DESCRIPTION
### Description

#### What is changing?

The aws clsfe test that used to check that an error was thrown if the region was invalid now only checks that a generic error is thrown and doesn't search for the region in the error message.

#### What is the motivation for this change?

This is a drivers-wide bug.  It seems like this will be the fix (see https://github.com/mongodb/specifications/pull/1171) and we can clean up the todo once the Node ticket is opened.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
