### PR TITLE
feat(NODE-4081): fix and deprecate change stream resume options

### DIFF
--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -76,6 +76,7 @@ const NO_CURSOR_ERROR = 'ChangeStream has no cursor';
 const CHANGESTREAM_CLOSED_ERROR = 'ChangeStream is closed';
 
 /**
+ * @public
  * @deprecated
  *
  * Please use the ChangeStreamCursorOptions instead.

--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -77,9 +77,7 @@ const CHANGESTREAM_CLOSED_ERROR = 'ChangeStream is closed';
 
 /**
  * @public
- * @deprecated
- *
- * Please use the ChangeStreamCursorOptions instead.
+ * @deprecated Please use the ChangeStreamCursorOptions type instead.
  */
 export interface ResumeOptions {
   startAtOperationTime?: Timestamp;

--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -941,11 +941,7 @@ export class ChangeStreamCursor<
       } else {
         options.resumeAfter = this.resumeToken;
       }
-    } else if (
-      this.resumeToken == null &&
-      this.startAtOperationTime != null &&
-      maxWireVersion(this.server) >= 7
-    ) {
+    } else if (this.startAtOperationTime != null && maxWireVersion(this.server) >= 7) {
       options.startAtOperationTime = this.startAtOperationTime;
     }
 

--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -930,19 +930,22 @@ export class ChangeStreamCursor<
       ...this.options
     };
 
