### PR TITLE
test(NODE-4152): make connect auth check configurable

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2,10 +2,11 @@ stepback: true
 command_type: system
 exec_timeout_secs: 1200
 timeout:
-  - command: shell.exec
+  - command: subprocess.exec
     params:
-      script: |
-        ls -la
+      binary: ls
+      args:
+        - '-la'
 functions:
   fetch source:
     - command: git.get_project

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -216,6 +216,7 @@ functions:
             bash ${PROJECT_DIRECTORY}/.evergreen/run-tests.sh
   run lint checks:
     - command: subprocess.exec
+      type: test
       params:
         working_dir: src
         timeout_secs: 60
@@ -226,6 +227,7 @@ functions:
           - ${PROJECT_DIRECTORY}/.evergreen/run-lint-checks.sh
   run unit tests:
     - command: subprocess.exec
+      type: test
       params:
         working_dir: src
         timeout_secs: 60
@@ -236,6 +238,7 @@ functions:
           - ${PROJECT_DIRECTORY}/.evergreen/run-unit-tests.sh
   run typescript next:
     - command: subprocess.exec
+      type: test
       params:
         working_dir: src
         timeout_secs: 60
@@ -247,6 +250,7 @@ functions:
           - ${PROJECT_DIRECTORY}/.evergreen/run-typescript.sh
   run typescript oldest:
     - command: subprocess.exec
+      type: test
       params:
         working_dir: src
         timeout_secs: 60
@@ -259,6 +263,7 @@ functions:
           - ${PROJECT_DIRECTORY}/.evergreen/run-typescript.sh
   run typescript current:
     - command: subprocess.exec
+      type: test
       params:
         working_dir: src
         timeout_secs: 60

--- a/.evergreen/config.yml.in
+++ b/.evergreen/config.yml.in
@@ -241,6 +241,7 @@ functions:
 
   "run lint checks":
     - command: subprocess.exec
+      type: test
       params:
         working_dir: "src"
         timeout_secs: 60
@@ -252,6 +253,7 @@ functions:
 
   "run unit tests":
     - command: subprocess.exec
+      type: test
       params:
         working_dir: "src"
         timeout_secs: 60
@@ -263,6 +265,7 @@ functions:
 
   "run typescript next":
     - command: subprocess.exec
+      type: test
       params:
         working_dir: "src"
         timeout_secs: 60
@@ -275,6 +278,7 @@ functions:
 
   "run typescript oldest":
     - command: subprocess.exec
+      type: test
       params:
         working_dir: "src"
         timeout_secs: 60
@@ -288,6 +292,7 @@ functions:
 
   "run typescript current":
     - command: subprocess.exec
+      type: test
       params:
         working_dir: "src"
         timeout_secs: 60

--- a/.evergreen/config.yml.in
+++ b/.evergreen/config.yml.in
@@ -15,10 +15,11 @@ exec_timeout_secs: 1200
 
 # What to do when evergreen hits the timeout (`post:` tasks are run automatically)
 timeout:
-  - command: shell.exec
+  - command: subprocess.exec
     params:
-      script: |
-        ls -la
+      binary: ls
+      args:
+        - "-la"
 
 functions:
   "fetch source":

--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -1239,5 +1239,8 @@ export const DEFAULT_OPTIONS = new CaseInsensitiveMap(
     .map(([k, d]) => [k, d.default])
 );
 
-/** Set of permitted feature flags @internal */
+/**
+ * Set of permitted feature flags
+ * @internal
+ */
 export const FEATURE_FLAGS = new Set([Symbol.for('@@mdb.skipPingOnConnect')]);

