### PR TITLE
remove map function from FILE_PATH_OPTIONS

### DIFF
--- a/lib/core/uri_parser.js
+++ b/lib/core/uri_parser.js
@@ -13,9 +13,7 @@ const emitWarningOnce = require('../utils').emitWarningOnce;
 const HOSTS_RX = /(mongodb(?:\+srv|)):\/\/(?: (?:[^:]*) (?: : ([^@]*) )? @ )?([^/?]*)(?:\/|)(.*)/;
 
 // Options that reference file paths should not be parsed
-const FILE_PATH_OPTIONS = new Set(
-  ['sslCA', 'sslCert', 'sslKey', 'tlsCAFile', 'tlsCertificateKeyFile'].map(key => key.toLowerCase())
-);
+const FILE_PATH_OPTIONS = new Set(['sslca', 'sslcert', 'sslkey', 'tlscafile', 'tlscertificatekeyfile']);
 
 /**
  * Determines whether a provided address matches the provided parent domain in order


### PR DESCRIPTION
Using lowercased items for FILE_PATH_OPTIONS would eliminate the need for mapping and lower casing that would save 100+ loops it has to go through with .map( ) and .toLowerCase( ) functions.

### Description

#### What is changing?

Removing redundant steps. 

##### Is there new documentation needed for these changes?
No.

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
