### PR TITLE
feat(NODE-4185): Allow opting out of disk use on cursor builder

### DIFF
--- a/src/cursor/find_cursor.ts
+++ b/src/cursor/find_cursor.ts
@@ -415,15 +415,16 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
   allowDiskUse(allow = true): this {
     assertUninitialized(this);
 
+    if (!this[kBuiltOptions].sort) {
+      throw new MongoInvalidArgumentError('Option "allowDiskUse" requires a sort specification');
+    }
+
     // As of 6.0 the default is true. This allows users to get back to the old behaviour.
     if (!allow) {
       this[kBuiltOptions].allowDiskUse = false;
       return this;
     }
 
-    if (!this[kBuiltOptions].sort) {
-      throw new MongoInvalidArgumentError('Option "allowDiskUse" requires a sort specification');
-    }
     this[kBuiltOptions].allowDiskUse = true;
     return this;
   }

--- a/src/cursor/find_cursor.ts
+++ b/src/cursor/find_cursor.ts
@@ -412,8 +412,15 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
    * @remarks
    * {@link https://docs.mongodb.com/manual/reference/command/find/#find-cmd-allowdiskuse | find command allowDiskUse documentation}
    */
-  allowDiskUse(): this {
+  allowDiskUse(allow = true): this {
     assertUninitialized(this);
+
+    // As of 6.0 the default is true. This allows users to get back to the old behaviour.
+    if (!allow) {
+      this[kBuiltOptions].allowDiskUse = false;
+      return this;
+    }
+
     if (!this[kBuiltOptions].sort) {
       throw new MongoInvalidArgumentError('Option "allowDiskUse" requires a sort specification');
     }

--- a/test/integration/crud/find_cursor_methods.test.js
+++ b/test/integration/crud/find_cursor_methods.test.js
@@ -335,5 +335,17 @@ describe('Find Cursor', function () {
         });
       })
     });
+
+    it('throws if the query does not have sort specified', {
+      metadata: { requires: { mongodb: '>=4.4' } },
+      test: withClientV2(function (client, done) {
+        const coll = client.db().collection('abstract_cursor');
+        const cursor = coll.find({});
+        expect(() => cursor.allowDiskUse(false)).to.throw(
+          'Option "allowDiskUse" requires a sort specification'
+        );
+        done();
+      })
+    });
   });
 });

--- a/test/integration/crud/find_cursor_methods.test.js
+++ b/test/integration/crud/find_cursor_methods.test.js
@@ -296,9 +296,9 @@ describe('Find Cursor', function () {
   });
 
   context('#allowDiskUse', function () {
-    it(
-      'should set allowDiskUse to true by default',
-      withClientV2(function (client, done) {
+    it('should set allowDiskUse to true by default', {
+      metadata: { requires: { mongodb: '>=4.4' } },
+      test: withClientV2(function (client, done) {
         const commands = [];
         client.on('commandStarted', filterForCommands(['find'], commands));
 
@@ -314,11 +314,11 @@ describe('Find Cursor', function () {
           done();
         });
       })
-    );
+    });
 
-    it(
-      'should set allowDiskUse to false if specified',
-      withClientV2(function (client, done) {
+    it('should set allowDiskUse to false if specified', {
+      metadata: { requires: { mongodb: '>=4.4' } },
+      test: withClientV2(function (client, done) {
         const commands = [];
         client.on('commandStarted', filterForCommands(['find'], commands));
 
@@ -334,6 +334,6 @@ describe('Find Cursor', function () {
           done();
         });
       })
-    );
+    });
   });
 });

--- a/test/integration/crud/find_cursor_methods.test.js
+++ b/test/integration/crud/find_cursor_methods.test.js
@@ -294,4 +294,46 @@ describe('Find Cursor', function () {
       })
     });
   });
+
+  context('#allowDiskUse', function () {
+    it(
+      'should set allowDiskUse to true by default',
+      withClientV2(function (client, done) {
+        const commands = [];
+        client.on('commandStarted', filterForCommands(['find'], commands));
+
+        const coll = client.db().collection('abstract_cursor');
+        const cursor = coll.find({}, { sort: 'foo' });
+        cursor.allowDiskUse();
+        this.defer(() => cursor.close());
+
+        cursor.toArray(err => {
+          expect(err).to.not.exist;
+          expect(commands).to.have.length(1);
+          expect(commands[0].command.allowDiskUse).to.equal(true);
+          done();
+        });
+      })
+    );
+
+    it(
+      'should set allowDiskUse to false if specified',
+      withClientV2(function (client, done) {
+        const commands = [];
+        client.on('commandStarted', filterForCommands(['find'], commands));
+
+        const coll = client.db().collection('abstract_cursor');
+        const cursor = coll.find({}, { sort: 'foo' });
+        cursor.allowDiskUse(false);
+        this.defer(() => cursor.close());
+
+        cursor.toArray(err => {
+          expect(err).to.not.exist;
+          expect(commands).to.have.length(1);
+          expect(commands[0].command.allowDiskUse).to.equal(false);
+          done();
+        });
+      })
+    );
+  });
 });


### PR DESCRIPTION
See also:

* https://jira.mongodb.org/browse/MONGOSH-1183
* https://jira.mongodb.org/browse/PM-2742

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
