### PR TITLE
fix(NODE-4108): improve return type for withTransaction()

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -36,6 +36,14 @@ declare global {
   }
 
   namespace Mocha {
+    interface SuiteFunction {
+      (title: string, metadata: MongoDBMetadataUI, fn: (this: Suite) => void): Mocha.Suite;
+    }
+
+    interface PendingSuiteFunction {
+      (title: string, metadata: MongoDBMetadataUI, fn: (this: Suite) => void): Mocha.Suite;
+    }
+
     interface TestFunction {
       (title: string, metadata: MongoDBMetadataUI, fn: Mocha.Func): Mocha.Test;
       (title: string, metadata: MongoDBMetadataUI, fn: Mocha.AsyncFunc): Mocha.Test;

--- a/src/transactions.ts
+++ b/src/transactions.ts
@@ -68,7 +68,7 @@ export interface TransactionOptions extends CommandOperationOptions {
   writeConcern?: WriteConcern;
   /** A default read preference for commands in this transaction */
   readPreference?: ReadPreference;
-
+  /** Specifies the maximum amount of time to allow a commit action on a transaction to run in milliseconds */
   maxCommitTimeMS?: number;
 }
 


### PR DESCRIPTION
### Description

The `withTransaction()` function signature implies that `withTransaction()` returns the same value that the user-provided callback returns but that is incorrect.

Reported in https://github.com/Automattic/mongoose/issues/9919

#### What is changing?

Function signature for `withTransaction()` maintains the T argument but goes unused. Added tests for asserting the expected outcomes.

#### What is the motivation for this change?

Fixes the type bug, but also adds documentation to the three possible outcomes of the function.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
