### PR TITLE
feat(NODE-4202): add FLE 2 behavior for create/drop collection

### DIFF
--- a/src/encrypter.ts
+++ b/src/encrypter.ts
@@ -72,7 +72,10 @@ export class Encrypter {
     if (internalClient == null) {
       const clonedOptions: MongoClientOptions = {};
 
-      for (const key of Object.keys(options)) {
+      for (const key of [
+        ...Object.getOwnPropertyNames(options),
+        ...Object.getOwnPropertySymbols(options)
+      ] as string[]) {
         if (['autoEncryption', 'minPoolSize', 'servers', 'caseTranslate', 'dbName'].includes(key))
           continue;
         Reflect.set(clonedOptions, key, Reflect.get(options, key));

--- a/src/operations/create_collection.ts
+++ b/src/operations/create_collection.ts
@@ -118,6 +118,10 @@ export class CreateCollectionOperation extends CommandOperation<Collection> {
           const createOp = new CreateCollectionOperation(db, collectionName);
           await createOp.executeWithoutEncryptedFieldsCheck(server, session);
         }
+
+        if (!options.encryptedFields) {
+          this.options = { ...this.options, encryptedFields };
+        }
       }
 
       const coll = await this.executeWithoutEncryptedFieldsCheck(server, session);

--- a/src/operations/create_collection.ts
+++ b/src/operations/create_collection.ts
@@ -110,9 +110,9 @@ export class CreateCollectionOperation extends CommandOperation<Collection> {
 
       if (encryptedFields) {
         // Create auxilliary collections for FLE2 support.
-        const escCollection = encryptedFields.escCollection || `enxcol_.${name}.esc`;
-        const eccCollection = encryptedFields.eccCollection || `enxcol_.${name}.ecc`;
-        const ecocCollection = encryptedFields.ecocCollection || `enxcol_.${name}.ecoc`;
+        const escCollection = encryptedFields.escCollection ?? `enxcol_.${name}.esc`;
+        const eccCollection = encryptedFields.eccCollection ?? `enxcol_.${name}.ecc`;
+        const ecocCollection = encryptedFields.ecocCollection ?? `enxcol_.${name}.ecoc`;
 
         for (const collectionName of [escCollection, eccCollection, ecocCollection]) {
           const createOp = new CreateCollectionOperation(db, collectionName);

--- a/src/operations/create_collection.ts
+++ b/src/operations/create_collection.ts
@@ -124,7 +124,12 @@ export class CreateCollectionOperation extends CommandOperation<Collection> {
 
       if (encryptedFields) {
         // Create the required index for FLE2 support.
-        const createIndexOp = new CreateIndexOperation(db, name, { __safeContent__: 1 }, {});
+        const createIndexOp = new CreateIndexOperation(
+          db,
+          name,
+          { __safeContent__: 1 },
+          { unique: true }
+        );
         await new Promise<void>((resolve, reject) => {
           createIndexOp.execute(server, session, err => (err ? reject(err) : resolve()));
         });

--- a/src/operations/create_collection.ts
+++ b/src/operations/create_collection.ts
@@ -99,99 +99,75 @@ export class CreateCollectionOperation extends CommandOperation<Collection> {
     session: ClientSession | undefined,
     callback: Callback<Collection>
   ): void {
-    const db = this.db;
-    const name = this.name;
-    const options = this.options;
+    (async () => {
+      const db = this.db;
+      const name = this.name;
+      const options = this.options;
 
-    const encryptedFields =
-      options.encryptedFields ??
-      db.s.client.options.autoEncryption?.encryptedFieldsMap?.[`${db.databaseName}.${name}`];
-    if (!encryptedFields) {
-      return this.executeWithoutEncryptedFieldCheck(server, session, callback);
-    }
+      const encryptedFields: Document | undefined =
+        options.encryptedFields ??
+        db.s.client.options.autoEncryption?.encryptedFieldsMap?.[`${db.databaseName}.${name}`];
 
-    const escCollection = encryptedFields.escCollection || `enxcol_.${name}.esc`;
-    const eccCollection = encryptedFields.eccCollection || `enxcol_.${name}.ecc`;
-    const ecocCollection = encryptedFields.ecocCollection || `enxcol_.${name}.ecoc`;
-    new CreateCollectionOperation(db, escCollection).executeWithoutEncryptedFieldCheck(
-      server,
-      session,
-      err => {
-        if (err) {
-          return callback(err);
+      if (encryptedFields) {
+        // Create auxilliary collections for FLE2 support.
+        const escCollection = encryptedFields.escCollection || `enxcol_.${name}.esc`;
+        const eccCollection = encryptedFields.eccCollection || `enxcol_.${name}.ecc`;
+        const ecocCollection = encryptedFields.ecocCollection || `enxcol_.${name}.ecoc`;
+
+        for (const collectionName of [escCollection, eccCollection, ecocCollection]) {
+          const createOp = new CreateCollectionOperation(db, collectionName);
+          await createOp.executeWithoutEncryptedFieldsCheck(server, session);
         }
-
-        new CreateCollectionOperation(db, eccCollection).executeWithoutEncryptedFieldCheck(
-          server,
-          session,
-          err => {
-            if (err) {
-              return callback(err);
-            }
-
-            new CreateCollectionOperation(db, ecocCollection).executeWithoutEncryptedFieldCheck(
-              server,
-              session,
-              err => {
-                if (err) {
-                  return callback(err);
-                }
-
-                this.executeWithoutEncryptedFieldCheck(server, session, (err, coll) => {
-                  if (err) {
-                    return callback(err);
-                  }
-
-                  new CreateIndexOperation(db, name, { __safeContent__: 1 }, {}).execute(
-                    server,
-                    session,
-                    err => {
-                      if (err) {
-                        return callback(err);
-                      }
-
-                      return callback(undefined, coll);
-                    }
-                  );
-                });
-              }
-            );
-          }
-        );
       }
+
+      const coll = await this.executeWithoutEncryptedFieldsCheck(server, session);
+
+      if (encryptedFields) {
+        // Create the required index for FLE2 support.
+        const createIndexOp = new CreateIndexOperation(db, name, { __safeContent__: 1 }, {});
+        await new Promise<void>((resolve, reject) => {
+          createIndexOp.execute(server, session, err => (err ? reject(err) : resolve()));
+        });
+      }
+
+      return coll;
+    })().then(
+      coll => callback(undefined, coll),
+      err => callback(err)
     );
   }
 
-  private executeWithoutEncryptedFieldCheck(
+  private executeWithoutEncryptedFieldsCheck(
     server: Server,
-    session: ClientSession | undefined,
-    callback: Callback<Collection>
-  ): void {
-    const db = this.db;
-    const name = this.name;
-    const options = this.options;
+    session: ClientSession | undefined
+  ): Promise<Collection> {
+    return new Promise<Collection>((resolve, reject) => {
+      const db = this.db;
+      const name = this.name;
+      const options = this.options;
 
-    const done: Callback = err => {
-      if (err) {
-        return callback(err);
+      const done: Callback = err => {
+        if (err) {
+          return reject(err);
+        }
+
+        resolve(new Collection(db, name, options));
+      };
+
+      const cmd: Document = { create: name };
+      for (const n in options) {
+        if (
+          (options as any)[n] != null &&
+          typeof (options as any)[n] !== 'function' &&
+          !ILLEGAL_COMMAND_FIELDS.has(n)
+        ) {
+          cmd[n] = (options as any)[n];
+        }
       }
 
-      callback(undefined, new Collection(db, name, options));
-    };
-
-    const cmd: Document = { create: name };
-    for (const n in options) {
-      if (
-        (options as any)[n] != null &&
-        typeof (options as any)[n] !== 'function' &&
-        !ILLEGAL_COMMAND_FIELDS.has(n)
-      ) {
-        cmd[n] = (options as any)[n];
-      }
-    }
-
-    // otherwise just execute the command
-    super.executeCommand(server, session, cmd, done);
+      // otherwise just execute the command
+      super.executeCommand(server, session, cmd, done);
+    });
   }
 }
 

--- a/src/operations/create_collection.ts
+++ b/src/operations/create_collection.ts
@@ -124,12 +124,7 @@ export class CreateCollectionOperation extends CommandOperation<Collection> {
 
       if (encryptedFields) {
         // Create the required index for FLE2 support.
-        const createIndexOp = new CreateIndexOperation(
-          db,
-          name,
-          { __safeContent__: 1 },
-          { unique: true }
-        );
+        const createIndexOp = new CreateIndexOperation(db, name, { __safeContent__: 1 }, {});
         await new Promise<void>((resolve, reject) => {
           createIndexOp.execute(server, session, err => (err ? reject(err) : resolve()));
         });

--- a/src/operations/drop.ts
+++ b/src/operations/drop.ts
@@ -79,7 +79,10 @@ export class DropCollectionOperation extends CommandOperation<boolean> {
           try {
             await dropOp.executeWithoutEncryptedFieldsCheck(server, session);
           } catch (err) {
-            if ((err instanceof MongoServerError && err.code !== MONGODB_ERROR_CODES.NamespaceNotFound)) {
+            if (
+              err instanceof MongoServerError &&
+              err.code !== MONGODB_ERROR_CODES.NamespaceNotFound
+            ) {
               throw err;
             }
           }

--- a/src/operations/drop.ts
+++ b/src/operations/drop.ts
@@ -58,7 +58,8 @@ export class DropCollectionOperation extends CommandOperation<boolean> {
       } catch (err) {
         if (
           !encryptedFields ||
-          (err instanceof MongoServerError && err.code !== MONGODB_ERROR_CODES.NamespaceNotFound)
+          !(err instanceof MongoServerError) ||
+          err.code !== MONGODB_ERROR_CODES.NamespaceNotFound
         ) {
           throw err;
         }
@@ -80,7 +81,7 @@ export class DropCollectionOperation extends CommandOperation<boolean> {
             await dropOp.executeWithoutEncryptedFieldsCheck(server, session);
           } catch (err) {
             if (
-              err instanceof MongoServerError &&
+              !(err instanceof MongoServerError) ||
               err.code !== MONGODB_ERROR_CODES.NamespaceNotFound
             ) {
               throw err;

--- a/src/operations/drop.ts
+++ b/src/operations/drop.ts
@@ -58,7 +58,7 @@ export class DropCollectionOperation extends CommandOperation<boolean> {
       } catch (err) {
         if (
           !encryptedFields ||
-          (err as MongoServerError).code !== MONGODB_ERROR_CODES.NamespaceNotFound
+          (err instanceof MongoServerError && err.code !== MONGODB_ERROR_CODES.NamespaceNotFound)
         ) {
           throw err;
         }
@@ -79,7 +79,7 @@ export class DropCollectionOperation extends CommandOperation<boolean> {
           try {
             await dropOp.executeWithoutEncryptedFieldsCheck(server, session);
           } catch (err) {
-            if ((err as MongoServerError).code !== MONGODB_ERROR_CODES.NamespaceNotFound) {
+            if ((err instanceof MongoServerError && err.code !== MONGODB_ERROR_CODES.NamespaceNotFound)) {
               throw err;
             }
           }

--- a/src/operations/drop.ts
+++ b/src/operations/drop.ts
@@ -1,4 +1,6 @@
+import type { Document } from '../bson';
 import type { Db } from '../db';
+import { MONGODB_ERROR_CODES, MongoServerError } from '../error';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
 import type { Callback } from '../utils';
@@ -6,20 +8,105 @@ import { CommandOperation, CommandOperationOptions } from './command';
 import { Aspect, defineAspects } from './operation';
 
 /** @public */
-export type DropCollectionOptions = CommandOperationOptions;
+export interface DropCollectionOptions extends CommandOperationOptions {
+  /** @experimental */
+  encryptedFields?: Document;
+}
 
 /** @internal */
 export class DropCollectionOperation extends CommandOperation<boolean> {
   override options: DropCollectionOptions;
+  db: Db;
   name: string;
 
-  constructor(db: Db, name: string, options: DropCollectionOptions) {
+  constructor(db: Db, name: string, options: DropCollectionOptions = {}) {
     super(db, options);
+    this.db = db;
     this.options = options;
     this.name = name;
   }
 
   override execute(
+    server: Server,
+    session: ClientSession | undefined,
+    callback: Callback<boolean>
+  ): void {
+    const db = this.db;
+    const options = this.options;
+    const name = this.name;
+    const encryptedFieldsMap = db.s.client.options.autoEncryption?.encryptedFieldsMap;
+    let encryptedFields: Document | undefined =
+      options.encryptedFields ?? encryptedFieldsMap?.[`${db.databaseName}.${name}`];
+    if (!encryptedFields && encryptedFieldsMap) {
+      db.listCollections({ name }, { nameOnly: false }).toArray((err, result) => {
+        if (err) {
+          return callback(err);
+        }
+
+        encryptedFields = result?.[0]?.options?.encryptedFields;
+        proceedAfterFetchingEncryptedFields(this);
+      });
+    } else {
+      proceedAfterFetchingEncryptedFields(this);
+    }
+
+    function proceedAfterFetchingEncryptedFields(self: DropCollectionOperation) {
+      self.executeWithoutEncryptedFieldsCheck(server, session, (err, result) => {
+        if (err && (err as MongoServerError).code !== MONGODB_ERROR_CODES.NamespaceNotFound) {
+          return callback(err);
+        }
+
+        if (!encryptedFields) {
+          return callback(err, result);
+        }
+
+        const errorForMainOperation = err;
+
+        const escCollection = encryptedFields.escCollection || `enxcol_.${name}.esc`;
+        const eccCollection = encryptedFields.eccCollection || `enxcol_.${name}.ecc`;
+        const ecocCollection = encryptedFields.ecocCollection || `enxcol_.${name}.ecoc`;
+        new DropCollectionOperation(db, escCollection).executeWithoutEncryptedFieldsCheck(
+          server,
+          session,
+          err => {
+            if (err && (err as MongoServerError).code !== MONGODB_ERROR_CODES.NamespaceNotFound) {
+              return callback(err);
+            }
+
+            new DropCollectionOperation(db, eccCollection).executeWithoutEncryptedFieldsCheck(
+              server,
+              session,
+              err => {
+                if (
+                  err &&
+                  (err as MongoServerError).code !== MONGODB_ERROR_CODES.NamespaceNotFound
+                ) {
+                  return callback(err);
+                }
+
+                new DropCollectionOperation(db, ecocCollection).executeWithoutEncryptedFieldsCheck(
+                  server,
+                  session,
+                  err => {
+                    if (
+                      err &&
+                      (err as MongoServerError).code !== MONGODB_ERROR_CODES.NamespaceNotFound
+                    ) {
+                      return callback(err);
+                    }
+
+                    return callback(errorForMainOperation, result);
+                  }
+                );
+              }
+            );
+          }
+        );
+      });
+    }
+  }
+
+  private executeWithoutEncryptedFieldsCheck(
     server: Server,
     session: ClientSession | undefined,
     callback: Callback<boolean>

--- a/test/spec/client-side-encryption/tests/fle2-CreateCollection.json
+++ b/test/spec/client-side-encryption/tests/fle2-CreateCollection.json
@@ -1,0 +1,1917 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "6.0.0",
+      "topology": [
+        "replicaset",
+        "sharded"
+      ]
+    }
+  ],
+  "database_name": "default",
+  "collection_name": "default",
+  "tests": [
+    {
+      "description": "state collections and index are created",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "aws": {}
+          },
+          "encryptedFieldsMap": {
+            "default.encryptedCollection": {
+              "escCollection": "encryptedCollection.esc",
+              "eccCollection": "encryptedCollection.ecc",
+              "ecocCollection": "encryptedCollection.ecoc",
+              "fields": [
+                {
+                  "path": "firstName",
+                  "bsonType": "string",
+                  "keyId": {
+                    "$binary": {
+                      "subType": "04",
+                      "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection.esc"
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection.ecc"
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection.ecoc"
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "assertIndexExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection",
+            "index": "__safeContent___1"
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection"
+            },
+            "commandName": "drop",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection.esc"
+            },
+            "commandName": "drop",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection.ecc"
+            },
+            "commandName": "drop",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection.ecoc"
+            },
+            "commandName": "drop",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "encryptedCollection.esc"
+            },
+            "commandName": "create",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "encryptedCollection.ecc"
+            },
+            "commandName": "create",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "encryptedCollection.ecoc"
+            },
+            "commandName": "create",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "encryptedCollection"
+            },
+            "commandName": "create",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "createIndexes": "encryptedCollection",
+              "indexes": [
+                {
+                  "name": "__safeContent___1",
+                  "key": {
+                    "__safeContent__": 1
+                  }
+                }
+              ]
+            },
+            "commandName": "createIndexes",
+            "databaseName": "default"
+          }
+        }
+      ]
+    },
+    {
+      "description": "default state collection names are applied",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "aws": {}
+          },
+          "encryptedFieldsMap": {
+            "default.encryptedCollection": {
+              "fields": [
+                {
+                  "path": "firstName",
+                  "bsonType": "string",
+                  "keyId": {
+                    "$binary": {
+                      "subType": "04",
+                      "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
+                    }
+                  },
+                  "queries": {
+                    "queryType": "equality",
+                    "contention": {
+                      "$numberLong": "0"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "enxcol_.encryptedCollection.esc"
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "enxcol_.encryptedCollection.ecc"
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "enxcol_.encryptedCollection.ecoc"
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "assertIndexExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection",
+            "index": "__safeContent___1"
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection"
+            },
+            "commandName": "drop",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "enxcol_.encryptedCollection.esc"
+            },
+            "commandName": "drop",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "enxcol_.encryptedCollection.ecc"
+            },
+            "commandName": "drop",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "enxcol_.encryptedCollection.ecoc"
+            },
+            "commandName": "drop",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "enxcol_.encryptedCollection.esc"
+            },
+            "commandName": "create",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "enxcol_.encryptedCollection.ecc"
+            },
+            "commandName": "create",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "enxcol_.encryptedCollection.ecoc"
+            },
+            "commandName": "create",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "encryptedCollection"
+            },
+            "commandName": "create",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "createIndexes": "encryptedCollection",
+              "indexes": [
+                {
+                  "name": "__safeContent___1",
+                  "key": {
+                    "__safeContent__": 1
+                  }
+                }
+              ]
+            },
+            "commandName": "createIndexes",
+            "databaseName": "default"
+          }
+        }
+      ]
+    },
+    {
+      "description": "drop removes all state collections",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "aws": {}
+          },
+          "encryptedFieldsMap": {
+            "default.encryptedCollection": {
+              "fields": [
+                {
+                  "path": "firstName",
+                  "bsonType": "string",
+                  "keyId": {
+                    "$binary": {
+                      "subType": "04",
+                      "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
+                    }
+                  },
+                  "queries": {
+                    "queryType": "equality",
+                    "contention": {
+                      "$numberLong": "0"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "enxcol_.encryptedCollection.esc"
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "enxcol_.encryptedCollection.ecc"
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "enxcol_.encryptedCollection.ecoc"
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "assertIndexExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection",
+            "index": "__safeContent___1"
+          }
+        },
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "assertCollectionNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "enxcol_.encryptedCollection.ecc"
+          }
+        },
+        {
+          "name": "assertCollectionNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "enxcol_.encryptedCollection.ecoc"
+          }
+        },
+        {
+          "name": "assertCollectionNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "assertIndexNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection",
+            "index": "__safeContent___1"
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection"
+            },
+            "commandName": "drop",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "enxcol_.encryptedCollection.esc"
+            },
+            "commandName": "drop",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "enxcol_.encryptedCollection.ecc"
+            },
+            "commandName": "drop",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "enxcol_.encryptedCollection.ecoc"
+            },
+            "commandName": "drop",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "enxcol_.encryptedCollection.esc"
+            },
+            "commandName": "create",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "enxcol_.encryptedCollection.ecc"
+            },
+            "commandName": "create",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "enxcol_.encryptedCollection.ecoc"
+            },
+            "commandName": "create",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "encryptedCollection"
+            },
+            "commandName": "create",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "createIndexes": "encryptedCollection",
+              "indexes": [
+                {
+                  "name": "__safeContent___1",
+                  "key": {
+                    "__safeContent__": 1
+                  }
+                }
+              ]
+            },
+            "commandName": "createIndexes",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection"
+            },
+            "commandName": "drop",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "enxcol_.encryptedCollection.esc"
+            },
+            "commandName": "drop",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "enxcol_.encryptedCollection.ecc"
+            },
+            "commandName": "drop",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "enxcol_.encryptedCollection.ecoc"
+            },
+            "commandName": "drop",
+            "databaseName": "default"
+          }
+        }
+      ]
+    },
+    {
+      "description": "encryptedFieldsMap with cyclic entries does not loop",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "aws": {}
+          },
+          "encryptedFieldsMap": {
+            "default.encryptedCollection": {
+              "escCollection": "encryptedCollection.esc",
+              "eccCollection": "encryptedCollection.ecc",
+              "ecocCollection": "encryptedCollection.ecoc",
+              "fields": [
+                {
+                  "path": "firstName",
+                  "bsonType": "string",
+                  "keyId": {
+                    "$binary": {
+                      "subType": "04",
+                      "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
+                    }
+                  }
+                }
+              ]
+            },
+            "default.encryptedCollection.esc": {
+              "escCollection": "encryptedCollection",
+              "eccCollection": "encryptedCollection.ecc",
+              "ecocCollection": "encryptedCollection.ecoc",
+              "fields": [
+                {
+                  "path": "firstName",
+                  "bsonType": "string",
+                  "keyId": {
+                    "$binary": {
+                      "subType": "04",
+                      "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection.esc"
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection.ecc"
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection.ecoc"
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "assertIndexExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection",
+            "index": "__safeContent___1"
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection"
+            },
+            "commandName": "drop",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection.esc"
+            },
+            "commandName": "drop",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection.ecc"
+            },
+            "commandName": "drop",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection.ecoc"
+            },
+            "commandName": "drop",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "encryptedCollection.esc"
+            },
+            "commandName": "create",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "encryptedCollection.ecc"
+            },
+            "commandName": "create",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "encryptedCollection.ecoc"
+            },
+            "commandName": "create",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "encryptedCollection"
+            },
+            "commandName": "create",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "createIndexes": "encryptedCollection",
+              "indexes": [
+                {
+                  "name": "__safeContent___1",
+                  "key": {
+                    "__safeContent__": 1
+                  }
+                }
+              ]
+            },
+            "commandName": "createIndexes",
+            "databaseName": "default"
+          }
+        }
+      ]
+    },
+    {
+      "description": "CreateCollection without encryptedFields.",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "aws": {}
+          },
+          "encryptedFieldsMap": {
+            "default.encryptedCollection": {
+              "escCollection": "encryptedCollection.esc",
+              "eccCollection": "encryptedCollection.ecc",
+              "ecocCollection": "encryptedCollection.ecoc",
+              "fields": [
+                {
+                  "path": "firstName",
+                  "bsonType": "string",
+                  "keyId": {
+                    "$binary": {
+                      "subType": "04",
+                      "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "plaintextCollection"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "plaintextCollection"
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "plaintextCollection"
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "listCollections": 1,
+              "filter": {
+                "name": "plaintextCollection"
+              }
+            },
+            "commandName": "listCollections",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "plaintextCollection"
+            },
+            "commandName": "drop",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "plaintextCollection"
+            },
+            "commandName": "create",
+            "databaseName": "default"
+          }
+        }
+      ]
+    },
+    {
+      "description": "CreateCollection from encryptedFieldsMap.",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "aws": {}
+          },
+          "encryptedFieldsMap": {
+            "default.encryptedCollection": {
+              "escCollection": "encryptedCollection.esc",
+              "eccCollection": "encryptedCollection.ecc",
+              "ecocCollection": "encryptedCollection.ecoc",
+              "fields": [
+                {
+                  "path": "firstName",
+                  "bsonType": "string",
+                  "keyId": {
+                    "$binary": {
+                      "subType": "04",
+                      "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection.esc"
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection.ecc"
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection.ecoc"
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "assertIndexExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection",
+            "index": "__safeContent___1"
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection"
+            },
+            "commandName": "drop",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection.esc"
+            },
+            "commandName": "drop",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection.ecc"
+            },
+            "commandName": "drop",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection.ecoc"
+            },
+            "commandName": "drop",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "encryptedCollection.esc"
+            },
+            "commandName": "create",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "encryptedCollection.ecc"
+            },
+            "commandName": "create",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "encryptedCollection.ecoc"
+            },
+            "commandName": "create",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "encryptedCollection"
+            },
+            "commandName": "create",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "createIndexes": "encryptedCollection",
+              "indexes": [
+                {
+                  "name": "__safeContent___1",
+                  "key": {
+                    "__safeContent__": 1
+                  }
+                }
+              ]
+            },
+            "commandName": "createIndexes",
+            "databaseName": "default"
+          }
+        }
+      ]
+    },
+    {
+      "description": "CreateCollection from encryptedFields.",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "aws": {}
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection",
+            "encryptedFields": {
+              "escCollection": "encryptedCollection.esc",
+              "eccCollection": "encryptedCollection.ecc",
+              "ecocCollection": "encryptedCollection.ecoc",
+              "fields": [
+                {
+                  "path": "firstName",
+                  "bsonType": "string",
+                  "keyId": {
+                    "$binary": {
+                      "subType": "04",
+                      "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection",
+            "encryptedFields": {
+              "escCollection": "encryptedCollection.esc",
+              "eccCollection": "encryptedCollection.ecc",
+              "ecocCollection": "encryptedCollection.ecoc",
+              "fields": [
+                {
+                  "path": "firstName",
+                  "bsonType": "string",
+                  "keyId": {
+                    "$binary": {
+                      "subType": "04",
+                      "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection.esc"
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection.ecc"
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection.ecoc"
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "assertIndexExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection",
+            "index": "__safeContent___1"
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection"
+            },
+            "commandName": "drop",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection.esc"
+            },
+            "commandName": "drop",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection.ecc"
+            },
+            "commandName": "drop",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection.ecoc"
+            },
+            "commandName": "drop",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "encryptedCollection.esc"
+            },
+            "commandName": "create",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "encryptedCollection.ecc"
+            },
+            "commandName": "create",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "encryptedCollection.ecoc"
+            },
+            "commandName": "create",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "encryptedCollection"
+            },
+            "commandName": "create",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "createIndexes": "encryptedCollection",
+              "indexes": [
+                {
+                  "name": "__safeContent___1",
+                  "key": {
+                    "__safeContent__": 1
+                  }
+                }
+              ]
+            },
+            "commandName": "createIndexes",
+            "databaseName": "default"
+          }
+        }
+      ]
+    },
+    {
+      "description": "DropCollection from encryptedFieldsMap",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "aws": {}
+          },
+          "encryptedFieldsMap": {
+            "default.encryptedCollection": {
+              "escCollection": "encryptedCollection.esc",
+              "eccCollection": "encryptedCollection.ecc",
+              "ecocCollection": "encryptedCollection.ecoc",
+              "fields": [
+                {
+                  "path": "firstName",
+                  "bsonType": "string",
+                  "keyId": {
+                    "$binary": {
+                      "subType": "04",
+                      "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection"
+            },
+            "commandName": "drop",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection.esc"
+            },
+            "commandName": "drop",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection.ecc"
+            },
+            "commandName": "drop",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection.ecoc"
+            },
+            "commandName": "drop",
+            "databaseName": "default"
+          }
+        }
+      ]
+    },
+    {
+      "description": "DropCollection from encryptedFields",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "aws": {}
+          },
+          "encryptedFieldsMap": {}
+        }
+      },
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection",
+            "encryptedFields": {
+              "escCollection": "encryptedCollection.esc",
+              "eccCollection": "encryptedCollection.ecc",
+              "ecocCollection": "encryptedCollection.ecoc",
+              "fields": [
+                {
+                  "path": "firstName",
+                  "bsonType": "string",
+                  "keyId": {
+                    "$binary": {
+                      "subType": "04",
+                      "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection",
+            "encryptedFields": {
+              "escCollection": "encryptedCollection.esc",
+              "eccCollection": "encryptedCollection.ecc",
+              "ecocCollection": "encryptedCollection.ecoc",
+              "fields": [
+                {
+                  "path": "firstName",
+                  "bsonType": "string",
+                  "keyId": {
+                    "$binary": {
+                      "subType": "04",
+                      "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection.esc"
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection.ecc"
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection.ecoc"
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "assertIndexExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection",
+            "index": "__safeContent___1"
+          }
+        },
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection",
+            "encryptedFields": {
+              "escCollection": "encryptedCollection.esc",
+              "eccCollection": "encryptedCollection.ecc",
+              "ecocCollection": "encryptedCollection.ecoc",
+              "fields": [
+                {
+                  "path": "firstName",
+                  "bsonType": "string",
+                  "keyId": {
+                    "$binary": {
+                      "subType": "04",
+                      "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "assertCollectionNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection.esc"
+          }
+        },
+        {
+          "name": "assertCollectionNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection.ecc"
+          }
+        },
+        {
+          "name": "assertCollectionNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection.ecoc"
+          }
+        },
+        {
+          "name": "assertCollectionNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection"
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection"
+            },
+            "commandName": "drop",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection.esc"
+            },
+            "commandName": "drop",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection.ecc"
+            },
+            "commandName": "drop",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection.ecoc"
+            },
+            "commandName": "drop",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "encryptedCollection.esc"
+            },
+            "commandName": "create",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "encryptedCollection.ecc"
+            },
+            "commandName": "create",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "encryptedCollection.ecoc"
+            },
+            "commandName": "create",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "encryptedCollection"
+            },
+            "commandName": "create",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "createIndexes": "encryptedCollection",
+              "indexes": [
+                {
+                  "name": "__safeContent___1",
+                  "key": {
+                    "__safeContent__": 1
+                  }
+                }
+              ]
+            },
+            "commandName": "createIndexes",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection"
+            },
+            "commandName": "drop",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection.esc"
+            },
+            "commandName": "drop",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection.ecc"
+            },
+            "commandName": "drop",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection.ecoc"
+            },
+            "commandName": "drop",
+            "databaseName": "default"
+          }
+        }
+      ]
+    },
+    {
+      "description": "DropCollection from remote encryptedFields",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "aws": {}
+          },
+          "encryptedFieldsMap": {}
+        }
+      },
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection",
+            "encryptedFields": {
+              "escCollection": "encryptedCollection.esc",
+              "eccCollection": "encryptedCollection.ecc",
+              "ecocCollection": "encryptedCollection.ecoc",
+              "fields": [
+                {
+                  "path": "firstName",
+                  "bsonType": "string",
+                  "keyId": {
+                    "$binary": {
+                      "subType": "04",
+                      "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection",
+            "encryptedFields": {
+              "escCollection": "encryptedCollection.esc",
+              "eccCollection": "encryptedCollection.ecc",
+              "ecocCollection": "encryptedCollection.ecoc",
+              "fields": [
+                {
+                  "path": "firstName",
+                  "bsonType": "string",
+                  "keyId": {
+                    "$binary": {
+                      "subType": "04",
+                      "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection.esc"
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection.ecc"
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection.ecoc"
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "assertIndexExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection",
+            "index": "__safeContent___1"
+          }
+        },
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "assertCollectionNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection.esc"
+          }
+        },
+        {
+          "name": "assertCollectionNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection.ecc"
+          }
+        },
+        {
+          "name": "assertCollectionNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection.ecoc"
+          }
+        },
+        {
+          "name": "assertCollectionNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection"
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection"
+            },
+            "commandName": "drop",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection.esc"
+            },
+            "commandName": "drop",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection.ecc"
+            },
+            "commandName": "drop",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection.ecoc"
+            },
+            "commandName": "drop",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "encryptedCollection.esc"
+            },
+            "commandName": "create",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "encryptedCollection.ecc"
+            },
+            "commandName": "create",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "encryptedCollection.ecoc"
+            },
+            "commandName": "create",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "encryptedCollection"
+            },
+            "commandName": "create",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "createIndexes": "encryptedCollection",
+              "indexes": [
+                {
+                  "name": "__safeContent___1",
+                  "key": {
+                    "__safeContent__": 1
+                  }
+                }
+              ]
+            },
+            "commandName": "createIndexes",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "listCollections": 1,
+              "filter": {
+                "name": "encryptedCollection"
+              }
+            },
+            "commandName": "listCollections",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection"
+            },
+            "commandName": "drop",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection.esc"
+            },
+            "commandName": "drop",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection.ecc"
+            },
+            "commandName": "drop",
+            "databaseName": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection.ecoc"
+            },
+            "commandName": "drop",
+            "databaseName": "default"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/client-side-encryption/tests/fle2-CreateCollection.yml
+++ b/test/spec/client-side-encryption/tests/fle2-CreateCollection.yml
@@ -1,0 +1,1209 @@
+runOn:
+  - minServerVersion: "6.0.0"
+    # FLE 2 Encrypted collections are not supported on standalone.
+    topology: [ "replicaset", "sharded" ]
+    
+database_name: &database_name "default"
+collection_name: &collection_name "default"
+
+tests:
+  - description: "state collections and index are created"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          aws: {} # Credentials filled in from environment.
+        encryptedFieldsMap:
+          default.encryptedCollection: {
+                "escCollection": "encryptedCollection.esc",
+                "eccCollection": "encryptedCollection.ecc",
+                "ecocCollection": "encryptedCollection.ecoc",
+                "fields": [
+                    {
+                        "path": "firstName",
+                        "bsonType": "string",
+                        "keyId": { "$binary": { "subType": "04", "base64": "AAAAAAAAAAAAAAAAAAAAAA==" }}
+                    }
+                ]
+            }
+
+    operations:
+      # Do an initial drop to remove collections that may exist from previous test runs.
+      - name: dropCollection
+        object: database
+        arguments:
+          collection: "encryptedCollection"
+      - name: createCollection
+        object: database
+        arguments:
+          collection: "encryptedCollection"
+      - name: assertCollectionExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: "encryptedCollection.esc"
+      - name: assertCollectionExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: "encryptedCollection.ecc"
+      - name: assertCollectionExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: "encryptedCollection.ecoc"
+      - name: assertCollectionExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: "encryptedCollection"
+      - name: assertIndexExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: "encryptedCollection"
+          index: __safeContent___1
+
+    expectations:
+        # events from dropCollection ... begin
+        - command_started_event:
+            command:
+              drop: "encryptedCollection"
+            commandName: drop
+            databaseName: *database_name
+        - command_started_event:
+            command:
+              drop: "encryptedCollection.esc"
+            commandName: drop
+            databaseName: *database_name
+        - command_started_event:
+            command:
+              drop: "encryptedCollection.ecc"
+            commandName: drop
+            databaseName: *database_name
+        - command_started_event:
+            command:
+              drop: "encryptedCollection.ecoc"
+            commandName: drop
+            databaseName: *database_name
+        # events from dropCollection ... end
+        # events from createCollection ... begin
+        # State collections are created first.
+        - command_started_event:
+            command:
+              create: "encryptedCollection.esc"
+            commandName: create
+            databaseName: *database_name
+        - command_started_event:
+            command:
+              create: "encryptedCollection.ecc"
+            commandName: create
+            databaseName: *database_name
+        - command_started_event:
+            command:
+              create: "encryptedCollection.ecoc"
+            commandName: create
+            databaseName: *database_name
+        # Data collection is created after.
+        - command_started_event:
+            command:
+              create: "encryptedCollection"
+            commandName: create
+            databaseName: *database_name
+        # Index on __safeContents__ is then created.
+        - command_started_event:
+            command:
+              createIndexes: "encryptedCollection"
+              indexes:
+                - name: __safeContent___1
+                  key: { __safeContent__: 1 }
+            commandName: createIndexes
+            databaseName: *database_name
+        # events from createCollection ... end
+  - description: "default state collection names are applied"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          aws: {} # Credentials filled in from environment.
+        encryptedFieldsMap:
+          default.encryptedCollection: {
+                "fields": [
+                    {
+                        "path": "firstName",
+                        "bsonType": "string",
+                        "keyId": { "$binary": { "subType": "04", "base64": "AAAAAAAAAAAAAAAAAAAAAA==" }},
+                        "queries": {
+                            "queryType": "equality",
+                            "contention": {
+                                "$numberLong": "0"
+                            }
+                        }
+                    }
+                ]
+            }
+
+    operations:
+      # Do an initial drop to remove collections that may exist from previous test runs.
+      - name: dropCollection
+        object: database
+        arguments:
+          collection: "encryptedCollection"
+      - name: createCollection
+        object: database
+        arguments:
+          collection: "encryptedCollection"
+      - name: assertCollectionExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: "enxcol_.encryptedCollection.esc"
+      - name: assertCollectionExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: "enxcol_.encryptedCollection.ecc"
+      - name: assertCollectionExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: "enxcol_.encryptedCollection.ecoc"
+      - name: assertCollectionExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: "encryptedCollection"
+      - name: assertIndexExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: "encryptedCollection"
+          index: __safeContent___1
+      
+    expectations:
+        # events from dropCollection ... begin
+        - command_started_event:
+            command:
+              drop: "encryptedCollection"
+            commandName: drop
+            databaseName: *database_name
+        - command_started_event:
+            command:
+              drop: "enxcol_.encryptedCollection.esc"
+            commandName: drop
+            databaseName: *database_name
+        - command_started_event:
+            command:
+              drop: "enxcol_.encryptedCollection.ecc"
+            commandName: drop
+            databaseName: *database_name
+        - command_started_event:
+            command:
+              drop: "enxcol_.encryptedCollection.ecoc"
+            commandName: drop
+            databaseName: *database_name
+        # events from dropCollection ... end
+        # events from createCollection ... begin
+        # State collections are created first.
+        - command_started_event:
+            command:
+              create: "enxcol_.encryptedCollection.esc"
+            commandName: create
+            databaseName: *database_name
+        - command_started_event:
+            command:
+              create: "enxcol_.encryptedCollection.ecc"
+            commandName: create
+            databaseName: *database_name
+        - command_started_event:
+            command:
+              create: "enxcol_.encryptedCollection.ecoc"
+            commandName: create
+            databaseName: *database_name
+        # Data collection is created after.
+        - command_started_event:
+            command:
+              create: "encryptedCollection"
+            commandName: create
+            databaseName: *database_name
+        # Index on __safeContents__ is then created.
+        - command_started_event:
+            command:
+              createIndexes: "encryptedCollection"
+              indexes:
+                - name: __safeContent___1
+                  key: { __safeContent__: 1 }
+            commandName: createIndexes
+            databaseName: *database_name
+        # events from createCollection ... end
+  - description: "drop removes all state collections"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          aws: {} # Credentials filled in from environment.
+        encryptedFieldsMap:
+          default.encryptedCollection: {
+                "fields": [
+                    {
+                        "path": "firstName",
+                        "bsonType": "string",
+                        "keyId": { "$binary": { "subType": "04", "base64": "AAAAAAAAAAAAAAAAAAAAAA==" }},
+                        "queries": {
+                            "queryType": "equality",
+                            "contention": {
+                                "$numberLong": "0"
+                            }
+                        }
+                    }
+                ]
+            }
+
+    operations:
+      # Do an initial drop to remove collections that may exist from previous test runs.
+      - name: dropCollection
+        object: database
+        arguments:
+          collection: "encryptedCollection"
+      - name: createCollection
+        object: database
+        arguments:
+          collection: "encryptedCollection"
+      - name: assertCollectionExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: "enxcol_.encryptedCollection.esc"
+      - name: assertCollectionExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: "enxcol_.encryptedCollection.ecc"
+      - name: assertCollectionExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: "enxcol_.encryptedCollection.ecoc"
+      - name: assertCollectionExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: "encryptedCollection"
+      - name: assertIndexExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: "encryptedCollection"
+          index: __safeContent___1
+      - name: dropCollection
+        object: database
+        arguments:
+          collection: "encryptedCollection"
+      - name: assertCollectionNotExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: "enxcol_.encryptedCollection.ecc"
+      - name: assertCollectionNotExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: "enxcol_.encryptedCollection.ecoc"
+      - name: assertCollectionNotExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: "encryptedCollection"
+      - name: assertIndexNotExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: "encryptedCollection"
+          index: __safeContent___1
+      
+    expectations:
+        # events from dropCollection ... begin
+        - command_started_event:
+            command:
+              drop: "encryptedCollection"
+            commandName: drop
+            databaseName: *database_name
+        - command_started_event:
+            command:
+              drop: "enxcol_.encryptedCollection.esc"
+            commandName: drop
+            databaseName: *database_name
+        - command_started_event:
+            command:
+              drop: "enxcol_.encryptedCollection.ecc"
+            commandName: drop
+            databaseName: *database_name
+        - command_started_event:
+            command:
+              drop: "enxcol_.encryptedCollection.ecoc"
+            commandName: drop
+            databaseName: *database_name
+        # events from dropCollection ... end
+        # events from createCollection ... begin
+        # State collections are created first.
+        - command_started_event:
+            command:
+              create: "enxcol_.encryptedCollection.esc"
+            commandName: create
+            databaseName: *database_name
+        - command_started_event:
+            command:
+              create: "enxcol_.encryptedCollection.ecc"
+            commandName: create
+            databaseName: *database_name
+        - command_started_event:
+            command:
+              create: "enxcol_.encryptedCollection.ecoc"
+            commandName: create
+            databaseName: *database_name
+        # Data collection is created after.
+        - command_started_event:
+            command:
+              create: "encryptedCollection"
+            commandName: create
+            databaseName: *database_name
+        # Index on __safeContents__ is then created.
+        - command_started_event:
+            command:
+              createIndexes: "encryptedCollection"
+              indexes:
+                - name: __safeContent___1
+                  key: { __safeContent__: 1 }
+            commandName: createIndexes
+            databaseName: *database_name
+        # events from createCollection ... end
+        # events from dropCollection ... begin
+        - command_started_event:
+            command:
+              drop: "encryptedCollection"
+            commandName: drop
+            databaseName: *database_name
+        - command_started_event:
+            command:
+              drop: "enxcol_.encryptedCollection.esc"
+            commandName: drop
+            databaseName: *database_name
+        - command_started_event:
+            command:
+              drop: "enxcol_.encryptedCollection.ecc"
+            commandName: drop
+            databaseName: *database_name
+        - command_started_event:
+            command:
+              drop: "enxcol_.encryptedCollection.ecoc"
+            commandName: drop
+            databaseName: *database_name
+        # events from dropCollection ... end
+  - description: "encryptedFieldsMap with cyclic entries does not loop"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          aws: {} # Credentials filled in from environment.
+        encryptedFieldsMap:
+          # encryptedCollection has encryptedCollection.esc as the escCollection.
+          # encryptedCollection.esc has encryptedCollection as the escCollection.
+          default.encryptedCollection: {
+                "escCollection": "encryptedCollection.esc",
+                "eccCollection": "encryptedCollection.ecc",
+                "ecocCollection": "encryptedCollection.ecoc",
+                "fields": [
+                    {
+                        "path": "firstName",
+                        "bsonType": "string",
+                        "keyId": { "$binary": { "subType": "04", "base64": "AAAAAAAAAAAAAAAAAAAAAA==" }}
+                    }
+                ]
+            }
+          default.encryptedCollection.esc: {
+              "escCollection": "encryptedCollection",
+              "eccCollection": "encryptedCollection.ecc",
+              "ecocCollection": "encryptedCollection.ecoc",
+              "fields": [
+                  {
+                      "path": "firstName",
+                      "bsonType": "string",
+                      "keyId": { "$binary": { "subType": "04", "base64": "AAAAAAAAAAAAAAAAAAAAAA==" }}
+                  }
+              ]
+          }
+    operations:
+      # Do an initial drop to remove collections that may exist from previous test runs.
+      - name: dropCollection
+        object: database
+        arguments:
+          collection: "encryptedCollection"
+      - name: createCollection
+        object: database
+        arguments:
+          collection: "encryptedCollection"
+      - name: assertCollectionExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: "encryptedCollection.esc"
+      - name: assertCollectionExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: "encryptedCollection.ecc"
+      - name: assertCollectionExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: "encryptedCollection.ecoc"
+      - name: assertCollectionExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: "encryptedCollection"
+      - name: assertIndexExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: "encryptedCollection"
+          index: __safeContent___1
+    expectations:
+        # events from dropCollection ... begin
+        - command_started_event:
+            command:
+              drop: "encryptedCollection"
+            commandName: drop
+            databaseName: *database_name
+        - command_started_event:
+            command:
+              drop: "encryptedCollection.esc"
+            commandName: drop
+            databaseName: *database_name
+        - command_started_event:
+            command:
+              drop: "encryptedCollection.ecc"
+            commandName: drop
+            databaseName: *database_name
+        - command_started_event:
+            command:
+              drop: "encryptedCollection.ecoc"
+            commandName: drop
+            databaseName: *database_name
+        # events from dropCollection ... end
+        # events from createCollection ... begin
+        # State collections are created first.
+        - command_started_event:
+            command:
+              create: "encryptedCollection.esc"
+            commandName: create
+            databaseName: *database_name
+        - command_started_event:
+            command:
+              create: "encryptedCollection.ecc"
+            commandName: create
+            databaseName: *database_name
+        - command_started_event:
+            command:
+              create: "encryptedCollection.ecoc"
+            commandName: create
+            databaseName: *database_name
+        # Data collection is created after.
+        - command_started_event:
+            command:
+              create: "encryptedCollection"
+            commandName: create
+            databaseName: *database_name
+        # Index on __safeContents__ is then created.
+        - command_started_event:
+            command:
+              createIndexes: "encryptedCollection"
+              indexes:
+                - name: __safeContent___1
+                  key: { __safeContent__: 1 }
+            commandName: createIndexes
+            databaseName: *database_name
+        # events from createCollection ... end
+  - description: "CreateCollection without encryptedFields."
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          aws: {} # Credentials filled in from environment.
+        encryptedFieldsMap:
+          default.encryptedCollection: {
+                "escCollection": "encryptedCollection.esc",
+                "eccCollection": "encryptedCollection.ecc",
+                "ecocCollection": "encryptedCollection.ecoc",
+                "fields": [
+                    {
+                        "path": "firstName",
+                        "bsonType": "string",
+                        "keyId": { "$binary": { "subType": "04", "base64": "AAAAAAAAAAAAAAAAAAAAAA==" }}
+                    }
+                ]
+            }
+    operations:
+      # Do an initial drop to remove collections that may exist from previous test runs.
+      - name: dropCollection
+        object: database
+        arguments:
+          collection: "plaintextCollection"
+      - name: createCollection
+        object: database
+        arguments:
+          collection: "plaintextCollection"
+      - name: assertCollectionExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: "plaintextCollection"
+
+    expectations:
+        # events from dropCollection ... begin
+        # expect listCollections to be sent on drop to check for remote encryptedFields.
+        - command_started_event:
+            command:
+              listCollections: 1
+              filter: { name: "plaintextCollection" }
+            commandName: listCollections
+            databaseName: *database_name
+        - command_started_event:
+            command:
+              drop: "plaintextCollection"
+            commandName: drop
+            databaseName: *database_name
+        # events from dropCollection ... end
+        - command_started_event:
+            command:
+              create: "plaintextCollection"
+            commandName: create
+            databaseName: *database_name
+  - description: "CreateCollection from encryptedFieldsMap."
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          aws: {} # Credentials filled in from environment.
+        encryptedFieldsMap:
+          default.encryptedCollection: {
+                "escCollection": "encryptedCollection.esc",
+                "eccCollection": "encryptedCollection.ecc",
+                "ecocCollection": "encryptedCollection.ecoc",
+                "fields": [
+                    {
+                        "path": "firstName",
+                        "bsonType": "string",
+                        "keyId": { "$binary": { "subType": "04", "base64": "AAAAAAAAAAAAAAAAAAAAAA==" }}
+                    }
+                ]
+            }
+    operations:
+      # Do an initial drop to remove collections that may exist from previous test runs.
+      - name: dropCollection
+        object: database
+        arguments:
+          collection: "encryptedCollection"
+      - name: createCollection
+        object: database
+        arguments:
+          collection: "encryptedCollection"
+      - name: assertCollectionExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: "encryptedCollection.esc"
+      - name: assertCollectionExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: "encryptedCollection.ecc"
+      - name: assertCollectionExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: "encryptedCollection.ecoc"
+      - name: assertCollectionExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: "encryptedCollection"
+      - name: assertIndexExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: "encryptedCollection"
+          index: __safeContent___1
+
+    expectations:
+        # events from dropCollection ... begin
+        - command_started_event:
+            command:
+              drop: "encryptedCollection"
+            commandName: drop
+            databaseName: *database_name
+        - command_started_event:
+            command:
+              drop: "encryptedCollection.esc"
+            commandName: drop
+            databaseName: *database_name
+        - command_started_event:
+            command:
+              drop: "encryptedCollection.ecc"
+            commandName: drop
+            databaseName: *database_name
+        - command_started_event:
+            command:
+              drop: "encryptedCollection.ecoc"
+            commandName: drop
+            databaseName: *database_name
+        # events from dropCollection ... end
+        # events from createCollection ... begin
+        # State collections are created first.
+        - command_started_event:
+            command:
+              create: "encryptedCollection.esc"
+            commandName: create
+            databaseName: *database_name
+        - command_started_event:
+            command:
+              create: "encryptedCollection.ecc"
+            commandName: create
+            databaseName: *database_name
+        - command_started_event:
+            command:
+              create: "encryptedCollection.ecoc"
+            commandName: create
+            databaseName: *database_name
+        # Data collection is created after.
+        - command_started_event:
+            command:
+              create: "encryptedCollection"
+            commandName: create
+            databaseName: *database_name
+        # Index on __safeContents__ is then created.
+        - command_started_event:
+            command:
+              createIndexes: "encryptedCollection"
+              indexes:
+                - name: __safeContent___1
+                  key: { __safeContent__: 1 }
+            commandName: createIndexes
+            databaseName: *database_name
+        # events from createCollection ... end
+  - description: "CreateCollection from encryptedFields."
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          aws: {} # Credentials filled in from environment.
+    operations:
+      # Do initial drops to remove collections that may exist from previous test runs.
+      - name: dropCollection
+        object: database
+        arguments:
+          collection: "encryptedCollection"
+          encryptedFields: {
+                "escCollection": "encryptedCollection.esc",
+                "eccCollection": "encryptedCollection.ecc",
+                "ecocCollection": "encryptedCollection.ecoc",
+                "fields": [
+                    {
+                        "path": "firstName",
+                        "bsonType": "string",
+                        "keyId": { "$binary": { "subType": "04", "base64": "AAAAAAAAAAAAAAAAAAAAAA==" }}
+                    }
+                ]
+            }
+      - name: createCollection
+        object: database
+        arguments:
+          collection: "encryptedCollection"
+          encryptedFields: {
+                "escCollection": "encryptedCollection.esc",
+                "eccCollection": "encryptedCollection.ecc",
+                "ecocCollection": "encryptedCollection.ecoc",
+                "fields": [
+                    {
+                        "path": "firstName",
+                        "bsonType": "string",
+                        "keyId": { "$binary": { "subType": "04", "base64": "AAAAAAAAAAAAAAAAAAAAAA==" }}
+                    }
+                ]
+            }
+      - name: assertCollectionExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: "encryptedCollection.esc"
+      - name: assertCollectionExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: "encryptedCollection.ecc"
+      - name: assertCollectionExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: "encryptedCollection.ecoc"
+      - name: assertCollectionExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: "encryptedCollection"
+      - name: assertIndexExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: "encryptedCollection"
+          index: __safeContent___1
+
+    expectations:
+        # events from dropCollection ... begin
+        - command_started_event:
+            command:
+              drop: "encryptedCollection"
+            commandName: drop
+            databaseName: *database_name
+        - command_started_event:
+            command:
+              drop: "encryptedCollection.esc"
+            commandName: drop
+            databaseName: *database_name
+        - command_started_event:
+            command:
+              drop: "encryptedCollection.ecc"
+            commandName: drop
+            databaseName: *database_name
+        - command_started_event:
+            command:
+              drop: "encryptedCollection.ecoc"
+            commandName: drop
+            databaseName: *database_name
+        # events from dropCollection ... end
+        # events from createCollection ... begin
+        # State collections are created first.
+        - command_started_event:
+            command:
+              create: "encryptedCollection.esc"
+            commandName: create
+            databaseName: *database_name
+        - command_started_event:
+            command:
+              create: "encryptedCollection.ecc"
+            commandName: create
+            databaseName: *database_name
+        - command_started_event:
+            command:
+              create: "encryptedCollection.ecoc"
+            commandName: create
+            databaseName: *database_name
+        # Data collection is created after.
+        - command_started_event:
+            command:
+              create: "encryptedCollection"
+            commandName: create
+            databaseName: *database_name
+        # Index on __safeContents__ is then created.
+        - command_started_event:
+            command:
+              createIndexes: "encryptedCollection"
+              indexes:
+                - name: __safeContent___1
+                  key: { __safeContent__: 1 }
+            commandName: createIndexes
+            databaseName: *database_name
+        # events from createCollection ... end
+
+  - description: "DropCollection from encryptedFieldsMap"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          aws: {} # Credentials filled in from environment.
+        encryptedFieldsMap:
+          default.encryptedCollection: {
+                "escCollection": "encryptedCollection.esc",
+                "eccCollection": "encryptedCollection.ecc",
+                "ecocCollection": "encryptedCollection.ecoc",
+                "fields": [
+                    {
+                        "path": "firstName",
+                        "bsonType": "string",
+                        "keyId": { "$binary": { "subType": "04", "base64": "AAAAAAAAAAAAAAAAAAAAAA==" }}
+                    }
+                ]
+            }
+    operations:
+      - name: dropCollection
+        object: database
+        arguments:
+          collection: "encryptedCollection"
+    expectations:
+        # events from dropCollection ... begin
+        - command_started_event:
+            command:
+              drop: "encryptedCollection"
+            commandName: drop
+            databaseName: *database_name
+        - command_started_event:
+            command:
+              drop: "encryptedCollection.esc"
+            commandName: drop
+            databaseName: *database_name
+        - command_started_event:
+            command:
+              drop: "encryptedCollection.ecc"
+            commandName: drop
+            databaseName: *database_name
+        - command_started_event:
+            command:
+              drop: "encryptedCollection.ecoc"
+            commandName: drop
+            databaseName: *database_name
+        # events from dropCollection ... end
+  - description: "DropCollection from encryptedFields"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          aws: {} # Credentials filled in from environment.
+        encryptedFieldsMap: {}
+    operations:
+      # Do initial drops to remove collections that may exist from previous test runs.
+      - name: dropCollection
+        object: database
+        arguments:
+          collection: "encryptedCollection"
+          encryptedFields: {
+                "escCollection": "encryptedCollection.esc",
+                "eccCollection": "encryptedCollection.ecc",
+                "ecocCollection": "encryptedCollection.ecoc",
+                "fields": [
+                    {
+                        "path": "firstName",
+                        "bsonType": "string",
+                        "keyId": { "$binary": { "subType": "04", "base64": "AAAAAAAAAAAAAAAAAAAAAA==" }}
+                    }
+                ]
+            }
+      - name: createCollection
+        object: database
+        arguments:
+          collection: "encryptedCollection"
+          encryptedFields: {
+                "escCollection": "encryptedCollection.esc",
+                "eccCollection": "encryptedCollection.ecc",
+                "ecocCollection": "encryptedCollection.ecoc",
+                "fields": [
+                    {
+                        "path": "firstName",
+                        "bsonType": "string",
+                        "keyId": { "$binary": { "subType": "04", "base64": "AAAAAAAAAAAAAAAAAAAAAA==" }}
+                    }
+                ]
+            }
+      - name: assertCollectionExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: "encryptedCollection.esc"
+      - name: assertCollectionExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: "encryptedCollection.ecc"
+      - name: assertCollectionExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: "encryptedCollection.ecoc"
+      - name: assertCollectionExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: "encryptedCollection"
+      - name: assertIndexExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: "encryptedCollection"
+          index: __safeContent___1
+      - name: dropCollection
+        object: database
+        arguments:
+          collection: "encryptedCollection"
+          encryptedFields: {
+                "escCollection": "encryptedCollection.esc",
+                "eccCollection": "encryptedCollection.ecc",
+                "ecocCollection": "encryptedCollection.ecoc",
+                "fields": [
+                    {
+                        "path": "firstName",
+                        "bsonType": "string",
+                        "keyId": { "$binary": { "subType": "04", "base64": "AAAAAAAAAAAAAAAAAAAAAA==" }}
+                    }
+                ]
+            }
+      - name: assertCollectionNotExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: "encryptedCollection.esc"
+      - name: assertCollectionNotExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: "encryptedCollection.ecc"
+      - name: assertCollectionNotExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: "encryptedCollection.ecoc"
+      - name: assertCollectionNotExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: "encryptedCollection"
+    expectations:
+        # events from dropCollection ... begin
+        - command_started_event:
+            command:
+              drop: "encryptedCollection"
+            commandName: drop
+            databaseName: *database_name
+        - command_started_event:
+            command:
+              drop: "encryptedCollection.esc"
+            commandName: drop
+            databaseName: *database_name
+        - command_started_event:
+            command:
+              drop: "encryptedCollection.ecc"
+            commandName: drop
+            databaseName: *database_name
+        - command_started_event:
+            command:
+              drop: "encryptedCollection.ecoc"
+            commandName: drop
+            databaseName: *database_name
+        # events from dropCollection ... end
+        # events from createCollection ... begin
+        - command_started_event:
+            command:
+              create: "encryptedCollection.esc"
+            commandName: create
+            databaseName: *database_name
+        - command_started_event:
+            command:
+              create: "encryptedCollection.ecc"
+            commandName: create
+            databaseName: *database_name
+        - command_started_event:
+            command:
+              create: "encryptedCollection.ecoc"
+            commandName: create
+            databaseName: *database_name
+        - command_started_event:
+            command:
+              create: "encryptedCollection"
+            commandName: create
+            databaseName: *database_name
+        # Index on __safeContents__ is then created.
+        - command_started_event:
+            command:
+              createIndexes: "encryptedCollection"
+              indexes:
+                - name: __safeContent___1
+                  key: { __safeContent__: 1 }
+            commandName: createIndexes
+            databaseName: *database_name
+        # events from createCollection ... end
+        # events from dropCollection ... begin
+        - command_started_event:
+            command:
+              drop: "encryptedCollection"
+            commandName: drop
+            databaseName: *database_name
+        - command_started_event:
+            command:
+              drop: "encryptedCollection.esc"
+            commandName: drop
+            databaseName: *database_name
+        - command_started_event:
+            command:
+              drop: "encryptedCollection.ecc"
+            commandName: drop
+            databaseName: *database_name
+        - command_started_event:
+            command:
+              drop: "encryptedCollection.ecoc"
+            commandName: drop
+            databaseName: *database_name
+        # events from dropCollection ... end
+
+  - description: "DropCollection from remote encryptedFields"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          aws: {} # Credentials filled in from environment.
+        encryptedFieldsMap: {}
+
+    operations:
+      # Do initial drops to remove collections that may exist from previous test runs.
+      - name: dropCollection
+        object: database
+        arguments:
+          collection: "encryptedCollection"
+          encryptedFields: {
+                "escCollection": "encryptedCollection.esc",
+                "eccCollection": "encryptedCollection.ecc",
+                "ecocCollection": "encryptedCollection.ecoc",
+                "fields": [
+                    {
+                        "path": "firstName",
+                        "bsonType": "string",
+                        "keyId": { "$binary": { "subType": "04", "base64": "AAAAAAAAAAAAAAAAAAAAAA==" }}
+                    }
+                ]
+            }
+      - name: createCollection
+        object: database
+        arguments:
+          collection: "encryptedCollection"
+          encryptedFields: {
+                "escCollection": "encryptedCollection.esc",
+                "eccCollection": "encryptedCollection.ecc",
+                "ecocCollection": "encryptedCollection.ecoc",
+                "fields": [
+                    {
+                        "path": "firstName",
+                        "bsonType": "string",
+                        "keyId": { "$binary": { "subType": "04", "base64": "AAAAAAAAAAAAAAAAAAAAAA==" }}
+                    }
+                ]
+            }
+      - name: assertCollectionExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: "encryptedCollection.esc"
+      - name: assertCollectionExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: "encryptedCollection.ecc"
+      - name: assertCollectionExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: "encryptedCollection.ecoc"
+      - name: assertCollectionExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: "encryptedCollection"
+      - name: assertIndexExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: "encryptedCollection"
+          index: __safeContent___1
+      - name: dropCollection
+        object: database
+        arguments:
+          collection: "encryptedCollection"
+      - name: assertCollectionNotExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: "encryptedCollection.esc"
+      - name: assertCollectionNotExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: "encryptedCollection.ecc"
+      - name: assertCollectionNotExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: "encryptedCollection.ecoc"
+      - name: assertCollectionNotExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: "encryptedCollection"
+
+    expectations:
+        # events from dropCollection ... begin
+        - command_started_event:
+            command:
+              drop: "encryptedCollection"
+            commandName: drop
+            databaseName: *database_name
+        - command_started_event:
+            command:
+              drop: "encryptedCollection.esc"
+            commandName: drop
+            databaseName: *database_name
+        - command_started_event:
+            command:
+              drop: "encryptedCollection.ecc"
+            commandName: drop
+            databaseName: *database_name
+        - command_started_event:
+            command:
+              drop: "encryptedCollection.ecoc"
+            commandName: drop
+            databaseName: *database_name
+        # events from dropCollection ... end
+        # events from createCollection ... begin
+        - command_started_event:
+            command:
+              create: "encryptedCollection.esc"
+            commandName: create
+            databaseName: *database_name
+        - command_started_event:
+            command:
+              create: "encryptedCollection.ecc"
+            commandName: create
+            databaseName: *database_name
+        - command_started_event:
+            command:
+              create: "encryptedCollection.ecoc"
+            commandName: create
+            databaseName: *database_name
+        - command_started_event:
+            command:
+              create: "encryptedCollection"
+            commandName: create
+            databaseName: *database_name
+        # Index on __safeContents__ is then created.
+        - command_started_event:
+            command:
+              createIndexes: "encryptedCollection"
+              indexes:
+                - name: __safeContent___1
+                  key: { __safeContent__: 1 }
+            commandName: createIndexes
+            databaseName: *database_name
+        # events from createCollection ... end
+        # events from dropCollection ... begin
+        - command_started_event:
+            command:
+              listCollections: 1
+              filter: { name: "encryptedCollection" }
+            commandName: listCollections
+            databaseName: *database_name
+        - command_started_event:
+            command:
+              drop: "encryptedCollection"
+            commandName: drop
+            databaseName: *database_name
+        - command_started_event:
+            command:
+              drop: "encryptedCollection.esc"
+            commandName: drop
+            databaseName: *database_name
+        - command_started_event:
+            command:
+              drop: "encryptedCollection.ecc"
+            commandName: drop
+            databaseName: *database_name
+        - command_started_event:
+            command:
+              drop: "encryptedCollection.ecoc"
+            commandName: drop
+            databaseName: *database_name
+        # events from dropCollection ... end

