### PR TITLE
feat(NODE-3938): Add support for pre/post images in change streams

### DIFF
--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -50,7 +50,8 @@ const CHANGE_STREAM_OPTIONS = [
   'resumeAfter',
   'startAfter',
   'startAtOperationTime',
-  'fullDocument'
+  'fullDocument',
+  'fullDocumentBeforeChange'
 ] as const;
 
 const CURSOR_OPTIONS = [
@@ -131,11 +132,35 @@ export type ChangeStreamAggregateRawResult<TChange> = {
  */
 export interface ChangeStreamOptions extends AggregateOptions {
   /**
-   * Allowed values: 'updateLookup'. When set to 'updateLookup',
-   * the change stream will include both a delta describing the changes to the document,
-   * as well as a copy of the entire document that was changed from some time after the change occurred.
+   * Allowed values: 'updateLookup', 'whenAvailable', 'required'.
+   *
+   * When set to 'updateLookup', the change notification for partial updates
+   * will include both a delta describing the changes to the document as well
+   * as a copy of the entire document that was changed from some time after
+   * the change occurred.
+   *
+   * When set to 'whenAvailable', configures the change stream to return the
+   * post-image of the modified document for replace and update change events
+   * if the post-image for this event is available.
+   *
+   * When set to 'required', the same behavior as 'whenAvailable' except that
+   * an error is raised if the post-image is not available.
    */
   fullDocument?: string;
+
+  /**
+   * Allowed values: 'whenAvailable', 'required', 'off'.
+   *
+   * The default is to not send a value, which is equivalent to 'off'.
+   *
+   * When set to 'whenAvailable', configures the change stream to return the
+   * pre-image of the modified document for replace, update, and delete change
+   * events if it is available.
+   *
+   * When set to 'required', the same behavior as 'whenAvailable' except that
+   * an error is raised if the pre-image is not available.
+   */
+  fullDocumentBeforeChange?: string;
   /** The maximum amount of time for the server to wait on new documents to satisfy a change stream query. */
   maxAwaitTimeMS?: number;
   /**
@@ -230,9 +255,9 @@ export interface ChangeStreamUpdateDocument<TSchema extends Document = Document>
   operationType: 'update';
   /**
    * This is only set if `fullDocument` is set to `'updateLookup'`
-   * The fullDocument document represents the most current majority-committed version of the updated document.
-   * The fullDocument document may vary from the document at the time of the update operation depending on the
-   * number of interleaving majority-committed operations that occur between the update operation and the document lookup.
+   * Contains the point-in-time post-image of the modified document if the
+   * post-image is available and either 'required' or 'whenAvailable' was
+   * specified for the 'fullDocument' option when creating the change stream.
    */
   fullDocument?: TSchema;
   /** Contains a description of updated and removed fields in this operation */

--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -271,7 +271,7 @@ export interface ChangeStreamUpdateDocument<TSchema extends Document = Document>
    * when creating the change stream. If 'whenAvailable' was specified but the
    * pre-image is unavailable, this will be explicitly set to null.
    */
-  fullDocumentBeforeChange?: Document;
+  fullDocumentBeforeChange?: TSchema;
 }
 
 /**
@@ -294,7 +294,7 @@ export interface ChangeStreamReplaceDocument<TSchema extends Document = Document
    * when creating the change stream. If 'whenAvailable' was specified but the
    * pre-image is unavailable, this will be explicitly set to null.
    */
-  fullDocumentBeforeChange?: Document;
+  fullDocumentBeforeChange?: TSchema;
 }
 
 /**
@@ -315,7 +315,7 @@ export interface ChangeStreamDeleteDocument<TSchema extends Document = Document>
    * when creating the change stream. If 'whenAvailable' was specified but the
    * pre-image is unavailable, this will be explicitly set to null.
    */
-  fullDocumentBeforeChange?: Document;
+  fullDocumentBeforeChange?: TSchema;
 }
 
 /**

--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -264,6 +264,14 @@ export interface ChangeStreamUpdateDocument<TSchema extends Document = Document>
   updateDescription: UpdateDescription<TSchema>;
   /** Namespace the update event occured on */
   ns: ChangeStreamNameSpace;
