### PR TITLE
feat(NODE-2993): implement maxConnecting

### DIFF
--- a/src/cmap/connection_pool.ts
+++ b/src/cmap/connection_pool.ts
@@ -545,7 +545,7 @@ function createConnection(pool: ConnectionPool, callback: Callback<Connection>) 
   // This is our version of a "virtual" no-I/O connection as the spec requires
   pool.emit(
     ConnectionPool.CONNECTION_CREATED,
-    new ConnectionCreatedEvent(pool, { id: connectOptions.id } as Connection)
+    new ConnectionCreatedEvent(pool, { id: connectOptions.id })
   );
 
   connect(connectOptions, (err, connection) => {

--- a/src/cmap/connection_pool.ts
+++ b/src/cmap/connection_pool.ts
@@ -515,6 +515,8 @@ function ensureMinPoolSize(pool: ConnectionPool) {
       }
       pool[kMinPoolSizeTimer] = setTimeout(() => ensureMinPoolSize(pool), 10);
     });
+  } else {
+    pool[kMinPoolSizeTimer] = setTimeout(() => ensureMinPoolSize(pool), 100);
   }
 }
 

--- a/src/cmap/connection_pool_events.ts
+++ b/src/cmap/connection_pool_events.ts
@@ -59,7 +59,7 @@ export class ConnectionCreatedEvent extends ConnectionPoolMonitoringEvent {
   connectionId: number | '<monitor>';
 
   /** @internal */
-  constructor(pool: ConnectionPool, connection: { id: number | 'monitor' }) {
+  constructor(pool: ConnectionPool, connection: { id: number | '<monitor>' }) {
     super(pool);
     this.connectionId = connection.id;
   }

--- a/src/cmap/connection_pool_events.ts
+++ b/src/cmap/connection_pool_events.ts
@@ -59,7 +59,7 @@ export class ConnectionCreatedEvent extends ConnectionPoolMonitoringEvent {
   connectionId: number | '<monitor>';
 
   /** @internal */
-  constructor(pool: ConnectionPool, connection: Connection) {
+  constructor(pool: ConnectionPool, connection: { id: number | 'monitor' }) {
     super(pool);
     this.connectionId = connection.id;
   }

--- a/test/integration/connection-monitoring-and-pooling/cmap-node-specs/pool-minPoolSize-population-stats.json
+++ b/test/integration/connection-monitoring-and-pooling/cmap-node-specs/pool-minPoolSize-population-stats.json
@@ -33,16 +33,16 @@
       "address": 42,
       "currentCheckedOutCount": 0,
       "availableConnectionCount": 0,
-      "pendingConnectionCount": 3,
-      "totalConnectionCount": 3
+      "pendingConnectionCount": 1,
+      "totalConnectionCount": 1
     },
     {
       "type": "ConnectionCreated",
       "connectionId": 42,
       "address": 42,
       "availableConnectionCount": 1,
-      "pendingConnectionCount": 2,
-      "totalConnectionCount": 3
+      "pendingConnectionCount": 1,
+      "totalConnectionCount": 2
     },
     {
       "type": "ConnectionCreated",

--- a/test/integration/connection-monitoring-and-pooling/cmap-node-specs/pool-minPoolSize-replace-removed-connections.json
+++ b/test/integration/connection-monitoring-and-pooling/cmap-node-specs/pool-minPoolSize-replace-removed-connections.json
@@ -1,0 +1,77 @@
+{
+  "version": 1,
+  "style": "unit",
+  "description": "must replace removed connections up to minPoolSize",
+  "poolOptions": {
+    "minPoolSize": 2
+  },
+  "operations": [
+    {
+      "name": "waitForEvent",
+      "event": "ConnectionReady",
+      "count": 2
+    },
+    {
+      "name": "wait",
+      "ms": 1000
+    },
+    {
+      "name": "checkOut",
+      "label": "conn"
+    },
+    {
+      "name": "clear"
+    },
+    {
+      "name": "checkIn",
+      "connection": "conn"
+    },
+    {
+      "name": "waitForEvent",
+      "event": "ConnectionReady",
+      "count": 3
+    }
+  ],
+  "events": [
+    {
+      "type": "ConnectionReady",
+      "address": 42
+    },
+    {
+      "type": "ConnectionReady",
+      "address": 42
+    },
+    {
+      "type": "ConnectionCheckedOut",
+      "address": 42
+    },
+    {
+      "type": "ConnectionPoolCleared",
+      "address": 42
+    },
+    {
+      "type": "ConnectionCheckedIn",
+      "address": 42
+    },
+    {
+      "type": "ConnectionClosed",
+      "reason": "stale",
+      "address": 42,
+      "availableConnectionCount": 1,
+      "pendingConnectionCount": 0,
+      "totalConnectionCount": 1
+    },
+    {
+      "type": "ConnectionReady",
+      "address": 42,
+      "availableConnectionCount": 1,
+      "pendingConnectionCount": 1,
+      "totalConnectionCount": 2
+    }
+  ],
+  "ignore": [
+    "ConnectionPoolCreated",
+    "ConnectionCreated",
+    "ConnectionCheckOutStarted"
+  ]
+}

--- a/test/integration/connection-monitoring-and-pooling/connection_monitoring_and_pooling.spec.test.ts
+++ b/test/integration/connection-monitoring-and-pooling/connection_monitoring_and_pooling.spec.test.ts
@@ -15,9 +15,14 @@ const LB_SKIP_TESTS: SkipDescription[] = [
 describe('Connection Monitoring and Pooling Spec Tests (Integration)', function () {
   const tests: CmapTest[] = loadSpecTests('connection-monitoring-and-pooling');
 
-  runCmapTestSuite(
-    // TODO(NODE-2993): unskip integration tests for maxConnecting
-    tests.filter(({ style }) => style === 'unit'),
-    { testsToSkip: LB_SKIP_TESTS }
-  );
+  runCmapTestSuite(tests, {
+    testsToSkip: LB_SKIP_TESTS.concat([
+      {
+        description: 'waiting on maxConnecting is limited by WaitQueueTimeoutMS',
+        skipIfCondition: 'always',
+        skipReason:
+          'not applicable: waitQueueTimeoutMS limits connection establishment time in our driver'
+      }
+    ])
+  });
 });

--- a/test/integration/connection-monitoring-and-pooling/connection_monitoring_and_pooling.test.ts
+++ b/test/integration/connection-monitoring-and-pooling/connection_monitoring_and_pooling.test.ts
@@ -6,5 +6,14 @@ describe('Connection Monitoring and Pooling (Node Driver)', function () {
     '../integration/connection-monitoring-and-pooling/cmap-node-specs'
   );
 
-  runCmapTestSuite(tests, { injectPoolStats: true });
+  runCmapTestSuite(tests, {
+    injectPoolStats: true,
+    testsToSkip: [
+      {
+        description: 'must replace removed connections up to minPoolSize',
+        skipIfCondition: 'loadBalanced',
+        skipReason: 'cannot run against load balancer due to reliance on pool.clear() command'
+      }
+    ]
+  });
 });

--- a/test/tools/cmap_spec_runner.ts
+++ b/test/tools/cmap_spec_runner.ts
@@ -419,7 +419,7 @@ export function runCmapTestSuite(
           const matchesLoadBalanceSkip =
             skipDescription.skipIfCondition === 'loadBalanced' && this.configuration.isLoadBalanced;
           if (matchesLoadBalanceSkip) {
-            (this.currentTest as Mocha.Runnable).skipReason = skipDescription.skipReason;
+            this.currentTest.skipReason = skipDescription.skipReason;
             this.skip();
           }
         }

--- a/test/tools/cmap_spec_runner.ts
+++ b/test/tools/cmap_spec_runner.ts
@@ -386,7 +386,11 @@ async function runCmapTest(test: CmapTest, threadContext: ThreadContext) {
     ev => !ignoreEvents.includes(getEventType(ev))
   );
 
-  expect(actualEvents).to.have.lengthOf(expectedEvents.length);
+  expect(actualEvents).to.have.lengthOf(
+    expectedEvents.length,
+    `Received: ${JSON.stringify(actualEvents)}`
+  );
+
   for (const expected of expectedEvents) {
     const actual = actualEvents.shift();
     const { type: eventType, ...eventPropsToCheck } = expected;
@@ -397,7 +401,7 @@ async function runCmapTest(test: CmapTest, threadContext: ThreadContext) {
 
 export type SkipDescription = {
   description: string;
-  skipIfCondition: 'loadBalanced';
+  skipIfCondition: 'loadBalanced' | 'always';
   skipReason: string;
 };
 
@@ -416,9 +420,11 @@ export function runCmapTestSuite(
           ({ description }) => description === test.description
         );
         if (skipDescription) {
+          const alwaysSkip = skipDescription.skipIfCondition === 'always';
           const matchesLoadBalanceSkip =
             skipDescription.skipIfCondition === 'loadBalanced' && this.configuration.isLoadBalanced;
-          if (matchesLoadBalanceSkip) {
+
+          if (alwaysSkip || matchesLoadBalanceSkip) {
             this.currentTest.skipReason = skipDescription.skipReason;
             this.skip();
           }


### PR DESCRIPTION
### Description
NODE-2993

#### What is changing?
- Connection pool can now attempt to check out up to maxConnecting number of connections in parallel (previously it would only establish the requested connections one at a time)
- ensureMinPoolSize will now only attempt to create one connection at a time so as not to block checkout requests from obtaining connections as quickly as possible (since ensureMinPoolSize always adds the connections to the available pool first, a checkout request would otherwise have to wait to retrieve it from the pool instead of obtaining it immediately; this nonblocking behavior is relied upon by the "threads blocked by maxConnecting check out minPoolSize connections" spec test)
- The ConnectionCreatedEvent is now fired *before* actually establishing the connection, as required by the spec (the maxConnecting tests rely on this to differentiate between pending and established connections)
- There was a bug in the cmap runner where the operations weren't actually queued using the main thread but rather in parallel across threads, this PR includes a fix for that
- Note: the new waitQueueTimeoutMS test is skipped because it is not applicable given our waitQueueTimeoutMS implementation (see the corresponding test yaml file for the relevant note)

##### Is there new documentation needed for these changes?
No

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
