### PR TITLE
fix(NODE-3565): Error for insertMany with partially empty array is unhelpful

### DIFF
--- a/src/bulk/common.ts
+++ b/src/bulk/common.ts
@@ -1,3 +1,4 @@
+/* eslint-disable prettier/prettier */
 import {
   BSONSerializeOptions,
   Document,
@@ -1133,6 +1134,9 @@ export abstract class BulkOperationBase {
 
   /** Specifies a raw operation to perform in the bulk write. */
   raw(op: AnyBulkWriteOperation): this {
+    if (!op) {
+      throw new MongoInvalidArgumentError('Cannot perform bulkwrite operation on undefined operation');
+    }
     if ('insertOne' in op) {
       const forceServerObjectId = shouldForceServerObjectId(this);
       if (op.insertOne && op.insertOne.document == null) {

--- a/src/bulk/common.ts
+++ b/src/bulk/common.ts
@@ -1,4 +1,3 @@
-/* eslint-disable prettier/prettier */
 import {
   BSONSerializeOptions,
   Document,
@@ -1135,7 +1134,7 @@ export abstract class BulkOperationBase {
   /** Specifies a raw operation to perform in the bulk write. */
   raw(op: AnyBulkWriteOperation): this {
     if (!op) {
-      throw new MongoInvalidArgumentError('Cannot perform bulkwrite operation on undefined operation');
+      throw new MongoInvalidArgumentError('Cannot call .raw() with an undefined operation');
     }
     if ('insertOne' in op) {
       const forceServerObjectId = shouldForceServerObjectId(this);

--- a/src/bulk/common.ts
+++ b/src/bulk/common.ts
@@ -1133,8 +1133,8 @@ export abstract class BulkOperationBase {
 
   /** Specifies a raw operation to perform in the bulk write. */
   raw(op: AnyBulkWriteOperation): this {
-    if (!op) {
-      throw new MongoInvalidArgumentError('Cannot call .raw() with an undefined operation');
+    if (op == null || typeof op !== 'object') {
+      throw new MongoInvalidArgumentError('Operation must be an object with an operation key');
     }
     if ('insertOne' in op) {
       const forceServerObjectId = shouldForceServerObjectId(this);

--- a/src/operations/insert.ts
+++ b/src/operations/insert.ts
@@ -139,7 +139,7 @@ export class InsertManyOperation extends AbstractOperation<InsertManyResult> {
       if (err || res == null) {
         if (err && err.message === 'Operation must be an object with an operation key') {
           err = new MongoInvalidArgumentError(
-            'Argument "docs" is a sparse array containing element(s) that are null or undefined'
+            'Collection.insertMany() cannot be called with an array that has null/undefined values'
           );
         }
         return callback(err);

--- a/src/operations/insert.ts
+++ b/src/operations/insert.ts
@@ -136,7 +136,14 @@ export class InsertManyOperation extends AbstractOperation<InsertManyResult> {
     );
 
     bulkWriteOperation.execute(server, session, (err, res) => {
-      if (err || res == null) return callback(err);
+      if (err || res == null) {
+        if (err && err.message === 'Operation must be an object with an operation key') {
+          err = new MongoInvalidArgumentError(
+            'Argument "docs" is a sparse array containing element(s) that are null or undefined'
+          );
+        }
+        return callback(err);
+      }
       callback(undefined, {
         acknowledged: writeConcern?.w !== 0 ?? true,
         insertedCount: res.insertedCount,

--- a/test/integration/crud/bulk.test.js
+++ b/test/integration/crud/bulk.test.js
@@ -27,10 +27,12 @@ describe('Bulk', function () {
   before(function () {
     return setupDatabase(this.configuration);
   });
-  describe('BulkOperationBase', () => {
+  // eslint-disable-next-line no-restricted-properties
+  describe.only('BulkOperationBase', () => {
     describe('#raw', function () {
+      let client;
       beforeEach(async function () {
-        const client = this.configuration.newClient();
+        client = this.configuration.newClient();
         await client.connect();
       });
       afterEach(async function () {
@@ -59,17 +61,19 @@ describe('Bulk', function () {
     });
   });
 
-  describe('Db.collection', function () {
+  // eslint-disable-next-line no-restricted-properties
+  describe.only('Db.collection', function () {
     describe('#insertMany', function () {
+      let client;
       beforeEach(async function () {
-        const client = this.configuration.newClient();
+        client = this.configuration.newClient();
         await client.connect();
       });
       afterEach(async function () {
         await client.close();
       });
       context('when passed an invalid or sparse list', function () {
-        it('insertmany should throw a MongoInvalidArgument error when called with a valid operation', async function () {
+        it('insertMany should throw a MongoInvalidArgument error when called with a valid operation', async function () {
           try {
             const docs = [];
             docs[1] = {}; // works for docs[0] = {}
@@ -81,11 +85,12 @@ describe('Bulk', function () {
         });
       });
       context('when passed a valid document list', function () {
-        it('insertmany should not throw a MongoInvalidArgument error when called with a valid operation', async function () {
+        it('insertMany should not throw a MongoInvalidArgument error when called with a valid operation', async function () {
           try {
             const docs = [];
             docs[0] = {}; // works for docs[0] = {}
-            await client.db('test').collection('test').insertMany(docs);
+            let result = await client.db('test').collection('test').insertMany(docs);
+            expect(result).to.be.true;
           } catch (error) {
             expect(error).not.to.exist;
           }

--- a/test/integration/crud/bulk.test.js
+++ b/test/integration/crud/bulk.test.js
@@ -76,7 +76,7 @@ describe('Bulk', function () {
         await client.close();
       });
       context('when passed an invalid docs argument', function () {
-        it('insertMany should throw a MongoInvalidArgument error when called with an invalid operation', async function () {
+        it('should throw a MongoInvalidArgument error', async function () {
           try {
             const docs = [];
             docs[1] = { color: 'red' };

--- a/test/integration/crud/bulk.test.js
+++ b/test/integration/crud/bulk.test.js
@@ -23,6 +23,72 @@ describe('Bulk', function () {
     return setupDatabase(this.configuration);
   });
 
+  context('ops tests', () => {
+    // eslint-disable-next-line no-restricted-properties
+    it.only('Should raise an error when attempting bulkwrite operation on undefined operation', function (done) {
+      var configuration = this.configuration;
+      const client = configuration.newClient();
+      const docs = [];
+      docs[1] = {}; // works for docs[0] = {}
+      // client.db('test').collection('test').insertMany(docs);
+      // client.close();
+
+      let error = null;
+      let result = null;
+
+      client
+        .connect()
+        .then(function (client) {
+          return client.db('test').collection('test').insertMany(docs);
+        })
+        .then(function (r) {
+          result = r;
+        })
+        .catch(function (err) {
+          console.log(err);
+          error = err;
+        })
+        .then(function () {
+          expect(result).to.not.exist;
+          test.ok(error);
+          console.log(error, 'KOBBY');
+          client.close(done);
+        });
+    });
+
+    // eslint-disable-next-line no-restricted-properties
+    it.only('Should not raise an error when attempting bulkwrite operation on undefined operation', function (done) {
+      var configuration = this.configuration;
+      const client = configuration.newClient();
+      const docs = [];
+      docs[0] = {}; // works for docs[0] = {}
+      // client.db('test').collection('test').insertMany(docs);
+      // client.close();
+
+      let error = null;
+      let result = null;
+
+      client
+        .connect()
+        .then(function (client) {
+          return client.db('test').collection('test').insertMany(docs);
+        })
+        .then(function (r) {
+          result = r;
+        })
+        .catch(function (err) {
+          console.log(err);
+          error = err;
+        })
+        .then(function () {
+          expect(error).to.not.exist;
+          console.log(result, 'KOBBY');
+          test.ok(result);
+          client.close(done);
+        });
+    });
+  });
+
   context('promise tests', () => {
     it('Should correctly execute unordered bulk operation in promise form', function (done) {
       const configuration = this.configuration;

--- a/test/integration/crud/bulk.test.js
+++ b/test/integration/crud/bulk.test.js
@@ -55,38 +55,6 @@ describe('Bulk', function () {
       }
       await client.close();
     });
-
-    // eslint-disable-next-line no-restricted-properties
-    it('Should not raise an error when attempting bulkwrite operation on undefined operation', function (done) {
-      var configuration = this.configuration;
-      const client = configuration.newClient();
-      // const docs = [];
-      // docs[0] = {}; // works for docs[0] = {}
-      // client.db('test').collection('test').insertMany(docs);
-      // client.close();
-      client.connect();
-      let error = null;
-      let result = null;
-
-      client
-        .connect()
-        .then(function (client) {
-          return client.db('test').collection('test').insertMany(docs);
-        })
-        .then(function (r) {
-          result = r;
-        })
-        .catch(function (err) {
-          console.log(err);
-          error = err;
-        })
-        .then(function () {
-          expect(error).to.not.exist;
-          console.log(result, 'KOBBY');
-          test.ok(result);
-          client.close(done);
-        });
-    });
   });
 
   context('promise tests', () => {

--- a/test/integration/crud/bulk.test.js
+++ b/test/integration/crud/bulk.test.js
@@ -27,33 +27,32 @@ describe('Bulk', function () {
   before(function () {
     return setupDatabase(this.configuration);
   });
+  describe('class BulkOperationBase', () => {
+    context('.raw()', () => {
+      it('should throw a MongoInvalidArgument error when called with an undefined operation', async function () {
+        const client = this.configuration.newClient();
+        await client.connect();
 
-  context('ops tests', () => {
-    it('Should raise an error when attempting bulkwrite operation on undefined operation', async function () {
-      var configuration = this.configuration;
-      const client = configuration.newClient();
-      await client.connect();
+        try {
+          client.db('test').collection('test').initializeUnorderedBulkOp().raw(undefined);
+          expect.fail('Failure to throw error');
+        } catch (error) {
+          expect(error).to.be.instanceOf(MongoInvalidArgumentError);
+        }
+        await client.close();
+      });
 
-      try {
-        client.db('test').collection('test').initializeUnorderedBulkOp().raw(undefined);
-        expect.fail('Failure to throw error');
-      } catch (error) {
-        expect(error).to.be.instanceOf(MongoInvalidArgumentError);
-      }
-      await client.close();
-    });
+      it('should not throw a MongoInvalidArgument error when called with a valid operation', async function () {
+        const client = this.configuration.newClient();
+        await client.connect();
 
-    it('Should not raise an error when attempting bulkwrite operation on undefined operation', async function () {
-      var configuration = this.configuration;
-      const client = configuration.newClient();
-      await client.connect();
-
-      try {
-        client.db('test').collection('test').initializeUnorderedBulkOp().raw({ insertOne: {} });
-      } catch (error) {
-        expect(error).not.to.exist;
-      }
-      await client.close();
+        try {
+          client.db('test').collection('test').initializeUnorderedBulkOp().raw({ insertOne: {} });
+        } catch (error) {
+          expect(error).not.to.exist;
+        }
+        await client.close();
+      });
     });
   });
 

--- a/test/integration/crud/bulk.test.js
+++ b/test/integration/crud/bulk.test.js
@@ -47,14 +47,9 @@ describe('Bulk', function () {
 
         it('should throw an error with the specifc message: "Operation must be an object with an operation key"', async function () {
           const bulkOp = client.db('test').collection('test').initializeUnorderedBulkOp();
-          try {
-            bulkOp.raw(undefined);
-            expect.fail(
-              'Expected passing argument of "undefined" to .raw to throw error, failed to throw error'
-            );
-          } catch (error) {
-            expect(error.message).to.equal('Operation must be an object with an operation key');
-          }
+          expect(() => bulkOp.raw(undefined))
+            .to.throw(MongoInvalidArgumentError)
+            .to.match(/Operation must be an object with an operation key/);
         });
       });
 
@@ -81,7 +76,7 @@ describe('Bulk', function () {
         await client.close();
       });
       context('when passed an invalid docs argument', function () {
-        it('insertMany should throw a MongoInvalidArgument error when called with a invalid operation', async function () {
+        it('insertMany should throw a MongoInvalidArgument error when called with an invalid operation', async function () {
           try {
             const docs = [];
             docs[1] = { color: 'red' };
@@ -89,6 +84,9 @@ describe('Bulk', function () {
             expect.fail('Expected insertMany to throw error, failed to throw error');
           } catch (error) {
             expect(error).to.be.instanceOf(MongoInvalidArgumentError);
+            expect(error.message).to.equal(
+              'Collection.insertMany() cannot be called with an array that has null/undefined values'
+            );
           }
         });
       });

--- a/test/integration/crud/bulk.test.js
+++ b/test/integration/crud/bulk.test.js
@@ -7,7 +7,12 @@ const {
   ignoreNsNotFound,
   assert: test
 } = require('../shared');
-const { Long, MongoBatchReExecutionError, MongoDriverError } = require('../../../src');
+const {
+  Long,
+  MongoBatchReExecutionError,
+  MongoDriverError,
+  MongoInvalidArgumentError
+} = require('../../../src');
 const crypto = require('crypto');
 const chai = require('chai');
 
@@ -24,47 +29,42 @@ describe('Bulk', function () {
   });
 
   context('ops tests', () => {
-    // eslint-disable-next-line no-restricted-properties
-    it.only('Should raise an error when attempting bulkwrite operation on undefined operation', function (done) {
+    it('Should raise an error when attempting bulkwrite operation on undefined operation', async function () {
       var configuration = this.configuration;
       const client = configuration.newClient();
-      const docs = [];
-      docs[1] = {}; // works for docs[0] = {}
-      // client.db('test').collection('test').insertMany(docs);
-      // client.close();
+      await client.connect();
 
-      let error = null;
-      let result = null;
+      try {
+        client.db('test').collection('test').initializeUnorderedBulkOp().raw(undefined);
+        expect.fail('Failure to throw error');
+      } catch (error) {
+        expect(error).to.be.instanceOf(MongoInvalidArgumentError);
+      }
+      await client.close();
+    });
 
-      client
-        .connect()
-        .then(function (client) {
-          return client.db('test').collection('test').insertMany(docs);
-        })
-        .then(function (r) {
-          result = r;
-        })
-        .catch(function (err) {
-          console.log(err);
-          error = err;
-        })
-        .then(function () {
-          expect(result).to.not.exist;
-          test.ok(error);
-          console.log(error, 'KOBBY');
-          client.close(done);
-        });
+    it('Should not raise an error when attempting bulkwrite operation on undefined operation', async function () {
+      var configuration = this.configuration;
+      const client = configuration.newClient();
+      await client.connect();
+
+      try {
+        client.db('test').collection('test').initializeUnorderedBulkOp().raw({ insertOne: {} });
+      } catch (error) {
+        expect(error).not.to.exist;
+      }
+      await client.close();
     });
 
     // eslint-disable-next-line no-restricted-properties
-    it.only('Should not raise an error when attempting bulkwrite operation on undefined operation', function (done) {
+    it('Should not raise an error when attempting bulkwrite operation on undefined operation', function (done) {
       var configuration = this.configuration;
       const client = configuration.newClient();
-      const docs = [];
-      docs[0] = {}; // works for docs[0] = {}
+      // const docs = [];
+      // docs[0] = {}; // works for docs[0] = {}
       // client.db('test').collection('test').insertMany(docs);
       // client.close();
-
+      client.connect();
       let error = null;
       let result = null;
 

--- a/test/integration/crud/bulk.test.js
+++ b/test/integration/crud/bulk.test.js
@@ -27,8 +27,7 @@ describe('Bulk', function () {
   before(function () {
     return setupDatabase(this.configuration);
   });
-  // eslint-disable-next-line no-restricted-properties
-  describe.only('BulkOperationBase', () => {
+  describe('BulkOperationBase', () => {
     describe('#raw', function () {
       let client;
       beforeEach(async function () {

--- a/test/integration/crud/bulk.test.js
+++ b/test/integration/crud/bulk.test.js
@@ -28,7 +28,8 @@ describe('Bulk', function () {
     return setupDatabase(this.configuration);
   });
   describe('BulkOperationBase', () => {
-    describe('#raw', function () {
+    // eslint-disable-next-line no-restricted-properties
+    describe.only('#raw', function () {
       let client;
       beforeEach(async function () {
         client = this.configuration.newClient();
@@ -44,6 +45,18 @@ describe('Bulk', function () {
           expect(() => bulkOp.raw(true)).to.throw(MongoInvalidArgumentError);
           expect(() => bulkOp.raw(3)).to.throw(MongoInvalidArgumentError);
         });
+
+        it('should throw an error with the specifc message: "Operation must be an object with an operation key"', async function () {
+          const bulkOp = client.db('test').collection('test').initializeUnorderedBulkOp();
+          try {
+            bulkOp.raw(undefined);
+            expect.fail(
+              'Expected passing argument of "undefined" to .raw to throw error, failed to throw error'
+            );
+          } catch (error) {
+            expect(error.message).to.equal('Operation must be an object with an operation key');
+          }
+        });
       });
 
       context('when called with a valid operation', function () {
@@ -58,6 +71,8 @@ describe('Bulk', function () {
     });
   });
 
+  //write test to check if error thrown at raw op hasnt changed
+
   describe('Db.collection', function () {
     describe('#insertMany', function () {
       let client;
@@ -68,8 +83,8 @@ describe('Bulk', function () {
       afterEach(async function () {
         await client.close();
       });
-      context('when passed an invalid or sparse list', function () {
-        it('insertMany should throw a MongoInvalidArgument error when called with a valid operation', async function () {
+      context('when passed an invalid docs argument', function () {
+        it('insertMany should throw a MongoInvalidArgument error when called with a invalid operation', async function () {
           try {
             const docs = [];
             docs[1] = { color: 'red' };

--- a/test/integration/crud/bulk.test.js
+++ b/test/integration/crud/bulk.test.js
@@ -27,8 +27,7 @@ describe('Bulk', function () {
   before(function () {
     return setupDatabase(this.configuration);
   });
-  // eslint-disable-next-line no-restricted-properties
-  describe.only('BulkOperationBase', () => {
+  describe('BulkOperationBase', () => {
     describe('#raw', function () {
       let client;
       beforeEach(async function () {
@@ -61,8 +60,7 @@ describe('Bulk', function () {
     });
   });
 
-  // eslint-disable-next-line no-restricted-properties
-  describe.only('Db.collection', function () {
+  describe('Db.collection', function () {
     describe('#insertMany', function () {
       let client;
       beforeEach(async function () {
@@ -76,9 +74,9 @@ describe('Bulk', function () {
         it('insertMany should throw a MongoInvalidArgument error when called with a valid operation', async function () {
           try {
             const docs = [];
-            docs[1] = {}; // works for docs[0] = {}
+            docs[1] = { color: 'red' };
             await client.db('test').collection('test').insertMany(docs);
-            expect.fail('Failure to throw error');
+            expect.fail('Expected insertMany to throw error, failed to throw error');
           } catch (error) {
             expect(error).to.be.instanceOf(MongoInvalidArgumentError);
           }
@@ -87,10 +85,11 @@ describe('Bulk', function () {
       context('when passed a valid document list', function () {
         it('insertMany should not throw a MongoInvalidArgument error when called with a valid operation', async function () {
           try {
-            const docs = [];
-            docs[0] = {}; // works for docs[0] = {}
-            let result = await client.db('test').collection('test').insertMany(docs);
-            expect(result).to.be.true;
+            let result = await client
+              .db('test')
+              .collection('test')
+              .insertMany([{ color: 'blue' }]);
+            expect(result).to.exist;
           } catch (error) {
             expect(error).not.to.exist;
           }

--- a/test/integration/crud/bulk.test.js
+++ b/test/integration/crud/bulk.test.js
@@ -27,31 +27,69 @@ describe('Bulk', function () {
   before(function () {
     return setupDatabase(this.configuration);
   });
-  describe('class BulkOperationBase', () => {
-    context('.raw()', () => {
-      it('should throw a MongoInvalidArgument error when called with an undefined operation', async function () {
+  describe('BulkOperationBase', () => {
+    describe('#raw', function () {
+      beforeEach(async function () {
         const client = this.configuration.newClient();
         await client.connect();
-
-        try {
-          client.db('test').collection('test').initializeUnorderedBulkOp().raw(undefined);
-          expect.fail('Failure to throw error');
-        } catch (error) {
-          expect(error).to.be.instanceOf(MongoInvalidArgumentError);
-        }
+      });
+      afterEach(async function () {
         await client.close();
       });
+      context('when called with an undefined operation', function () {
+        it('should throw a MongoInvalidArgument error ', async function () {
+          try {
+            client.db('test').collection('test').initializeUnorderedBulkOp().raw(undefined);
+            expect.fail('Failure to throw error');
+          } catch (error) {
+            expect(error).to.be.instanceOf(MongoInvalidArgumentError);
+          }
+        });
+      });
 
-      it('should not throw a MongoInvalidArgument error when called with a valid operation', async function () {
+      context('when called with a valid operation', function () {
+        it('should not throw a MongoInvalidArgument error', async function () {
+          try {
+            client.db('test').collection('test').initializeUnorderedBulkOp().raw({ insertOne: {} });
+          } catch (error) {
+            expect(error).not.to.exist;
+          }
+        });
+      });
+    });
+  });
+
+  describe('Db.collection', function () {
+    describe('#insertMany', function () {
+      beforeEach(async function () {
         const client = this.configuration.newClient();
         await client.connect();
-
-        try {
-          client.db('test').collection('test').initializeUnorderedBulkOp().raw({ insertOne: {} });
-        } catch (error) {
-          expect(error).not.to.exist;
-        }
+      });
+      afterEach(async function () {
         await client.close();
+      });
+      context('when passed an invalid or sparse list', function () {
+        it('insertmany should throw a MongoInvalidArgument error when called with a valid operation', async function () {
+          try {
+            const docs = [];
+            docs[1] = {}; // works for docs[0] = {}
+            await client.db('test').collection('test').insertMany(docs);
+            expect.fail('Failure to throw error');
+          } catch (error) {
+            expect(error).to.be.instanceOf(MongoInvalidArgumentError);
+          }
+        });
+      });
+      context('when passed a valid document list', function () {
+        it('insertmany should not throw a MongoInvalidArgument error when called with a valid operation', async function () {
+          try {
+            const docs = [];
+            docs[0] = {}; // works for docs[0] = {}
+            await client.db('test').collection('test').insertMany(docs);
+          } catch (error) {
+            expect(error).not.to.exist;
+          }
+        });
       });
     });
   });

--- a/test/integration/crud/bulk.test.js
+++ b/test/integration/crud/bulk.test.js
@@ -27,7 +27,8 @@ describe('Bulk', function () {
   before(function () {
     return setupDatabase(this.configuration);
   });
-  describe('BulkOperationBase', () => {
+  // eslint-disable-next-line no-restricted-properties
+  describe.only('BulkOperationBase', () => {
     describe('#raw', function () {
       let client;
       beforeEach(async function () {
@@ -39,12 +40,10 @@ describe('Bulk', function () {
       });
       context('when called with an undefined operation', function () {
         it('should throw a MongoInvalidArgument error ', async function () {
-          try {
-            client.db('test').collection('test').initializeUnorderedBulkOp().raw(undefined);
-            expect.fail('Failure to throw error');
-          } catch (error) {
-            expect(error).to.be.instanceOf(MongoInvalidArgumentError);
-          }
+          const bulkOp = client.db('test').collection('test').initializeUnorderedBulkOp();
+          expect(() => bulkOp.raw(undefined)).to.throw(MongoInvalidArgumentError);
+          expect(() => bulkOp.raw(true)).to.throw(MongoInvalidArgumentError);
+          expect(() => bulkOp.raw(3)).to.throw(MongoInvalidArgumentError);
         });
       });
 

--- a/test/integration/crud/bulk.test.js
+++ b/test/integration/crud/bulk.test.js
@@ -28,8 +28,7 @@ describe('Bulk', function () {
     return setupDatabase(this.configuration);
   });
   describe('BulkOperationBase', () => {
-    // eslint-disable-next-line no-restricted-properties
-    describe.only('#raw', function () {
+    describe('#raw', function () {
       let client;
       beforeEach(async function () {
         client = this.configuration.newClient();
@@ -70,8 +69,6 @@ describe('Bulk', function () {
       });
     });
   });
-
-  //write test to check if error thrown at raw op hasnt changed
 
   describe('Db.collection', function () {
     describe('#insertMany', function () {

--- a/test/integration/crud/bulk.test.js
+++ b/test/integration/crud/bulk.test.js
@@ -28,7 +28,7 @@ describe('Bulk', function () {
     return setupDatabase(this.configuration);
   });
   describe('BulkOperationBase', () => {
-    describe('#raw', function () {
+    describe('#raw()', function () {
       let client;
       beforeEach(async function () {
         client = this.configuration.newClient();
@@ -65,8 +65,8 @@ describe('Bulk', function () {
     });
   });
 
-  describe('Db.collection', function () {
-    describe('#insertMany', function () {
+  describe('Collection', function () {
+    describe('#insertMany()', function () {
       let client;
       beforeEach(async function () {
         client = this.configuration.newClient();


### PR DESCRIPTION
### Description
[NODE-3565](https://jira.mongodb.org/browse/NODE-3565)
#### What is changing? 
- Adding a conditional to check if invalid operation is passed to raw, then throwing a more descriptive error.
- Adding int tests to verify the new error is being thrown at the appropriate time

##### Is there new documentation needed for these changes?
No

#### What is the motivation for this change?
The previous error being thrown was not descriptive.
<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
