### PR TITLE
feat(NODE-4229): bump maxWireVersion to 17

### DIFF
--- a/src/cmap/wire_protocol/constants.ts
+++ b/src/cmap/wire_protocol/constants.ts
@@ -1,7 +1,7 @@
 export const MIN_SUPPORTED_SERVER_VERSION = '3.6';
-export const MAX_SUPPORTED_SERVER_VERSION = '5.1';
+export const MAX_SUPPORTED_SERVER_VERSION = '6.0';
 export const MIN_SUPPORTED_WIRE_VERSION = 6;
-export const MAX_SUPPORTED_WIRE_VERSION = 14;
+export const MAX_SUPPORTED_WIRE_VERSION = 17;
 export const OP_REPLY = 1;
 export const OP_UPDATE = 2001;
 export const OP_INSERT = 2002;

--- a/test/unit/assorted/wire_version.test.js
+++ b/test/unit/assorted/wire_version.test.js
@@ -7,7 +7,7 @@ const { isHello } = require('../../../src/utils');
 
 const minCompatErrMsg = `minimum wire version ${
   Number.MAX_SAFE_INTEGER - 1
-}, but this version of the Node.js Driver requires at most 14`;
+}, but this version of the Node.js Driver requires at most 17`;
 const maxCompatErrMsg = `reports maximum wire version 1, but this version of the Node.js Driver requires at least 6`;
 
 describe('Wire Protocol Version', () => {
@@ -36,7 +36,7 @@ describe('Wire Protocol Version', () => {
     await mock.cleanup();
   });
 
-  describe('minimum is greater than 14', () => {
+  describe('minimum is greater than max supported', () => {
     it('should raise a compatibility error', async function () {
       setWireProtocolMessageHandler(Number.MAX_SAFE_INTEGER - 1, Number.MAX_SAFE_INTEGER);
 
@@ -54,7 +54,7 @@ describe('Wire Protocol Version', () => {
     });
   });
 
-  describe('maximum is less than 2', () => {
+  describe('maximum is less than min supported', () => {
     it('should raise a compatibility error', async function () {
       setWireProtocolMessageHandler(1, 1);
 

--- a/test/unit/cmap/wire_protocol/constants.test.js
+++ b/test/unit/cmap/wire_protocol/constants.test.js
@@ -14,8 +14,8 @@ describe('Wire Protocol Constants', function () {
   });
 
   describe('MAX_SUPPORTED_SERVER_VERSION', function () {
-    it('returns 5.1', function () {
-      expect(MAX_SUPPORTED_SERVER_VERSION).to.equal('5.1');
+    it('returns 6.0', function () {
+      expect(MAX_SUPPORTED_SERVER_VERSION).to.equal('6.0');
     });
   });
 
@@ -26,8 +26,8 @@ describe('Wire Protocol Constants', function () {
   });
 
   describe('MAX_SUPPORTED_WIRE_VERSION', function () {
-    it('returns 14', function () {
-      expect(MAX_SUPPORTED_WIRE_VERSION).to.equal(14);
+    it('returns 17', function () {
+      expect(MAX_SUPPORTED_WIRE_VERSION).to.equal(17);
     });
   });
 });


### PR DESCRIPTION
### Description
NODE-4229
#### What is changing?
Bumping maxWireVersion to 17 and max supported server version to 6.0 and updating the corresponding tests.

##### Is there new documentation needed for these changes?
No

#### What is the motivation for this change?
Keeping up with server updates

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [N/A] New TODOs have a related JIRA ticket
