### PR TITLE
fix(NODE-4254): allow csfle to be dynamically required

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1630,7 +1630,7 @@ tasks:
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: latest
-          TOPOLOGY: server
+          TOPOLOGY: replica_set
       - func: bootstrap kms servers
       - func: run custom csfle tests
   - name: test-latest-server-noauth

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -512,7 +512,7 @@ oneOffFuncAsTasks.push({
       func: 'bootstrap mongo-orchestration',
       vars: {
         VERSION: 'latest',
-        TOPOLOGY: 'server'
+        TOPOLOGY: 'replica_set'
       }
     },
     { func: 'bootstrap kms servers' },

--- a/src/encrypter.ts
+++ b/src/encrypter.ts
@@ -124,9 +124,15 @@ export class Encrypter {
 
   static checkForMongoCrypt(): void {
     let mongodbClientEncryption = undefined;
+    // Ensure you always wrap an optional require in the try block NODE-3199
     try {
-      // Ensure you always wrap an optional require in the try block NODE-3199
-      mongodbClientEncryption = require('mongodb-client-encryption');
+      // Note (NODE-4254): This is to get around the circular dependency between
+      // mongodb-client-encryption and the driver in the test scenarios.
+      if (process.env.MONGODB_CLIENT_ENCRYPTION_OVERRIDE) {
+        mongodbClientEncryption = require(process.env.MONGODB_CLIENT_ENCRYPTION_OVERRIDE);
+      } else {
+        mongodbClientEncryption = require('mongodb-client-encryption');
+      }
     } catch (err) {
       throw new MongoMissingDependencyError(
         'Auto-encryption requested, but the module is not installed. ' +


### PR DESCRIPTION
### Description

Allows setting mongodb-client-encryption to an env variable to locate it on the local filesystem.

Needs https://github.com/mongodb/libmongocrypt/pull/342 to work.

Update: changed csfle tests to run on replica sets here (NODE-4236) in order to get the now running tests to pass.

#### What is changing?

If `MONGODB_CLIENT_ENCRYPTION_OVERRIDE` is present, will attempt to require csfle from that location.

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

NODE-4254

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
