### PR TITLE
test(NODE-4255): sync clustered index spec tests

### DIFF
--- a/test/spec/collection-management/clustered-indexes.json
+++ b/test/spec/collection-management/clustered-indexes.json
@@ -10,14 +10,17 @@
   "createEntities": [
     {
       "client": {
-        "id": "client0"
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
       }
     },
     {
       "database": {
         "id": "database0",
         "client": "client0",
-        "databaseName": "ts-tests"
+        "databaseName": "ci-tests"
       }
     },
     {
@@ -31,7 +34,7 @@
   "initialData": [
     {
       "collectionName": "test",
-      "databaseName": "ts-tests",
+      "databaseName": "ci-tests",
       "documents": []
     }
   ],
@@ -64,9 +67,39 @@
           "name": "assertCollectionExists",
           "object": "testRunner",
           "arguments": {
-            "databaseName": "ts-tests",
+            "databaseName": "ci-tests",
             "collectionName": "test"
           }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "drop": "test"
+                },
+                "databaseName": "ci-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "create": "test",
+                  "clusteredIndex": {
+                    "key": {
+                      "_id": 1
+                    },
+                    "unique": true,
+                    "name": "test index"
+                  }
+                },
+                "databaseName": "ci-tests"
+              }
+            }
+          ]
         }
       ]
     },
@@ -125,6 +158,49 @@
             }
           ]
         }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "drop": "test"
+                },
+                "databaseName": "ci-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "create": "test",
+                  "clusteredIndex": {
+                    "key": {
+                      "_id": 1
+                    },
+                    "unique": true,
+                    "name": "test index"
+                  }
+                },
+                "databaseName": "ci-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "listCollections": 1,
+                  "filter": {
+                    "name": {
+                      "$eq": "test"
+                    }
+                  }
+                },
+                "databaseName": "ci-tests"
+              }
+            }
+          ]
+        }
       ]
     },
     {
@@ -167,6 +243,44 @@
                   "int",
                   "long"
                 ]
+              }
+            }
+          ]
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "drop": "test"
+                },
+                "databaseName": "ci-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "create": "test",
+                  "clusteredIndex": {
+                    "key": {
+                      "_id": 1
+                    },
+                    "unique": true,
+                    "name": "test index"
+                  }
+                },
+                "databaseName": "ci-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "listIndexes": "test"
+                },
+                "databaseName": "ci-tests"
               }
             }
           ]

--- a/test/spec/collection-management/clustered-indexes.yml
+++ b/test/spec/collection-management/clustered-indexes.yml
@@ -9,10 +9,11 @@ runOnRequirements:
 createEntities:
   - client:
       id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
   - database:
       id: &database0 database0
       client: *client0
-      databaseName: &database0Name ts-tests
+      databaseName: &database0Name ci-tests
   - collection:
       id: &collection0 collection0
       database: *database0
@@ -34,7 +35,7 @@ tests:
         object: *database0
         arguments:
           collection: *collection0Name
-          clusteredIndex:
+          clusteredIndex: &clusteredIndex
             key: { _id: 1 }
             unique: true
             name: &index0Name "test index"
@@ -43,6 +44,18 @@ tests:
         arguments:
           databaseName: *database0Name
           collectionName: *collection0Name
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                drop: *collection0Name
+              databaseName: *database0Name
+          - commandStartedEvent:
+              command:
+                create: *collection0Name
+                clusteredIndex: *clusteredIndex
+              databaseName: *database0Name
 
   - description: "listCollections includes clusteredIndex"
     operations:
@@ -54,14 +67,11 @@ tests:
         object: *database0
         arguments:
           collection: *collection0Name
-          clusteredIndex:
-            key: { _id: 1 }
-            unique: true
-            name: &index0Name "test index"
+          clusteredIndex: *clusteredIndex
       - name: listCollections
         object: *database0
         arguments:
-          filter: { name: { $eq: *collection0Name } }
+          filter: &filter { name: { $eq: *collection0Name } }
         expectResult:
           - name: *collection0Name
             options:
@@ -70,6 +80,23 @@ tests:
                 unique: true
                 name: *index0Name
                 v: { $$type: [ int, long ] }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                drop: *collection0Name
+              databaseName: *database0Name
+          - commandStartedEvent:
+              command:
+                create: *collection0Name
+                clusteredIndex: *clusteredIndex
+              databaseName: *database0Name
+          - commandStartedEvent:
+              command:
+                listCollections: 1
+                filter: *filter
+              databaseName: *database0Name
 
   - description: "listIndexes returns the index"
     operations:
@@ -81,10 +108,7 @@ tests:
         object: *database0
         arguments:
           collection: *collection0Name
-          clusteredIndex:
-            key: { _id: 1 }
-            unique: true
-            name: *index0Name
+          clusteredIndex: *clusteredIndex
       - name: listIndexes
         object: *collection0
         expectResult:
@@ -93,3 +117,19 @@ tests:
             clustered: true
             unique: true
             v: { $$type: [ int, long ] }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                drop: *collection0Name
+              databaseName: *database0Name
+          - commandStartedEvent:
+              command:
+                create: *collection0Name
+                clusteredIndex: *clusteredIndex
+              databaseName: *database0Name
+          - commandStartedEvent:
+              command:
+                listIndexes: *collection0Name
+              databaseName: *database0Name


### PR DESCRIPTION
### Description
NODE-4255

#### What is changing?
Sync latest clustered index spec tests

##### Is there new documentation needed for these changes?
No

#### What is the motivation for this change?
Spec compliance

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] Changes are covered by tests
- [N/A] New TODOs have a related JIRA ticket