-    if (this.resumeToken || this.startAtOperationTime) {
-      for (const key of ['resumeAfter', 'startAfter', 'startAtOperationTime'] as const) {
-        delete options[key];
-      }
+    for (const key of ['resumeAfter', 'startAfter', 'startAtOperationTime'] as const) {
+      delete options[key];
+    }
 
-      if (this.resumeToken) {
-        const resumeKey =
-          this.options.startAfter && !this.hasReceived ? 'startAfter' : 'resumeAfter';
-
-        options[resumeKey] = this.resumeToken;
-      } else if (this.startAtOperationTime && maxWireVersion(this.server) >= 7) {
-        options.startAtOperationTime = this.startAtOperationTime;
+    if (this.resumeToken != null) {
+      if (this.options.startAfter && !this.hasReceived) {
+        options.startAfter = this.resumeToken;
+      } else {
+        options.resumeAfter = this.resumeToken;
       }
+    } else if (
+      this.resumeToken == null &&
+      this.startAtOperationTime != null &&
+      maxWireVersion(this.server) >= 7
+    ) {
+      options.startAtOperationTime = this.startAtOperationTime;
     }
 
     return options;

--- a/test/unit/change_stream.test.ts
+++ b/test/unit/change_stream.test.ts
@@ -7,7 +7,10 @@ import { MongoClient } from '../../src/mongo_client';
 import { MongoDBNamespace } from '../../src/utils';
 
 describe('class ChangeStreamCursor', function () {
-  afterEach(() => sinon.restore());
+  afterEach(function () {
+    sinon.restore();
+  });
+
   describe('get resumeOptions()', function () {
     context('non-resume related options', function () {
       it('copies all options from the original cursor', function () {
@@ -25,9 +28,11 @@ describe('class ChangeStreamCursor', function () {
         });
       });
     });
+
     context('when there is a cached resumeToken', function () {
       context('when the cursor was started with startAfter', function () {
         let cursor: ChangeStreamCursor;
+
         beforeEach(function () {
           cursor = new ChangeStreamCursor(
             new MongoClient('mongodb://localhost:27027'),
@@ -37,6 +42,7 @@ describe('class ChangeStreamCursor', function () {
           );
           cursor.resumeToken = 'resume token';
         });
+
         context('when the cursor has not yet returned a document', function () {
           beforeEach(function () {
             cursor.hasReceived = false;
@@ -103,6 +109,7 @@ describe('class ChangeStreamCursor', function () {
           );
           cursor.resumeToken = 'resume token';
         });
+
         it('sets the resumeAfter option to the cached resumeToken', function () {
           expect(cursor.resumeOptions).to.haveOwnProperty('resumeAfter', 'resume token');
         });
@@ -132,7 +139,6 @@ describe('class ChangeStreamCursor', function () {
       context('when the cursor has a saved operation time', function () {
         context('when the maxWireVersion >= 7', function () {
           let cursor: ChangeStreamCursor;
-
           beforeEach(function () {
             cursor = new ChangeStreamCursor(
               new MongoClient('mongodb://localhost:27027'),
@@ -144,17 +150,18 @@ describe('class ChangeStreamCursor', function () {
                 startAtOperationTime: new Timestamp(Long.ZERO)
               }
             );
-
             cursor.resumeToken = null;
-
             sinon.stub(cursor, 'server').get(() => ({ hello: { maxWireVersion: 7 } }));
           });
+
           it('does NOT set the resumeAfter option', function () {
             expect(cursor.resumeOptions).not.to.haveOwnProperty('resumeAfter');
           });
+
           it('does NOT set the startAfter option', function () {
             expect(cursor.resumeOptions).not.to.haveOwnProperty('startAfter');
           });
+
           it('does set the startAtOperationTime option', function () {
             expect(cursor.resumeOptions).to.haveOwnProperty('startAtOperationTime');
           });
@@ -162,7 +169,6 @@ describe('class ChangeStreamCursor', function () {
 
         context('when the maxWireVersion < 7', function () {
           let cursor: ChangeStreamCursor;
-
           beforeEach(function () {
             cursor = new ChangeStreamCursor(
               new MongoClient('mongodb://localhost:27027'),
@@ -174,17 +180,18 @@ describe('class ChangeStreamCursor', function () {
                 startAtOperationTime: new Timestamp(Long.ZERO)
               }
             );
-
             cursor.resumeToken = null;
-
             sinon.stub(cursor, 'server').get(() => ({ hello: { maxWireVersion: 6 } }));
           });
+
           it('does NOT set the resumeAfter option', function () {
             expect(cursor.resumeOptions).not.to.haveOwnProperty('resumeAfter');
           });
+
           it('does NOT set the startAfter option', function () {
             expect(cursor.resumeOptions).not.to.haveOwnProperty('startAfter');
           });
+
           it('does NOT set the startAtOperationTime option', function () {
             expect(cursor.resumeOptions).not.to.haveOwnProperty('startAtOperationTime');
           });
@@ -194,7 +201,6 @@ describe('class ChangeStreamCursor', function () {
       context('when the cursor does NOT have a saved operation time', function () {
         context('when the maxWireVersion >= 7', function () {
           let cursor: ChangeStreamCursor;
-
           beforeEach(function () {
             cursor = new ChangeStreamCursor(
               new MongoClient('mongodb://localhost:27027'),
@@ -205,17 +211,18 @@ describe('class ChangeStreamCursor', function () {
                 resumeAfter: 'resume after'
               }
             );
-
             cursor.resumeToken = null;
-
             sinon.stub(cursor, 'server').get(() => ({ hello: { maxWireVersion: 7 } }));
           });
+
           it('does NOT set the resumeAfter option', function () {
             expect(cursor.resumeOptions).not.to.haveOwnProperty('resumeAfter');
           });
+
           it('does NOT set the startAfter option', function () {
             expect(cursor.resumeOptions).not.to.haveOwnProperty('startAfter');
           });
+
           it('does NOT set the startAtOperationTime option', function () {
             expect(cursor.resumeOptions).not.to.haveOwnProperty('startAtOperationTime');
           });
@@ -223,7 +230,6 @@ describe('class ChangeStreamCursor', function () {
 
         context('when the maxWireVersion < 7', function () {
           let cursor: ChangeStreamCursor;
-
           beforeEach(function () {
             cursor = new ChangeStreamCursor(
               new MongoClient('mongodb://localhost:27027'),
@@ -235,17 +241,18 @@ describe('class ChangeStreamCursor', function () {
                 startAtOperationTime: new Timestamp(Long.ZERO)
               }
             );
-
             cursor.resumeToken = null;
-
             sinon.stub(cursor, 'server').get(() => ({ hello: { maxWireVersion: 6 } }));
           });
+
           it('does NOT set the resumeAfter option', function () {
             expect(cursor.resumeOptions).not.to.haveOwnProperty('resumeAfter');
           });
+
           it('does NOT set the startAfter option', function () {
             expect(cursor.resumeOptions).not.to.haveOwnProperty('startAfter');
           });
+
           it('does NOT set the startAtOperationTime option', function () {
             expect(cursor.resumeOptions).not.to.haveOwnProperty('startAtOperationTime');
           });

--- a/test/unit/change_stream.test.ts
+++ b/test/unit/change_stream.test.ts
@@ -12,8 +12,6 @@ describe('ChangeStreamCursor', function () {
   });
 
   describe('get resumeOptions()', function () {
-    context('when no resume related options are present on the cursor', function () {});
-
     context('when there is a cached resumeToken', function () {
       it('copies all non-resume related options from the original cursor', function () {
         const cursor = new ChangeStreamCursor(

--- a/test/unit/change_stream.test.ts
+++ b/test/unit/change_stream.test.ts
@@ -6,7 +6,7 @@ import { ChangeStreamCursor } from '../../src/change_stream';
 import { MongoClient } from '../../src/mongo_client';
 import { MongoDBNamespace } from '../../src/utils';
 
-describe('class ChangeStreamCursor', function () {
+describe('ChangeStreamCursor', function () {
   afterEach(function () {
     sinon.restore();
   });

--- a/test/unit/change_stream.test.ts
+++ b/test/unit/change_stream.test.ts
@@ -4,13 +4,9 @@ import * as sinon from 'sinon';
 
 import { ChangeStreamCursor } from '../../src/change_stream';
 import { MongoClient } from '../../src/mongo_client';
-import { Server } from '../../src/sdam/server';
-import { ServerDescription } from '../../src/sdam/server_description';
-import { Topology } from '../../src/sdam/topology';
 import { MongoDBNamespace } from '../../src/utils';
-import { getSymbolFrom } from '../tools/utils';
 
-describe.only('class ChangeStreamCursor', function () {
+describe('class ChangeStreamCursor', function () {
   afterEach(() => sinon.restore());
   describe('get resumeOptions()', function () {
     context('non-resume related options', function () {

--- a/test/unit/change_stream.test.ts
+++ b/test/unit/change_stream.test.ts
@@ -6,7 +6,7 @@ import { ChangeStreamCursor } from '../../src/change_stream';
 import { MongoClient } from '../../src/mongo_client';
 import { MongoDBNamespace } from '../../src/utils';
 
-describe.only('ChangeStreamCursor', function () {
+describe('ChangeStreamCursor', function () {
   afterEach(function () {
     sinon.restore();
   });

--- a/test/unit/change_stream.test.ts
+++ b/test/unit/change_stream.test.ts
@@ -26,7 +26,7 @@ describe('class ChangeStreamCursor', function () {
       });
     });
     context('when there is a cached resumeToken', function () {
-      context('when startAfter is set', function () {
+      context('when the cursor was started with startAfter', function () {
         let cursor: ChangeStreamCursor;
         beforeEach(function () {
           cursor = new ChangeStreamCursor(
@@ -37,42 +37,69 @@ describe('class ChangeStreamCursor', function () {
           );
           cursor.resumeToken = 'resume token';
         });
-        it('sets the startAfter option to the cached resumeToken', function () {
-          expect(cursor.resumeOptions).to.haveOwnProperty('startAfter', 'resume token');
-        });
-        it('does NOT set the resumeAfter option', function () {
-          expect(cursor.resumeOptions).not.to.haveOwnProperty('resumeAfter');
-        });
+        context('when the cursor has not yet returned a document', function () {
+          beforeEach(function () {
+            cursor.hasReceived = false;
+          });
 
-        context('when the startAtOperationTime option is NOT set', function () {
-          it('does not set the startAtOperationTime option', function () {
-            expect(cursor.resumeOptions).not.to.haveOwnProperty('startAtOperationTime');
+          it('sets the startAfter option to the cached resumeToken', function () {
+            expect(cursor.resumeOptions).to.haveOwnProperty('startAfter', 'resume token');
+          });
+
+          it('does NOT set the resumeAfter option', function () {
+            expect(cursor.resumeOptions).not.to.haveOwnProperty('resumeAfter');
+          });
+
+          context('when the startAtOperationTime option is NOT set', function () {
+            it('does NOT set the startAtOperationTime option', function () {
+              expect(cursor.resumeOptions).not.to.haveOwnProperty('startAtOperationTime');
+            });
+          });
+
+          context('when the startAtOperationTime option is set', function () {
+            it('does NOT set the startAtOperationTime option', function () {
+              cursor.startAtOperationTime = new Timestamp(Long.ZERO);
+              expect(cursor.resumeOptions).not.to.haveOwnProperty('startAtOperationTime');
+            });
           });
         });
 
-        context('when the startAtOperationTime option is set', function () {
-          it('does not set the startAtOperationTime option', function () {
-            const cursor = new ChangeStreamCursor(
-              new MongoClient('mongodb://localhost:27027'),
-              new MongoDBNamespace('db', 'collection'),
-              [],
-              { startAfter: 'start after', startAtOperationTime: new Timestamp(Long.ZERO) }
-            );
-            cursor.resumeToken = 'resume token';
+        context('when the cursor has returned a document', function () {
+          beforeEach(function () {
+            cursor.hasReceived = true;
+          });
 
-            expect(cursor.resumeOptions).not.to.haveOwnProperty('startAtOperationTime');
+          it('does NOT set the startAfter option', function () {
+            expect(cursor.resumeOptions).not.to.haveOwnProperty('startAfter');
+          });
+
+          it('sets the resumeAFter option to the cached resumeToken', function () {
+            expect(cursor.resumeOptions).to.haveOwnProperty('resumeAfter', 'resume token');
+          });
+
+          context('when the startAtOperationTime option is NOT set', function () {
+            it('does NOT set the startAtOperationTime option', function () {
+              expect(cursor.resumeOptions).not.to.haveOwnProperty('startAtOperationTime');
+            });
+          });
+
+          context('when the startAtOperationTime option is set', function () {
+            it('does NOT set the startAtOperationTime option', function () {
+              cursor.startAtOperationTime = new Timestamp(Long.ZERO);
+              expect(cursor.resumeOptions).not.to.haveOwnProperty('startAtOperationTime');
+            });
           });
         });
       });
 
-      context('when resumeAfter is set', function () {
+      context('when the cursor was not initialized with startAfter set', function () {
         let cursor: ChangeStreamCursor;
         beforeEach(function () {
           cursor = new ChangeStreamCursor(
             new MongoClient('mongodb://localhost:27027'),
             new MongoDBNamespace('db', 'collection'),
             [],
-            { resumeAfter: 'resume after' }
+            {}
           );
           cursor.resumeToken = 'resume token';
         });
@@ -84,31 +111,20 @@ describe('class ChangeStreamCursor', function () {
           expect(cursor.resumeOptions).not.to.haveOwnProperty('startAfter');
         });
 
-        context(
-          'when the startAtOperationTime option is NOT set on the aggregation pipeline',
-          function () {
-            it('does not set the startAtOperationTime option', function () {
-              expect(cursor.resumeOptions).not.to.haveOwnProperty('startAtOperationTime');
-            });
-          }
-        );
+        context('when the startAtOperationTime option is NOT set', function () {
+          it('does NOT set the startAtOperationTime option', function () {
+            expect(cursor.resumeOptions).not.to.haveOwnProperty('startAtOperationTime');
+          });
+        });
 
-        context(
-          'when the startAtOperationTime option is set on the aggregation pipeline',
-          function () {
-            it('does not set the startAtOperationTime option', function () {
-              const cursor = new ChangeStreamCursor(
-                new MongoClient('mongodb://localhost:27027'),
-                new MongoDBNamespace('db', 'collection'),
-                [],
-                { resumeAfter: 'resume after', startAtOperationTime: new Timestamp(Long.ZERO) }
-              );
-              cursor.resumeToken = 'resume token';
+        context('when the startAtOperationTime option is set', function () {
+          it('does NOT set the startAtOperationTime option', function () {
+            cursor.startAtOperationTime = new Timestamp(Long.ZERO);
+            cursor.resumeToken = 'resume token';
 
-              expect(cursor.resumeOptions).not.to.haveOwnProperty('startAtOperationTime');
-            });
-          }
-        );
+            expect(cursor.resumeOptions).not.to.haveOwnProperty('startAtOperationTime');
+          });
+        });
       });
     });
 
@@ -175,7 +191,7 @@ describe('class ChangeStreamCursor', function () {
         });
       });
 
-      context('when the cursor does not have a saved operation time', function () {
+      context('when the cursor does NOT have a saved operation time', function () {
         context('when the maxWireVersion >= 7', function () {
           let cursor: ChangeStreamCursor;
 

--- a/test/unit/change_stream.test.ts
+++ b/test/unit/change_stream.test.ts
@@ -1,0 +1,244 @@
+import { Long, Timestamp } from 'bson';
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+
+import { ChangeStreamCursor } from '../../src/change_stream';
+import { MongoClient } from '../../src/mongo_client';
+import { Server } from '../../src/sdam/server';
+import { ServerDescription } from '../../src/sdam/server_description';
+import { Topology } from '../../src/sdam/topology';
+import { MongoDBNamespace } from '../../src/utils';
+import { getSymbolFrom } from '../tools/utils';
+
+describe.only('class ChangeStreamCursor', function () {
+  afterEach(() => sinon.restore());
+  describe('get resumeOptions()', function () {
+    context('non-resume related options', function () {
+      it('copies all options from the original cursor', function () {
+        const cursor = new ChangeStreamCursor(
+          new MongoClient('mongodb://localhost:27027'),
+          new MongoDBNamespace('db', 'collection'),
+          [],
+          { promoteBuffers: true, promoteLongs: false, maxAwaitTimeMS: 5000 }
+        );
+
+        expect(cursor.resumeOptions).to.deep.equal({
+          promoteBuffers: true,
+          promoteLongs: false,
+          maxAwaitTimeMS: 5000
+        });
+      });
+    });
+    context('when there is a cached resumeToken', function () {
+      context('when startAfter is set', function () {
+        let cursor: ChangeStreamCursor;
+        beforeEach(function () {
+          cursor = new ChangeStreamCursor(
+            new MongoClient('mongodb://localhost:27027'),
+            new MongoDBNamespace('db', 'collection'),
+            [],
+            { startAfter: 'start after' }
+          );
+          cursor.resumeToken = 'resume token';
+        });
+        it('sets the startAfter option to the cached resumeToken', function () {
+          expect(cursor.resumeOptions).to.haveOwnProperty('startAfter', 'resume token');
+        });
+        it('does NOT set the resumeAfter option', function () {
+          expect(cursor.resumeOptions).not.to.haveOwnProperty('resumeAfter');
+        });
+
+        context('when the startAtOperationTime option is NOT set', function () {
+          it('does not set the startAtOperationTime option', function () {
+            expect(cursor.resumeOptions).not.to.haveOwnProperty('startAtOperationTime');
+          });
+        });
+
+        context('when the startAtOperationTime option is set', function () {
+          it('does not set the startAtOperationTime option', function () {
+            const cursor = new ChangeStreamCursor(
+              new MongoClient('mongodb://localhost:27027'),
+              new MongoDBNamespace('db', 'collection'),
+              [],
+              { startAfter: 'start after', startAtOperationTime: new Timestamp(Long.ZERO) }
+            );
+            cursor.resumeToken = 'resume token';
+
+            expect(cursor.resumeOptions).not.to.haveOwnProperty('startAtOperationTime');
+          });
+        });
+      });
+
+      context('when resumeAfter is set', function () {
+        let cursor: ChangeStreamCursor;
+        beforeEach(function () {
+          cursor = new ChangeStreamCursor(
+            new MongoClient('mongodb://localhost:27027'),
+            new MongoDBNamespace('db', 'collection'),
+            [],
+            { resumeAfter: 'resume after' }
+          );
+          cursor.resumeToken = 'resume token';
+        });
+        it('sets the resumeAfter option to the cached resumeToken', function () {
+          expect(cursor.resumeOptions).to.haveOwnProperty('resumeAfter', 'resume token');
+        });
+
+        it('does NOT set the startAfter option', function () {
+          expect(cursor.resumeOptions).not.to.haveOwnProperty('startAfter');
+        });
+
+        context(
+          'when the startAtOperationTime option is NOT set on the aggregation pipeline',
+          function () {
+            it('does not set the startAtOperationTime option', function () {
+              expect(cursor.resumeOptions).not.to.haveOwnProperty('startAtOperationTime');
+            });
+          }
+        );
+
+        context(
+          'when the startAtOperationTime option is set on the aggregation pipeline',
+          function () {
+            it('does not set the startAtOperationTime option', function () {
+              const cursor = new ChangeStreamCursor(
+                new MongoClient('mongodb://localhost:27027'),
+                new MongoDBNamespace('db', 'collection'),
+                [],
+                { resumeAfter: 'resume after', startAtOperationTime: new Timestamp(Long.ZERO) }
+              );
+              cursor.resumeToken = 'resume token';
+
+              expect(cursor.resumeOptions).not.to.haveOwnProperty('startAtOperationTime');
+            });
+          }
+        );
+      });
+    });
+
+    context('when there is no cached resumeToken', function () {
+      context('when the cursor has a saved operation time', function () {
+        context('when the maxWireVersion >= 7', function () {
+          let cursor: ChangeStreamCursor;
+
+          beforeEach(function () {
+            cursor = new ChangeStreamCursor(
+              new MongoClient('mongodb://localhost:27027'),
+              new MongoDBNamespace('db', 'collection'),
+              [],
+              {
+                startAfter: 'start after',
+                resumeAfter: 'resume after',
+                startAtOperationTime: new Timestamp(Long.ZERO)
+              }
+            );
+
+            cursor.resumeToken = null;
+
+            sinon.stub(cursor, 'server').get(() => ({ hello: { maxWireVersion: 7 } }));
+          });
+          it('does NOT set the resumeAfter option', function () {
+            expect(cursor.resumeOptions).not.to.haveOwnProperty('resumeAfter');
+          });
+          it('does NOT set the startAfter option', function () {
+            expect(cursor.resumeOptions).not.to.haveOwnProperty('startAfter');
+          });
+          it('does set the startAtOperationTime option', function () {
+            expect(cursor.resumeOptions).to.haveOwnProperty('startAtOperationTime');
+          });
+        });
+
+        context('when the maxWireVersion < 7', function () {
+          let cursor: ChangeStreamCursor;
+
+          beforeEach(function () {
+            cursor = new ChangeStreamCursor(
+              new MongoClient('mongodb://localhost:27027'),
+              new MongoDBNamespace('db', 'collection'),
+              [],
+              {
+                startAfter: 'start after',
+                resumeAfter: 'resume after',
+                startAtOperationTime: new Timestamp(Long.ZERO)
+              }
+            );
+
+            cursor.resumeToken = null;
+
+            sinon.stub(cursor, 'server').get(() => ({ hello: { maxWireVersion: 6 } }));
+          });
+          it('does NOT set the resumeAfter option', function () {
+            expect(cursor.resumeOptions).not.to.haveOwnProperty('resumeAfter');
+          });
+          it('does NOT set the startAfter option', function () {
+            expect(cursor.resumeOptions).not.to.haveOwnProperty('startAfter');
+          });
+          it('does NOT set the startAtOperationTime option', function () {
+            expect(cursor.resumeOptions).not.to.haveOwnProperty('startAtOperationTime');
+          });
+        });
+      });
+
+      context('when the cursor does not have a saved operation time', function () {
+        context('when the maxWireVersion >= 7', function () {
+          let cursor: ChangeStreamCursor;
+
+          beforeEach(function () {
+            cursor = new ChangeStreamCursor(
+              new MongoClient('mongodb://localhost:27027'),
+              new MongoDBNamespace('db', 'collection'),
+              [],
+              {
+                startAfter: 'start after',
+                resumeAfter: 'resume after'
+              }
+            );
+
+            cursor.resumeToken = null;
+
+            sinon.stub(cursor, 'server').get(() => ({ hello: { maxWireVersion: 7 } }));
+          });
+          it('does NOT set the resumeAfter option', function () {
+            expect(cursor.resumeOptions).not.to.haveOwnProperty('resumeAfter');
+          });
+          it('does NOT set the startAfter option', function () {
+            expect(cursor.resumeOptions).not.to.haveOwnProperty('startAfter');
+          });
+          it('does NOT set the startAtOperationTime option', function () {
+            expect(cursor.resumeOptions).not.to.haveOwnProperty('startAtOperationTime');
+          });
+        });
+
+        context('when the maxWireVersion < 7', function () {
+          let cursor: ChangeStreamCursor;
+
+          beforeEach(function () {
+            cursor = new ChangeStreamCursor(
+              new MongoClient('mongodb://localhost:27027'),
+              new MongoDBNamespace('db', 'collection'),
+              [],
+              {
+                startAfter: 'start after',
+                resumeAfter: 'resume after',
+                startAtOperationTime: new Timestamp(Long.ZERO)
+              }
+            );
+
+            cursor.resumeToken = null;
+
+            sinon.stub(cursor, 'server').get(() => ({ hello: { maxWireVersion: 6 } }));
+          });
+          it('does NOT set the resumeAfter option', function () {
+            expect(cursor.resumeOptions).not.to.haveOwnProperty('resumeAfter');
+          });
+          it('does NOT set the startAfter option', function () {
+            expect(cursor.resumeOptions).not.to.haveOwnProperty('startAfter');
+          });
+          it('does NOT set the startAtOperationTime option', function () {
+            expect(cursor.resumeOptions).not.to.haveOwnProperty('startAtOperationTime');
+          });
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
### Description

#### What is changing?

- The `resumeOptions` getter on the change stream class copies all of the existing options (including bson options)
- The `resumeOptions` getter applies the `startAfter`, `resumeAfter` and `startAtOperationTime` properties to the resume options according to the spec (outlined [here](https://github.com/mongodb/specifications/blob/master/source/change-streams/change-streams.rst#resume-process))
- Deprecates the no longer used `ResumeOptions` interface
- Removes usages of `Reflect` in the `ResumeOptions` getter so that we have Typescript support when constructing the `ResumeOptions`

##### Is there new documentation needed for these changes?

No.

#### What is the motivation for this change?

This PR is the first step in addressing the change stream resumability issues in the Node driver.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
