### PR TITLE
feat(NODE-4064): deprecate legacy bulk operation methods and classes

### DIFF
--- a/src/bulk/ordered.ts
+++ b/src/bulk/ordered.ts
@@ -6,7 +6,11 @@ import type { DeleteStatement } from '../operations/delete';
 import type { UpdateStatement } from '../operations/update';
 import { Batch, BatchType, BulkOperationBase, BulkWriteOptions } from './common';
 
-/** @public */
+/**
+ * @public
+ *
+ * @deprecated Please use collection.bulkWrite() instead
+ */
 export class OrderedBulkOperation extends BulkOperationBase {
   constructor(collection: Collection, options: BulkWriteOptions) {
     super(collection, options, true);

--- a/src/bulk/unordered.ts
+++ b/src/bulk/unordered.ts
@@ -7,7 +7,11 @@ import type { UpdateStatement } from '../operations/update';
 import type { Callback } from '../utils';
 import { Batch, BatchType, BulkOperationBase, BulkWriteOptions, BulkWriteResult } from './common';
 
-/** @public */
+/**
+ * @public
+ *
+ * @deprecated Please use collection.bulkWrite() instead
+ */
 export class UnorderedBulkOperation extends BulkOperationBase {
   constructor(collection: Collection, options: BulkWriteOptions) {
     super(collection, options, false);

--- a/src/cmap/auth/scram.ts
+++ b/src/cmap/auth/scram.ts
@@ -9,7 +9,7 @@ import {
   MongoRuntimeError,
   MongoServerError
 } from '../../error';
-import { Callback, emitWarning, ns } from '../../utils';
+import { Callback, emitWarningOnce, ns } from '../../utils';
 import type { HandshakeDocument } from '../connect';
 import { AuthContext, AuthProvider } from './auth_provider';
 import type { MongoCredentials } from './mongo_credentials';
@@ -31,7 +31,7 @@ class ScramSHA extends AuthProvider {
       return callback(new MongoMissingCredentialsError('AuthContext must provide credentials.'));
     }
     if (cryptoMethod === 'sha256' && saslprep == null) {
-      emitWarning('Warning: no saslprep library specified. Passwords will not be sanitized');
+      emitWarningOnce('Warning: no saslprep library specified. Passwords will not be sanitized');
     }
 
     crypto.randomBytes(24, (err, nonce) => {

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -1506,13 +1506,25 @@ export class Collection<TSchema extends Document = Document> {
     );
   }
 
-  /** Initiate an Out of order batch write operation. All operations will be buffered into insert/update/remove commands executed out of order. */
+  /**
+   * Initiate an Out of order batch write operation. All operations will be buffered into insert/update/remove commands executed out of order.
+   * @deprecated Please use collection.bulkWrite() instead
+   */
   initializeUnorderedBulkOp(options?: BulkWriteOptions): UnorderedBulkOperation {
+    emitWarningOnce(
+      'initializeUnorderedBulkOp is deprecated and will be removed in the next major version, please use collection.bulkWrite() instead'
+    );
     return new UnorderedBulkOperation(this as TODO_NODE_3286, resolveOptions(this, options));
   }
 
-  /** Initiate an In order bulk write operation. Operations will be serially executed in the order they are added, creating a new operation for each switch in types. */
+  /**
+   * Initiate an In order bulk write operation. Operations will be serially executed in the order they are added, creating a new operation for each switch in types.
+   * @deprecated Please use collection.bulkWrite() instead
+   */
   initializeOrderedBulkOp(options?: BulkWriteOptions): OrderedBulkOperation {
+    emitWarningOnce(
+      'initializeOrderedBulkOp is deprecated and will be removed in the next major version, please use collection.bulkWrite() instead'
+    );
     return new OrderedBulkOperation(this as TODO_NODE_3286, resolveOptions(this, options));
   }
 

--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -28,7 +28,6 @@ import {
   AnyOptions,
   Callback,
   DEFAULT_PK_FACTORY,
-  emitWarning,
   emitWarningOnce,
   HostAddress,
   isRecord,
@@ -533,7 +532,7 @@ function setOption(
 
   if (deprecated) {
     const deprecatedMsg = typeof deprecated === 'string' ? `: ${deprecated}` : '';
-    emitWarning(`${key} is a deprecated option${deprecatedMsg}`);
+    emitWarningOnce(`${key} is a deprecated option${deprecatedMsg}`);
   }
 
   switch (type) {
@@ -834,7 +833,7 @@ export const OPTIONS = {
       if (value instanceof Logger) {
         return value;
       }
-      emitWarning('Alternative loggers might not be supported');
+      emitWarningOnce('Alternative loggers might not be supported');
       // TODO: make Logger an interface that others can implement, make usage consistent in driver
       // DRIVERS-1204
       return;

--- a/src/sdam/topology.ts
+++ b/src/sdam/topology.ts
@@ -41,7 +41,7 @@ import {
   Callback,
   ClientMetadata,
   eachAsync,
-  emitWarning,
+  emitWarningOnce,
   EventEmitterWithState,
   HostAddress,
   makeStateMachine,
@@ -777,7 +777,7 @@ export class Topology extends TypedEventEmitter<TopologyEvents> {
    * @deprecated This function is deprecated and will be removed in the next major version.
    */
   unref(): void {
-    emitWarning('`unref` is a noop and will be removed in the next major version');
+    emitWarningOnce('`unref` is a noop and will be removed in the next major version');
   }
 
   // NOTE: There are many places in code where we explicitly check the last hello

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1297,11 +1297,15 @@ export const DEFAULT_PK_FACTORY = {
 export const MONGODB_WARNING_CODE = 'MONGODB DRIVER' as const;
 
 /** @internal */
-export function emitWarning(message: string): void {
+function emitWarning(message: string): void {
   return process.emitWarning(message, { code: MONGODB_WARNING_CODE } as any);
 }
 
-const emittedWarnings = new Set();
+/**
+ * This is exported so downstream users can override which warnings are emitted
+ * @internal
+ */
+export const emittedWarnings = new Set();
 /**
  * Will emit a warning once for the duration of the application.
  * Uses the message to identify if it has already been emitted


### PR DESCRIPTION
### Description

#### What is changing?

Adding a deprecation to legacy methods and classes

#### What is the motivation for this change?

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
