### PR TITLE
chore: use latest version of mongodb-client-encryption

### DIFF
--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -47,7 +47,7 @@ else
   source "$DRIVERS_TOOLS"/.evergreen/csfle/set-temp-creds.sh
 fi
 
-npm install mongodb-client-encryption@">=2.0.0-beta.4"
+npm install mongodb-client-encryption@">=2.2.0-alpha.0"
 
 export AUTH=$AUTH
 export SINGLE_MONGOS_LB_URI=${SINGLE_MONGOS_LB_URI}


### PR DESCRIPTION
### Description

#### What is changing?

Pull in latest crypt lib for CI

#### What is the motivation for this change?

CI needs the latest release

### Double check the following

- [N/A] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [N/A] New TODOs have a related JIRA ticket
