### PR TITLE
chore(NODE-4217): remove todos for won't do jira ticket

### DIFF
--- a/test/integration/server-selection/operation_count.test.ts
+++ b/test/integration/server-selection/operation_count.test.ts
@@ -219,9 +219,7 @@ describe('Server Operation Count Tests', function () {
       expect(server.s.operationCount).to.equal(0);
       const killCursorsSpy = sinon.spy(server, 'killCursors');
 
-      await cursor.close().catch(err => err);
-      // TODO(NODE-4217): update test to check for error existence
-      // expect(error).to.exist;
+      await cursor.close();
 
       expect(killCursorsSpy.called).to.be.true;
       expect(server.s.operationCount).to.equal(0);
@@ -291,9 +289,7 @@ describe('Server Operation Count Tests', function () {
           });
           const killCursorsSpy = sinon.spy(server, 'killCursors');
 
-          await cursor.close().catch(err => err);
-          // TODO(NODE-4217): update test to check for error existence
-          // expect(error).to.exist;
+          await cursor.close();
 
           expect(killCursorsSpy.called).to.be.true;
           expect(server.s.operationCount).to.equal(0);


### PR DESCRIPTION
### Description

#### What is changing?

##### Is there new documentation needed for these changes?

No.

#### What is the motivation for this change?

We don't want to do TODOs for closed Jira tickets in the driver! 

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
