### PR TITLE
refactor(NODE-2993): align internal cmap implementation with spec

### DIFF
--- a/src/cmap/connection_pool.ts
+++ b/src/cmap/connection_pool.ts
@@ -39,7 +39,7 @@ const kLogger = Symbol('logger');
 /** @internal */
 const kConnections = Symbol('connections');
 /** @internal */
-const kPermits = Symbol('permits');
+const kPending = Symbol('pending');
 /** @internal */
 const kMinPoolSizeTimer = Symbol('minPoolSizeTimer');
 /** @internal */
@@ -112,11 +112,10 @@ export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
   [kLogger]: Logger;
   /** @internal */
   [kConnections]: Denque<Connection>;
-  /**
-   * An integer expressing how many total connections are permitted
-   * @internal
-   */
-  [kPermits]: number;
+  /** @internal */
+  [kPending]: number;
+  /** @internal */
+  [kCheckedOut]: number;
   /** @internal */
   [kMinPoolSizeTimer]?: NodeJS.Timeout;
   /**
@@ -136,8 +135,6 @@ export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
   [kWaitQueue]: Denque<WaitQueueMember>;
   /** @internal */
   [kMetrics]: ConnectionPoolMetrics;
-  /** @internal */
-  [kCheckedOut]: number;
   /** @internal */
   [kProcessingWaitQueue]: boolean;
 
@@ -216,7 +213,8 @@ export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
 
     this[kLogger] = new Logger('ConnectionPool');
     this[kConnections] = new Denque();
-    this[kPermits] = this.options.maxPoolSize;
+    this[kPending] = 0;
+    this[kCheckedOut] = 0;
     this[kMinPoolSizeTimer] = undefined;
     this[kGeneration] = 0;
     this[kServiceGenerations] = new Map();
@@ -225,7 +223,6 @@ export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
     this[kCancellationToken].setMaxListeners(Infinity);
     this[kWaitQueue] = new Denque();
     this[kMetrics] = new ConnectionPoolMetrics();
