### PR TITLE
feat(NODE-4139): streaming protocol message changes

### DIFF
--- a/src/cmap/connection.ts
+++ b/src/cmap/connection.ts
@@ -293,14 +293,13 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
     this[kHello] = response;
   }
 
-  // Set the whether the message stream is for a monitoring connection using the
-  // streaming protocol.
-  set isStreamingProtocol(value: boolean) {
-    this[kMessageStream].isStreamingProtocol = value;
+  // Set the whether the message stream is for a monitoring connection.
+  set isMonitoringConnection(value: boolean) {
+    this[kMessageStream].isMonitoringConnection = value;
   }
 
-  get isStreamingProtocol(): boolean {
-    return this[kMessageStream].isStreamingProtocol;
+  get isMonitoringConnection(): boolean {
+    return this[kMessageStream].isMonitoringConnection;
   }
 
   get serviceId(): ObjectId | undefined {

--- a/src/cmap/connection.ts
+++ b/src/cmap/connection.ts
@@ -293,6 +293,16 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
     this[kHello] = response;
   }
 
+  // Set the whether the message stream is for a monitoring connection using the
+  // streaming protocol.
+  set isStreamingProtocol(value: boolean) {
+    this[kMessageStream].isStreamingProtocol = value;
+  }
+
+  get isStreamingProtocol(): boolean {
+    return this[kMessageStream].isStreamingProtocol;
+  }
+
   get serviceId(): ObjectId | undefined {
     return this.hello?.serviceId;
   }

--- a/src/cmap/message_stream.ts
+++ b/src/cmap/message_stream.ts
@@ -180,7 +180,7 @@ function processIncomingData(stream: MessageStream, callback: Callback<Buffer>) 
       }
     }
     return false;
