### PR TITLE
chore: fix sinon leak in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ pids
 *.tmp
 *.dat
 *.png
+*.heapsnapshot
+*.cpuprofile
+*.heapprofile
 test*.*
 output
 etc/docs/template/.hugo_build.lock

--- a/test/integration/node-specific/bson-options/utf8_validation.test.ts
+++ b/test/integration/node-specific/bson-options/utf8_validation.test.ts
@@ -1,9 +1,7 @@
 import { expect } from 'chai';
-import { spy } from 'sinon';
+import * as sinon from 'sinon';
 
 import * as BSON from '../../../../src/bson';
-
-const deserializeSpy = spy(BSON, 'deserialize');
 
 const EXPECTED_VALIDATION_DISABLED_ARGUMENT = {
   utf8: false
@@ -16,8 +14,16 @@ const EXPECTED_VALIDATION_ENABLED_ARGUMENT = {
 };
 
 describe('class BinMsg', () => {
+  let deserializeSpy: sinon.SinonSpy;
+
   beforeEach(() => {
+    deserializeSpy = sinon.spy(BSON, 'deserialize');
     deserializeSpy.resetHistory();
+  });
+
+  afterEach(() => {
+    deserializeSpy.restore();
+    deserializeSpy = null;
   });
 
   describe('enableUtf8Validation option set to false', () => {

--- a/test/integration/node-specific/bson-options/utf8_validation.test.ts
+++ b/test/integration/node-specific/bson-options/utf8_validation.test.ts
@@ -18,7 +18,6 @@ describe('class BinMsg', () => {
 
   beforeEach(() => {
     deserializeSpy = sinon.spy(BSON, 'deserialize');
-    deserializeSpy.resetHistory();
   });
 
   afterEach(() => {


### PR DESCRIPTION
### Description

#### What is changing?

We accidentally left a sinon spy outstanding which accumulates memory for all the usages of the function. It started to cause an issue on my connect expirementation PR because failures seems to exagerrate the problem, with this change the memory usage of a test run remains constant.

#### What is the motivation for this change?

Quick fix to help others that might hit this.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