+  /**
+   * Contains the pre-image of the modified or deleted document if the
+   * pre-image is available for the change event and either 'required' or
+   * 'whenAvailable' was specified for the 'fullDocumentBeforeChange' option
+   * when creating the change stream. If 'whenAvailable' was specified but the
+   * pre-image is unavailable, this will be explicitly set to null.
+   */
+  fullDocumentBeforeChange?: Document;
 }
 
 /**
@@ -279,6 +287,14 @@ export interface ChangeStreamReplaceDocument<TSchema extends Document = Document
   fullDocument: TSchema;
   /** Namespace the replace event occured on */
   ns: ChangeStreamNameSpace;
+  /**
+   * Contains the pre-image of the modified or deleted document if the
+   * pre-image is available for the change event and either 'required' or
+   * 'whenAvailable' was specified for the 'fullDocumentBeforeChange' option
+   * when creating the change stream. If 'whenAvailable' was specified but the
+   * pre-image is unavailable, this will be explicitly set to null.
+   */
+  fullDocumentBeforeChange?: Document;
 }
 
 /**
@@ -292,6 +308,14 @@ export interface ChangeStreamDeleteDocument<TSchema extends Document = Document>
   operationType: 'delete';
   /** Namespace the delete event occured on */
   ns: ChangeStreamNameSpace;
+  /**
+   * Contains the pre-image of the modified or deleted document if the
+   * pre-image is available for the change event and either 'required' or
+   * 'whenAvailable' was specified for the 'fullDocumentBeforeChange' option
+   * when creating the change stream. If 'whenAvailable' was specified but the
+   * pre-image is unavailable, this will be explicitly set to null.
+   */
+  fullDocumentBeforeChange?: Document;
 }
 
 /**

--- a/src/operations/create_collection.ts
+++ b/src/operations/create_collection.ts
@@ -95,7 +95,7 @@ export interface CreateCollectionOptions extends CommandOperationOptions {
    * If set, enables pre-update and post-update document events to be included for any
    * change streams that listen on this collection.
    */
-  changeStreamPreAndPostImages?: { enabled: true };
+  changeStreamPreAndPostImages?: { enabled: boolean };
 }
 
 /** @internal */

--- a/src/operations/create_collection.ts
+++ b/src/operations/create_collection.ts
@@ -91,6 +91,11 @@ export interface CreateCollectionOptions extends CommandOperationOptions {
   expireAfterSeconds?: number;
   /** @experimental */
   encryptedFields?: Document;
+  /**
+   * If set, enables pre-update and post-update document events to be included for any
+   * change streams that listen on this collection.
+   */
+  changeStreamPreAndPostImages?: { enabled: true };
 }
 
 /** @internal */

--- a/test/integration/collection-management/collection_management.spec.test.js
+++ b/test/integration/collection-management/collection_management.spec.test.js
@@ -3,6 +3,9 @@
 const { loadSpecTests } = require('../../spec/index');
 const { runUnifiedSuite } = require('../../tools/unified-spec-runner/runner');
 
