### PR TITLE
test(NODE-4226): send encrypted fields in options

### DIFF
--- a/test/spec/client-side-encryption/tests/fle2-CreateCollection.json
+++ b/test/spec/client-side-encryption/tests/fle2-CreateCollection.json
@@ -102,8 +102,8 @@
             "command": {
               "drop": "encryptedCollection"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -111,8 +111,8 @@
             "command": {
               "drop": "encryptedCollection.esc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -120,8 +120,8 @@
             "command": {
               "drop": "encryptedCollection.ecc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -129,8 +129,8 @@
             "command": {
               "drop": "encryptedCollection.ecoc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -138,8 +138,8 @@
             "command": {
               "create": "encryptedCollection.esc"
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
@@ -147,8 +147,8 @@
             "command": {
               "create": "encryptedCollection.ecc"
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
@@ -156,17 +156,34 @@
             "command": {
               "create": "encryptedCollection.ecoc"
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection"
+              "create": "encryptedCollection",
+              "encryptedFields": {
+                "escCollection": "encryptedCollection.esc",
+                "eccCollection": "encryptedCollection.ecc",
+                "ecocCollection": "encryptedCollection.ecoc",
+                "fields": [
+                  {
+                    "path": "firstName",
+                    "bsonType": "string",
+                    "keyId": {
+                      "$binary": {
+                        "subType": "04",
+                        "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
+                      }
+                    }
+                  }
+                ]
+              }
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
@@ -182,8 +199,8 @@
                 }
               ]
             },
-            "commandName": "createIndexes",
-            "databaseName": "default"
+            "command_name": "createIndexes",
+            "database_name": "default"
           }
         }
       ]
@@ -282,8 +299,8 @@
             "command": {
               "drop": "encryptedCollection"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -291,8 +308,8 @@
             "command": {
               "drop": "enxcol_.encryptedCollection.esc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -300,8 +317,8 @@
             "command": {
               "drop": "enxcol_.encryptedCollection.ecc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -309,8 +326,8 @@
             "command": {
               "drop": "enxcol_.encryptedCollection.ecoc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -318,8 +335,8 @@
             "command": {
               "create": "enxcol_.encryptedCollection.esc"
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
@@ -327,8 +344,8 @@
             "command": {
               "create": "enxcol_.encryptedCollection.ecc"
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
@@ -336,17 +353,37 @@
             "command": {
               "create": "enxcol_.encryptedCollection.ecoc"
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection"
+              "create": "encryptedCollection",
+              "encryptedFields": {
+                "fields": [
+                  {
+                    "path": "firstName",
+                    "bsonType": "string",
+                    "keyId": {
+                      "$binary": {
+                        "subType": "04",
+                        "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
+                      }
+                    },
+                    "queries": {
+                      "queryType": "equality",
+                      "contention": {
+                        "$numberLong": "0"
+                      }
+                    }
+                  }
+                ]
+              }
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
@@ -362,8 +399,8 @@
                 }
               ]
             },
-            "commandName": "createIndexes",
-            "databaseName": "default"
+            "command_name": "createIndexes",
+            "database_name": "default"
           }
         }
       ]
@@ -502,8 +539,8 @@
             "command": {
               "drop": "encryptedCollection"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -511,8 +548,8 @@
             "command": {
               "drop": "enxcol_.encryptedCollection.esc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -520,8 +557,8 @@
             "command": {
               "drop": "enxcol_.encryptedCollection.ecc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -529,8 +566,8 @@
             "command": {
               "drop": "enxcol_.encryptedCollection.ecoc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -538,8 +575,8 @@
             "command": {
               "create": "enxcol_.encryptedCollection.esc"
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
@@ -547,8 +584,8 @@
             "command": {
               "create": "enxcol_.encryptedCollection.ecc"
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
@@ -556,17 +593,37 @@
             "command": {
               "create": "enxcol_.encryptedCollection.ecoc"
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection"
+              "create": "encryptedCollection",
+              "encryptedFields": {
+                "fields": [
+                  {
+                    "path": "firstName",
+                    "bsonType": "string",
+                    "keyId": {
+                      "$binary": {
+                        "subType": "04",
+                        "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
+                      }
+                    },
+                    "queries": {
+                      "queryType": "equality",
+                      "contention": {
+                        "$numberLong": "0"
+                      }
+                    }
+                  }
+                ]
+              }
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
@@ -582,8 +639,8 @@
                 }
               ]
             },
-            "commandName": "createIndexes",
-            "databaseName": "default"
+            "command_name": "createIndexes",
+            "database_name": "default"
           }
         },
         {
@@ -591,8 +648,8 @@
             "command": {
               "drop": "encryptedCollection"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -600,8 +657,8 @@
             "command": {
               "drop": "enxcol_.encryptedCollection.esc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -609,8 +666,8 @@
             "command": {
               "drop": "enxcol_.encryptedCollection.ecc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -618,8 +675,8 @@
             "command": {
               "drop": "enxcol_.encryptedCollection.ecoc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         }
       ]
@@ -732,8 +789,8 @@
             "command": {
               "drop": "encryptedCollection"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -741,8 +798,8 @@
             "command": {
               "drop": "encryptedCollection.esc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -750,8 +807,8 @@
             "command": {
               "drop": "encryptedCollection.ecc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -759,8 +816,8 @@
             "command": {
               "drop": "encryptedCollection.ecoc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -768,8 +825,8 @@
             "command": {
               "create": "encryptedCollection.esc"
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
@@ -777,8 +834,8 @@
             "command": {
               "create": "encryptedCollection.ecc"
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
@@ -786,17 +843,34 @@
             "command": {
               "create": "encryptedCollection.ecoc"
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection"
+              "create": "encryptedCollection",
+              "encryptedFields": {
+                "escCollection": "encryptedCollection.esc",
+                "eccCollection": "encryptedCollection.ecc",
+                "ecocCollection": "encryptedCollection.ecoc",
+                "fields": [
+                  {
+                    "path": "firstName",
+                    "bsonType": "string",
+                    "keyId": {
+                      "$binary": {
+                        "subType": "04",
+                        "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
+                      }
+                    }
+                  }
+                ]
+              }
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
@@ -812,8 +886,8 @@
                 }
               ]
             },
-            "commandName": "createIndexes",
-            "databaseName": "default"
+            "command_name": "createIndexes",
+            "database_name": "default"
           }
         }
       ]
@@ -879,8 +953,8 @@
                 "name": "plaintextCollection"
               }
             },
-            "commandName": "listCollections",
-            "databaseName": "default"
+            "command_name": "listCollections",
+            "database_name": "default"
           }
         },
         {
@@ -888,8 +962,8 @@
             "command": {
               "drop": "plaintextCollection"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -897,8 +971,8 @@
             "command": {
               "create": "plaintextCollection"
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         }
       ]
@@ -994,8 +1068,8 @@
             "command": {
               "drop": "encryptedCollection"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -1003,8 +1077,8 @@
             "command": {
               "drop": "encryptedCollection.esc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -1012,8 +1086,8 @@
             "command": {
               "drop": "encryptedCollection.ecc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -1021,8 +1095,8 @@
             "command": {
               "drop": "encryptedCollection.ecoc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -1030,8 +1104,8 @@
             "command": {
               "create": "encryptedCollection.esc"
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
@@ -1039,8 +1113,8 @@
             "command": {
               "create": "encryptedCollection.ecc"
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
@@ -1048,17 +1122,34 @@
             "command": {
               "create": "encryptedCollection.ecoc"
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection"
+              "create": "encryptedCollection",
+              "encryptedFields": {
+                "escCollection": "encryptedCollection.esc",
+                "eccCollection": "encryptedCollection.ecc",
+                "ecocCollection": "encryptedCollection.ecoc",
+                "fields": [
+                  {
+                    "path": "firstName",
+                    "bsonType": "string",
+                    "keyId": {
+                      "$binary": {
+                        "subType": "04",
+                        "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
+                      }
+                    }
+                  }
+                ]
+              }
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
@@ -1074,8 +1165,8 @@
                 }
               ]
             },
-            "commandName": "createIndexes",
-            "databaseName": "default"
+            "command_name": "createIndexes",
+            "database_name": "default"
           }
         }
       ]
@@ -1186,8 +1277,8 @@
             "command": {
               "drop": "encryptedCollection"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -1195,8 +1286,8 @@
             "command": {
               "drop": "encryptedCollection.esc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -1204,8 +1295,8 @@
             "command": {
               "drop": "encryptedCollection.ecc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -1213,8 +1304,8 @@
             "command": {
               "drop": "encryptedCollection.ecoc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -1222,8 +1313,8 @@
             "command": {
               "create": "encryptedCollection.esc"
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
@@ -1231,8 +1322,8 @@
             "command": {
               "create": "encryptedCollection.ecc"
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
@@ -1240,17 +1331,34 @@
             "command": {
               "create": "encryptedCollection.ecoc"
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection"
+              "create": "encryptedCollection",
+              "encryptedFields": {
+                "escCollection": "encryptedCollection.esc",
+                "eccCollection": "encryptedCollection.ecc",
+                "ecocCollection": "encryptedCollection.ecoc",
+                "fields": [
+                  {
+                    "path": "firstName",
+                    "bsonType": "string",
+                    "keyId": {
+                      "$binary": {
+                        "subType": "04",
+                        "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
+                      }
+                    }
+                  }
+                ]
+              }
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
@@ -1266,8 +1374,8 @@
                 }
               ]
             },
-            "commandName": "createIndexes",
-            "databaseName": "default"
+            "command_name": "createIndexes",
+            "database_name": "default"
           }
         }
       ]
@@ -1315,8 +1423,8 @@
             "command": {
               "drop": "encryptedCollection"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -1324,8 +1432,8 @@
             "command": {
               "drop": "encryptedCollection.esc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -1333,8 +1441,8 @@
             "command": {
               "drop": "encryptedCollection.ecc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -1342,8 +1450,8 @@
             "command": {
               "drop": "encryptedCollection.ecoc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         }
       ]
@@ -1511,8 +1619,8 @@
             "command": {
               "drop": "encryptedCollection"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -1520,8 +1628,8 @@
             "command": {
               "drop": "encryptedCollection.esc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -1529,8 +1637,8 @@
             "command": {
               "drop": "encryptedCollection.ecc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -1538,8 +1646,8 @@
             "command": {
               "drop": "encryptedCollection.ecoc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -1547,8 +1655,8 @@
             "command": {
               "create": "encryptedCollection.esc"
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
@@ -1556,8 +1664,8 @@
             "command": {
               "create": "encryptedCollection.ecc"
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
@@ -1565,17 +1673,34 @@
             "command": {
               "create": "encryptedCollection.ecoc"
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection"
+              "create": "encryptedCollection",
+              "encryptedFields": {
+                "escCollection": "encryptedCollection.esc",
+                "eccCollection": "encryptedCollection.ecc",
+                "ecocCollection": "encryptedCollection.ecoc",
+                "fields": [
+                  {
+                    "path": "firstName",
+                    "bsonType": "string",
+                    "keyId": {
+                      "$binary": {
+                        "subType": "04",
+                        "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
+                      }
+                    }
+                  }
+                ]
+              }
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
@@ -1591,8 +1716,8 @@
                 }
               ]
             },
-            "commandName": "createIndexes",
-            "databaseName": "default"
+            "command_name": "createIndexes",
+            "database_name": "default"
           }
         },
         {
@@ -1600,8 +1725,8 @@
             "command": {
               "drop": "encryptedCollection"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -1609,8 +1734,8 @@
             "command": {
               "drop": "encryptedCollection.esc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -1618,8 +1743,8 @@
             "command": {
               "drop": "encryptedCollection.ecc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -1627,8 +1752,8 @@
             "command": {
               "drop": "encryptedCollection.ecoc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         }
       ]
@@ -1779,8 +1904,8 @@
             "command": {
               "drop": "encryptedCollection"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -1788,8 +1913,8 @@
             "command": {
               "drop": "encryptedCollection.esc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -1797,8 +1922,8 @@
             "command": {
               "drop": "encryptedCollection.ecc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -1806,8 +1931,8 @@
             "command": {
               "drop": "encryptedCollection.ecoc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -1815,8 +1940,8 @@
             "command": {
               "create": "encryptedCollection.esc"
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
@@ -1824,8 +1949,8 @@
             "command": {
               "create": "encryptedCollection.ecc"
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
@@ -1833,17 +1958,34 @@
             "command": {
               "create": "encryptedCollection.ecoc"
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection"
+              "create": "encryptedCollection",
+              "encryptedFields": {
+                "escCollection": "encryptedCollection.esc",
+                "eccCollection": "encryptedCollection.ecc",
+                "ecocCollection": "encryptedCollection.ecoc",
+                "fields": [
+                  {
+                    "path": "firstName",
+                    "bsonType": "string",
+                    "keyId": {
+                      "$binary": {
+                        "subType": "04",
+                        "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
+                      }
+                    }
+                  }
+                ]
+              }
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
@@ -1859,8 +2001,8 @@
                 }
               ]
             },
-            "commandName": "createIndexes",
-            "databaseName": "default"
+            "command_name": "createIndexes",
+            "database_name": "default"
           }
         },
         {
@@ -1871,8 +2013,8 @@
                 "name": "encryptedCollection"
               }
             },
-            "commandName": "listCollections",
-            "databaseName": "default"
+            "command_name": "listCollections",
+            "database_name": "default"
           }
         },
         {
@@ -1880,8 +2022,8 @@
             "command": {
               "drop": "encryptedCollection"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -1889,8 +2031,8 @@
             "command": {
               "drop": "encryptedCollection.esc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -1898,8 +2040,8 @@
             "command": {
               "drop": "encryptedCollection.ecc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -1907,8 +2049,8 @@
             "command": {
               "drop": "encryptedCollection.ecoc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         }
       ]

--- a/test/spec/client-side-encryption/tests/fle2-CreateCollection.yml
+++ b/test/spec/client-side-encryption/tests/fle2-CreateCollection.yml
@@ -13,7 +13,7 @@ tests:
         kmsProviders:
           aws: {} # Credentials filled in from environment.
         encryptedFieldsMap:
-          default.encryptedCollection: {
+          default.encryptedCollection: &encrypted_fields0 {
                 "escCollection": "encryptedCollection.esc",
                 "eccCollection": "encryptedCollection.ecc",
                 "ecocCollection": "encryptedCollection.ecoc",
@@ -68,47 +68,48 @@ tests:
         - command_started_event:
             command:
               drop: "encryptedCollection"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "encryptedCollection.esc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "encryptedCollection.ecc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "encryptedCollection.ecoc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         # events from dropCollection ... end
         # events from createCollection ... begin
         # State collections are created first.
         - command_started_event:
             command:
               create: "encryptedCollection.esc"
-            commandName: create
-            databaseName: *database_name
+            command_name: create
+            database_name: *database_name
         - command_started_event:
             command:
               create: "encryptedCollection.ecc"
-            commandName: create
-            databaseName: *database_name
+            command_name: create
+            database_name: *database_name
         - command_started_event:
             command:
               create: "encryptedCollection.ecoc"
-            commandName: create
-            databaseName: *database_name
+            command_name: create
+            database_name: *database_name
         # Data collection is created after.
         - command_started_event:
             command:
               create: "encryptedCollection"
-            commandName: create
-            databaseName: *database_name
+              encryptedFields: *encrypted_fields0
+            command_name: create
+            database_name: *database_name
         # Index on __safeContents__ is then created.
         - command_started_event:
             command:
@@ -116,8 +117,8 @@ tests:
               indexes:
                 - name: __safeContent___1
                   key: { __safeContent__: 1 }
-            commandName: createIndexes
-            databaseName: *database_name
+            command_name: createIndexes
+            database_name: *database_name
         # events from createCollection ... end
   - description: "default state collection names are applied"
     clientOptions:
@@ -125,7 +126,7 @@ tests:
         kmsProviders:
           aws: {} # Credentials filled in from environment.
         encryptedFieldsMap:
-          default.encryptedCollection: {
+          default.encryptedCollection: &encrypted_fields1 {
                 "fields": [
                     {
                         "path": "firstName",
@@ -183,47 +184,48 @@ tests:
         - command_started_event:
             command:
               drop: "encryptedCollection"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "enxcol_.encryptedCollection.esc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "enxcol_.encryptedCollection.ecc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "enxcol_.encryptedCollection.ecoc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         # events from dropCollection ... end
         # events from createCollection ... begin
         # State collections are created first.
         - command_started_event:
             command:
               create: "enxcol_.encryptedCollection.esc"
-            commandName: create
-            databaseName: *database_name
+            command_name: create
+            database_name: *database_name
         - command_started_event:
             command:
               create: "enxcol_.encryptedCollection.ecc"
-            commandName: create
-            databaseName: *database_name
+            command_name: create
+            database_name: *database_name
         - command_started_event:
             command:
               create: "enxcol_.encryptedCollection.ecoc"
-            commandName: create
-            databaseName: *database_name
+            command_name: create
+            database_name: *database_name
         # Data collection is created after.
         - command_started_event:
             command:
               create: "encryptedCollection"
-            commandName: create
-            databaseName: *database_name
+              encryptedFields: *encrypted_fields1
+            command_name: create
+            database_name: *database_name
         # Index on __safeContents__ is then created.
         - command_started_event:
             command:
@@ -231,8 +233,8 @@ tests:
               indexes:
                 - name: __safeContent___1
                   key: { __safeContent__: 1 }
-            commandName: createIndexes
-            databaseName: *database_name
+            command_name: createIndexes
+            database_name: *database_name
         # events from createCollection ... end
   - description: "drop removes all state collections"
     clientOptions:
@@ -240,7 +242,7 @@ tests:
         kmsProviders:
           aws: {} # Credentials filled in from environment.
         encryptedFieldsMap:
-          default.encryptedCollection: {
+          default.encryptedCollection: &encrypted_fields2 {
                 "fields": [
                     {
                         "path": "firstName",
@@ -323,47 +325,48 @@ tests:
         - command_started_event:
             command:
               drop: "encryptedCollection"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "enxcol_.encryptedCollection.esc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "enxcol_.encryptedCollection.ecc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "enxcol_.encryptedCollection.ecoc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         # events from dropCollection ... end
         # events from createCollection ... begin
         # State collections are created first.
         - command_started_event:
             command:
               create: "enxcol_.encryptedCollection.esc"
-            commandName: create
-            databaseName: *database_name
+            command_name: create
+            database_name: *database_name
         - command_started_event:
             command:
               create: "enxcol_.encryptedCollection.ecc"
-            commandName: create
-            databaseName: *database_name
+            command_name: create
+            database_name: *database_name
         - command_started_event:
             command:
               create: "enxcol_.encryptedCollection.ecoc"
-            commandName: create
-            databaseName: *database_name
+            command_name: create
+            database_name: *database_name
         # Data collection is created after.
         - command_started_event:
             command:
               create: "encryptedCollection"
-            commandName: create
-            databaseName: *database_name
+              encryptedFields: *encrypted_fields2
+            command_name: create
+            database_name: *database_name
         # Index on __safeContents__ is then created.
         - command_started_event:
             command:
@@ -371,30 +374,30 @@ tests:
               indexes:
                 - name: __safeContent___1
                   key: { __safeContent__: 1 }
-            commandName: createIndexes
-            databaseName: *database_name
+            command_name: createIndexes
+            database_name: *database_name
         # events from createCollection ... end
         # events from dropCollection ... begin
         - command_started_event:
             command:
               drop: "encryptedCollection"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "enxcol_.encryptedCollection.esc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "enxcol_.encryptedCollection.ecc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "enxcol_.encryptedCollection.ecoc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         # events from dropCollection ... end
   - description: "encryptedFieldsMap with cyclic entries does not loop"
     clientOptions:
@@ -404,7 +407,7 @@ tests:
         encryptedFieldsMap:
           # encryptedCollection has encryptedCollection.esc as the escCollection.
           # encryptedCollection.esc has encryptedCollection as the escCollection.
-          default.encryptedCollection: {
+          default.encryptedCollection: &encrypted_fields3 {
                 "escCollection": "encryptedCollection.esc",
                 "eccCollection": "encryptedCollection.ecc",
                 "ecocCollection": "encryptedCollection.ecoc",
@@ -469,47 +472,48 @@ tests:
         - command_started_event:
             command:
               drop: "encryptedCollection"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "encryptedCollection.esc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "encryptedCollection.ecc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "encryptedCollection.ecoc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         # events from dropCollection ... end
         # events from createCollection ... begin
         # State collections are created first.
         - command_started_event:
             command:
               create: "encryptedCollection.esc"
-            commandName: create
-            databaseName: *database_name
+            command_name: create
+            database_name: *database_name
         - command_started_event:
             command:
               create: "encryptedCollection.ecc"
-            commandName: create
-            databaseName: *database_name
+            command_name: create
+            database_name: *database_name
         - command_started_event:
             command:
               create: "encryptedCollection.ecoc"
-            commandName: create
-            databaseName: *database_name
+            command_name: create
+            database_name: *database_name
         # Data collection is created after.
         - command_started_event:
             command:
               create: "encryptedCollection"
-            commandName: create
-            databaseName: *database_name
+              encryptedFields: *encrypted_fields3
+            command_name: create
+            database_name: *database_name
         # Index on __safeContents__ is then created.
         - command_started_event:
             command:
@@ -517,8 +521,8 @@ tests:
               indexes:
                 - name: __safeContent___1
                   key: { __safeContent__: 1 }
-            commandName: createIndexes
-            databaseName: *database_name
+            command_name: createIndexes
+            database_name: *database_name
         # events from createCollection ... end
   - description: "CreateCollection without encryptedFields."
     clientOptions:
@@ -561,26 +565,26 @@ tests:
             command:
               listCollections: 1
               filter: { name: "plaintextCollection" }
-            commandName: listCollections
-            databaseName: *database_name
+            command_name: listCollections
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "plaintextCollection"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         # events from dropCollection ... end
         - command_started_event:
             command:
               create: "plaintextCollection"
-            commandName: create
-            databaseName: *database_name
+            command_name: create
+            database_name: *database_name
   - description: "CreateCollection from encryptedFieldsMap."
     clientOptions:
       autoEncryptOpts:
         kmsProviders:
           aws: {} # Credentials filled in from environment.
         encryptedFieldsMap:
-          default.encryptedCollection: {
+          default.encryptedCollection: &encrypted_fields4 {
                 "escCollection": "encryptedCollection.esc",
                 "eccCollection": "encryptedCollection.ecc",
                 "ecocCollection": "encryptedCollection.ecoc",
@@ -634,47 +638,48 @@ tests:
         - command_started_event:
             command:
               drop: "encryptedCollection"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "encryptedCollection.esc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "encryptedCollection.ecc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "encryptedCollection.ecoc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         # events from dropCollection ... end
         # events from createCollection ... begin
         # State collections are created first.
         - command_started_event:
             command:
               create: "encryptedCollection.esc"
-            commandName: create
-            databaseName: *database_name
+            command_name: create
+            database_name: *database_name
         - command_started_event:
             command:
               create: "encryptedCollection.ecc"
-            commandName: create
-            databaseName: *database_name
+            command_name: create
+            database_name: *database_name
         - command_started_event:
             command:
               create: "encryptedCollection.ecoc"
-            commandName: create
-            databaseName: *database_name
+            command_name: create
+            database_name: *database_name
         # Data collection is created after.
         - command_started_event:
             command:
               create: "encryptedCollection"
-            commandName: create
-            databaseName: *database_name
+              encryptedFields: *encrypted_fields4
+            command_name: create
+            database_name: *database_name
         # Index on __safeContents__ is then created.
         - command_started_event:
             command:
@@ -682,8 +687,8 @@ tests:
               indexes:
                 - name: __safeContent___1
                   key: { __safeContent__: 1 }
-            commandName: createIndexes
-            databaseName: *database_name
+            command_name: createIndexes
+            database_name: *database_name
         # events from createCollection ... end
   - description: "CreateCollection from encryptedFields."
     clientOptions:
@@ -712,7 +717,7 @@ tests:
         object: database
         arguments:
           collection: "encryptedCollection"
-          encryptedFields: {
+          encryptedFields: &encrypted_fields5 {
                 "escCollection": "encryptedCollection.esc",
                 "eccCollection": "encryptedCollection.ecc",
                 "ecocCollection": "encryptedCollection.ecoc",
@@ -756,47 +761,48 @@ tests:
         - command_started_event:
             command:
               drop: "encryptedCollection"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "encryptedCollection.esc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "encryptedCollection.ecc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "encryptedCollection.ecoc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         # events from dropCollection ... end
         # events from createCollection ... begin
         # State collections are created first.
         - command_started_event:
             command:
               create: "encryptedCollection.esc"
-            commandName: create
-            databaseName: *database_name
+            command_name: create
+            database_name: *database_name
         - command_started_event:
             command:
               create: "encryptedCollection.ecc"
-            commandName: create
-            databaseName: *database_name
+            command_name: create
+            database_name: *database_name
         - command_started_event:
             command:
               create: "encryptedCollection.ecoc"
-            commandName: create
-            databaseName: *database_name
+            command_name: create
+            database_name: *database_name
         # Data collection is created after.
         - command_started_event:
             command:
               create: "encryptedCollection"
-            commandName: create
-            databaseName: *database_name
+              encryptedFields: *encrypted_fields5
+            command_name: create
+            database_name: *database_name
         # Index on __safeContents__ is then created.
         - command_started_event:
             command:
@@ -804,8 +810,8 @@ tests:
               indexes:
                 - name: __safeContent___1
                   key: { __safeContent__: 1 }
-            commandName: createIndexes
-            databaseName: *database_name
+            command_name: createIndexes
+            database_name: *database_name
         # events from createCollection ... end
 
   - description: "DropCollection from encryptedFieldsMap"
@@ -836,23 +842,23 @@ tests:
         - command_started_event:
             command:
               drop: "encryptedCollection"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "encryptedCollection.esc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "encryptedCollection.ecc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "encryptedCollection.ecoc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         # events from dropCollection ... end
   - description: "DropCollection from encryptedFields"
     clientOptions:
@@ -924,7 +930,7 @@ tests:
         object: database
         arguments:
           collection: "encryptedCollection"
-          encryptedFields: {
+          encryptedFields: &encrypted_fields6 {
                 "escCollection": "encryptedCollection.esc",
                 "eccCollection": "encryptedCollection.ecc",
                 "ecocCollection": "encryptedCollection.ecoc",
@@ -961,45 +967,46 @@ tests:
         - command_started_event:
             command:
               drop: "encryptedCollection"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "encryptedCollection.esc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "encryptedCollection.ecc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "encryptedCollection.ecoc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         # events from dropCollection ... end
         # events from createCollection ... begin
         - command_started_event:
             command:
               create: "encryptedCollection.esc"
-            commandName: create
-            databaseName: *database_name
+            command_name: create
+            database_name: *database_name
         - command_started_event:
             command:
               create: "encryptedCollection.ecc"
-            commandName: create
-            databaseName: *database_name
+            command_name: create
+            database_name: *database_name
         - command_started_event:
             command:
               create: "encryptedCollection.ecoc"
-            commandName: create
-            databaseName: *database_name
+            command_name: create
+            database_name: *database_name
         - command_started_event:
             command:
               create: "encryptedCollection"
-            commandName: create
-            databaseName: *database_name
+              encryptedFields: *encrypted_fields6
+            command_name: create
+            database_name: *database_name
         # Index on __safeContents__ is then created.
         - command_started_event:
             command:
@@ -1007,30 +1014,30 @@ tests:
               indexes:
                 - name: __safeContent___1
                   key: { __safeContent__: 1 }
-            commandName: createIndexes
-            databaseName: *database_name
+            command_name: createIndexes
+            database_name: *database_name
         # events from createCollection ... end
         # events from dropCollection ... begin
         - command_started_event:
             command:
               drop: "encryptedCollection"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "encryptedCollection.esc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "encryptedCollection.ecc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "encryptedCollection.ecoc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         # events from dropCollection ... end
 
   - description: "DropCollection from remote encryptedFields"
@@ -1062,7 +1069,7 @@ tests:
         object: database
         arguments:
           collection: "encryptedCollection"
-          encryptedFields: {
+          encryptedFields: &encrypted_fields7 {
                 "escCollection": "encryptedCollection.esc",
                 "eccCollection": "encryptedCollection.ecc",
                 "ecocCollection": "encryptedCollection.ecoc",
@@ -1130,45 +1137,46 @@ tests:
         - command_started_event:
             command:
               drop: "encryptedCollection"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "encryptedCollection.esc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "encryptedCollection.ecc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "encryptedCollection.ecoc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         # events from dropCollection ... end
         # events from createCollection ... begin
         - command_started_event:
             command:
               create: "encryptedCollection.esc"
-            commandName: create
-            databaseName: *database_name
+            command_name: create
+            database_name: *database_name
         - command_started_event:
             command:
               create: "encryptedCollection.ecc"
-            commandName: create
-            databaseName: *database_name
+            command_name: create
+            database_name: *database_name
         - command_started_event:
             command:
               create: "encryptedCollection.ecoc"
-            commandName: create
-            databaseName: *database_name
+            command_name: create
+            database_name: *database_name
         - command_started_event:
             command:
               create: "encryptedCollection"
-            commandName: create
-            databaseName: *database_name
+              encryptedFields: *encrypted_fields7
+            command_name: create
+            database_name: *database_name
         # Index on __safeContents__ is then created.
         - command_started_event:
             command:
@@ -1176,34 +1184,34 @@ tests:
               indexes:
                 - name: __safeContent___1
                   key: { __safeContent__: 1 }
-            commandName: createIndexes
-            databaseName: *database_name
+            command_name: createIndexes
+            database_name: *database_name
         # events from createCollection ... end
         # events from dropCollection ... begin
         - command_started_event:
             command:
               listCollections: 1
               filter: { name: "encryptedCollection" }
-            commandName: listCollections
-            databaseName: *database_name
+            command_name: listCollections
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "encryptedCollection"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "encryptedCollection.esc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "encryptedCollection.ecc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "encryptedCollection.ecoc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         # events from dropCollection ... end


### PR DESCRIPTION
### Description

Syncs tests for for DRIVERS-2310/NODE-4226

#### What is changing?

Updates the create collection encryption tests to assert encrypted fields are passed.

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

NODE-4225/DRIVERS-2310

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
