### PR TITLE
test: add api version when creating new test client

### DIFF
--- a/test/tools/runner/config.ts
+++ b/test/tools/runner/config.ts
@@ -198,6 +198,10 @@ export class TestConfiguration {
       dbOptions.loadBalanced = true;
     }
 
+    if (process.env.MONGODB_API_VERSION) {
+      dbOptions.apiVersion = process.env.MONGODB_API_VERSION;
+    }
+
     const urlOptions: url.UrlObject = {
       protocol: 'mongodb',
       slashes: true,


### PR DESCRIPTION
### Description

CMAP spec tests were validly failing on CI when ran in the versioned api suite

#### What is changing?

Adds the `apiVersion` to the `MongoClient` when creating a new client from the test config via `newClient()` when `MONGODB_API_VERSION` is in the env. Should cover all cases for futureproofing.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

Red build.

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
