### PR TITLE
test: fix flakey operation count test

### DIFF
--- a/test/integration/server-selection/operation_count.test.ts
+++ b/test/integration/server-selection/operation_count.test.ts
@@ -141,11 +141,11 @@ describe('Server Operation Count Tests', function () {
 
       const getMoreSpy = sinon.spy(server, 'getMore');
 
-      const operations = Array.from({ length: 10 }, () => cursor.next());
+      const operation = cursor.next();
 
-      expect(server.s.operationCount).to.equal(10);
+      expect(server.s.operationCount).to.equal(1);
 
-      await Promise.all(operations);
+      await operation;
 
       expect(getMoreSpy.called).to.be.true;
       expect(server.s.operationCount).to.equal(0);


### PR DESCRIPTION
### Description

#### What is changing?

This PR fixes a flakey test introduced in the operation count work.

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
