### PR TITLE
fix(NODE-4031): options parsing for array options

### DIFF
--- a/test/unit/connection_string.test.ts
+++ b/test/unit/connection_string.test.ts
@@ -87,6 +87,7 @@ describe('Connection String', function () {
       });
     });
 
+    // TODO(NODE-4172): align uri behavior with object options behavior
     context('when set in the uri', () => {
       it('should parse a string value', () => {
         const options = parseOptions('mongodb://localhost?ca=hello', {});

--- a/test/unit/connection_string.test.ts
+++ b/test/unit/connection_string.test.ts
@@ -174,25 +174,25 @@ describe('Connection String', function () {
     context('when the options are provided in the URI', function () {
       context('when the options are equal', function () {
         context('when both options are true', function () {
-          const options = parseOptions('mongodb://localhost/?tls=true&ssl=true');
-
           it('sets the tls option', function () {
+          const options = parseOptions('mongodb://localhost/?tls=true&ssl=true');
             expect(options.tls).to.be.true;
           });
 
           it('does not set the ssl option', function () {
+            const options = parseOptions('mongodb://localhost/?tls=true&ssl=true');
             expect(options).to.not.have.property('ssl');
           });
         });
 
         context('when both options are false', function () {
-          const options = parseOptions('mongodb://localhost/?tls=false&ssl=false');
-
           it('sets the tls option', function () {
+          const options = parseOptions('mongodb://localhost/?tls=false&ssl=false');
             expect(options.tls).to.be.false;
           });
 
           it('does not set the ssl option', function () {
+            const options = parseOptions('mongodb://localhost/?tls=false&ssl=false');
             expect(options).to.not.have.property('ssl');
           });
         });
@@ -210,38 +210,38 @@ describe('Connection String', function () {
     context('when the options are provided in the options', function () {
       context('when the options are equal', function () {
         context('when both options are true', function () {
-          const options = parseOptions('mongodb://localhost/', { tls: true, ssl: true });
-
           it('sets the tls option', function () {
+          const options = parseOptions('mongodb://localhost/', { tls: true, ssl: true });
             expect(options.tls).to.be.true;
           });
 
           it('does not set the ssl option', function () {
+            const options = parseOptions('mongodb://localhost/', { tls: true, ssl: true });
             expect(options).to.not.have.property('ssl');
           });
         });
 
         context('when both options are false', function () {
           context('when the URI is an SRV URI', function () {
-            const options = parseOptions('mongodb+srv://localhost/', { tls: false, ssl: false });
-
             it('overrides the tls option', function () {
+            const options = parseOptions('mongodb+srv://localhost/', { tls: false, ssl: false });
               expect(options.tls).to.be.false;
             });
 
             it('does not set the ssl option', function () {
+              const options = parseOptions('mongodb+srv://localhost/', { tls: false, ssl: false });
               expect(options).to.not.have.property('ssl');
             });
           });
 
           context('when the URI is not SRV', function () {
-            const options = parseOptions('mongodb://localhost/', { tls: false, ssl: false });
-
             it('sets the tls option', function () {
+            const options = parseOptions('mongodb://localhost/', { tls: false, ssl: false });
               expect(options.tls).to.be.false;
             });
 
             it('does not set the ssl option', function () {
+              const options = parseOptions('mongodb://localhost/', { tls: false, ssl: false });
               expect(options).to.not.have.property('ssl');
             });
           });


### PR DESCRIPTION
### Description

#### What is changing?

https://github.com/mongodb/node-mongodb-native/pull/3138 broke options parsing for options that allow arrays of values.  This PR reverts the breaking changes from https://github.com/mongodb/node-mongodb-native/pull/3138, and then fixes read preference tags parsing again.

##### Is there new documentation needed for these changes?

No.


### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
