### PR TITLE
fix(NODE-4232): stream() also returns generic AsyncIterable

### DIFF
--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -385,7 +385,7 @@ export class ChangeStream<
   /** @internal */
   [kResumeQueue]: Denque<Callback<ChangeStreamCursor<TSchema, TChange>>>;
   /** @internal */
-  [kCursorStream]?: Readable;
+  [kCursorStream]?: Readable & AsyncIterable<TChange>;
   /** @internal */
   [kClosed]: boolean;
   /** @internal */
@@ -473,7 +473,7 @@ export class ChangeStream<
   }
 
   /** @internal */
-  get cursorStream(): Readable | undefined {
+  get cursorStream(): (Readable & AsyncIterable<TChange>) | undefined {
     return this[kCursorStream];
   }
 
@@ -542,7 +542,7 @@ export class ChangeStream<
    * Return a modified Readable stream including a possible transform method.
    * @throws MongoDriverError if this.cursor is undefined
    */
-  stream(options?: CursorStreamOptions): Readable {
+  stream(options?: CursorStreamOptions): Readable & AsyncIterable<TChange> {
     this.streamOptions = options;
     if (!this.cursor) throw new MongoChangeStreamError(NO_CURSOR_ERROR);
     return this.cursor.stream(options);

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -258,7 +258,7 @@ export abstract class AbstractCursor<
     };
   }
 
-  stream(options?: CursorStreamOptions): Readable {
+  stream(options?: CursorStreamOptions): Readable & AsyncIterable<TSchema> {
     if (options?.transform) {
       const transform = options.transform;
       const readable = makeCursorStream(this);

--- a/test/types/community/cursor.test-d.ts
+++ b/test/types/community/cursor.test-d.ts
@@ -30,9 +30,15 @@ const cursor = collection
   .sort({})
   .map(result => ({ foo: result.age }));
 
+const cursorStream = cursor.stream();
 expectType<FindCursor<{ foo: number }>>(cursor);
-expectType<Readable>(cursor.stream());
+expectType<Readable & AsyncIterable<{ foo: number }>>(cursorStream);
 expectType<FindCursor<Document>>(cursor.project({}));
+(async () => {
+  for await (const doc of cursorStream) {
+    expectType<{ foo: number }>(doc);
+  }
+})();
 
 collection.find().project({});
 collection.find().project({ notExistingField: 1 });


### PR DESCRIPTION
### Description

#### What is changing?
AbstractCursor#stream also returns `AsyncIterator<TSchema>`

##### Is there new documentation needed for these changes?
update autogenerated docs maybe

#### What is the motivation for this change?
need to carry the type when doing async iteration over stream() result

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