--- a/test/spec/client-side-encryption/tests/noSchema.json
+++ b/test/spec/client-side-encryption/tests/noSchema.json
@@ -1,0 +1,67 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.1.10"
+    }
+  ],
+  "database_name": "default",
+  "collection_name": "unencrypted",
+  "tests": [
+    {
+      "description": "Insert on an unencrypted collection",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "aws": {}
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "insertOne",
+          "arguments": {
+            "document": {
+              "_id": 1
+            }
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "listCollections": 1,
+              "filter": {
+                "name": "unencrypted"
+              }
+            },
+            "command_name": "listCollections"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "unencrypted",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true
+            },
+            "command_name": "insert"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/test/spec/client-side-encryption/tests/noSchema.yml
+++ b/test/spec/client-side-encryption/tests/noSchema.yml
@@ -1,0 +1,37 @@
+# Test auto encryption on a collection with no jsonSchema configured.
+# This is a regression test for MONGOCRYPT-378/PYTHON-3188.
+runOn:
+  - minServerVersion: "4.1.10"
+database_name: &database_name "default"
+collection_name: &collection_name "unencrypted"
+
+tests:
+  - description: "Insert on an unencrypted collection"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          aws: {} # Credentials filled in from environment.
+    operations:
+      - name: insertOne
+        arguments:
+          document: &doc0 { _id: 1 }
+    expectations:
+      # Auto encryption will request the collection info.
+      - command_started_event:
+          command:
+            listCollections: 1
+            filter:
+              name: *collection_name
+          command_name: listCollections
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - *doc0
+            ordered: true
+          command_name: insert
+    outcome:
+      collection:
+        # Outcome is checked using a separate MongoClient without auto encryption.
+        data:
+          - *doc0

--- a/test/tools/spec-runner/index.js
+++ b/test/tools/spec-runner/index.js
@@ -100,9 +100,14 @@ function gatherTestSuites(specPath) {
     .readdirSync(specPath)
     .filter(x => x.indexOf('.json') !== -1)
     .map(x =>
-      Object.assign(EJSON.parse(fs.readFileSync(path.join(specPath, x)), { relaxed: true }), {
-        name: path.basename(x, '.json')
-      })
+      Object.assign(
+        EJSON.parse(fs.readFileSync(path.join(specPath, x)), {
+          relaxed: !x.includes('fle2-CreateCollection')
+        }),
+        {
+          name: path.basename(x, '.json')
+        }
+      )
     );
 }
 

--- a/test/tools/spec-runner/index.js
+++ b/test/tools/spec-runner/index.js
@@ -11,6 +11,7 @@ const resolveConnectionString = require('./utils').resolveConnectionString;
 const { LEGACY_HELLO_COMMAND } = require('../../../src/constants');
 const { isAnyRequirementSatisfied } = require('../unified-spec-runner/unified-utils');
 const ClientSideEncryptionFilter = require('../runner/filters/client_encryption_filter');
+const { MONGODB_ERROR_CODES } = require('../../../src/error');
 
 // Promise.try alternative https://stackoverflow.com/questions/60624081/promise-try-without-bluebird/60624164?noredirect=1#comment107255389_60624164
 function promiseTry(callback) {
@@ -597,6 +598,18 @@ function maybeSession(operation, context) {
   );
 }
 
+function withoutCommandMonitoring(client, fn) {
+  const listeners = client.rawListeners('commandStarted');
+  client.removeAllListeners('commandStarted');
+  return Promise.resolve()
+    .then(() => fn())
+    .finally(() => {
+      for (const listener of listeners) {
+        client.on('commandStarted', listener);
+      }
+    });
+}
+
 const kOperations = new Map([
   [
     'recordPrimary',
@@ -636,16 +649,22 @@ const kOperations = new Map([
     'createCollection',
     (operation, db, context /*, options */) => {
       const collectionName = operation.arguments.collection;
+      const encryptedFields = operation.arguments.encryptedFields;
       const session = maybeSession(operation, context);
-      return db.createCollection(collectionName, { session });
+      return db.createCollection(collectionName, { session, encryptedFields });
     }
   ],
   [
     'dropCollection',
     (operation, db, context /*, options */) => {
       const collectionName = operation.arguments.collection;
+      const encryptedFields = operation.arguments.encryptedFields;
       const session = maybeSession(operation, context);
-      return db.dropCollection(collectionName, { session });
+      return db.dropCollection(collectionName, { session, encryptedFields }).catch(err => {
+        if (err.code !== MONGODB_ERROR_CODES.NamespaceNotFound) {
+          throw err;
+        }
+      });
     }
   ],
   [
@@ -665,6 +684,74 @@ const kOperations = new Map([
       const options = { session: maybeSession(operation, context) };
       if (args.out) options.out = args.out;
       return collection.mapReduce(map, reduce, options);
+    }
+  ],
+  [
+    'assertCollectionExists',
+    (operation, testRunnerContext, context /*, options */) => {
+      const collectionName = operation.arguments.collection;
+      const session = maybeSession(operation, context);
+      const db = context.client.db(operation.arguments.database);
+      return withoutCommandMonitoring(context.client, () =>
+        db
+          .listCollections({ session })
+          .toArray()
+          .then(results => results.map(({ name }) => name))
+          .then(collections => expect(collections).to.include(collectionName))
+      );
+    }
+  ],
+  [
+    'assertCollectionNotExists',
+    (operation, testRunnerContext, context /*, options */) => {
+      const collectionName = operation.arguments.collection;
+      const session = maybeSession(operation, context);
+      const db = context.client.db(operation.arguments.database);
+      return withoutCommandMonitoring(context.client, () =>
+        db
+          .listCollections({ session })
+          .toArray()
+          .then(results => results.map(({ name }) => name))
+          .then(collections => expect(collections).to.not.include(collectionName))
+      );
+    }
+  ],
+  [
+    'assertIndexExists',
+    (operation, testRunnerContext, context /*, options */) => {
+      const collectionName = operation.arguments.collection;
+      const indexName = operation.arguments.index;
+      const session = maybeSession(operation, context);
+      const db = context.client.db(operation.arguments.database);
+      return withoutCommandMonitoring(context.client, () =>
+        db
+          .collection(collectionName)
+          .listIndexes({ session })
+          .toArray()
+          .then(results => results.map(({ name }) => name))
+          .then(indexes => expect(indexes).to.include(indexName))
+      );
+    }
+  ],
+  [
+    'assertIndexNotExists',
+    (operation, testRunnerContext, context /*, options */) => {
+      const collectionName = operation.arguments.collection;
+      const indexName = operation.arguments.index;
+      const session = maybeSession(operation, context);
+      const db = context.client.db(operation.arguments.database);
+      return withoutCommandMonitoring(context.client, () =>
+        db
+          .collection(collectionName)
+          .listIndexes({ session })
+          .toArray()
+          .then(results => results.map(({ name }) => name))
+          .then(indexes => expect(indexes).to.not.include(indexName))
+      ).catch(err => {
+        if (err.code !== MONGODB_ERROR_CODES.NamespaceNotFound) {
+          throw err;
+        }
+      });
     }
   ]
 ]);
@@ -774,6 +861,9 @@ function testOperation(operation, obj, context, options) {
       const cursor = obj[operationName].apply(obj, args);
       opPromise = cursor.toArray();
     } else {
+      if (!obj[operationName]) {
+        throw new Error(`Unknown operation "${operationName}"`);
+      }
       // wrap this in a `promiseTry` because some operations might throw
       opPromise = promiseTry(() => obj[operationName].apply(obj, args));
     }


### PR DESCRIPTION
### Description

See NODE-4202 / https://github.com/mongodb/specifications/commit/0142955943d91a783fc0314fb41a14e392bd15b6

#### What is changing?

Collection creation and dropping are extended to account for FLE2 properties according to spec.

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
