### PR TITLE
chore(NODE-4265): fle2 -> queryable encryption

### DIFF
--- a/src/operations/create_collection.ts
+++ b/src/operations/create_collection.ts
@@ -127,7 +127,7 @@ export class CreateCollectionOperation extends CommandOperation<Collection> {
         db.s.client.options.autoEncryption?.encryptedFieldsMap?.[`${db.databaseName}.${name}`];
 
       if (encryptedFields) {
-        // Create auxilliary collections for FLE2 support.
+        // Create auxilliary collections for queryable encryption support.
         const escCollection = encryptedFields.escCollection ?? `enxcol_.${name}.esc`;
         const eccCollection = encryptedFields.eccCollection ?? `enxcol_.${name}.ecc`;
         const ecocCollection = encryptedFields.ecocCollection ?? `enxcol_.${name}.ecoc`;
@@ -145,7 +145,7 @@ export class CreateCollectionOperation extends CommandOperation<Collection> {
       const coll = await this.executeWithoutEncryptedFieldsCheck(server, session);
 
       if (encryptedFields) {
-        // Create the required index for FLE2 support.
+        // Create the required index for queryable encryption support.
         const createIndexOp = new CreateIndexOperation(db, name, { __safeContent__: 1 }, {});
         await new Promise<void>((resolve, reject) => {
           createIndexOp.execute(server, session, err => (err ? reject(err) : resolve()));


### PR DESCRIPTION
### Description

Replace instances in code of FLE2 with Queryable Encryption.

#### What is changing?

2 comments in the code.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-4265

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