-describe('Collection management unified spec tests', function () {
-  runUnifiedSuite(loadSpecTests('collection-management'));
+// The Node driver does not have a Collection.modifyCollection helper.
+const SKIPPED_TESTS = ['modifyCollection to changeStreamPreAndPostImages enabled'];
+
+describe.only('Collection management unified spec tests', function () {
+  runUnifiedSuite(loadSpecTests('collection-management'), SKIPPED_TESTS);
 });

--- a/test/integration/collection-management/collection_management.spec.test.js
+++ b/test/integration/collection-management/collection_management.spec.test.js
@@ -6,6 +6,6 @@ const { runUnifiedSuite } = require('../../tools/unified-spec-runner/runner');
 // The Node driver does not have a Collection.modifyCollection helper.
 const SKIPPED_TESTS = ['modifyCollection to changeStreamPreAndPostImages enabled'];
 
-describe.only('Collection management unified spec tests', function () {
+describe('Collection management unified spec tests', function () {
   runUnifiedSuite(loadSpecTests('collection-management'), SKIPPED_TESTS);
 });

--- a/test/spec/change-streams/unified/change-streams-pre_and_post_images.json
+++ b/test/spec/change-streams/unified/change-streams-pre_and_post_images.json
@@ -1,0 +1,826 @@
+{
+  "description": "change-streams-pre_and_post_images",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "6.0.0",
+      "topologies": [
+        "replicaset",
+        "sharded-replicaset",
+        "load-balanced"
+      ]
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ],
+        "ignoreCommandMonitoringEvents": [
+          "collMod",
+          "insert",
+          "update",
+          "getMore",
+          "killCursors"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "change-stream-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "test",
+      "databaseName": "change-stream-tests",
+      "documents": [
+        {
+          "_id": 1
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "fullDocument:whenAvailable with changeStreamPreAndPostImages enabled",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "collMod",
+            "command": {
+              "collMod": "test",
+              "changeStreamPreAndPostImages": {
+                "enabled": true
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "fullDocument": "whenAvailable"
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "update",
+            "ns": {
+              "db": "change-stream-tests",
+              "coll": "test"
+            },
+            "updateDescription": {
+              "$$type": "object"
+            },
+            "fullDocument": {
+              "_id": 1,
+              "x": 1
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "fullDocument": "whenAvailable"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "fullDocument:whenAvailable with changeStreamPreAndPostImages disabled",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "collMod",
+            "command": {
+              "collMod": "test",
+              "changeStreamPreAndPostImages": {
+                "enabled": false
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "fullDocument": "whenAvailable"
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "update",
+            "ns": {
+              "db": "change-stream-tests",
+              "coll": "test"
+            },
+            "updateDescription": {
+              "$$type": "object"
+            },
+            "fullDocument": null
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "fullDocument": "whenAvailable"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "fullDocument:required with changeStreamPreAndPostImages enabled",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "collMod",
+            "command": {
+              "collMod": "test",
+              "changeStreamPreAndPostImages": {
+                "enabled": true
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "fullDocument": "required"
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "update",
+            "ns": {
+              "db": "change-stream-tests",
+              "coll": "test"
+            },
+            "updateDescription": {
+              "$$type": "object"
+            },
+            "fullDocument": {
+              "_id": 1,
+              "x": 1
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "fullDocument": "required"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "fullDocument:required with changeStreamPreAndPostImages disabled",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "collMod",
+            "command": {
+              "collMod": "test",
+              "changeStreamPreAndPostImages": {
+                "enabled": false
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "fullDocument": "required"
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "fullDocument": "required"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "fullDocumentBeforeChange:whenAvailable with changeStreamPreAndPostImages enabled",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "collMod",
+            "command": {
+              "collMod": "test",
+              "changeStreamPreAndPostImages": {
+                "enabled": true
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "fullDocumentBeforeChange": "whenAvailable"
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "update",
+            "ns": {
+              "db": "change-stream-tests",
+              "coll": "test"
+            },
+            "updateDescription": {
+              "$$type": "object"
+            },
+            "fullDocumentBeforeChange": {
+              "_id": 1
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "fullDocumentBeforeChange": "whenAvailable"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "fullDocumentBeforeChange:whenAvailable with changeStreamPreAndPostImages disabled",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "collMod",
+            "command": {
+              "collMod": "test",
+              "changeStreamPreAndPostImages": {
+                "enabled": false
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "fullDocumentBeforeChange": "whenAvailable"
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "update",
+            "ns": {
+              "db": "change-stream-tests",
+              "coll": "test"
+            },
+            "updateDescription": {
+              "$$type": "object"
+            },
+            "fullDocumentBeforeChange": null
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "fullDocumentBeforeChange": "whenAvailable"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "fullDocumentBeforeChange:required with changeStreamPreAndPostImages enabled",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "collMod",
+            "command": {
+              "collMod": "test",
+              "changeStreamPreAndPostImages": {
+                "enabled": true
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "fullDocumentBeforeChange": "required"
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "update",
+            "ns": {
+              "db": "change-stream-tests",
+              "coll": "test"
+            },
+            "updateDescription": {
+              "$$type": "object"
+            },
+            "fullDocumentBeforeChange": {
+              "_id": 1
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "fullDocumentBeforeChange": "required"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "fullDocumentBeforeChange:required with changeStreamPreAndPostImages disabled",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "collMod",
+            "command": {
+              "collMod": "test",
+              "changeStreamPreAndPostImages": {
+                "enabled": false
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "fullDocumentBeforeChange": "required"
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "fullDocumentBeforeChange": "required"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "fullDocumentBeforeChange:off with changeStreamPreAndPostImages enabled",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "collMod",
+            "command": {
+              "collMod": "test",
+              "changeStreamPreAndPostImages": {
+                "enabled": true
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "fullDocumentBeforeChange": "off"
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "update",
+            "ns": {
+              "db": "change-stream-tests",
+              "coll": "test"
+            },
+            "updateDescription": {
+              "$$type": "object"
+            },
+            "fullDocumentBeforeChange": {
+              "$$exists": false
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "fullDocumentBeforeChange": "off"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "fullDocumentBeforeChange:off with changeStreamPreAndPostImages disabled",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "collMod",
+            "command": {
+              "collMod": "test",
+              "changeStreamPreAndPostImages": {
+                "enabled": false
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "fullDocumentBeforeChange": "off"
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "update",
+            "ns": {
+              "db": "change-stream-tests",
+              "coll": "test"
+            },
+            "updateDescription": {
+              "$$type": "object"
+            },
+            "fullDocumentBeforeChange": {
+              "$$exists": false
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "fullDocumentBeforeChange": "off"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/change-streams/unified/change-streams-pre_and_post_images.yml
+++ b/test/spec/change-streams/unified/change-streams-pre_and_post_images.yml
@@ -1,0 +1,350 @@
+description: "change-streams-pre_and_post_images"
+
+schemaVersion: "1.3"
+
+runOnRequirements:
+  - minServerVersion: "6.0.0"
+    topologies: [ replicaset, sharded-replicaset, load-balanced ]
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+      ignoreCommandMonitoringEvents: [ collMod, insert, update, getMore, killCursors ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name change-stream-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name test
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1 }
+
+tests:
+  - description: "fullDocument:whenAvailable with changeStreamPreAndPostImages enabled"
+    operations:
+      - name: runCommand
+        object: *database0
+        arguments: &enablePreAndPostImages
+          commandName: collMod
+          command:
+            collMod: *collection0Name
+            changeStreamPreAndPostImages: { enabled: true }
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+          fullDocument: "whenAvailable"
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { x: 1 }}
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "update"
+          ns: { db: *database0Name, coll: *collection0Name }
+          updateDescription: { $$type: "object" }
+          fullDocument: { _id: 1, x: 1 }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline:
+                  - $changeStream: { fullDocument: "whenAvailable" }
+
+  - description: "fullDocument:whenAvailable with changeStreamPreAndPostImages disabled"
+    operations:
+      - name: runCommand
+        object: *database0
+        arguments: &disablePreAndPostImages
+          commandName: collMod
+          command:
+            collMod: *collection0Name
+            changeStreamPreAndPostImages: { enabled: false }
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+          fullDocument: "whenAvailable"
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { x: 1 }}
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "update"
+          ns: { db: *database0Name, coll: *collection0Name }
+          updateDescription: { $$type: "object" }
+          fullDocument: null
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline:
+                  - $changeStream: { fullDocument: "whenAvailable" }
+
+  - description: "fullDocument:required with changeStreamPreAndPostImages enabled"
+    operations:
+      - name: runCommand
+        object: *database0
+        arguments: *enablePreAndPostImages
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+          fullDocument: "required"
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { x: 1 }}
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "update"
+          ns: { db: *database0Name, coll: *collection0Name }
+          updateDescription: { $$type: "object" }
+          fullDocument: { _id: 1, x: 1 }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline:
+                  - $changeStream: { fullDocument: "required" }
+
+  - description: "fullDocument:required with changeStreamPreAndPostImages disabled"
+    operations:
+      - name: runCommand
+        object: *database0
+        arguments: *disablePreAndPostImages
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+          fullDocument: "required"
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { x: 1 }}
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectError:
+          isClientError: false
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline:
+                  - $changeStream: { fullDocument: "required" }
+
+  - description: "fullDocumentBeforeChange:whenAvailable with changeStreamPreAndPostImages enabled"
+    operations:
+      - name: runCommand
+        object: *database0
+        arguments: *enablePreAndPostImages
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+          fullDocumentBeforeChange: "whenAvailable"
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { x: 1 }}
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "update"
+          ns: { db: *database0Name, coll: *collection0Name }
+          updateDescription: { $$type: "object" }
+          fullDocumentBeforeChange: { _id: 1 }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline:
+                  - $changeStream: { fullDocumentBeforeChange: "whenAvailable" }
+
+  - description: "fullDocumentBeforeChange:whenAvailable with changeStreamPreAndPostImages disabled"
+    operations:
+      - name: runCommand
+        object: *database0
+        arguments: *disablePreAndPostImages
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+          fullDocumentBeforeChange: "whenAvailable"
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { x: 1 }}
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "update"
+          ns: { db: *database0Name, coll: *collection0Name }
+          updateDescription: { $$type: "object" }
+          fullDocumentBeforeChange: null
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline:
+                  - $changeStream: { fullDocumentBeforeChange: "whenAvailable" }
+
+  - description: "fullDocumentBeforeChange:required with changeStreamPreAndPostImages enabled"
+    operations:
+      - name: runCommand
+        object: *database0
+        arguments: *enablePreAndPostImages
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+          fullDocumentBeforeChange: "required"
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { x: 1 }}
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "update"
+          ns: { db: *database0Name, coll: *collection0Name }
+          updateDescription: { $$type: "object" }
+          fullDocumentBeforeChange: { _id: 1 }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline:
+                  - $changeStream: { fullDocumentBeforeChange: "required" }
+
+  - description: "fullDocumentBeforeChange:required with changeStreamPreAndPostImages disabled"
+    operations:
+      - name: runCommand
+        object: *database0
+        arguments: *disablePreAndPostImages
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+          fullDocumentBeforeChange: "required"
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { x: 1 }}
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectError:
+          isClientError: false
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline:
+                  - $changeStream: { fullDocumentBeforeChange: "required" }
+
+  - description: "fullDocumentBeforeChange:off with changeStreamPreAndPostImages enabled"
+    operations:
+      - name: runCommand
+        object: *database0
+        arguments: *enablePreAndPostImages
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+          fullDocumentBeforeChange: "off"
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { x: 1 }}
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "update"
+          ns: { db: *database0Name, coll: *collection0Name }
+          updateDescription: { $$type: "object" }
+          fullDocumentBeforeChange: { $$exists: false }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline:
+                  - $changeStream: { fullDocumentBeforeChange: "off" }
+
+  - description: "fullDocumentBeforeChange:off with changeStreamPreAndPostImages disabled"
+    operations:
+      - name: runCommand
+        object: *database0
+        arguments: *disablePreAndPostImages
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+          fullDocumentBeforeChange: "off"
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { x: 1 }}
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "update"
+          ns: { db: *database0Name, coll: *collection0Name }
+          updateDescription: { $$type: "object" }
+          fullDocumentBeforeChange: { $$exists: false }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline:
+                  - $changeStream: { fullDocumentBeforeChange: "off" }

--- a/test/spec/collection-management/clustered-indexes.json
+++ b/test/spec/collection-management/clustered-indexes.json
@@ -1,9 +1,10 @@
 {
   "description": "clustered-indexes",
-  "schemaVersion": "1.0",
+  "schemaVersion": "1.4",
   "runOnRequirements": [
     {
-      "minServerVersion": "5.3"
+      "minServerVersion": "5.3",
+      "serverless": "forbid"
     }
   ],
   "createEntities": [

--- a/test/spec/collection-management/clustered-indexes.yml
+++ b/test/spec/collection-management/clustered-indexes.yml
@@ -1,9 +1,10 @@
 description: "clustered-indexes"
 
-schemaVersion: "1.0"
+schemaVersion: "1.4"
 
 runOnRequirements:
   - minServerVersion: "5.3"
+    serverless: forbid
 
 createEntities:
   - client:

--- a/test/spec/collection-management/createCollection-pre_and_post_images.json
+++ b/test/spec/collection-management/createCollection-pre_and_post_images.json
@@ -1,0 +1,91 @@
+{
+  "description": "createCollection-pre_and_post_images",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "6.0"
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "papi-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "createCollection with changeStreamPreAndPostImages enabled",
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "test"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "test",
+            "changeStreamPreAndPostImages": {
+              "enabled": true
+            }
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "databaseName": "papi-tests",
+            "collectionName": "test"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "drop": "test"
+                },
+                "databaseName": "papi-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "create": "test",
+                  "changeStreamPreAndPostImages": {
+                    "enabled": true
+                  }
+                },
+                "databaseName": "papi-tests"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/collection-management/createCollection-pre_and_post_images.json
+++ b/test/spec/collection-management/createCollection-pre_and_post_images.json
@@ -1,9 +1,10 @@
 {
   "description": "createCollection-pre_and_post_images",
-  "schemaVersion": "1.0",
+  "schemaVersion": "1.4",
   "runOnRequirements": [
     {
-      "minServerVersion": "6.0"
+      "minServerVersion": "6.0",
+      "serverless": "forbid"
     }
   ],
   "createEntities": [

--- a/test/spec/collection-management/createCollection-pre_and_post_images.yml
+++ b/test/spec/collection-management/createCollection-pre_and_post_images.yml
@@ -1,0 +1,49 @@
+description: "createCollection-pre_and_post_images"
+
+schemaVersion: "1.0"
+
+runOnRequirements:
+  - minServerVersion: "6.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name papi-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name test
+
+tests:
+  - description: "createCollection with changeStreamPreAndPostImages enabled"
+    operations:
+      - name: dropCollection
+        object: *database0
+        arguments:
+          collection: *collection0Name
+      - name: createCollection
+        object: *database0
+        arguments:
+          collection: *collection0Name
+          changeStreamPreAndPostImages: { enabled: true }
+      - name: assertCollectionExists
+        object: testRunner
+        arguments:
+          databaseName: *database0Name
+          collectionName: *collection0Name
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                drop: *collection0Name
+              databaseName: *database0Name
+          - commandStartedEvent:
+              command:
+                create: *collection0Name
+                changeStreamPreAndPostImages: { enabled: true }
+              databaseName: *database0Name

--- a/test/spec/collection-management/createCollection-pre_and_post_images.yml
+++ b/test/spec/collection-management/createCollection-pre_and_post_images.yml
@@ -1,9 +1,10 @@
 description: "createCollection-pre_and_post_images"
 
-schemaVersion: "1.0"
+schemaVersion: "1.4"
 
 runOnRequirements:
   - minServerVersion: "6.0"
+    serverless: forbid
 
 createEntities:
   - client:

--- a/test/spec/collection-management/modifyCollection-pre_and_post_images.json
+++ b/test/spec/collection-management/modifyCollection-pre_and_post_images.json
@@ -1,0 +1,110 @@
+{
+  "description": "modifyCollection-pre_and_post_images",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "6.0"
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "papi-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "modifyCollection to changeStreamPreAndPostImages enabled",
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "test"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "test",
+            "changeStreamPreAndPostImages": {
+              "enabled": false
+            }
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "databaseName": "papi-tests",
+            "collectionName": "test"
+          }
+        },
+        {
+          "name": "modifyCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "test",
+            "changeStreamPreAndPostImages": {
+              "enabled": true
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "drop": "test"
+                },
+                "databaseName": "papi-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "create": "test",
+                  "changeStreamPreAndPostImages": {
+                    "enabled": false
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "collMod": "test",
+                  "changeStreamPreAndPostImages": {
+                    "enabled": true
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/collection-management/modifyCollection-pre_and_post_images.json
+++ b/test/spec/collection-management/modifyCollection-pre_and_post_images.json
@@ -1,9 +1,10 @@
 {
   "description": "modifyCollection-pre_and_post_images",
-  "schemaVersion": "1.0",
+  "schemaVersion": "1.4",
   "runOnRequirements": [
     {
-      "minServerVersion": "6.0"
+      "minServerVersion": "6.0",
+      "serverless": "forbid"
     }
   ],
   "createEntities": [

--- a/test/spec/collection-management/modifyCollection-pre_and_post_images.yml
+++ b/test/spec/collection-management/modifyCollection-pre_and_post_images.yml
@@ -1,9 +1,10 @@
 description: "modifyCollection-pre_and_post_images"
 
-schemaVersion: "1.0"
+schemaVersion: "1.4"
 
 runOnRequirements:
   - minServerVersion: "6.0"
+    serverless: forbid
 
 createEntities:
   - client:

--- a/test/spec/collection-management/modifyCollection-pre_and_post_images.yml
+++ b/test/spec/collection-management/modifyCollection-pre_and_post_images.yml
@@ -1,0 +1,57 @@
+description: "modifyCollection-pre_and_post_images"
+
+schemaVersion: "1.0"
+
+runOnRequirements:
+  - minServerVersion: "6.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name papi-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name test
+
+tests:
+  - description: "modifyCollection to changeStreamPreAndPostImages enabled"
+    operations:
+      - name: dropCollection
+        object: *database0
+        arguments:
+          collection: *collection0Name
+      - name: createCollection
+        object: *database0
+        arguments:
+          collection: *collection0Name
+          changeStreamPreAndPostImages: { enabled: false }
+      - name: assertCollectionExists
+        object: testRunner
+        arguments:
+          databaseName: *database0Name
+          collectionName: *collection0Name
+      - name: modifyCollection
+        object: *database0
+        arguments:
+          collection: *collection0Name
+          changeStreamPreAndPostImages: { enabled: true }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                drop: *collection0Name
+              databaseName: *database0Name
+          - commandStartedEvent:
+              command:
+                create: *collection0Name
+                changeStreamPreAndPostImages: { enabled: false }
+          - commandStartedEvent:
+              command:
+                collMod: *collection0Name
+                changeStreamPreAndPostImages: { enabled: true }


### PR DESCRIPTION
### Description

#### What is changing?

- Adds support for pre/post images in change streams (https://jira.mongodb.org/browse/DRIVERS-1915)
- Adds tests for create collection and modify collection with pre/post image (https://jira.mongodb.org/browse/NODE-4210)
- Includes changes from https://github.com/mongodb/specifications/commit/d1458823bd810014df9da16d3a5354d2269ab865 (this commit is linked in NODE-4210)

##### Is there new documentation needed for these changes?

No.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