--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -273,12 +273,7 @@ export function parseOptions(
   // Feature flags
   for (const flag of Object.getOwnPropertySymbols(options)) {
     if (FEATURE_FLAGS.has(flag)) {
-      Object.defineProperty(mongoOptions, flag, {
-        value: options[flag],
-        enumerable: false,
-        writable: true,
-        configurable: true
-      });
+      mongoOptions[flag] = options[flag];
     }
   }
 
@@ -1245,4 +1240,4 @@ export const DEFAULT_OPTIONS = new CaseInsensitiveMap(
 );
 
 /** Set of permitted feature flags @internal */
-export const FEATURE_FLAGS = new Set([Symbol.for('@@mdb.skipInitialPing')]);
+export const FEATURE_FLAGS = new Set([Symbol.for('@@mdb.skipPingOnConnect')]);

--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -269,6 +269,18 @@ export function parseOptions(
   const { hosts, isSRV } = url;
 
   const mongoOptions = Object.create(null);
+
+  // Feature flag capturing
+  for (const [flag, defaultFeatureSetting] of FEATURE_FLAGS) {
+    // Use 'in' to support null values for flags
+    Object.defineProperty(mongoOptions, flag, {
+      value: flag in options ? options[flag] : defaultFeatureSetting,
+      enumerable: false,
+      writable: true,
+      configurable: true
+    });
+  }
+
   mongoOptions.hosts = isSRV ? [] : hosts.map(HostAddress.fromString);
 
   const urlOptions = new CaseInsensitiveMap<any[]>();
@@ -1230,3 +1242,6 @@ export const DEFAULT_OPTIONS = new CaseInsensitiveMap(
     .filter(([, descriptor]) => descriptor.default != null)
     .map(([k, d]) => [k, d.default])
 );
+
+/** Specify the default values of feature flags */
+export const FEATURE_FLAGS = new Map([[Symbol.for('@@mdb.check.auth.on.connect'), true]]);

--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -270,15 +270,16 @@ export function parseOptions(
 
   const mongoOptions = Object.create(null);
 
-  // Feature flag capturing
-  for (const [flag, defaultFeatureSetting] of FEATURE_FLAGS) {
-    // Use 'in' to support null values for flags
-    Object.defineProperty(mongoOptions, flag, {
-      value: flag in options ? options[flag] : defaultFeatureSetting,
-      enumerable: false,
-      writable: true,
-      configurable: true
-    });
+  // Feature flags
+  for (const flag of Object.getOwnPropertySymbols(options)) {
+    if (FEATURE_FLAGS.has(flag)) {
+      Object.defineProperty(mongoOptions, flag, {
+        value: options[flag],
+        enumerable: false,
+        writable: true,
+        configurable: true
+      });
+    }
   }
 
   mongoOptions.hosts = isSRV ? [] : hosts.map(HostAddress.fromString);
@@ -1243,5 +1244,5 @@ export const DEFAULT_OPTIONS = new CaseInsensitiveMap(
     .map(([k, d]) => [k, d.default])
 );
 
-/** Specify the default values of feature flags */
-export const FEATURE_FLAGS = new Map([[Symbol.for('@@mdb.check.auth.on.connect'), true]]);
+/** Set of permitted feature flags @internal */
+export const FEATURE_FLAGS = new Set([Symbol.for('@@mdb.skipInitialPing')]);

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -270,6 +270,8 @@ export interface MongoClientPrivate {
   readonly writeConcern?: WriteConcern;
   readonly readPreference: ReadPreference;
   readonly logger: Logger;
+
+  [featureFlag: symbol]: any;
 }
 
 /** @public */
@@ -363,7 +365,10 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> {
       },
       get logger() {
         return client[kOptions].logger;
-      }
+      },
+
+      // Known feature flags:
+      [Symbol.for('@@mdb.check.auth.on.connect')]: true
     };
   }
 
@@ -696,8 +701,5 @@ export interface MongoOptions
    */
   tls: boolean;
 
-  /**
-   * Turn these options into a reusable connection URI
-   */
-  toURI(): string;
+  [featureFlag: symbol]: any;
 }

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -254,6 +254,9 @@ export interface MongoClientOptions extends BSONSerializeOptions, SupportedNodeC
   srvPoller?: SrvPoller;
   /** @internal */
   connectionType?: typeof Connection;
+
+  /** @internal */
+  [featureFlag: symbol]: any;
 }
 
 /** @public */
@@ -270,8 +273,6 @@ export interface MongoClientPrivate {
   readonly writeConcern?: WriteConcern;
   readonly readPreference: ReadPreference;
   readonly logger: Logger;
-
-  [featureFlag: symbol]: any;
 }
 
 /** @public */
@@ -365,10 +366,7 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> {
       },
       get logger() {
         return client[kOptions].logger;
-      },
-
-      // Known feature flags:
-      [Symbol.for('@@mdb.check.auth.on.connect')]: true
+      }
     };
   }
 

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -699,5 +699,6 @@ export interface MongoOptions
    */
   tls: boolean;
 
