### PR TITLE
fix(NODE-4108): improve return type for `withTransaction()`

### DIFF
--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -467,10 +467,10 @@ export class ClientSession extends TypedEventEmitter<ClientSessionEvents> {
    * @param fn - A lambda to run within a transaction
    * @param options - Optional settings for the transaction
    */
-  withTransaction<T = void>(
-    fn: WithTransactionCallback<T>,
+  withTransaction(
+    fn: WithTransactionCallback<void>,
     options?: TransactionOptions
-  ): ReturnType<typeof fn> {
+  ): Promise<void> {
     const startTime = now();
     return attemptTransaction(this, startTime, fn, options);
   }


### PR DESCRIPTION
### Description

The `withTransaction()` function signature implies that `withTransaction()` returns the same value that the user-provided callback returns. But that isn't the case, it always returns something like this:

```
{
  ok: 1,
  '$clusterTime': {
    clusterTime: new Timestamp({ t: 1650213729, i: 1 }),
    signature: {
      hash: new Binary(Buffer.from("0000000000000000000000000000000000000000", "hex"), 0),
      keyId: 0
    }
  },
  operationTime: new Timestamp({ t: 1650213729, i: 1 })
}
```

Reported in https://github.com/Automattic/mongoose/issues/9919

#### What is changing?

Function signature for `withTransaction()`

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