-  }
+  };
 
   let ResponseType = messageHeader.opCode === OP_MSG ? BinMsg : Response;
   if (messageHeader.opCode !== OP_COMPRESSED) {

--- a/src/cmap/message_stream.ts
+++ b/src/cmap/message_stream.ts
@@ -173,7 +173,7 @@ function processIncomingData(stream: MessageStream, callback: Callback<Buffer>) 
       // Can we read the next message size?
       if (buffer.length >= 4) {
         const sizeOfMessage = buffer.peek(4).readInt32LE();
-        if (sizeOfMessage < buffer.length) {
+        if (sizeOfMessage <= buffer.length) {
           return true;
         }
       }

--- a/src/sdam/monitor.ts
+++ b/src/sdam/monitor.ts
@@ -279,6 +279,10 @@ function checkServer(monitor: Monitor, callback: Callback<Document | null>) {
       // if we are using the streaming protocol then we immediately issue another `started`
       // event, otherwise the "check" is complete and return to the main monitor loop
       if (isAwaitable && hello.topologyVersion) {
+        // Tell the connection that we are using the streaming protocol so that the
+        // connection's message stream will only read the last hello on the buffer.
+        connection.isStreamingProtocol = true;
+
         monitor.emit(
           Server.SERVER_HEARTBEAT_STARTED,
           new ServerHeartbeatStartedEvent(monitor.address)

--- a/test/unit/cmap/message_stream.test.js
+++ b/test/unit/cmap/message_stream.test.js
@@ -21,7 +21,7 @@ function bufferToStream(buffer) {
 }
 
 describe('MessageStream', function () {
-  context('when the stream uses the streaming protocol', function () {
+  context('when the stream is for a monitoring connection', function () {
     const response = { isWritablePrimary: true };
     let firstHello;
     let secondHello;
@@ -39,7 +39,7 @@ describe('MessageStream', function () {
     it('only reads the last message in the buffer', async function () {
       const inputStream = bufferToStream(Buffer.concat([firstHello, secondHello, thirdHello]));
       const messageStream = new MessageStream();
-      messageStream.isStreamingProtocol = true;
+      messageStream.isMonitoringConnection = true;
 
       inputStream.pipe(messageStream);
       const messages = await once(messageStream, 'message');
@@ -55,7 +55,7 @@ describe('MessageStream', function () {
         Buffer.concat([firstHello, secondHello, thirdHello, partial])
       );
       const messageStream = new MessageStream();
-      messageStream.isStreamingProtocol = true;
+      messageStream.isMonitoringConnection = true;
 
       inputStream.pipe(messageStream);
       const messages = await once(messageStream, 'message');
@@ -67,7 +67,7 @@ describe('MessageStream', function () {
     });
   });
 
-  context('when the stream is not using the streaming protocol', function () {
+  context('when the stream is not for a monitoring connection', function () {
     context('when the messages are valid', function () {
       const response = { isWritablePrimary: true };
       let firstHello;

--- a/test/unit/cmap/message_stream.test.js
+++ b/test/unit/cmap/message_stream.test.js
@@ -23,6 +23,7 @@ function bufferToStream(buffer) {
 describe('MessageStream', function () {
   context('when the stream is for a monitoring connection', function () {
     const response = { isWritablePrimary: true };
+    const lastResponse = { ok: 1 };
     let firstHello;
     let secondHello;
     let thirdHello;
@@ -31,7 +32,7 @@ describe('MessageStream', function () {
     beforeEach(function () {
       firstHello = generateOpMsgBuffer(response);
       secondHello = generateOpMsgBuffer(response);
-      thirdHello = generateOpMsgBuffer(response);
+      thirdHello = generateOpMsgBuffer(lastResponse);
       partial = Buffer.alloc(5);
       partial.writeInt32LE(100, 0);
     });
@@ -45,7 +46,7 @@ describe('MessageStream', function () {
       const messages = await once(messageStream, 'message');
       const msg = messages[0];
       msg.parse();
-      expect(msg).to.have.property('documents').that.deep.equals([response]);
+      expect(msg).to.have.property('documents').that.deep.equals([lastResponse]);
       // Make sure there is nothing left in the buffer.
       expect(messageStream.buffer.length).to.equal(0);
     });
@@ -61,7 +62,7 @@ describe('MessageStream', function () {
       const messages = await once(messageStream, 'message');
       const msg = messages[0];
       msg.parse();
-      expect(msg).to.have.property('documents').that.deep.equals([response]);
+      expect(msg).to.have.property('documents').that.deep.equals([lastResponse]);
       // Make sure the buffer wasn't read to the end.
       expect(messageStream.buffer.length).to.equal(5);
     });

--- a/test/unit/cmap/message_stream.test.js
+++ b/test/unit/cmap/message_stream.test.js
@@ -5,6 +5,7 @@ const { MessageStream } = require('../../../src/cmap/message_stream');
 const { Msg } = require('../../../src/cmap/commands');
 const expect = require('chai').expect;
 const { LEGACY_HELLO_COMMAND } = require('../../../src/constants');
+const { generateOpMsgBuffer } = require('../../tools/utils');
 
 function bufferToStream(buffer) {
   const stream = new Readable();
@@ -18,26 +19,27 @@ function bufferToStream(buffer) {
   return stream;
 }
 
-describe('Message Stream', function () {
+describe('MessageStream', function () {
   context('when the stream uses the streaming protocol', function () {
-    const data = Buffer.from(
-      '370000000100000001000000010000000000000000000000000000000000000001000000130000001069736d6173746572000100000000' +
-        '370000000100000001000000010000000000000000000000000000000000000001000000130000001069736d6173746572000100000000' +
-        '370000000100000001000000010000000000000000000000000000000000000001000000130000001069736d6173746572000100000000' +
-        '370000000100000001000000010000000000000000000000000000000000000001000000130000001069736d6173746572000100000000',
-      'hex'
-    );
+    const response = { isWritablePrimary: true };
+    let firstHello;
+    let secondHello;
+    let thirdHello;
+
+    beforeEach(function () {
+      firstHello = generateOpMsgBuffer(response);
+      secondHello = generateOpMsgBuffer(response);
+      thirdHello = generateOpMsgBuffer(response);
+    });
 
     it('only reads the last message in the buffer', function (done) {
-      const inputStream = bufferToStream(data);
+      const inputStream = bufferToStream(Buffer.concat([firstHello, secondHello, thirdHello]));
       const messageStream = new MessageStream();
       messageStream.isStreamingProtocol = true;
 
       messageStream.once('message', msg => {
         msg.parse();
-        expect(msg)
-          .to.have.property('documents')
-          .that.deep.equals([{ [LEGACY_HELLO_COMMAND]: 1 }]);
+        expect(msg).to.have.property('documents').that.deep.equals([response]);
         // Make sure there is nothing left in the buffer.
         expect(messageStream.buffer.length).to.equal(0);
         done();
@@ -47,116 +49,73 @@ describe('Message Stream', function () {
     });
   });
 
-  describe('reading', function () {
-    [
-      {
-        description: 'valid OP_REPLY',
-        data: Buffer.from(
-          '370000000100000001000000010000000000000000000000000000000000000001000000130000001069736d6173746572000100000000',
-          'hex'
-        ),
-        documents: [{ [LEGACY_HELLO_COMMAND]: 1 }]
-      },
-      {
-        description: 'valid multiple OP_REPLY',
-        expectedMessageCount: 4,
-        data: Buffer.from(
-          '370000000100000001000000010000000000000000000000000000000000000001000000130000001069736d6173746572000100000000' +
-            '370000000100000001000000010000000000000000000000000000000000000001000000130000001069736d6173746572000100000000' +
-            '370000000100000001000000010000000000000000000000000000000000000001000000130000001069736d6173746572000100000000' +
-            '370000000100000001000000010000000000000000000000000000000000000001000000130000001069736d6173746572000100000000',
-          'hex'
-        ),
-        documents: [{ [LEGACY_HELLO_COMMAND]: 1 }]
-      },
-      {
-        description: 'valid OP_REPLY (partial)',
-        data: [
-          Buffer.from('37', 'hex'),
-          Buffer.from('0000', 'hex'),
-          Buffer.from(
-            '000100000001000000010000000000000000000000000000000000000001000000130000001069736d6173746572000100000000',
-            'hex'
-          )
-        ],
-        documents: [{ [LEGACY_HELLO_COMMAND]: 1 }]
-      },
+  context('when the stream is not using the streaming protocol', function () {
+    context('when the messages are valid', function () {
+      const response = { isWritablePrimary: true };
+      let firstHello;
+      let secondHello;
+      let thirdHello;
+      let messageCount = 0;
 
-      {
-        description: 'valid OP_MSG',
-        data: Buffer.from(
-          '370000000100000000000000dd0700000000000000220000001069736d6173746572000100000002246462000600000061646d696e0000',
-          'hex'
-        ),
-        documents: [{ $db: 'admin', [LEGACY_HELLO_COMMAND]: 1 }]
-      },
-      {
-        description: 'valid multiple OP_MSG',
-        expectedMessageCount: 4,
-        data: Buffer.from(
-          '370000000100000000000000dd0700000000000000220000001069736d6173746572000100000002246462000600000061646d696e0000' +
-            '370000000100000000000000dd0700000000000000220000001069736d6173746572000100000002246462000600000061646d696e0000' +
-            '370000000100000000000000dd0700000000000000220000001069736d6173746572000100000002246462000600000061646d696e0000' +
-            '370000000100000000000000dd0700000000000000220000001069736d6173746572000100000002246462000600000061646d696e0000',
-          'hex'
-        ),
-        documents: [{ $db: 'admin', [LEGACY_HELLO_COMMAND]: 1 }]
-      },
+      beforeEach(function () {
+        firstHello = generateOpMsgBuffer(response);
+        secondHello = generateOpMsgBuffer(response);
+        thirdHello = generateOpMsgBuffer(response);
+      });
 
-      {
-        description: 'Invalid message size (negative)',
-        data: Buffer.from('ffffffff', 'hex'),
-        error: 'Invalid message size: -1'
-      },
-      {
-        description: 'Invalid message size (exceeds maximum)',
-        data: Buffer.from('01000004', 'hex'),
-        error: 'Invalid message size: 67108865, max allowed: 67108864'
-      }
-    ].forEach(test => {
-      it(test.description, function (done) {
-        const error = test.error;
-        const expectedMessageCount = test.expectedMessageCount || 1;
-        const inputStream = bufferToStream(test.data);
+      it('reads all messages in the buffer', function (done) {
+        const inputStream = bufferToStream(Buffer.concat([firstHello, secondHello, thirdHello]));
         const messageStream = new MessageStream();
 
-        let messageCount = 0;
         messageStream.on('message', msg => {
           messageCount++;
-          if (error) {
-            done(new Error(`expected error: ${error}`));
-            return;
-          }
-
           msg.parse();
-
-          if (test.documents) {
-            expect(msg).to.have.property('documents').that.deep.equals(test.documents);
-          }
-
-          if (messageCount === expectedMessageCount) {
+          expect(msg).to.have.property('documents').that.deep.equals([response]);
+          // Test will not complete until 3 messages processed.
+          if (messageCount === 3) {
             done();
           }
-        });
-
-        messageStream.on('error', err => {
-          if (error == null) {
-            done(err);
-            return;
-          }
-
-          expect(err).to.have.property('message').that.equals(error);
-
-          done();
         });
 
         inputStream.pipe(messageStream);
       });
     });
+
+    context('when the messages are invalid', function () {
+      context('when the message size is negative', function () {
+        it('emits an error', function (done) {
+          const inputStream = bufferToStream(Buffer.from('ffffffff', 'hex'));
+          const messageStream = new MessageStream();
+
+          messageStream.on('error', err => {
+            expect(err).to.have.property('message').that.equals('Invalid message size: -1');
+            done();
+          });
+
+          inputStream.pipe(messageStream);
+        });
+      });
+
+      context('when the message size exceeds the bson maximum', function () {
+        it('emits an error', function (done) {
+          const inputStream = bufferToStream(Buffer.from('01000004', 'hex'));
+          const messageStream = new MessageStream();
+
+          messageStream.on('error', err => {
+            expect(err)
+              .to.have.property('message')
+              .that.equals('Invalid message size: 67108865, max allowed: 67108864');
+            done();
+          });
+
+          inputStream.pipe(messageStream);
+        });
+      });
+    });
   });
 
-  describe('writing', function () {
-    it('should write a message to the stream', function (done) {
+  context('when writing to the message stream', function () {
+    it('pushes the message', function (done) {
       const readableStream = new Readable({ read() {} });
       const writeableStream = new Writable({
         write: (chunk, _, callback) => {

--- a/test/unit/sdam/monitor.test.js
+++ b/test/unit/sdam/monitor.test.js
@@ -115,7 +115,10 @@ describe('monitoring', function () {
       monitor = new Monitor(server, {});
 
       monitor.on('serverHeartbeatFailed', () => done(new Error('unexpected heartbeat failure')));
-      monitor.on('serverHeartbeatSucceeded', () => done());
+      monitor.on('serverHeartbeatSucceeded', () => {
+        expect(monitor.connection.isMonitoringConnection).to.be.true;
+        done();
+      });
       monitor.connect();
     });
 


### PR DESCRIPTION
### Description

Only emits the last message from the message stream's buffer when using the streaming protocol.

#### What is changing?

The monitor will now tell the connection that it's using the streaming protocol, which in turn will
set the flag on the connection's message stream. When the stream is in this mode, it will only ever
emit the message event with the very last message in the buffer pool. So if there's more data in the
buffer, the stream essentially skips its emit.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-4139

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