+  /** @internal */
   [featureFlag: symbol]: any;
 }

--- a/src/operations/connect.ts
+++ b/src/operations/connect.ts
@@ -57,10 +57,6 @@ function createTopology(
   options: MongoOptions,
   callback: Callback<Topology>
 ) {
-  // Map feature on to options
-  options[Symbol.for('@@mdb.check.auth.on.connect')] =
-    mongoClient.s[Symbol.for('@@mdb.check.auth.on.connect')] ?? true;
-
   // Create the topology
   const topology = new Topology(options.hosts, options);
   // Events can be emitted before initialization is complete so we have to

--- a/src/operations/connect.ts
+++ b/src/operations/connect.ts
@@ -57,6 +57,10 @@ function createTopology(
   options: MongoOptions,
   callback: Callback<Topology>
 ) {
+  // Map feature on to options
+  options[Symbol.for('@@mdb.check.auth.on.connect')] =
+    mongoClient.s[Symbol.for('@@mdb.check.auth.on.connect')] ?? true;
+
   // Create the topology
   const topology = new Topology(options.hosts, options);
   // Events can be emitted before initialization is complete so we have to

--- a/src/operations/execute_operation.ts
+++ b/src/operations/execute_operation.ts
@@ -95,6 +95,7 @@ export function executeOperation<
   return maybePromise(callback, callback => {
     let topology: Topology;
     try {
+      // TODO(NODE-4151): Use skipPingOnConnect and call connect here to make client.connect optional
       topology = getTopology(topologyProvider);
     } catch (error) {
       return callback(error);

--- a/src/sdam/topology.ts
+++ b/src/sdam/topology.ts
@@ -449,11 +449,8 @@ export class Topology extends TypedEventEmitter<TopologyEvents> {
       }
 
       // TODO: NODE-2471
-      if (
-        server &&
-        this.s.credentials &&
-        this.s.options[Symbol.for('@@mdb.check.auth.on.connect')]
-      ) {
+      const skipInitialPing = this.s.options[Symbol.for('@@mdb.skipInitialPing')] === true;
+      if (!skipInitialPing && server && this.s.credentials) {
         server.command(ns('admin.$cmd'), { ping: 1 }, {}, err => {
           if (err) {
             typeof callback === 'function' ? callback(err) : this.emit(Topology.ERROR, err);

--- a/src/sdam/topology.ts
+++ b/src/sdam/topology.ts
@@ -4,7 +4,7 @@ import { deserialize, serialize } from '../bson';
 import type { MongoCredentials } from '../cmap/auth/mongo_credentials';
 import type { ConnectionEvents, DestroyOptions } from '../cmap/connection';
 import type { CloseOptions, ConnectionPoolEvents } from '../cmap/connection_pool';
-import { DEFAULT_OPTIONS } from '../connection_string';
+import { DEFAULT_OPTIONS, FEATURE_FLAGS } from '../connection_string';
 import {
   CLOSE,
   CONNECT,
@@ -154,7 +154,7 @@ export interface TopologyOptions extends BSONSerializeOptions, ServerOptions {
   /** MongoDB server API version */
   serverApi?: ServerApi;
 
-  [feature: symbol]: any;
+  [featureFlag: symbol]: any;
 }
 
 /** @public */
@@ -250,22 +250,8 @@ export class Topology extends TypedEventEmitter<TopologyEvents> {
     // Options should only be undefined in tests, MongoClient will always have defined options
     options = options ?? {
       hosts: [HostAddress.fromString('localhost:27017')],
-      retryReads: DEFAULT_OPTIONS.get('retryReads'),
-      retryWrites: DEFAULT_OPTIONS.get('retryWrites'),
-      serverSelectionTimeoutMS: DEFAULT_OPTIONS.get('serverSelectionTimeoutMS'),
-      directConnection: DEFAULT_OPTIONS.get('directConnection'),
-      loadBalanced: DEFAULT_OPTIONS.get('loadBalanced'),
-      metadata: DEFAULT_OPTIONS.get('metadata'),
-      monitorCommands: DEFAULT_OPTIONS.get('monitorCommands'),
-      tls: DEFAULT_OPTIONS.get('tls'),
-      maxPoolSize: DEFAULT_OPTIONS.get('maxPoolSize'),
-      minPoolSize: DEFAULT_OPTIONS.get('minPoolSize'),
-      waitQueueTimeoutMS: DEFAULT_OPTIONS.get('waitQueueTimeoutMS'),
-      connectionType: DEFAULT_OPTIONS.get('connectionType'),
-      connectTimeoutMS: DEFAULT_OPTIONS.get('connectTimeoutMS'),
-      maxIdleTimeMS: DEFAULT_OPTIONS.get('maxIdleTimeMS'),
-      heartbeatFrequencyMS: DEFAULT_OPTIONS.get('heartbeatFrequencyMS'),
-      minHeartbeatFrequencyMS: DEFAULT_OPTIONS.get('minHeartbeatFrequencyMS')
+      ...Object.fromEntries(DEFAULT_OPTIONS.entries()),
+      ...Object.fromEntries(FEATURE_FLAGS.entries())
     };
 
     if (typeof seeds === 'string') {

--- a/src/sdam/topology.ts
+++ b/src/sdam/topology.ts
@@ -153,6 +153,8 @@ export interface TopologyOptions extends BSONSerializeOptions, ServerOptions {
   metadata: ClientMetadata;
   /** MongoDB server API version */
   serverApi?: ServerApi;
+
+  [feature: symbol]: any;
 }
 
 /** @public */
@@ -333,7 +335,6 @@ export class Topology extends TypedEventEmitter<TopologyEvents> {
 
       // timer management
       connectionTimers: new Set<NodeJS.Timeout>(),
-
       detectShardedTopology: ev => this.detectShardedTopology(ev),
       detectSrvRecords: ev => this.detectSrvRecords(ev)
     };
@@ -462,7 +463,11 @@ export class Topology extends TypedEventEmitter<TopologyEvents> {
       }
 
       // TODO: NODE-2471
-      if (server && this.s.credentials) {
+      if (
+        server &&
+        this.s.credentials &&
+        this.s.options[Symbol.for('@@mdb.check.auth.on.connect')]
+      ) {
         server.command(ns('admin.$cmd'), { ping: 1 }, {}, err => {
           if (err) {
             typeof callback === 'function' ? callback(err) : this.emit(Topology.ERROR, err);

--- a/src/sdam/topology.ts
+++ b/src/sdam/topology.ts
@@ -449,8 +449,8 @@ export class Topology extends TypedEventEmitter<TopologyEvents> {
       }
 
       // TODO: NODE-2471
-      const skipInitialPing = this.s.options[Symbol.for('@@mdb.skipInitialPing')] === true;
-      if (!skipInitialPing && server && this.s.credentials) {
+      const skipPingOnConnect = this.s.options[Symbol.for('@@mdb.skipPingOnConnect')] === true;
+      if (!skipPingOnConnect && server && this.s.credentials) {
         server.command(ns('admin.$cmd'), { ping: 1 }, {}, err => {
           if (err) {
             typeof callback === 'function' ? callback(err) : this.emit(Topology.ERROR, err);

--- a/src/sdam/topology.ts
+++ b/src/sdam/topology.ts
@@ -153,7 +153,7 @@ export interface TopologyOptions extends BSONSerializeOptions, ServerOptions {
   metadata: ClientMetadata;
   /** MongoDB server API version */
   serverApi?: ServerApi;
-
+  /** @internal */
   [featureFlag: symbol]: any;
 }
 

--- a/test/integration/node-specific/feature_flags.test.ts
+++ b/test/integration/node-specific/feature_flags.test.ts
@@ -1,0 +1,37 @@
+import { expect } from 'chai';
+
+describe.only('Feature Flags', () => {
+  describe('@@mdb.skipInitialPing', () => {
+    const tests = [
+      // only skipInitiaPing=true will have no events upon connect
+      { description: 'should skip ping command when set to true', value: true, expectEvents: 0 },
+      {
+        description: 'should not skip ping command when set to false',
+        value: false,
+        expectEvents: 1
+      },
+      { description: 'should not skip ping command when unset', value: undefined, expectEvents: 1 }
+    ];
+    for (const { description, value, expectEvents } of tests) {
+      it(description, async function () {
+        const options = value === undefined ? {} : { [Symbol.for('@@mdb.skipInitialPing')]: value };
+        const client = this.configuration.newClient({}, { ...options, monitorCommands: true });
+        const events = [];
+        client.on('commandStarted', event => events.push(event));
+
+        try {
+          await client.connect();
+        } finally {
+          await client.close();
+        }
+
+        expect(events).to.have.lengthOf(expectEvents);
+        if (expectEvents > 1) {
+          for (const event of events) {
+            expect(event).to.have.property('commandName', 'ping');
+          }
+        }
+      });
+    }
+  });
+});

--- a/test/integration/node-specific/feature_flags.test.ts
+++ b/test/integration/node-specific/feature_flags.test.ts
@@ -1,7 +1,14 @@
 import { expect } from 'chai';
 
 describe('Feature Flags', () => {
-  describe('@@mdb.skipInitialPing', () => {
+  beforeEach(function () {
+    if (process.env.AUTH !== 'auth') {
+      this.currentTest.skipReason = 'ping count relies on auth to be enabled';
+      this.skip();
+    }
+  });
+
+  describe('@@mdb.skipPingOnConnect', () => {
     const tests = [
       // only skipInitiaPing=true will have no events upon connect
       { description: 'should skip ping command when set to true', value: true, expectEvents: 0 },
@@ -14,7 +21,8 @@ describe('Feature Flags', () => {
     ];
     for (const { description, value, expectEvents } of tests) {
       it(description, async function () {
-        const options = value === undefined ? {} : { [Symbol.for('@@mdb.skipInitialPing')]: value };
+        const options =
+          value === undefined ? {} : { [Symbol.for('@@mdb.skipPingOnConnect')]: value };
         const client = this.configuration.newClient({}, { ...options, monitorCommands: true });
         const events = [];
         client.on('commandStarted', event => events.push(event));

--- a/test/integration/node-specific/feature_flags.test.ts
+++ b/test/integration/node-specific/feature_flags.test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 
-describe.only('Feature Flags', () => {
+describe('Feature Flags', () => {
   describe('@@mdb.skipInitialPing', () => {
     const tests = [
       // only skipInitiaPing=true will have no events upon connect

--- a/test/integration/node-specific/feature_flags.test.ts
+++ b/test/integration/node-specific/feature_flags.test.ts
@@ -1,14 +1,14 @@
 import { expect } from 'chai';
 
 describe('Feature Flags', () => {
-  beforeEach(function () {
-    if (process.env.AUTH !== 'auth') {
-      this.currentTest.skipReason = 'ping count relies on auth to be enabled';
-      this.skip();
-    }
-  });
-
   describe('@@mdb.skipPingOnConnect', () => {
+    beforeEach(function () {
+      if (process.env.AUTH !== 'auth') {
+        this.currentTest.skipReason = 'ping count relies on auth to be enabled';
+        this.skip();
+      }
+    });
+
     const tests = [
       // only skipInitiaPing=true will have no events upon connect
       { description: 'should skip ping command when set to true', value: true, expectEvents: 0 },

--- a/test/tools/spec-runner/index.js
+++ b/test/tools/spec-runner/index.js
@@ -339,7 +339,6 @@ const CMAP_EVENTS = new Set([
   'connectionPoolCleared'
 ]);
 
-let displayCommands = false;
 function runTestSuiteTest(configuration, spec, context) {
   context.commandEvents = [];
   const clientOptions = translateClientOptions(
@@ -355,27 +354,13 @@ function runTestSuiteTest(configuration, spec, context) {
 
   const url = resolveConnectionString(configuration, spec, context);
   const client = configuration.newClient(url, clientOptions);
+  client.s[Symbol.for('@@mdb.check.auth.on.connect')] = false; // skip initial ping
   CMAP_EVENTS.forEach(eventName => client.on(eventName, event => context.cmapEvents.push(event)));
   SDAM_EVENTS.forEach(eventName => client.on(eventName, event => context.sdamEvents.push(event)));
 
-  let skippedInitialPing = false;
   client.on('commandStarted', event => {
-    if (IGNORED_COMMANDS.has(event.commandName)) {
-      return;
-    }
-
-    // If credentials were provided, then the Topology sends an initial `ping` command
-    // that we want to skip
-    if (event.commandName === 'ping' && client.topology.s.credentials && !skippedInitialPing) {
-      skippedInitialPing = true;
-      return;
-    }
-
-    context.commandEvents.push(event);
-
-    // very useful for debugging
-    if (displayCommands) {
-      // console.dir(event, { depth: 5 });
+    if (!IGNORED_COMMANDS.has(event.commandName)) {
+      context.commandEvents.push(event);
     }
   });
 
@@ -406,8 +391,6 @@ function runTestSuiteTest(configuration, spec, context) {
         // ignore
       }
     }
-    // enable to see useful APM debug information at the time of actual test run
-    // displayCommands = true;
 
     const operationContext = {
       client,

--- a/test/tools/spec-runner/index.js
+++ b/test/tools/spec-runner/index.js
@@ -346,7 +346,7 @@ function runTestSuiteTest(configuration, spec, context) {
     minHeartbeatFrequencyMS: 100,
     monitorCommands: true,
     ...spec.clientOptions,
-    [Symbol.for('@@mdb.check.auth.on.connect')]: false
+    [Symbol.for('@@mdb.skipInitialPing')]: false
   });
 
   const url = resolveConnectionString(configuration, spec, context);

--- a/test/tools/spec-runner/index.js
+++ b/test/tools/spec-runner/index.js
@@ -346,7 +346,7 @@ function runTestSuiteTest(configuration, spec, context) {
     minHeartbeatFrequencyMS: 100,
     monitorCommands: true,
     ...spec.clientOptions,
-    [Symbol.for('@@mdb.skipInitialPing')]: false
+    [Symbol.for('@@mdb.skipPingOnConnect')]: true
   });
 
   const url = resolveConnectionString(configuration, spec, context);

--- a/test/tools/spec-runner/index.js
+++ b/test/tools/spec-runner/index.js
@@ -341,19 +341,15 @@ const CMAP_EVENTS = new Set([
 
 function runTestSuiteTest(configuration, spec, context) {
   context.commandEvents = [];
-  const clientOptions = translateClientOptions(
-    Object.assign(
-      {
-        heartbeatFrequencyMS: 100,
-        minHeartbeatFrequencyMS: 100,
-        monitorCommands: true
-      },
-      spec.clientOptions
-    )
-  );
+  const clientOptions = translateClientOptions({
+    heartbeatFrequencyMS: 100,
+    minHeartbeatFrequencyMS: 100,
+    monitorCommands: true,
+    ...spec.clientOptions,
+    [Symbol.for('@@mdb.check.auth.on.connect')]: false
+  });
 
   const url = resolveConnectionString(configuration, spec, context);
-  clientOptions[Symbol.for('@@mdb.check.auth.on.connect')] = false;
   const client = configuration.newClient(url, clientOptions);
   CMAP_EVENTS.forEach(eventName => client.on(eventName, event => context.cmapEvents.push(event)));
   SDAM_EVENTS.forEach(eventName => client.on(eventName, event => context.sdamEvents.push(event)));

--- a/test/tools/spec-runner/index.js
+++ b/test/tools/spec-runner/index.js
@@ -353,8 +353,8 @@ function runTestSuiteTest(configuration, spec, context) {
   );
 
   const url = resolveConnectionString(configuration, spec, context);
+  clientOptions[Symbol.for('@@mdb.check.auth.on.connect')] = false;
   const client = configuration.newClient(url, clientOptions);
-  client.s[Symbol.for('@@mdb.check.auth.on.connect')] = false; // skip initial ping
   CMAP_EVENTS.forEach(eventName => client.on(eventName, event => context.cmapEvents.push(event)));
   SDAM_EVENTS.forEach(eventName => client.on(eventName, event => context.sdamEvents.push(event)));
 

--- a/test/tools/unified-spec-runner/entities.ts
+++ b/test/tools/unified-spec-runner/entities.ts
@@ -100,11 +100,12 @@ export class UnifiedMongoClient extends MongoClient {
     connectionCheckedInEvent: 'connectionCheckedIn'
   } as const;
 
-  constructor(uri: string, description: ClientEntity) {
+  constructor(uri: string, description: ClientEntity, options: MongoClientOptions) {
     super(uri, {
       monitorCommands: true,
       ...getEnvironmentalOptions(),
-      ...(description.serverApi ? { serverApi: description.serverApi } : {})
+      ...(description.serverApi ? { serverApi: description.serverApi } : {}),
+      ...options
     });
 
     this.commandEvents = [];
@@ -349,8 +350,9 @@ export class EntitiesMap<E = Entity> extends Map<string, E> {
           config.url({ useMultipleMongoses }),
           entity.client.uriOptions
         );
-        const client = new UnifiedMongoClient(uri, entity.client);
-        client.s[Symbol.for('@@mdb.check.auth.on.connect')] = false; // no initial ping
+        const client = new UnifiedMongoClient(uri, entity.client, {
+          [Symbol.for('@@mdb.check.auth.on.connect')]: false
+        });
         try {
           await client.connect();
         } catch (error) {

--- a/test/tools/unified-spec-runner/entities.ts
+++ b/test/tools/unified-spec-runner/entities.ts
@@ -103,7 +103,7 @@ export class UnifiedMongoClient extends MongoClient {
   constructor(uri: string, description: ClientEntity) {
     super(uri, {
       monitorCommands: true,
-      [Symbol.for('@@mdb.skipInitialPing')]: false,
+      [Symbol.for('@@mdb.skipPingOnConnect')]: true,
       ...getEnvironmentalOptions(),
       ...(description.serverApi ? { serverApi: description.serverApi } : {})
     });

--- a/test/tools/unified-spec-runner/entities.ts
+++ b/test/tools/unified-spec-runner/entities.ts
@@ -26,7 +26,6 @@ import {
   GridFSBucket,
   HostAddress,
   MongoClient,
-  MongoClientOptions,
   MongoCredentials
 } from '../../../src/index';
 import { ReadConcern } from '../../../src/read_concern';

--- a/test/tools/unified-spec-runner/entities.ts
+++ b/test/tools/unified-spec-runner/entities.ts
@@ -103,7 +103,7 @@ export class UnifiedMongoClient extends MongoClient {
   constructor(uri: string, description: ClientEntity) {
     super(uri, {
       monitorCommands: true,
-      [Symbol.for('@@mdb.check.auth.on.connect')]: false,
+      [Symbol.for('@@mdb.skipInitialPing')]: false,
       ...getEnvironmentalOptions(),
       ...(description.serverApi ? { serverApi: description.serverApi } : {})
     });

--- a/test/unit/connection_string.test.ts
+++ b/test/unit/connection_string.test.ts
@@ -439,10 +439,10 @@ describe('Connection String', function () {
 
     it('should only exist if specified on options', () => {
       expect(FEATURE_FLAGS.size).to.be.greaterThanOrEqual(1);
-      const flag = Array.from(FEATURE_FLAGS.keys())[0]; // grab a random supported flag
+      const flag = Array.from(FEATURE_FLAGS)[0]; // grab a random supported flag
       const client = new MongoClient('mongodb://iLoveJavaScript', { [flag]: true });
       expect(client.s.options).to.have.property(flag, true);
-      expect(client.options).to.not.have.property(flag);
+      expect(client.options).to.have.property(flag, true);
     });
 
     it('should support nullish values', () => {

--- a/test/unit/connection_string.test.ts
+++ b/test/unit/connection_string.test.ts
@@ -412,6 +412,12 @@ describe('Connection String', function () {
   });
 
   describe('feature flags', () => {
+    it('should be stored in the FEATURE_FLAGS Set', () => {
+      expect(FEATURE_FLAGS.size).to.equal(1);
+      expect(FEATURE_FLAGS.has(Symbol.for('@@mdb.skipPingOnConnect'))).to.be.true;
+      // Add more flags here
+    });
+
     it('should should ignore unknown symbols', () => {
       const randomFlag = Symbol();
       const client = new MongoClient('mongodb://iLoveJavaScript', { [randomFlag]: 23n });
@@ -419,8 +425,7 @@ describe('Connection String', function () {
     });
 
     it('should be prefixed with @@mdb.', () => {
-      expect(FEATURE_FLAGS.size).to.be.greaterThanOrEqual(1);
-      for (const flag of FEATURE_FLAGS.keys()) {
+      for (const flag of FEATURE_FLAGS) {
         expect(flag).to.be.a('symbol');
         expect(flag).to.have.property('description');
         expect(flag.description).to.match(/@@mdb\..+/);
@@ -428,7 +433,6 @@ describe('Connection String', function () {
     });
 
     it('should only exist if specified on options', () => {
-      expect(FEATURE_FLAGS.size).to.be.greaterThanOrEqual(1);
       const flag = Array.from(FEATURE_FLAGS)[0]; // grab a random supported flag
       const client = new MongoClient('mongodb://iLoveJavaScript', { [flag]: true });
       expect(client.s.options).to.have.property(flag, true);
@@ -436,7 +440,6 @@ describe('Connection String', function () {
     });
 
     it('should support nullish values', () => {
-      expect(FEATURE_FLAGS.size).to.be.greaterThanOrEqual(1);
       const flag = Array.from(FEATURE_FLAGS.keys())[0]; // grab a random supported flag
       const client = new MongoClient('mongodb://iLoveJavaScript', { [flag]: null });
       expect(client.s.options).to.have.property(flag, null);

--- a/test/unit/connection_string.test.ts
+++ b/test/unit/connection_string.test.ts
@@ -412,20 +412,10 @@ describe('Connection String', function () {
   });
 
   describe('feature flags', () => {
-    it('should map known symbols onto options', () => {
+    it('should should ignore unknown symbols', () => {
       const randomFlag = Symbol();
       const client = new MongoClient('mongodb://iLoveJavaScript', { [randomFlag]: 23n });
       expect(client.s.options).to.not.have.property(randomFlag);
-    });
-
-    it('should map all default symbols and values onto options', () => {
-      const client = new MongoClient('mongodb://iLoveJavaScript');
-      expect(FEATURE_FLAGS.size).to.be.greaterThanOrEqual(1);
-      for (const flag of FEATURE_FLAGS) {
-        // Flags do not have default values
-        expect(client.s.options).to.not.have.property(flag);
-        expect(client.options).to.not.have.property(flag);
-      }
     });
 
     it('should be prefixed with @@mdb.', () => {

--- a/test/unit/connection_string.test.ts
+++ b/test/unit/connection_string.test.ts
@@ -421,16 +421,9 @@ describe('Connection String', function () {
     it('should map all default symbols and values onto options', () => {
       const client = new MongoClient('mongodb://iLoveJavaScript');
       expect(FEATURE_FLAGS.size).to.be.greaterThanOrEqual(1);
-      for (const [flag, featureSetting] of FEATURE_FLAGS) {
-        // asserts value and flag is NOT enumerable
-        expect(client.s.options).to.have.ownPropertyDescriptor(flag, {
-          value: featureSetting,
-          enumerable: false,
-          writable: true,
-          configurable: true
-        });
-
-        // Non-enumerable properties do not get surfaced to the public options
+      for (const flag of FEATURE_FLAGS) {
+        // Flags do not have default values
+        expect(client.s.options).to.not.have.property(flag);
         expect(client.options).to.not.have.property(flag);
       }
     });
@@ -442,6 +435,14 @@ describe('Connection String', function () {
         expect(flag).to.have.property('description');
         expect(flag.description).to.match(/@@mdb\..+/);
       }
+    });
+
+    it('should only exist if specified on options', () => {
+      expect(FEATURE_FLAGS.size).to.be.greaterThanOrEqual(1);
+      const flag = Array.from(FEATURE_FLAGS.keys())[0]; // grab a random supported flag
+      const client = new MongoClient('mongodb://iLoveJavaScript', { [flag]: true });
+      expect(client.s.options).to.have.property(flag, true);
+      expect(client.options).to.not.have.property(flag);
     });
 
     it('should support nullish values', () => {


### PR DESCRIPTION
### Description

#### What is changing?

We can now disable the initial ping with a flag. The unified runner and spec runner now disable the initial ping, and have had their "initial ping" handler code removed. 

Necessary drive by fixes:
- SCRAM iteration tests declared to the Topology directly which is something we want to do less of in tests anyway but this resulted in a timeout before fixing the defaulting of the flag. 
- EVG typescript tests were not marked as "test"s so they would appear purple instead of red when they failed
- TS fixes inside UnifiedMongoClient class, should be a type error free file now

#### What is the motivation for this change?

For use only in testing, we can disable the fact that connect will send a ping if there are credentials, this will make auth errors surface during the first operation a test performs instead of during entity creation.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
