### PR TITLE
NODE-4214: Support cert and key values

### DIFF
--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -1075,13 +1075,21 @@ export const OPTIONS = {
   sslCert: {
     target: 'cert',
     transform({ values: [value] }) {
-      return fs.readFileSync(String(value), { encoding: 'ascii' });
+      let text = String(value);
+      if (!fs.existsSync(text)) {
+        return text;
+      }
+      return fs.readFileSync(text, { encoding: 'ascii' });
     }
   },
   sslKey: {
     target: 'key',
     transform({ values: [value] }) {
-      return fs.readFileSync(String(value), { encoding: 'ascii' });
+      let text = String(value);
+      if (!fs.existsSync(text)) {
+        return text;
+      }
+      return fs.readFileSync(text, { encoding: 'ascii' });
     }
   },
   sslPass: {

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -193,9 +193,9 @@ export interface MongoClientOptions extends BSONSerializeOptions, SupportedNodeC
   sslValidate?: boolean;
   /** SSL Certificate file path. */
   sslCA?: string;
-  /** SSL Certificate file path. */
+  /** SSL Certificate file path, or certificate value. */
   sslCert?: string;
-  /** SSL Key file file path. */
+  /** SSL Key file file path, or key value. */
   sslKey?: string;
   /** SSL Certificate pass phrase. */
   sslPass?: string;


### PR DESCRIPTION
### Description

#### What is changing?
This change adds back support to keys and certificates being values.

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

The ability to pass ssl keys and certificates as values (instead of file paths) was removed. This creates a security vulnerability in our application by forcing us to write our private keys to the disk.

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [X] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
