### PR TITLE
chore(NODE-4142): bump bson to 4.6.3 and fix broken link in docs

### DIFF
--- a/docs/4.2/index.html
+++ b/docs/4.2/index.html
@@ -3,7 +3,7 @@
   <h1>MongoDB NodeJS Driver</h1>
 </a>
 <p>The official <a href="https://www.mongodb.com/">MongoDB</a> driver for Node.js.</p>
-<p><strong>Upgrading to version 4? Take a look at our <a href="https://github.com/mongodb/node-mongodb-native/blob/HEAD/docs/CHANGES_4.0.0.md">upgrade guide here</a>!</strong></p>
+<p><strong>Upgrading to version 4? Take a look at our <a href="https://github.com/mongodb/node-mongodb-native/blob/HEAD/etc/notes/CHANGES_4.0.0.md">upgrade guide here</a>!</strong></p>
 
 <a href="#quick-links" id="quick-links" style="color: inherit; text-decoration: none;">
   <h2>Quick Links</h2>
@@ -41,7 +41,7 @@
 </tr>
 <tr>
 <td>upgrade to v4</td>
-<td><a href="https://github.com/mongodb/node-mongodb-native/blob/HEAD/docs/CHANGES_4.0.0.md">docs/CHANGES_4.0.0.md</a></td>
+<td><a href="https://github.com/mongodb/node-mongodb-native/blob/HEAD/etc/notes/CHANGES_4.0.0.md">docs/CHANGES_4.0.0.md</a></td>
 </tr>
 <tr>
 <td>contributing</td>

--- a/docs/4.3/index.html
+++ b/docs/4.3/index.html
@@ -3,7 +3,7 @@
   <h1>MongoDB NodeJS Driver</h1>
 </a>
 <p>The official <a href="https://www.mongodb.com/">MongoDB</a> driver for Node.js.</p>
-<p><strong>Upgrading to version 4? Take a look at our <a href="https://github.com/mongodb/node-mongodb-native/blob/HEAD/docs/CHANGES_4.0.0.md">upgrade guide here</a>!</strong></p>
+<p><strong>Upgrading to version 4? Take a look at our <a href="https://github.com/mongodb/node-mongodb-native/blob/HEAD/etc/notes/CHANGES_4.0.0.md">upgrade guide here</a>!</strong></p>
 
 <a href="#quick-links" id="quick-links" style="color: inherit; text-decoration: none;">
   <h2>Quick Links</h2>
@@ -41,7 +41,7 @@
 </tr>
 <tr>
 <td>upgrade to v4</td>
-<td><a href="https://github.com/mongodb/node-mongodb-native/blob/HEAD/docs/CHANGES_4.0.0.md">docs/CHANGES_4.0.0.md</a></td>
+<td><a href="https://github.com/mongodb/node-mongodb-native/blob/HEAD/etc/notes/CHANGES_4.0.0.md">docs/CHANGES_4.0.0.md</a></td>
 </tr>
 <tr>
 <td>contributing</td>

--- a/docs/4.4/index.html
+++ b/docs/4.4/index.html
@@ -3,7 +3,7 @@
   <h1>MongoDB NodeJS Driver</h1>
 </a>
 <p>The official <a href="https://www.mongodb.com/">MongoDB</a> driver for Node.js.</p>
-<p><strong>Upgrading to version 4? Take a look at our <a href="https://github.com/mongodb/node-mongodb-native/blob/HEAD/docs/CHANGES_4.0.0.md">upgrade guide here</a>!</strong></p>
+<p><strong>Upgrading to version 4? Take a look at our <a href="https://github.com/mongodb/node-mongodb-native/blob/HEAD/etc/notes/CHANGES_4.0.0.md">upgrade guide here</a>!</strong></p>
 
 <a href="#quick-links" id="quick-links" style="color: inherit; text-decoration: none;">
   <h2>Quick Links</h2>
@@ -41,7 +41,7 @@
 </tr>
 <tr>
 <td>upgrade to v4</td>
-<td><a href="https://github.com/mongodb/node-mongodb-native/blob/HEAD/docs/CHANGES_4.0.0.md">docs/CHANGES_4.0.0.md</a></td>
+<td><a href="https://github.com/mongodb/node-mongodb-native/blob/HEAD/etc/notes/CHANGES_4.0.0.md">docs/CHANGES_4.0.0.md</a></td>
 </tr>
 <tr>
 <td>contributing</td>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.5.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "bson": "^4.6.2",
+        "bson": "^4.6.3",
         "denque": "^2.0.1",
         "mongodb-connection-string-url": "^2.5.2",
         "socks": "^2.6.2"
@@ -1724,9 +1724,9 @@
       }
     },
     "node_modules/bson": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-4.6.2.tgz",
-      "integrity": "sha512-VeJKHShcu1b/ugl0QiujlVuBepab714X9nNyBdA1kfekuDGecxgpTA2Z6nYbagrWFeiIyzSWIOzju3lhj+RNyQ==",
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.6.3.tgz",
+      "integrity": "sha512-rAqP5hcUVJhXP2MCSNVsf0oM2OGU1So6A9pVRDYayvJ5+hygXHQApf87wd5NlhPM1J9RJnbqxIG/f8QTzRoQ4A==",
       "dependencies": {
         "buffer": "^5.6.0"
       },
@@ -9378,9 +9378,9 @@
       }
     },
     "bson": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-4.6.2.tgz",
-      "integrity": "sha512-VeJKHShcu1b/ugl0QiujlVuBepab714X9nNyBdA1kfekuDGecxgpTA2Z6nYbagrWFeiIyzSWIOzju3lhj+RNyQ==",
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.6.3.tgz",
+      "integrity": "sha512-rAqP5hcUVJhXP2MCSNVsf0oM2OGU1So6A9pVRDYayvJ5+hygXHQApf87wd5NlhPM1J9RJnbqxIG/f8QTzRoQ4A==",
       "requires": {
         "buffer": "^5.6.0"
       }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "email": "dbx-node@mongodb.com"
   },
   "dependencies": {
-    "bson": "^4.6.2",
+    "bson": "^4.6.3",
     "denque": "^2.0.1",
     "mongodb-connection-string-url": "^2.5.2",
     "socks": "^2.6.2"


### PR DESCRIPTION
### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
