### PR TITLE
chore(NODE-4171): add timestamp breaking change to 4_0_0 migration notes

### DIFF
--- a/etc/notes/CHANGES_4.0.0.md
+++ b/etc/notes/CHANGES_4.0.0.md
@@ -326,7 +326,7 @@ await db.collection('fs.files').updateOne({ _id }, { $set: { md5 } });
 
 ### BSON
 
-> Updated 4/19/2022
+> Updated April 4th, 2022
 
 This version includes an upgrade from js-bson 1.x to js-bson 4.x.
 

--- a/etc/notes/CHANGES_4.0.0.md
+++ b/etc/notes/CHANGES_4.0.0.md
@@ -330,7 +330,7 @@ await db.collection('fs.files').updateOne({ _id }, { $set: { md5 } });
 
 This version includes an upgrade from js-bson 1.x to js-bson 4.x.
 
-#### Timestamps no longer inherit from `Long`
+#### Timestamps math operations return Javascript `Long`s
 
 In versions prior to 4.x of the BSON library, Timestamps were represented with a custom class.  In version 4.x of the BSON library, the Timestamp class was refactored to
 be a subclass of the Javascript Long class.  As a result of this refactor, math operations on Timestamp objects now return Long objects instead of Timestamp objects.

--- a/etc/notes/CHANGES_4.0.0.md
+++ b/etc/notes/CHANGES_4.0.0.md
@@ -328,11 +328,11 @@ await db.collection('fs.files').updateOne({ _id }, { $set: { md5 } });
 
 > Updated 4/19/2022
 
-This version includes an upgrade from BSON 1.x to BSON 4.x.
+This version includes an upgrade from js-bson 1.x to js-bson 4.x.
 
 #### Timestamps no longer inherit from `Long`
 
-In versions prior to 1.x of the BSON library, Timestamps were represented with a custom class.  In version 4.x of the BSON library, the Timestamp class was refactored to
+In versions prior to 4.x of the BSON library, Timestamps were represented with a custom class.  In version 4.x of the BSON library, the Timestamp class was refactored to
 be a subclass of the Javascript Long class.  As a result of this refactor, math operations on Timestamp objects now return Long objects instead of Timestamp objects.
 
 Math operations with Timestamps is not recommended.  However, if Timestamp math must be used, the old behavior can be replicated by using the Timestamp

--- a/etc/notes/CHANGES_4.0.0.md
+++ b/etc/notes/CHANGES_4.0.0.md
@@ -324,6 +324,26 @@ const md5 = await new Promise((resolve, reject) => {
 await db.collection('fs.files').updateOne({ _id }, { $set: { md5 } });
 ```
 
+### BSON
+
+> Updated 4/19/2022
+
+This version includes an upgrade from BSON 1.x to BSON 4.x.
+
+#### Timestamps no longer inherit from `Long`
+
+In versions prior to 1.x of the BSON library, Timestamps were represented with a custom class.  In version 4.x of the BSON library, the Timestamp class was refactored to
+be a subclass of the Javascript Long class.  As a result of this refactor, math operations on Timestamp objects now return Long objects instead of Timestamp objects.
+
+Math operations with Timestamps is not recommended.  However, if Timestamp math must be used, the old behavior can be replicated by using the Timestamp
+constructor, which takes a Long as an argument.
+
+```typescript
+const four = Timestamp.fromNumber(4);
+const five = Timestamp.fromNumber(5);
+const nine = new TimeStamp(four.add(five));
+```
+
 ## Intentional Breaking Changes
 
 - [`NODE-3368`](https://jira.mongodb.org/browse/NODE-3368): make name prop on error classes read-only ([#2879](https://github.com/mongodb/node-mongodb-native/pull/2879))


### PR DESCRIPTION
### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
