### PR TITLE
fix(NODE-4208): add aws http request timeout handler

### DIFF
--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -599,6 +599,7 @@ functions:
         working_dir: "src"
         script: |
           ${PREPARE_SHELL}
+          IS_EC2=true
           ${PROJECT_DIRECTORY}/.evergreen/run-mongodb-aws-test.sh
 
   "run aws auth test with aws credentials as environment variables":

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -599,7 +599,7 @@ functions:
         working_dir: "src"
         script: |
           ${PREPARE_SHELL}
-          IS_EC2=true
+          export IS_EC2=true
           ${PROJECT_DIRECTORY}/.evergreen/run-mongodb-aws-test.sh
 
   "run aws auth test with aws credentials as environment variables":

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -565,6 +565,7 @@ functions:
         working_dir: src
         script: |
           ${PREPARE_SHELL}
+          IS_EC2=true
           ${PROJECT_DIRECTORY}/.evergreen/run-mongodb-aws-test.sh
   run aws auth test with aws credentials as environment variables:
     - command: shell.exec

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -565,7 +565,7 @@ functions:
         working_dir: src
         script: |
           ${PREPARE_SHELL}
-          IS_EC2=true
+          export IS_EC2=true
           ${PROJECT_DIRECTORY}/.evergreen/run-mongodb-aws-test.sh
   run aws auth test with aws credentials as environment variables:
     - command: shell.exec

--- a/src/cmap/auth/mongodb_aws.ts
+++ b/src/cmap/auth/mongodb_aws.ts
@@ -6,6 +6,7 @@ import type { Binary, BSONSerializeOptions } from '../../bson';
 import * as BSON from '../../bson';
 import { aws4 } from '../../deps';
 import {
+  MongoAWSError,
   MongoCompatibilityError,
   MongoMissingCredentialsError,
   MongoRuntimeError
@@ -284,8 +285,7 @@ function request(uri: string, _options: RequestOptions | undefined, callback: Ca
   });
 
   req.on('timeout', () => {
-    console.log('DEBUG: hit timeout');
-    req.destroy(new Error('Aws request timed out'));
+    req.destroy(new MongoAWSError(`AWS request to ${uri} timed out after ${options.timeout} ms`));
   });
 
   req.on('error', err => callback(err));

--- a/src/cmap/auth/mongodb_aws.ts
+++ b/src/cmap/auth/mongodb_aws.ts
@@ -283,6 +283,11 @@ function request(uri: string, _options: RequestOptions | undefined, callback: Ca
     });
   });
 
+  req.on('timeout', () => {
+    console.log('DEBUG: hit timeout');
+    req.destroy(new Error('Aws request timed out'));
+  });
+
   req.on('error', err => callback(err));
   req.end();
 }

--- a/src/error.ts
+++ b/src/error.ts
@@ -348,6 +348,23 @@ export class MongoKerberosError extends MongoRuntimeError {
 }
 
 /**
+ * A error generated when the user attempts to authenticate
+ * via AWS, but fails
+ *
+ * @public
+ * @category Error
+ */
+export class MongoAWSError extends MongoRuntimeError {
+  constructor(message: string) {
+    super(message);
+  }
+
+  override get name(): string {
+    return 'MongoAWSError';
+  }
+}
+
+/**
  * An error generated when a ChangeStream operation fails to execute.
  *
  * @public

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,7 @@ export const ObjectID = ObjectId;
 export { AnyBulkWriteOperation, BulkWriteOptions, MongoBulkWriteError } from './bulk/common';
 export {
   MongoAPIError,
+  MongoAWSError,
   MongoBatchReExecutionError,
   MongoChangeStreamError,
   MongoCompatibilityError,


### PR DESCRIPTION
### Description
NODE-4208

#### What is changing?
- Adding a new subclass of `MongoRunTimeError`: `MongoAWSError` (inspired by the analogous error class for Kerberos)
- Adding a handler for the http request timeout error for AWS requests
- Adding a new environment variable to the EC2 test suite so that the new integration test can run only in the EC2 environment (since the other AWS test suites have credentials already available without the http call)

##### Is there new documentation needed for these changes?
No

#### What is the motivation for this change?
Fixes a bug where the default specified timeout of 10000ms for aws http requests was not being respected.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [N/A] New TODOs have a related JIRA ticket
