### PR TITLE
feat(NODE-4189): Support clustered collections

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -337,6 +337,7 @@ export type { IndexInformationOptions } from './operations/common_functions';
 export type { CountOptions } from './operations/count';
 export type { CountDocumentsOptions } from './operations/count_documents';
 export type {
+  ClusteredCollectionOptions,
   CreateCollectionOptions,
   TimeSeriesCollectionOptions
 } from './operations/create_collection';

--- a/src/operations/create_collection.ts
+++ b/src/operations/create_collection.ts
@@ -47,8 +47,8 @@ export interface TimeSeriesCollectionOptions extends Document {
  */
 export interface ClusteredCollectionOptions extends Document {
   name?: string;
-  key?: Document;
-  unique?: boolean;
+  key: Document;
+  unique: boolean;
   v?: string;
 }
 

--- a/src/operations/create_collection.ts
+++ b/src/operations/create_collection.ts
@@ -50,7 +50,6 @@ export interface ClusteredCollectionOptions extends Document {
   name?: string;
   key: Document;
   unique: boolean;
-  v?: string;
 }
 
 /** @public */

--- a/src/operations/create_collection.ts
+++ b/src/operations/create_collection.ts
@@ -84,7 +84,7 @@ export interface CreateCollectionOptions extends CommandOperationOptions {
   pkFactory?: PkFactory;
   /** A document specifying configuration options for timeseries collections. */
   timeseries?: TimeSeriesCollectionOptions;
-  /** A document specifying configuration options for clustered collections. */
+  /** A document specifying configuration options for clustered collections. For MongoDB 5.3 and above. */
   clusteredIndex?: ClusteredCollectionOptions;
   /** The number of seconds after which a document in a timeseries or clustered collection expires. */
   expireAfterSeconds?: number;

--- a/src/operations/create_collection.ts
+++ b/src/operations/create_collection.ts
@@ -41,6 +41,17 @@ export interface TimeSeriesCollectionOptions extends Document {
   granularity?: 'seconds' | 'minutes' | 'hours' | string;
 }
 
+/** @public
+ * Configuration options for clustered collections
+ * @see https://www.mongodb.com/docs/v5.3/core/clustered-collections/
+ */
+export interface ClusteredCollectionOptions extends Document {
+  name?: string;
+  key?: Document;
+  unique?: boolean;
+  v?: string;
+}
+
 /** @public */
 export interface CreateCollectionOptions extends CommandOperationOptions {
   /** Returns an error if the collection does not exist */
@@ -73,7 +84,9 @@ export interface CreateCollectionOptions extends CommandOperationOptions {
   pkFactory?: PkFactory;
   /** A document specifying configuration options for timeseries collections. */
   timeseries?: TimeSeriesCollectionOptions;
-  /** The number of seconds after which a document in a timeseries collection expires. */
+  /** A document specifying configuration options for clustered collections. */
+  clusteredIndex?: ClusteredCollectionOptions;
+  /** The number of seconds after which a document in a timeseries or clustered collection expires. */
   expireAfterSeconds?: number;
 }
 

--- a/src/operations/create_collection.ts
+++ b/src/operations/create_collection.ts
@@ -43,6 +43,7 @@ export interface TimeSeriesCollectionOptions extends Document {
 
 /** @public
  * Configuration options for clustered collections
+ * TODO: NODE-4230 replace with normal manual link once it is on there.
  * @see https://www.mongodb.com/docs/v5.3/core/clustered-collections/
  */
 export interface ClusteredCollectionOptions extends Document {

--- a/src/operations/indexes.ts
+++ b/src/operations/indexes.ts
@@ -95,6 +95,8 @@ export interface IndexDescription
   collation?: CollationOptions;
   name?: string;
   key: Document;
+  /* Specifies that this index is clustered. This is not a valid option to provide to 'createIndexes', but can appear in the options returned for an index via 'listIndexes'. */
+  clustered?: boolean;
 }
 
 /** @public */

--- a/src/operations/indexes.ts
+++ b/src/operations/indexes.ts
@@ -95,8 +95,6 @@ export interface IndexDescription
   collation?: CollationOptions;
   name?: string;
   key: Document;
-  /* Specifies that this index is clustered. This is not a valid option to provide to 'createIndexes', but can appear in the options returned for an index via 'listIndexes'. */
-  clustered?: boolean;
 }
 
 /** @public */

--- a/test/spec/collection-management/clustered-indexes.json
+++ b/test/spec/collection-management/clustered-indexes.json
@@ -1,0 +1,176 @@
+{
+  "description": "clustered-indexes",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "5.3"
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "ts-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "test",
+      "databaseName": "ts-tests",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "createCollection with clusteredIndex",
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "test"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "test",
+            "clusteredIndex": {
+              "key": {
+                "_id": 1
+              },
+              "unique": true,
+              "name": "test index"
+            }
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "databaseName": "ts-tests",
+            "collectionName": "test"
+          }
+        }
+      ]
+    },
+    {
+      "description": "listCollections includes clusteredIndex",
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "test"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "test",
+            "clusteredIndex": {
+              "key": {
+                "_id": 1
+              },
+              "unique": true,
+              "name": "test index"
+            }
+          }
+        },
+        {
+          "name": "listCollections",
+          "object": "database0",
+          "arguments": {
+            "filter": {
+              "name": {
+                "$eq": "test"
+              }
+            }
+          },
+          "expectResult": [
+            {
+              "name": "test",
+              "options": {
+                "clusteredIndex": {
+                  "key": {
+                    "_id": 1
+                  },
+                  "unique": true,
+                  "name": "test index",
+                  "v": {
+                    "$$type": [
+                      "int",
+                      "long"
+                    ]
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "listIndexes returns the index",
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "test"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "test",
+            "clusteredIndex": {
+              "key": {
+                "_id": 1
+              },
+              "unique": true,
+              "name": "test index"
+            }
+          }
+        },
+        {
+          "name": "listIndexes",
+          "object": "collection0",
+          "expectResult": [
+            {
+              "key": {
+                "_id": 1
+              },
+              "name": "test index",
+              "clustered": true,
+              "unique": true,
+              "v": {
+                "$$type": [
+                  "int",
+                  "long"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/collection-management/clustered-indexes.yml
+++ b/test/spec/collection-management/clustered-indexes.yml
@@ -1,0 +1,94 @@
+description: "clustered-indexes"
+
+schemaVersion: "1.0"
+
+runOnRequirements:
+  - minServerVersion: "5.3"
+
+createEntities:
+  - client:
+      id: &client0 client0
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name ts-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name test
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents: []
+
+tests:
+  - description: "createCollection with clusteredIndex"
+    operations:
+      - name: dropCollection
+        object: *database0
+        arguments:
+          collection: *collection0Name
+      - name: createCollection
+        object: *database0
+        arguments:
+          collection: *collection0Name
+          clusteredIndex:
+            key: { _id: 1 }
+            unique: true
+            name: &index0Name "test index"
+      - name: assertCollectionExists
+        object: testRunner
+        arguments:
+          databaseName: *database0Name
+          collectionName: *collection0Name
+
+  - description: "listCollections includes clusteredIndex"
+    operations:
+      - name: dropCollection
+        object: *database0
+        arguments:
+          collection: *collection0Name
+      - name: createCollection
+        object: *database0
+        arguments:
+          collection: *collection0Name
+          clusteredIndex:
+            key: { _id: 1 }
+            unique: true
+            name: &index0Name "test index"
+      - name: listCollections
+        object: *database0
+        arguments:
+          filter: { name: { $eq: *collection0Name } }
+        expectResult:
+          - name: *collection0Name
+            options:
+              clusteredIndex:
+                key: { _id: 1 }
+                unique: true
+                name: *index0Name
+                v: { $$type: [ int, long ] }
+
+  - description: "listIndexes returns the index"
+    operations:
+      - name: dropCollection
+        object: *database0
+        arguments:
+          collection: *collection0Name
+      - name: createCollection
+        object: *database0
+        arguments:
+          collection: *collection0Name
+          clusteredIndex:
+            key: { _id: 1 }
+            unique: true
+            name: *index0Name
+      - name: listIndexes
+        object: *collection0
+        expectResult:
+          - key: { _id: 1 }
+            name: *index0Name
+            clustered: true
+            unique: true
+            v: { $$type: [ int, long ] }


### PR DESCRIPTION
MongoDB 5.3 added support for clustered collections. Clustered collections are collections with a clustered index.

I based the changes in this PR off how timeseries collections work.


Scope: https://docs.google.com/document/d/1r_1BBIlfELnKBz5qAzzLDUB-BJfGrQKTS2TNHXu4DRg/edit#heading=h.b1os3ai9s8t3



- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
