### PR TITLE
fix(NODE-4156): remove comment from commands pre-4.4

### DIFF
--- a/src/operations/command.ts
+++ b/src/operations/command.ts
@@ -179,10 +179,6 @@ export abstract class CommandOperation<T> extends AbstractOperation<T> {
       cmd.maxTimeMS = options.maxTimeMS;
     }
 
-    if (typeof options.comment === 'string') {
-      cmd.comment = options.comment;
-    }
-
     if (this.hasAspect(Aspect.EXPLAINABLE) && this.explain) {
       if (serverWireVersion < 6 && cmd.aggregate) {
         // Prior to 3.6, with aggregate, verbosity is ignored, and we must pass in "explain: true"

--- a/test/integration/enumerate_collections.test.ts
+++ b/test/integration/enumerate_collections.test.ts
@@ -25,7 +25,8 @@ const testSuite = new UnifiedTestSuiteBuilder('listCollections with comment opti
           {
             commandStartedEvent: {
               command: {
-                listCollections: 1
+                listCollections: 1,
+                comment: { $$exists: false }
               }
             }
           }

--- a/test/integration/enumerate_databases.test.ts
+++ b/test/integration/enumerate_databases.test.ts
@@ -156,7 +156,8 @@ const testSuite = new UnifiedTestSuiteBuilder('listDatabases with comment option
       .operation({
         name: 'listDatabases',
         arguments: {
-          filter: {}
+          filter: {},
+          comment: 'string value'
         },
         object: 'client0'
       })
@@ -166,7 +167,8 @@ const testSuite = new UnifiedTestSuiteBuilder('listDatabases with comment option
           {
             commandStartedEvent: {
               command: {
-                listDatabases: 1
+                listDatabases: 1,
+                comment: { $$exists: false }
               }
             }
           }

--- a/test/integration/enumerate_indexes.test.ts
+++ b/test/integration/enumerate_indexes.test.ts
@@ -24,7 +24,10 @@ const testSuite = new UnifiedTestSuiteBuilder('listIndexes with comment option')
         events: [
           {
             commandStartedEvent: {
-              command: {}
+              command: {
+                listIndexes: 'coll0',
+                comment: { $$exists: false }
+              }
             }
           }
         ]

--- a/test/tools/unified-spec-runner/match.ts
+++ b/test/tools/unified-spec-runner/match.ts
@@ -253,7 +253,12 @@ export function specialCheck(
   } else if (isExistsOperator(expected)) {
     // $$exists
     const actualExists = actual !== undefined && actual !== null;
-    expect((expected.$$exists && actualExists) || (!expected.$$exists && !actualExists)).to.be.true;
+    expect(
+      (expected.$$exists && actualExists) || (!expected.$$exists && !actualExists),
+      `expected value at ${path.join('')} to not exist, but received ${JSON.stringify(
+        actual
+      )} instead`
+    ).to.be.true;
   } else {
     expect.fail(`Unknown special operator: ${JSON.stringify(expected)}`);
   }

--- a/test/tools/unified-spec-runner/match.ts
+++ b/test/tools/unified-spec-runner/match.ts
@@ -256,11 +256,15 @@ export function specialCheck(
     const actualExists = actual !== undefined && actual !== null;
 
     if (expected.$$exists) {
-      expect(actualExists, ejson`expected value at path ${path.join} to exist, but received ${actual}`)
-        .to.be.true;
+      expect(
+        actualExists,
+        ejson`expected value at path ${path.join} to exist, but received ${actual}`
+      ).to.be.true;
     } else {
-      expect(actualExists, ejson`expected value at path ${path.join} NOT to exist, but received ${actual}`)
-        .to.be.false;
+      expect(
+        actualExists,
+        ejson`expected value at path ${path.join} NOT to exist, but received ${actual}`
+      ).to.be.false;
     }
   } else {
     expect.fail(`Unknown special operator: ${JSON.stringify(expected)}`);

--- a/test/tools/unified-spec-runner/match.ts
+++ b/test/tools/unified-spec-runner/match.ts
@@ -19,6 +19,7 @@ import {
   ConnectionPoolCreatedEvent,
   ConnectionReadyEvent
 } from '../../../src/cmap/connection_pool_events';
+import { ejson } from '../utils';
 import { CmapEvent, CommandEvent, EntitiesMap } from './entities';
 import { ExpectedCmapEvent, ExpectedCommandEvent, ExpectedError } from './schema';
 
@@ -253,12 +254,14 @@ export function specialCheck(
   } else if (isExistsOperator(expected)) {
     // $$exists
     const actualExists = actual !== undefined && actual !== null;
-    expect(
-      (expected.$$exists && actualExists) || (!expected.$$exists && !actualExists),
-      `expected value at ${path.join('')} to not exist, but received ${JSON.stringify(
-        actual
-      )} instead`
-    ).to.be.true;
+
+    if (expected.$$exists) {
+      expect(actualExists, ejson`expected value at path ${path.join} to exist, but received ${actual}`)
+        .to.be.true;
+    } else {
+      expect(actualExists, ejson`expected value at path ${path.join} NOT to exist, but received ${actual}`)
+        .to.be.false;
+    }
   } else {
     expect.fail(`Unknown special operator: ${JSON.stringify(expected)}`);
   }


### PR DESCRIPTION
### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
