### PR TITLE
fix(NODE-4139): allow monitor to yield control

### DIFF
--- a/src/sdam/monitor.ts
+++ b/src/sdam/monitor.ts
@@ -279,11 +279,13 @@ function checkServer(monitor: Monitor, callback: Callback<Document | null>) {
       // if we are using the streaming protocol then we immediately issue another `started`
       // event, otherwise the "check" is complete and return to the main monitor loop
       if (isAwaitable && hello.topologyVersion) {
-        monitor.emit(
-          Server.SERVER_HEARTBEAT_STARTED,
-          new ServerHeartbeatStartedEvent(monitor.address)
-        );
-        start = now();
+        setTimeout(function () {
+          monitor.emit(
+            Server.SERVER_HEARTBEAT_STARTED,
+            new ServerHeartbeatStartedEvent(monitor.address)
+          );
+          start = now();
+        }, 0);
       } else {
         monitor[kRTTPinger]?.close();
         monitor[kRTTPinger] = undefined;


### PR DESCRIPTION
### Description

Changes the monitor to process incoming hellos when the streaming protocol is enabled in a timeout, so that it can yield the process to other potential commands.

#### What is changing?

Adds a `setTimeout` in the callback after the hello command is run. This has been shown on aws lambda to reduce processing time after a function is idle for hours from over 20 seconds to ~400ms.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-4140

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
