### PR TITLE
fix(NODE-3928): don't throw error in Response constructor

### DIFF
--- a/test/unit/cmap/commands.test.js
+++ b/test/unit/cmap/commands.test.js
@@ -35,9 +35,8 @@ describe('commands', function () {
         it('does not throw an exception', function () {
           let error;
           try {
-            const response = new Response(message, header, body);
-          }
-          catch(err) {
+            new Response(message, header, body);
+          } catch (err) {
             error = err;
           }
           expect(error).to.be.undefined;

--- a/test/unit/cmap/commands.test.js
+++ b/test/unit/cmap/commands.test.js
@@ -1,0 +1,24 @@
+const { expect } = require('chai');
+const { Response } = require('../../../src/cmap/commands');
+
+describe('commands', function () {
+  describe('Response', function () {
+    describe('#constructor', function () {
+      context('when the message body is invalid', function () {
+        const message = Buffer.from([]);
+        const header = {
+          length: 0,
+          requestId: 0,
+          responseTo: 0,
+          opCode: 0
+        };
+        const body = Buffer.from([]);
+
+        it('does not throw an exception', function () {
+          const response = new Response(message, header, body);
+          expect(response.numberReturned).to.be.undefined;
+        });
+      });
+    });
+  });
+});

--- a/test/unit/cmap/commands.test.js
+++ b/test/unit/cmap/commands.test.js
@@ -3,6 +3,24 @@ const { Response } = require('../../../src/cmap/commands');
 
 describe('commands', function () {
   describe('Response', function () {
+    describe('#parse', function () {
+      context('when the message body is invalid', function () {
+        const message = Buffer.from([]);
+        const header = {
+          length: 0,
+          requestId: 0,
+          responseTo: 0,
+          opCode: 0
+        };
+        const body = Buffer.from([]);
+
+        it('throws an exception', function () {
+          const response = new Response(message, header, body);
+          expect(() => response.parse()).to.throw();
+        });
+      });
+    });
+
     describe('#constructor', function () {
       context('when the message body is invalid', function () {
         const message = Buffer.from([]);
@@ -15,8 +33,59 @@ describe('commands', function () {
         const body = Buffer.from([]);
 
         it('does not throw an exception', function () {
+          let error;
+          try {
+            const response = new Response(message, header, body);
+          }
+          catch(err) {
+            error = err;
+          }
+          expect(error).to.be.undefined;
+        });
+
+        it('initializes the documents to an empty array', function () {
+          const response = new Response(message, header, body);
+          expect(response.documents).to.be.empty;
+        });
+
+        it('does not set the responseFlags', function () {
+          const response = new Response(message, header, body);
+          expect(response.responseFlags).to.be.undefined;
+        });
+
+        it('does not set the cursorNotFound flag', function () {
+          const response = new Response(message, header, body);
+          expect(response.cursorNotFound).to.be.undefined;
+        });
+
+        it('does not set the cursorId', function () {
+          const response = new Response(message, header, body);
+          expect(response.cursorId).to.be.undefined;
+        });
+
+        it('does not set startingFrom', function () {
+          const response = new Response(message, header, body);
+          expect(response.startingFrom).to.be.undefined;
+        });
+
+        it('does not set numberReturned', function () {
           const response = new Response(message, header, body);
           expect(response.numberReturned).to.be.undefined;
+        });
+
+        it('does not set queryFailure', function () {
+          const response = new Response(message, header, body);
+          expect(response.queryFailure).to.be.undefined;
+        });
+
+        it('does not set shardConfigStale', function () {
+          const response = new Response(message, header, body);
+          expect(response.shardConfigStale).to.be.undefined;
+        });
+
+        it('does not set awaitCapable', function () {
+          const response = new Response(message, header, body);
+          expect(response.awaitCapable).to.be.undefined;
         });
       });
     });

--- a/test/unit/cmap/commands.test.js
+++ b/test/unit/cmap/commands.test.js
@@ -5,18 +5,37 @@ describe('commands', function () {
   describe('Response', function () {
     describe('#parse', function () {
       context('when the message body is invalid', function () {
-        const message = Buffer.from([]);
-        const header = {
-          length: 0,
-          requestId: 0,
-          responseTo: 0,
-          opCode: 0
-        };
-        const body = Buffer.from([]);
+        context('when the buffer is empty', function () {
+          const message = Buffer.from([]);
+          const header = {
+            length: 0,
+            requestId: 0,
+            responseTo: 0,
+            opCode: 0
+          };
+          const body = Buffer.from([]);
 
-        it('throws an exception', function () {
-          const response = new Response(message, header, body);
-          expect(() => response.parse()).to.throw();
+          it('throws an exception', function () {
+            const response = new Response(message, header, body);
+            expect(() => response.parse()).to.throw(RangeError, /outside buffer bounds/);
+          });
+        });
+
+        context('when numReturned is invalid', function () {
+          const message = Buffer.from([]);
+          const header = {
+            length: 0,
+            requestId: 0,
+            responseTo: 0,
+            opCode: 0
+          };
+          const body = Buffer.alloc(5 * 4);
+          body.writeInt32LE(-1, 16);
+
+          it('throws an exception', function () {
+            const response = new Response(message, header, body);
+            expect(() => response.parse()).to.throw(RangeError, /Invalid array length/);
+          });
         });
       });
     });


### PR DESCRIPTION
### Description

Don't raise an error in the `Response` constructor.

#### What is changing?

Moves all logic that reads from the message body into the `parse` method to allow for any raised exception to be properly handled in a callback.

##### Is there new documentation needed for these changes?

No.

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

NODE-3928

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