-    this[kCheckedOut] = 0;
     this[kProcessingWaitQueue] = false;
 
     process.nextTick(() => {
@@ -244,14 +241,24 @@ export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
     return this[kGeneration];
   }
 
-  /** An integer expressing how many total connections (active + in use) the pool currently has */
+  /** An integer expressing how many total connections (available + pending + in use) the pool currently has */
   get totalConnectionCount(): number {
-    return this[kConnections].length + (this.options.maxPoolSize - this[kPermits]);
+    return (
+      this.availableConnectionCount + this.pendingConnectionCount + this.currentCheckedOutCount
+    );
   }
 
   /** An integer expressing how many connections are currently available in the pool. */
   get availableConnectionCount(): number {
     return this[kConnections].length;
+  }
+
+  get pendingConnectionCount(): number {
+    return this[kPending];
+  }
+
+  get currentCheckedOutCount(): number {
+    return this[kCheckedOut];
   }
 
   get waitQueueSize(): number {
@@ -264,10 +271,6 @@ export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
 
   get serviceGenerations(): Map<string, number> {
     return this[kServiceGenerations];
-  }
-
-  get currentCheckedOutCount(): number {
-    return this[kCheckedOut];
   }
 
   /**
@@ -319,7 +322,6 @@ export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
       }, waitQueueTimeoutMS);
     }
 
-    this[kCheckedOut] = this[kCheckedOut] + 1;
     this[kWaitQueue].push(waitQueueMember);
     process.nextTick(processWaitQueue, this);
   }
@@ -527,10 +529,10 @@ function createConnection(pool: ConnectionPool, callback?: Callback<Connection>)
     cancellationToken: pool[kCancellationToken]
   };
 
-  pool[kPermits]--;
+  pool[kPending]++;
   connect(connectOptions, (err, connection) => {
     if (err || !connection) {
-      pool[kPermits]++;
+      pool[kPending]--;
       pool[kLogger].debug(`connection attempt failed with error [${JSON.stringify(err)}]`);
       if (typeof callback === 'function') {
         callback(err);
@@ -541,6 +543,7 @@ function createConnection(pool: ConnectionPool, callback?: Callback<Connection>)
 
     // The pool might have closed since we started trying to create a connection
     if (pool.closed) {
+      pool[kPending]--;
       connection.destroy({ force: true });
       return;
     }
@@ -574,21 +577,21 @@ function createConnection(pool: ConnectionPool, callback?: Callback<Connection>)
 
     // if a callback has been provided, check out the connection immediately
     if (typeof callback === 'function') {
+      pool[kCheckedOut]++;
+      pool[kPending]--;
       callback(undefined, connection);
       return;
     }
 
     // otherwise add it to the pool for later acquisition, and try to process the wait queue
     pool[kConnections].push(connection);
+    pool[kPending]--;
     process.nextTick(processWaitQueue, pool);
   });
 }
 
 function destroyConnection(pool: ConnectionPool, connection: Connection, reason: string) {
   pool.emit(ConnectionPool.CONNECTION_CLOSED, new ConnectionClosedEvent(pool, connection, reason));
-
-  // allow more connections to be created
-  pool[kPermits]++;
 
   // destroy the connection
   process.nextTick(() => connection.destroy());
@@ -624,6 +627,7 @@ function processWaitQueue(pool: ConnectionPool) {
     const isStale = connectionIsStale(pool, connection);
     const isIdle = connectionIsIdle(pool, connection);
     if (!isStale && !isIdle && !connection.closed) {
+      pool[kCheckedOut]++;
       pool.emit(
         ConnectionPool.CONNECTION_CHECKED_OUT,
         new ConnectionCheckedOutEvent(pool, connection)

--- a/test/integration/connection-monitoring-and-pooling/cmap-node-specs/pool-checkin-stats.json
+++ b/test/integration/connection-monitoring-and-pooling/cmap-node-specs/pool-checkin-stats.json
@@ -32,6 +32,7 @@
       "options": 42,
       "totalConnectionCount": 0,
       "availableConnectionCount": 0,
+      "pendingConnectionCount": 0,
       "currentCheckedOutCount": 0
     },
     {
@@ -60,6 +61,7 @@
       "address": 42,
       "currentCheckedOutCount": 0,
       "availableConnectionCount": 3,
+      "pendingConnectionCount": 0,
       "totalConnectionCount": 3
     }
   ],

--- a/test/integration/connection-monitoring-and-pooling/cmap-node-specs/pool-checkin-stats.json
+++ b/test/integration/connection-monitoring-and-pooling/cmap-node-specs/pool-checkin-stats.json
@@ -1,0 +1,71 @@
+{
+  "version": 1,
+  "style": "unit",
+  "description": "must correctly update pool stats when checking in a connection",
+  "poolOptions": {
+    "minPoolSize": 3
+  },
+  "operations": [
+    {
+      "name": "waitForEvent",
+      "event": "ConnectionCreated",
+      "count": 3
+    },
+    {
+      "name": "waitForEvent",
+      "event": "ConnectionReady",
+      "count": 3
+    },
+    {
+      "name": "checkOut",
+      "label": "conn"
+    },
+    {
+      "name": "checkIn",
+      "connection": "conn"
+    }
+  ],
+  "events": [
+    {
+      "type": "ConnectionPoolCreated",
+      "address": 42,
+      "options": 42,
+      "totalConnectionCount": 0,
+      "availableConnectionCount": 0,
+      "currentCheckedOutCount": 0
+    },
+    {
+      "type": "ConnectionCreated",
+      "connectionId": 42,
+      "address": 42
+    },
+    {
+      "type": "ConnectionCreated",
+      "connectionId": 42,
+      "address": 42
+    },
+    {
+      "type": "ConnectionCreated",
+      "connectionId": 42,
+      "address": 42
+    },
+    {
+      "type": "ConnectionCheckedOut",
+      "connectionId": 42,
+      "address": 42
+    },
+    {
+      "type": "ConnectionCheckedIn",
+      "connectionId": 42,
+      "address": 42,
+      "currentCheckedOutCount": 0,
+      "availableConnectionCount": 3,
+      "totalConnectionCount": 3
+    }
+  ],
+  "ignore": [
+    "ConnectionReady",
+    "ConnectionClosed",
+    "ConnectionCheckOutStarted"
+  ]
+}

--- a/test/integration/connection-monitoring-and-pooling/cmap-node-specs/pool-checkout-stats.json
+++ b/test/integration/connection-monitoring-and-pooling/cmap-node-specs/pool-checkout-stats.json
@@ -1,0 +1,61 @@
+{
+  "version": 1,
+  "style": "unit",
+  "description": "must correctly update pool stats when checking out a connection",
+  "poolOptions": {
+    "minPoolSize": 3
+  },
+  "operations": [
+    {
+      "name": "waitForEvent",
+      "event": "ConnectionCreated",
+      "count": 3
+    },
+    {
+      "name": "waitForEvent",
+      "event": "ConnectionReady",
+      "count": 3
+    },
+    {
+      "name": "checkOut"
+    }
+  ],
+  "events": [
+    {
+      "type": "ConnectionPoolCreated",
+      "address": 42,
+      "options": 42,
+      "currentCheckedOutCount": 0,
+      "availableConnectionCount": 0,
+      "totalConnectionCount": 0
+    },
+    {
+      "type": "ConnectionCreated",
+      "connectionId": 42,
+      "address": 42
+    },
+    {
+      "type": "ConnectionCreated",
+      "connectionId": 42,
+      "address": 42
+    },
+    {
+      "type": "ConnectionCreated",
+      "connectionId": 42,
+      "address": 42
+    },
+    {
+      "type": "ConnectionCheckedOut",
+      "connectionId": 42,
+      "address": 42,
+      "currentCheckedOutCount": 1,
+      "availableConnectionCount": 2,
+      "totalConnectionCount": 3
+    }
+  ],
+  "ignore": [
+    "ConnectionReady",
+    "ConnectionClosed",
+    "ConnectionCheckOutStarted"
+  ]
+}

--- a/test/integration/connection-monitoring-and-pooling/cmap-node-specs/pool-minPoolSize-population-stats.json
+++ b/test/integration/connection-monitoring-and-pooling/cmap-node-specs/pool-minPoolSize-population-stats.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "style": "unit",
-  "description": "must correctly update pool stats when checking out a connection",
+  "description": "must correctly update pool stats when populating the pool up to minPoolSize",
   "poolOptions": {
     "minPoolSize": 3
   },
@@ -15,9 +15,6 @@
       "name": "waitForEvent",
       "event": "ConnectionReady",
       "count": 3
-    },
-    {
-      "name": "checkOut"
     }
   ],
   "events": [
@@ -33,31 +30,31 @@
     {
       "type": "ConnectionCreated",
       "connectionId": 42,
-      "address": 42
+      "address": 42,
+      "currentCheckedOutCount": 0,
+      "availableConnectionCount": 0,
+      "pendingConnectionCount": 3,
+      "totalConnectionCount": 3
     },
     {
       "type": "ConnectionCreated",
-      "connectionId": 42,
-      "address": 42
-    },
-    {
-      "type": "ConnectionCreated",
-      "connectionId": 42,
-      "address": 42
-    },
-    {
-      "type": "ConnectionCheckedOut",
       "connectionId": 42,
       "address": 42,
-      "currentCheckedOutCount": 1,
+      "availableConnectionCount": 1,
+      "pendingConnectionCount": 2,
+      "totalConnectionCount": 3
+    },
+    {
+      "type": "ConnectionCreated",
+      "connectionId": 42,
+      "address": 42,
       "availableConnectionCount": 2,
-      "pendingConnectionCount": 0,
+      "pendingConnectionCount": 1,
       "totalConnectionCount": 3
     }
   ],
   "ignore": [
     "ConnectionReady",
-    "ConnectionClosed",
-    "ConnectionCheckOutStarted"
+    "ConnectionClosed"
   ]
 }

--- a/test/integration/connection-monitoring-and-pooling/connection_monitoring_and_pooling.spec.test.ts
+++ b/test/integration/connection-monitoring-and-pooling/connection_monitoring_and_pooling.spec.test.ts
@@ -18,6 +18,6 @@ describe('Connection Monitoring and Pooling Spec Tests (Integration)', function 
   runCmapTestSuite(
     // TODO(NODE-2993): unskip integration tests for maxConnecting
     tests.filter(({ style }) => style === 'unit'),
-    LB_SKIP_TESTS
+    { testsToSkip: LB_SKIP_TESTS }
   );
 });

--- a/test/integration/connection-monitoring-and-pooling/connection_monitoring_and_pooling.spec.test.ts
+++ b/test/integration/connection-monitoring-and-pooling/connection_monitoring_and_pooling.spec.test.ts
@@ -18,7 +18,7 @@ describe('Connection Monitoring and Pooling Spec Tests (Integration)', function 
     // TODO(NODE-2993): unskip integration tests for maxConnecting
     return test.style === 'unit';
   })) {
-    describe(test.description, function () {
+    describe(test.name, function () {
       let hostAddress: HostAddress, threadContext: ThreadContext, client: MongoClient;
 
       beforeEach(async function () {
@@ -85,7 +85,7 @@ describe('Connection Monitoring and Pooling Spec Tests (Integration)', function 
         await client.close();
       });
 
-      it('should pass', async function () {
+      it(test.description, async function () {
         await runCmapTest(test, threadContext);
       });
     });

--- a/test/integration/connection-monitoring-and-pooling/connection_monitoring_and_pooling.spec.test.ts
+++ b/test/integration/connection-monitoring-and-pooling/connection_monitoring_and_pooling.spec.test.ts
@@ -1,93 +1,23 @@
-import { HostAddress, MongoClient } from '../../../src';
-import { shuffle } from '../../../src/utils';
 import { loadSpecTests } from '../../spec';
-import { CmapTest, runCmapTest, ThreadContext } from '../../tools/cmap_spec_runner';
-import { isAnyRequirementSatisfied } from '../../tools/unified-spec-runner/unified-utils';
+import { CmapTest, runCmapTestSuite, SkipDescription } from '../../tools/cmap_spec_runner';
 
 // These tests rely on a simple "pool.clear()" command, which is not sufficient
 // to properly clear the pool in LB mode, since it requires a serviceId to be passed in
-const LB_SKIP_TESTS = [
+const LB_SKIP_TESTS: SkipDescription[] = [
   'must destroy checked in connection if it is stale',
   'must destroy and must not check out a stale connection if found while iterating available connections'
-];
+].map(description => ({
+  description,
+  skipIfCondition: 'loadBalanced',
+  skipReason: 'cannot run against a load balanced environment'
+}));
 
 describe('Connection Monitoring and Pooling Spec Tests (Integration)', function () {
-  const suites: CmapTest[] = loadSpecTests('connection-monitoring-and-pooling');
+  const tests: CmapTest[] = loadSpecTests('connection-monitoring-and-pooling');
 
-  for (const test of suites.filter(test => {
+  runCmapTestSuite(
     // TODO(NODE-2993): unskip integration tests for maxConnecting
-    return test.style === 'unit';
-  })) {
-    describe(test.name, function () {
-      let hostAddress: HostAddress, threadContext: ThreadContext, client: MongoClient;
-
-      beforeEach(async function () {
-        let utilClient: MongoClient;
-        if (this.configuration.isLoadBalanced) {
-          if (LB_SKIP_TESTS.some(testDescription => testDescription === test.description)) {
-            this.currentTest.skipReason = 'cannot run against a load balanced environment';
-            this.skip();
-          }
-          // The util client can always point at the single mongos LB frontend.
-          utilClient = this.configuration.newClient(this.configuration.singleMongosLoadBalancerUri);
-        } else {
-          utilClient = this.configuration.newClient();
-        }
-
-        await utilClient.connect();
-
-        const allRequirements = test.runOn || [];
-
-        const someRequirementMet =
-          !allRequirements.length ||
-          (await isAnyRequirementSatisfied(this.currentTest.ctx, allRequirements, utilClient));
-
-        if (!someRequirementMet) {
-          await utilClient.close();
-          this.skip();
-          // NOTE: the rest of the code below won't execute after the skip is invoked
-        }
-
-        try {
-          const serverMap = utilClient.topology.s.description.servers;
-          const hosts = shuffle(serverMap.keys());
-          const selectedHostUri = hosts[0];
-          hostAddress = serverMap.get(selectedHostUri).hostAddress;
-          threadContext = new ThreadContext(
-            hostAddress,
-            this.configuration.isLoadBalanced ? { loadBalanced: true } : {}
-          );
-
-          if (test.failPoint) {
-            client = this.configuration.newClient(
-              `mongodb://${hostAddress}/${
-                this.configuration.isLoadBalanced ? '?loadBalanced=true' : '?directConnection=true'
-              }`
-            );
-            await client.connect();
-            await client.db('admin').command(test.failPoint);
-          }
-        } finally {
-          await utilClient.close();
-        }
-      });
-
-      afterEach(async function () {
-        await threadContext?.tearDown();
-        if (!client) {
-          return;
-        }
-        if (test.failPoint) {
-          await client
-            .db('admin')
-            .command({ configureFailPoint: test.failPoint.configureFailPoint, mode: 'off' });
-        }
-        await client.close();
-      });
-
-      it(test.description, async function () {
-        await runCmapTest(test, threadContext);
-      });
-    });
-  }
+    tests.filter(({ style }) => style === 'unit'),
+    LB_SKIP_TESTS
+  );
 });

--- a/test/integration/connection-monitoring-and-pooling/connection_monitoring_and_pooling.test.ts
+++ b/test/integration/connection-monitoring-and-pooling/connection_monitoring_and_pooling.test.ts
@@ -1,0 +1,10 @@
+import { loadSpecTests } from '../../spec';
+import { CmapTest, runCmapTestSuite } from '../../tools/cmap_spec_runner';
+
+describe('Connection Monitoring and Pooling (Node Driver)', function () {
+  const tests: CmapTest[] = loadSpecTests(
+    '../integration/connection-monitoring-and-pooling/cmap-node-specs'
+  );
+
+  runCmapTestSuite(tests, { injectPoolStats: true });
+});

--- a/test/tools/cmap_spec_runner.ts
+++ b/test/tools/cmap_spec_runner.ts
@@ -290,6 +290,7 @@ export class ThreadContext {
         if (this.#injectPoolStats) {
           x.totalConnectionCount = this.pool.totalConnectionCount;
           x.availableConnectionCount = this.pool.availableConnectionCount;
+          x.pendingConnectionCount = this.pool.pendingConnectionCount;
           x.currentCheckedOutCount = this.pool.currentCheckedOutCount;
         }
         this.poolEvents.push(x);


### PR DESCRIPTION
### Description
NODE-2993 part 1; also fixes a bug where the `totalConnectionCount` would double count the available connections tracked by `kConnections`

#### What is changing?
- Replaced `kPermit` logic: added a new property to track pending connections and updated the existing checkout connection tracking to be more accurate
- Refactored CMAP spec runner: before/after logic now happens in the runner file so that it can be reused with our own "spec"-like tests
- The CMAP test runner can now optionally inject pool stats into pool events; we use this to check that the connection counts for pending, available, and checked out are updated correctly at each step (NOTE: at the point of the `ConnectionCreatedEvent`, the connection is still pending and continues to contribute to the pending count until it is either checked out or added to the available connection pool) 

##### Is there new documentation needed for these changes?
No

#### What is the motivation for this change?
Make it easier to implement the maxConnecting spec.

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
