### PR TITLE
feat(NODE-4136): revise FLE shared library typings for spec changes

### DIFF
--- a/src/deps.ts
+++ b/src/deps.ts
@@ -277,8 +277,12 @@ export interface AutoEncryptionOptions {
    * Other validation rules in the JSON schema will not be enforced by the driver and will result in an error.
    */
   schemaMap?: Document;
+  /** @experimental */
+  encryptedFieldsMap?: Document;
   /** Allows the user to bypass auto encryption, maintaining implicit decryption */
   bypassAutoEncryption?: boolean;
+  /** @experimental */
+  bypassQueryAnalysis?: boolean;
   options?: {
     /** An optional hook to catch logging messages from the underlying encryption engine */
     logger?: (level: AutoEncryptionLoggerLevel, message: string) => void;

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -313,13 +313,15 @@ export interface AutoEncryptionOptions {
      * If this option is not provided and `csfleRequired` is not specified,
      * the AutoEncrypter will attempt to spawn and/or use mongocryptd according
      * to the mongocryptd-specific `extraOptions` options.
+     *
+     * Specifying a path prevents mongocryptd from being used as a fallback.
      */
     csflePath?: string;
     /**
      * If specified, never use mongocryptd and instead fail when the CSFLE shared library
      * could not be loaded.
      *
-     * This is implied when `csflePath` is specified.
+     * This is always true when `csflePath` is specified.
      */
     csfleRequired?: boolean;
     /**

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -296,13 +296,36 @@ export interface AutoEncryptionOptions {
     /** Command line arguments to use when auto-spawning a mongocryptd */
     mongocryptdSpawnArgs?: string[];
     /**
-     * Full path to a CSFLE shared library to be used (instead of mongocryptd)
-     * @experimental
+     * Full path to a CSFLE shared library to be used (instead of mongocryptd).
+     *
+     * This needs to be the path to the file itself, not a directory.
+     * It can be an absolute or relative path. If the path is relative and
+     * its first component is `$ORIGIN`, it will be replaced by the directory
+     * containing the mongodb-client-encryption native addon file. Otherwise,
+     * the path will be interpreted relative to the current working directory.
+     *
+     * Currently, loading different CSFLE shared library files from different
+     * MongoClients in the same process is not supported.
+     *
+     * If this option is provided and no CSFLE shared library could be loaded
+     * from the specified location, creating the MongoClient will fail.
+     *
+     * If this option is not provided and `csfleRequired` is not specified,
+     * the AutoEncrypter will attempt to spawn and/or use mongocryptd according
+     * to the mongocryptd-specific `extraOptions` options.
      */
     csflePath?: string;
     /**
+     * If specified, never use mongocryptd and instead fail when the CSFLE shared library
+     * could not be loaded.
+     *
+     * This is implied when `csflePath` is specified.
+     */
+    csfleRequired?: boolean;
+    /**
      * Search paths for a CSFLE shared library to be used (instead of mongocryptd)
-     * @experimental
+     * Only for driver testing!
+     * @internal
      */
     csfleSearchPaths?: string[];
   };


### PR DESCRIPTION
### Description

Typings changes for https://github.com/mongodb/libmongocrypt/pull/306

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
