### PR TITLE
test(NODE-4251): sync csfle create spec tests

### DIFF
--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -56,7 +56,7 @@ else
   source "$DRIVERS_TOOLS"/.evergreen/csfle/set-temp-creds.sh
 fi
 
-npm install mongodb-client-encryption@">=2.2.0-alpha.0"
+npm install mongodb-client-encryption@">=2.2.0-alpha.2"
 npm install @mongodb-js/zstd
 npm install snappy
 

--- a/src/cmap/connection.ts
+++ b/src/cmap/connection.ts
@@ -727,7 +727,6 @@ export class CryptoConnection extends Connection {
         callback(err, null);
         return;
       }
-
       super.command(ns, encrypted, options, (err, response) => {
         if (err || response == null) {
           callback(err, response);

--- a/src/encrypter.ts
+++ b/src/encrypter.ts
@@ -83,6 +83,9 @@ export class Encrypter {
 
       clonedOptions.minPoolSize = 0;
 
+      clonedOptions.promoteValues = false;
+      clonedOptions.promoteLongs = false;
+
       internalClient = new MongoClient(uri, clonedOptions);
       this[kInternalClient] = internalClient;
 

--- a/test/integration/client-side-encryption/client_side_encryption.spec.test.js
+++ b/test/integration/client-side-encryption/client_side_encryption.spec.test.js
@@ -60,13 +60,7 @@ const skippedMaxWireVersionTest = 'operation fails with maxWireVersion < 8';
 const SKIPPED_TESTS = new Set([
   ...(isAuthEnabled
     ? skippedAuthTests.concat(skippedMaxWireVersionTest)
-    : [skippedMaxWireVersionTest]),
-  // TODO(NODE-4288): Fix FLE 2 tests
-  'default state collection names are applied',
-  'drop removes all state collections',
-  'CreateCollection from encryptedFields.',
-  'DropCollection from encryptedFields',
-  'DropCollection from remote encryptedFields'
+    : [skippedMaxWireVersionTest])
 ]);
 
 describe('Client Side Encryption', function () {

--- a/test/spec/client-side-encryption/tests/create-and-createIndexes.json
+++ b/test/spec/client-side-encryption/tests/create-and-createIndexes.json
@@ -1,0 +1,115 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.1.10"
+    }
+  ],
+  "database_name": "default",
+  "collection_name": "default",
+  "data": [],
+  "tests": [
+    {
+      "description": "create is OK",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "local": {
+              "key": {
+                "$binary": {
+                  "base64": "Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk",
+                  "subType": "00"
+                }
+              }
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "unencryptedCollection"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "unencryptedCollection",
+            "validator": {
+              "unencrypted_string": "foo"
+            }
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "unencryptedCollection"
+          }
+        }
+      ]
+    },
+    {
+      "description": "createIndexes is OK",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "local": {
+              "key": {
+                "$binary": {
+                  "base64": "Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk",
+                  "subType": "00"
+                }
+              }
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "unencryptedCollection"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "unencryptedCollection"
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "command": {
+              "createIndexes": "unencryptedCollection",
+              "indexes": [
+                {
+                  "name": "name",
+                  "key": {
+                    "name": 1
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "assertIndexExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "unencryptedCollection",
+            "index": "name"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/client-side-encryption/tests/create-and-createIndexes.yml
+++ b/test/spec/client-side-encryption/tests/create-and-createIndexes.yml
@@ -1,0 +1,58 @@
+runOn:
+  - minServerVersion: "4.1.10"
+database_name: &database_name "default"
+collection_name: &collection_name "default"
+
+data: []
+tests:
+  - description: "create is OK"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          local: {'key': {'$binary': {'base64': 'Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk', 'subType': '00'}}}
+    operations:
+    # Drop to remove a collection that may exist from previous test runs.
+    - name: dropCollection
+      object: database
+      arguments:
+        collection: "unencryptedCollection"
+    - name: createCollection
+      object: database
+      arguments:
+        collection: "unencryptedCollection"
+        validator:
+          unencrypted_string: "foo"
+    - name: assertCollectionExists
+      object: testRunner
+      arguments:
+        database: *database_name
+        collection: "unencryptedCollection"
+  - description: "createIndexes is OK"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          local: {'key': {'$binary': {'base64': 'Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk', 'subType': '00'}}}
+    operations:
+    # Drop to remove a collection that may exist from previous test runs.
+    - name: dropCollection
+      object: database
+      arguments:
+        collection: "unencryptedCollection"
+    - name: createCollection
+      object: database
+      arguments:
+        collection: "unencryptedCollection"
+    - name: runCommand
+      object: database
+      arguments:
+        command:
+          createIndexes: "unencryptedCollection"
+          indexes:
+            - name: "name"
+              key: { name: 1 }
+    - name: assertIndexExists
+      object: testRunner
+      arguments:
+        database: *database_name
+        collection: "unencryptedCollection"
+        index: name

--- a/test/spec/client-side-encryption/tests/fle2-CreateCollection.json
+++ b/test/spec/client-side-encryption/tests/fle2-CreateCollection.json
@@ -1472,6 +1472,18 @@
         {
           "command_started_event": {
             "command": {
+              "listCollections": 1,
+              "filter": {
+                "name": "encryptedCollection"
+              }
+            },
+            "command_name": "listCollections",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
               "createIndexes": "encryptedCollection",
               "indexes": [
                 {
@@ -1832,6 +1844,18 @@
         {
           "command_started_event": {
             "command": {
+              "listCollections": 1,
+              "filter": {
+                "name": "encryptedCollection"
+              }
+            },
+            "command_name": "listCollections",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
               "createIndexes": "encryptedCollection",
               "indexes": [
                 {
@@ -2129,6 +2153,18 @@
               }
             },
             "command_name": "create",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "listCollections": 1,
+              "filter": {
+                "name": "encryptedCollection"
+              }
+            },
+            "command_name": "listCollections",
             "database_name": "default"
           }
         },

--- a/test/spec/client-side-encryption/tests/fle2-CreateCollection.yml
+++ b/test/spec/client-side-encryption/tests/fle2-CreateCollection.yml
@@ -1,3 +1,4 @@
+# This test requires libmongocrypt 1.5.0-alpha2.
 runOn:
   - minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
@@ -821,6 +822,13 @@ tests:
               encryptedFields: *encrypted_fields5
             command_name: create
             database_name: *database_name
+        # libmongocrypt requests listCollections to get a schema for the "createIndexes" command.
+        - command_started_event:
+            command:
+              listCollections: 1
+              filter: { name: "encryptedCollection" }
+            command_name: listCollections
+            database_name: *database_name
         # Index on __safeContents__ is then created.
         - command_started_event:
             command:
@@ -1028,6 +1036,13 @@ tests:
               encryptedFields: *encrypted_fields6
             command_name: create
             database_name: *database_name
+        # libmongocrypt requests listCollections to get a schema for the "createIndexes" command.
+        - command_started_event:
+            command:
+              listCollections: 1
+              filter: { name: "encryptedCollection" }
+            command_name: listCollections
+            database_name: *database_name
         # Index on __safeContents__ is then created.
         - command_started_event:
             command:
@@ -1200,6 +1215,13 @@ tests:
               create: "encryptedCollection"
               encryptedFields: *encrypted_fields7
             command_name: create
+            database_name: *database_name
+        # libmongocrypt requests listCollections to get a schema for the "createIndexes" command.
+        - command_started_event:
+            command:
+              listCollections: 1
+              filter: { name: "encryptedCollection" }
+            command_name: listCollections
             database_name: *database_name
         # Index on __safeContents__ is then created.
         - command_started_event:

--- a/test/spec/client-side-encryption/tests/fle2-validatorAndPartialFieldExpression.json
+++ b/test/spec/client-side-encryption/tests/fle2-validatorAndPartialFieldExpression.json
@@ -1,0 +1,520 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "6.0.0",
+      "topology": [
+        "replicaset",
+        "sharded"
+      ]
+    }
+  ],
+  "database_name": "default",
+  "collection_name": "default",
+  "data": [],
+  "tests": [
+    {
+      "description": "create with a validator on an unencrypted field is OK",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "local": {
+              "key": {
+                "$binary": {
+                  "base64": "Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk",
+                  "subType": "00"
+                }
+              }
+            }
+          },
+          "encryptedFieldsMap": {
+            "default.encryptedCollection": {
+              "escCollection": "enxcol_.default.esc",
+              "eccCollection": "enxcol_.default.ecc",
+              "ecocCollection": "enxcol_.default.ecoc",
+              "fields": [
+                {
+                  "keyId": {
+                    "$binary": {
+                      "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+                      "subType": "04"
+                    }
+                  },
+                  "path": "encryptedIndexed",
+                  "bsonType": "string",
+                  "queries": {
+                    "queryType": "equality",
+                    "contention": {
+                      "$numberLong": "0"
+                    }
+                  }
+                },
+                {
+                  "keyId": {
+                    "$binary": {
+                      "base64": "q83vqxI0mHYSNBI0VniQEg==",
+                      "subType": "04"
+                    }
+                  },
+                  "path": "encryptedUnindexed",
+                  "bsonType": "string"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection",
+            "validator": {
+              "unencrypted_string": "foo"
+            }
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection"
+          }
+        }
+      ]
+    },
+    {
+      "description": "create with a validator on an encrypted field is an error",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "local": {
+              "key": {
+                "$binary": {
+                  "base64": "Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk",
+                  "subType": "00"
+                }
+              }
+            }
+          },
+          "encryptedFieldsMap": {
+            "default.encryptedCollection": {
+              "escCollection": "enxcol_.default.esc",
+              "eccCollection": "enxcol_.default.ecc",
+              "ecocCollection": "enxcol_.default.ecoc",
+              "fields": [
+                {
+                  "keyId": {
+                    "$binary": {
+                      "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+                      "subType": "04"
+                    }
+                  },
+                  "path": "encryptedIndexed",
+                  "bsonType": "string",
+                  "queries": {
+                    "queryType": "equality",
+                    "contention": {
+                      "$numberLong": "0"
+                    }
+                  }
+                },
+                {
+                  "keyId": {
+                    "$binary": {
+                      "base64": "q83vqxI0mHYSNBI0VniQEg==",
+                      "subType": "04"
+                    }
+                  },
+                  "path": "encryptedUnindexed",
+                  "bsonType": "string"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection",
+            "validator": {
+              "encryptedIndexed": "foo"
+            }
+          },
+          "result": {
+            "errorContains": "Comparison to encrypted fields not supported"
+          }
+        }
+      ]
+    },
+    {
+      "description": "collMod with a validator on an unencrypted field is OK",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "local": {
+              "key": {
+                "$binary": {
+                  "base64": "Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk",
+                  "subType": "00"
+                }
+              }
+            }
+          },
+          "encryptedFieldsMap": {
+            "default.encryptedCollection": {
+              "escCollection": "enxcol_.default.esc",
+              "eccCollection": "enxcol_.default.ecc",
+              "ecocCollection": "enxcol_.default.ecoc",
+              "fields": [
+                {
+                  "keyId": {
+                    "$binary": {
+                      "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+                      "subType": "04"
+                    }
+                  },
+                  "path": "encryptedIndexed",
+                  "bsonType": "string",
+                  "queries": {
+                    "queryType": "equality",
+                    "contention": {
+                      "$numberLong": "0"
+                    }
+                  }
+                },
+                {
+                  "keyId": {
+                    "$binary": {
+                      "base64": "q83vqxI0mHYSNBI0VniQEg==",
+                      "subType": "04"
+                    }
+                  },
+                  "path": "encryptedUnindexed",
+                  "bsonType": "string"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "command": {
+              "collMod": "encryptedCollection",
+              "validator": {
+                "unencrypted_string": "foo"
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "collMod with a validator on an encrypted field is an error",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "local": {
+              "key": {
+                "$binary": {
+                  "base64": "Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk",
+                  "subType": "00"
+                }
+              }
+            }
+          },
+          "encryptedFieldsMap": {
+            "default.encryptedCollection": {
+              "escCollection": "enxcol_.default.esc",
+              "eccCollection": "enxcol_.default.ecc",
+              "ecocCollection": "enxcol_.default.ecoc",
+              "fields": [
+                {
+                  "keyId": {
+                    "$binary": {
+                      "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+                      "subType": "04"
+                    }
+                  },
+                  "path": "encryptedIndexed",
+                  "bsonType": "string",
+                  "queries": {
+                    "queryType": "equality",
+                    "contention": {
+                      "$numberLong": "0"
+                    }
+                  }
+                },
+                {
+                  "keyId": {
+                    "$binary": {
+                      "base64": "q83vqxI0mHYSNBI0VniQEg==",
+                      "subType": "04"
+                    }
+                  },
+                  "path": "encryptedUnindexed",
+                  "bsonType": "string"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "command": {
+              "collMod": "encryptedCollection",
+              "validator": {
+                "encryptedIndexed": "foo"
+              }
+            }
+          },
+          "result": {
+            "errorContains": "Comparison to encrypted fields not supported"
+          }
+        }
+      ]
+    },
+    {
+      "description": "createIndexes with a partialFilterExpression on an unencrypted field is OK",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "local": {
+              "key": {
+                "$binary": {
+                  "base64": "Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk",
+                  "subType": "00"
+                }
+              }
+            }
+          },
+          "encryptedFieldsMap": {
+            "default.encryptedCollection": {
+              "escCollection": "enxcol_.default.esc",
+              "eccCollection": "enxcol_.default.ecc",
+              "ecocCollection": "enxcol_.default.ecoc",
+              "fields": [
+                {
+                  "keyId": {
+                    "$binary": {
+                      "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+                      "subType": "04"
+                    }
+                  },
+                  "path": "encryptedIndexed",
+                  "bsonType": "string",
+                  "queries": {
+                    "queryType": "equality",
+                    "contention": {
+                      "$numberLong": "0"
+                    }
+                  }
+                },
+                {
+                  "keyId": {
+                    "$binary": {
+                      "base64": "q83vqxI0mHYSNBI0VniQEg==",
+                      "subType": "04"
+                    }
+                  },
+                  "path": "encryptedUnindexed",
+                  "bsonType": "string"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "command": {
+              "createIndexes": "encryptedCollection",
+              "indexes": [
+                {
+                  "name": "name",
+                  "key": {
+                    "name": 1
+                  },
+                  "partialFilterExpression": {
+                    "unencrypted_string": "foo"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "assertIndexExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection",
+            "index": "name"
+          }
+        }
+      ]
+    },
+    {
+      "description": "createIndexes with a partialFilterExpression on an encrypted field is an error",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "local": {
+              "key": {
+                "$binary": {
+                  "base64": "Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk",
+                  "subType": "00"
+                }
+              }
+            }
+          },
+          "encryptedFieldsMap": {
+            "default.encryptedCollection": {
+              "escCollection": "enxcol_.default.esc",
+              "eccCollection": "enxcol_.default.ecc",
+              "ecocCollection": "enxcol_.default.ecoc",
+              "fields": [
+                {
+                  "keyId": {
+                    "$binary": {
+                      "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+                      "subType": "04"
+                    }
+                  },
+                  "path": "encryptedIndexed",
+                  "bsonType": "string",
+                  "queries": {
+                    "queryType": "equality",
+                    "contention": {
+                      "$numberLong": "0"
+                    }
+                  }
+                },
+                {
+                  "keyId": {
+                    "$binary": {
+                      "base64": "q83vqxI0mHYSNBI0VniQEg==",
+                      "subType": "04"
+                    }
+                  },
+                  "path": "encryptedUnindexed",
+                  "bsonType": "string"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "command": {
+              "createIndexes": "encryptedCollection",
+              "indexes": [
+                {
+                  "name": "name",
+                  "key": {
+                    "name": 1
+                  },
+                  "partialFilterExpression": {
+                    "encryptedIndexed": "foo"
+                  }
+                }
+              ]
+            }
+          },
+          "result": {
+            "errorContains": "Comparison to encrypted fields not supported"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/client-side-encryption/tests/fle2-validatorAndPartialFieldExpression.yml
+++ b/test/spec/client-side-encryption/tests/fle2-validatorAndPartialFieldExpression.yml
@@ -1,0 +1,168 @@
+# This test requires libmongocrypt 1.5.0-alpha2.
+runOn:
+    # Require server version 6.0.0 to get behavior added in SERVER-64911.
+    - minServerVersion: "6.0.0"
+      # FLE 2 Encrypted collections are not supported on standalone.
+      topology: [ "replicaset", "sharded" ]
+
+database_name: &database_name "default"
+collection_name: &collection_name "default"
+data: []
+tests:
+  - description: "create with a validator on an unencrypted field is OK"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          local: {'key': {'$binary': {'base64': 'Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk', 'subType': '00'}}}
+        encryptedFieldsMap:
+          "default.encryptedCollection": {'escCollection': 'enxcol_.default.esc', 'eccCollection': 'enxcol_.default.ecc', 'ecocCollection': 'enxcol_.default.ecoc', 'fields': [{'keyId': {'$binary': {'base64': 'EjRWeBI0mHYSNBI0VniQEg==', 'subType': '04'}}, 'path': 'encryptedIndexed', 'bsonType': 'string', 'queries': {'queryType': 'equality', 'contention': {'$numberLong': '0'}}}, {'keyId': {'$binary': {'base64': 'q83vqxI0mHYSNBI0VniQEg==', 'subType': '04'}}, 'path': 'encryptedUnindexed', 'bsonType': 'string'}]}
+    operations:
+    # Drop to remove a collection that may exist from previous test runs.
+    - name: dropCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+    - name: createCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+        validator:
+          unencrypted_string: "foo"
+    - name: assertCollectionExists
+      object: testRunner
+      arguments:
+        database: *database_name
+        collection: "encryptedCollection"
+  - description: "create with a validator on an encrypted field is an error"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          local: {'key': {'$binary': {'base64': 'Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk', 'subType': '00'}}}
+        encryptedFieldsMap:
+          "default.encryptedCollection": {'escCollection': 'enxcol_.default.esc', 'eccCollection': 'enxcol_.default.ecc', 'ecocCollection': 'enxcol_.default.ecoc', 'fields': [{'keyId': {'$binary': {'base64': 'EjRWeBI0mHYSNBI0VniQEg==', 'subType': '04'}}, 'path': 'encryptedIndexed', 'bsonType': 'string', 'queries': {'queryType': 'equality', 'contention': {'$numberLong': '0'}}}, {'keyId': {'$binary': {'base64': 'q83vqxI0mHYSNBI0VniQEg==', 'subType': '04'}}, 'path': 'encryptedUnindexed', 'bsonType': 'string'}]}
+    operations:
+    # Drop to remove a collection that may exist from previous test runs.
+    - name: dropCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+    - name: createCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+        validator:
+          encryptedIndexed: "foo"
+      result:
+        errorContains: "Comparison to encrypted fields not supported"
+  - description: "collMod with a validator on an unencrypted field is OK"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          local: {'key': {'$binary': {'base64': 'Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk', 'subType': '00'}}}
+        encryptedFieldsMap:
+          "default.encryptedCollection": {'escCollection': 'enxcol_.default.esc', 'eccCollection': 'enxcol_.default.ecc', 'ecocCollection': 'enxcol_.default.ecoc', 'fields': [{'keyId': {'$binary': {'base64': 'EjRWeBI0mHYSNBI0VniQEg==', 'subType': '04'}}, 'path': 'encryptedIndexed', 'bsonType': 'string', 'queries': {'queryType': 'equality', 'contention': {'$numberLong': '0'}}}, {'keyId': {'$binary': {'base64': 'q83vqxI0mHYSNBI0VniQEg==', 'subType': '04'}}, 'path': 'encryptedUnindexed', 'bsonType': 'string'}]}
+    operations:
+    # Drop to remove a collection that may exist from previous test runs.
+    - name: dropCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+    - name: createCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+    - name: runCommand
+      object: database
+      arguments:
+        command:
+          collMod: "encryptedCollection"
+          validator:
+            unencrypted_string: "foo"
+  - description: "collMod with a validator on an encrypted field is an error"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          local: {'key': {'$binary': {'base64': 'Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk', 'subType': '00'}}}
+        encryptedFieldsMap:
+          "default.encryptedCollection": {'escCollection': 'enxcol_.default.esc', 'eccCollection': 'enxcol_.default.ecc', 'ecocCollection': 'enxcol_.default.ecoc', 'fields': [{'keyId': {'$binary': {'base64': 'EjRWeBI0mHYSNBI0VniQEg==', 'subType': '04'}}, 'path': 'encryptedIndexed', 'bsonType': 'string', 'queries': {'queryType': 'equality', 'contention': {'$numberLong': '0'}}}, {'keyId': {'$binary': {'base64': 'q83vqxI0mHYSNBI0VniQEg==', 'subType': '04'}}, 'path': 'encryptedUnindexed', 'bsonType': 'string'}]}
+    operations:
+    # Drop to remove a collection that may exist from previous test runs.
+    - name: dropCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+    - name: createCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+    - name: runCommand
+      object: database
+      arguments:
+        command:
+          collMod: "encryptedCollection"
+          validator:
+            encryptedIndexed: "foo"
+      result:
+        errorContains: "Comparison to encrypted fields not supported"
+  - description: "createIndexes with a partialFilterExpression on an unencrypted field is OK"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          local: {'key': {'$binary': {'base64': 'Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk', 'subType': '00'}}}
+        encryptedFieldsMap:
+          "default.encryptedCollection": {'escCollection': 'enxcol_.default.esc', 'eccCollection': 'enxcol_.default.ecc', 'ecocCollection': 'enxcol_.default.ecoc', 'fields': [{'keyId': {'$binary': {'base64': 'EjRWeBI0mHYSNBI0VniQEg==', 'subType': '04'}}, 'path': 'encryptedIndexed', 'bsonType': 'string', 'queries': {'queryType': 'equality', 'contention': {'$numberLong': '0'}}}, {'keyId': {'$binary': {'base64': 'q83vqxI0mHYSNBI0VniQEg==', 'subType': '04'}}, 'path': 'encryptedUnindexed', 'bsonType': 'string'}]}
+    operations:
+    # Drop to remove a collection that may exist from previous test runs.
+    - name: dropCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+    - name: createCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+    - name: runCommand
+      object: database
+      arguments:
+        command:
+          createIndexes: "encryptedCollection"
+          indexes:
+            - name: "name"
+              key: { name: 1 }
+              partialFilterExpression:
+                unencrypted_string: "foo"
+    - name: assertIndexExists
+      object: testRunner
+      arguments:
+        database: *database_name
+        collection: "encryptedCollection"
+        index: name
+  - description: "createIndexes with a partialFilterExpression on an encrypted field is an error"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          local: {'key': {'$binary': {'base64': 'Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk', 'subType': '00'}}}
+        encryptedFieldsMap:
+          "default.encryptedCollection": {'escCollection': 'enxcol_.default.esc', 'eccCollection': 'enxcol_.default.ecc', 'ecocCollection': 'enxcol_.default.ecoc', 'fields': [{'keyId': {'$binary': {'base64': 'EjRWeBI0mHYSNBI0VniQEg==', 'subType': '04'}}, 'path': 'encryptedIndexed', 'bsonType': 'string', 'queries': {'queryType': 'equality', 'contention': {'$numberLong': '0'}}}, {'keyId': {'$binary': {'base64': 'q83vqxI0mHYSNBI0VniQEg==', 'subType': '04'}}, 'path': 'encryptedUnindexed', 'bsonType': 'string'}]}
+    operations:
+    # Drop to remove a collection that may exist from previous test runs.
+    - name: dropCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+    - name: createCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+    - name: runCommand
+      object: database
+      arguments:
+        command:
+          createIndexes: "encryptedCollection"
+          indexes:
+            - name: "name"
+              key: { name: 1 }
+              partialFilterExpression:
+                encryptedIndexed: "foo"
+      result:
+        errorContains: "Comparison to encrypted fields not supported"

--- a/test/spec/client-side-encryption/tests/validatorAndPartialFieldExpression.json
+++ b/test/spec/client-side-encryption/tests/validatorAndPartialFieldExpression.json
@@ -1,0 +1,642 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "6.0.0"
+    }
+  ],
+  "database_name": "default",
+  "collection_name": "default",
+  "data": [],
+  "tests": [
+    {
+      "description": "create with a validator on an unencrypted field is OK",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "local": {
+              "key": {
+                "$binary": {
+                  "base64": "Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk",
+                  "subType": "00"
+                }
+              }
+            }
+          },
+          "schemaMap": {
+            "default.encryptedCollection": {
+              "properties": {
+                "encrypted_w_altname": {
+                  "encrypt": {
+                    "keyId": "/altname",
+                    "bsonType": "string",
+                    "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
+                  }
+                },
+                "encrypted_string": {
+                  "encrypt": {
+                    "keyId": [
+                      {
+                        "$binary": {
+                          "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                          "subType": "04"
+                        }
+                      }
+                    ],
+                    "bsonType": "string",
+                    "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+                  }
+                },
+                "random": {
+                  "encrypt": {
+                    "keyId": [
+                      {
+                        "$binary": {
+                          "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                          "subType": "04"
+                        }
+                      }
+                    ],
+                    "bsonType": "string",
+                    "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
+                  }
+                },
+                "encrypted_string_equivalent": {
+                  "encrypt": {
+                    "keyId": [
+                      {
+                        "$binary": {
+                          "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                          "subType": "04"
+                        }
+                      }
+                    ],
+                    "bsonType": "string",
+                    "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+                  }
+                }
+              },
+              "bsonType": "object"
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection",
+            "validator": {
+              "unencrypted_string": "foo"
+            }
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection"
+          }
+        }
+      ]
+    },
+    {
+      "description": "create with a validator on an encrypted field is an error",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "local": {
+              "key": {
+                "$binary": {
+                  "base64": "Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk",
+                  "subType": "00"
+                }
+              }
+            }
+          },
+          "schemaMap": {
+            "default.encryptedCollection": {
+              "properties": {
+                "encrypted_w_altname": {
+                  "encrypt": {
+                    "keyId": "/altname",
+                    "bsonType": "string",
+                    "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
+                  }
+                },
+                "encrypted_string": {
+                  "encrypt": {
+                    "keyId": [
+                      {
+                        "$binary": {
+                          "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                          "subType": "04"
+                        }
+                      }
+                    ],
+                    "bsonType": "string",
+                    "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+                  }
+                },
+                "random": {
+                  "encrypt": {
+                    "keyId": [
+                      {
+                        "$binary": {
+                          "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                          "subType": "04"
+                        }
+                      }
+                    ],
+                    "bsonType": "string",
+                    "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
+                  }
+                },
+                "encrypted_string_equivalent": {
+                  "encrypt": {
+                    "keyId": [
+                      {
+                        "$binary": {
+                          "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                          "subType": "04"
+                        }
+                      }
+                    ],
+                    "bsonType": "string",
+                    "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+                  }
+                }
+              },
+              "bsonType": "object"
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection",
+            "validator": {
+              "encrypted_string": "foo"
+            }
+          },
+          "result": {
+            "errorContains": "Comparison to encrypted fields not supported"
+          }
+        }
+      ]
+    },
+    {
+      "description": "collMod with a validator on an unencrypted field is OK",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "local": {
+              "key": {
+                "$binary": {
+                  "base64": "Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk",
+                  "subType": "00"
+                }
+              }
+            }
+          },
+          "schemaMap": {
+            "default.encryptedCollection": {
+              "properties": {
+                "encrypted_w_altname": {
+                  "encrypt": {
+                    "keyId": "/altname",
+                    "bsonType": "string",
+                    "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
+                  }
+                },
+                "encrypted_string": {
+                  "encrypt": {
+                    "keyId": [
+                      {
+                        "$binary": {
+                          "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                          "subType": "04"
+                        }
+                      }
+                    ],
+                    "bsonType": "string",
+                    "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+                  }
+                },
+                "random": {
+                  "encrypt": {
+                    "keyId": [
+                      {
+                        "$binary": {
+                          "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                          "subType": "04"
+                        }
+                      }
+                    ],
+                    "bsonType": "string",
+                    "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
+                  }
+                },
+                "encrypted_string_equivalent": {
+                  "encrypt": {
+                    "keyId": [
+                      {
+                        "$binary": {
+                          "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                          "subType": "04"
+                        }
+                      }
+                    ],
+                    "bsonType": "string",
+                    "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+                  }
+                }
+              },
+              "bsonType": "object"
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "command": {
+              "collMod": "encryptedCollection",
+              "validator": {
+                "unencrypted_string": "foo"
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "collMod with a validator on an encrypted field is an error",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "local": {
+              "key": {
+                "$binary": {
+                  "base64": "Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk",
+                  "subType": "00"
+                }
+              }
+            }
+          },
+          "schemaMap": {
+            "default.encryptedCollection": {
+              "properties": {
+                "encrypted_w_altname": {
+                  "encrypt": {
+                    "keyId": "/altname",
+                    "bsonType": "string",
+                    "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
+                  }
+                },
+                "encrypted_string": {
+                  "encrypt": {
+                    "keyId": [
+                      {
+                        "$binary": {
+                          "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                          "subType": "04"
+                        }
+                      }
+                    ],
+                    "bsonType": "string",
+                    "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+                  }
+                },
+                "random": {
+                  "encrypt": {
+                    "keyId": [
+                      {
+                        "$binary": {
+                          "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                          "subType": "04"
+                        }
+                      }
+                    ],
+                    "bsonType": "string",
+                    "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
+                  }
+                },
+                "encrypted_string_equivalent": {
+                  "encrypt": {
+                    "keyId": [
+                      {
+                        "$binary": {
+                          "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                          "subType": "04"
+                        }
+                      }
+                    ],
+                    "bsonType": "string",
+                    "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+                  }
+                }
+              },
+              "bsonType": "object"
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "command": {
+              "collMod": "encryptedCollection",
+              "validator": {
+                "encrypted_string": "foo"
+              }
+            }
+          },
+          "result": {
+            "errorContains": "Comparison to encrypted fields not supported"
+          }
+        }
+      ]
+    },
+    {
+      "description": "createIndexes with a partialFilterExpression on an unencrypted field is OK",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "local": {
+              "key": {
+                "$binary": {
+                  "base64": "Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk",
+                  "subType": "00"
+                }
+              }
+            }
+          },
+          "schemaMap": {
+            "default.encryptedCollection": {
+              "properties": {
+                "encrypted_w_altname": {
+                  "encrypt": {
+                    "keyId": "/altname",
+                    "bsonType": "string",
+                    "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
+                  }
+                },
+                "encrypted_string": {
+                  "encrypt": {
+                    "keyId": [
+                      {
+                        "$binary": {
+                          "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                          "subType": "04"
+                        }
+                      }
+                    ],
+                    "bsonType": "string",
+                    "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+                  }
+                },
+                "random": {
+                  "encrypt": {
+                    "keyId": [
+                      {
+                        "$binary": {
+                          "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                          "subType": "04"
+                        }
+                      }
+                    ],
+                    "bsonType": "string",
+                    "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
+                  }
+                },
+                "encrypted_string_equivalent": {
+                  "encrypt": {
+                    "keyId": [
+                      {
+                        "$binary": {
+                          "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                          "subType": "04"
+                        }
+                      }
+                    ],
+                    "bsonType": "string",
+                    "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+                  }
+                }
+              },
+              "bsonType": "object"
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "command": {
+              "createIndexes": "encryptedCollection",
+              "indexes": [
+                {
+                  "name": "name",
+                  "key": {
+                    "name": 1
+                  },
+                  "partialFilterExpression": {
+                    "unencrypted_string": "foo"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "assertIndexExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection",
+            "index": "name"
+          }
+        }
+      ]
+    },
+    {
+      "description": "createIndexes with a partialFilterExpression on an encrypted field is an error",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "local": {
+              "key": {
+                "$binary": {
+                  "base64": "Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk",
+                  "subType": "00"
+                }
+              }
+            }
+          },
+          "schemaMap": {
+            "default.encryptedCollection": {
+              "properties": {
+                "encrypted_w_altname": {
+                  "encrypt": {
+                    "keyId": "/altname",
+                    "bsonType": "string",
+                    "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
+                  }
+                },
+                "encrypted_string": {
+                  "encrypt": {
+                    "keyId": [
+                      {
+                        "$binary": {
+                          "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                          "subType": "04"
+                        }
+                      }
+                    ],
+                    "bsonType": "string",
+                    "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+                  }
+                },
+                "random": {
+                  "encrypt": {
+                    "keyId": [
+                      {
+                        "$binary": {
+                          "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                          "subType": "04"
+                        }
+                      }
+                    ],
+                    "bsonType": "string",
+                    "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
+                  }
+                },
+                "encrypted_string_equivalent": {
+                  "encrypt": {
+                    "keyId": [
+                      {
+                        "$binary": {
+                          "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                          "subType": "04"
+                        }
+                      }
+                    ],
+                    "bsonType": "string",
+                    "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+                  }
+                }
+              },
+              "bsonType": "object"
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "command": {
+              "createIndexes": "encryptedCollection",
+              "indexes": [
+                {
+                  "name": "name",
+                  "key": {
+                    "name": 1
+                  },
+                  "partialFilterExpression": {
+                    "encrypted_string": "foo"
+                  }
+                }
+              ]
+            }
+          },
+          "result": {
+            "errorContains": "Comparison to encrypted fields not supported"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/client-side-encryption/tests/validatorAndPartialFieldExpression.yml
+++ b/test/spec/client-side-encryption/tests/validatorAndPartialFieldExpression.yml
@@ -1,0 +1,166 @@
+# This test requires libmongocrypt 1.5.0-alpha2.
+runOn:
+  # Require server version 6.0.0 to get behavior added in SERVER-64911.
+  - minServerVersion: "6.0.0"
+
+database_name: &database_name "default"
+collection_name: &collection_name "default"
+data: []
+tests:
+  - description: "create with a validator on an unencrypted field is OK"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          local: {'key': {'$binary': {'base64': 'Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk', 'subType': '00'}}}
+        schemaMap:
+          "default.encryptedCollection": {'properties': {'encrypted_w_altname': {'encrypt': {'keyId': '/altname', 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Random'}}, 'encrypted_string': {'encrypt': {'keyId': [{'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}}], 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'}}, 'random': {'encrypt': {'keyId': [{'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}}], 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Random'}}, 'encrypted_string_equivalent': {'encrypt': {'keyId': [{'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}}], 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'}}}, 'bsonType': 'object'}
+    operations:
+    # Drop to remove a collection that may exist from previous test runs.
+    - name: dropCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+    - name: createCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+        validator:
+          unencrypted_string: "foo"
+    - name: assertCollectionExists
+      object: testRunner
+      arguments:
+        database: *database_name
+        collection: "encryptedCollection"
+  - description: "create with a validator on an encrypted field is an error"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          local: {'key': {'$binary': {'base64': 'Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk', 'subType': '00'}}}
+        schemaMap:
+          "default.encryptedCollection": {'properties': {'encrypted_w_altname': {'encrypt': {'keyId': '/altname', 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Random'}}, 'encrypted_string': {'encrypt': {'keyId': [{'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}}], 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'}}, 'random': {'encrypt': {'keyId': [{'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}}], 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Random'}}, 'encrypted_string_equivalent': {'encrypt': {'keyId': [{'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}}], 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'}}}, 'bsonType': 'object'}
+    operations:
+    # Drop to remove a collection that may exist from previous test runs.
+    - name: dropCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+    - name: createCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+        validator:
+          encrypted_string: "foo"
+      result:
+        errorContains: "Comparison to encrypted fields not supported"
+  - description: "collMod with a validator on an unencrypted field is OK"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          local: {'key': {'$binary': {'base64': 'Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk', 'subType': '00'}}}
+        schemaMap:
+          "default.encryptedCollection": {'properties': {'encrypted_w_altname': {'encrypt': {'keyId': '/altname', 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Random'}}, 'encrypted_string': {'encrypt': {'keyId': [{'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}}], 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'}}, 'random': {'encrypt': {'keyId': [{'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}}], 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Random'}}, 'encrypted_string_equivalent': {'encrypt': {'keyId': [{'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}}], 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'}}}, 'bsonType': 'object'}
+    operations:
+    # Drop to remove a collection that may exist from previous test runs.
+    - name: dropCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+    - name: createCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+    - name: runCommand
+      object: database
+      arguments:
+        command:
+          collMod: "encryptedCollection"
+          validator:
+            unencrypted_string: "foo"
+  - description: "collMod with a validator on an encrypted field is an error"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          local: {'key': {'$binary': {'base64': 'Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk', 'subType': '00'}}}
+        schemaMap:
+          "default.encryptedCollection": {'properties': {'encrypted_w_altname': {'encrypt': {'keyId': '/altname', 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Random'}}, 'encrypted_string': {'encrypt': {'keyId': [{'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}}], 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'}}, 'random': {'encrypt': {'keyId': [{'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}}], 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Random'}}, 'encrypted_string_equivalent': {'encrypt': {'keyId': [{'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}}], 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'}}}, 'bsonType': 'object'}
+    operations:
+    # Drop to remove a collection that may exist from previous test runs.
+    - name: dropCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+    - name: createCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+    - name: runCommand
+      object: database
+      arguments:
+        command:
+          collMod: "encryptedCollection"
+          validator:
+            encrypted_string: "foo"
+      result:
+        errorContains: "Comparison to encrypted fields not supported"
+  - description: "createIndexes with a partialFilterExpression on an unencrypted field is OK"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          local: {'key': {'$binary': {'base64': 'Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk', 'subType': '00'}}}
+        schemaMap:
+          "default.encryptedCollection": {'properties': {'encrypted_w_altname': {'encrypt': {'keyId': '/altname', 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Random'}}, 'encrypted_string': {'encrypt': {'keyId': [{'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}}], 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'}}, 'random': {'encrypt': {'keyId': [{'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}}], 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Random'}}, 'encrypted_string_equivalent': {'encrypt': {'keyId': [{'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}}], 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'}}}, 'bsonType': 'object'}
+    operations:
+    # Drop to remove a collection that may exist from previous test runs.
+    - name: dropCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+    - name: createCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+    - name: runCommand
+      object: database
+      arguments:
+        command:
+          createIndexes: "encryptedCollection"
+          indexes:
+            - name: "name"
+              key: { name: 1 }
+              partialFilterExpression:
+                unencrypted_string: "foo"
+    - name: assertIndexExists
+      object: testRunner
+      arguments:
+        database: *database_name
+        collection: "encryptedCollection"
+        index: name
+  - description: "createIndexes with a partialFilterExpression on an encrypted field is an error"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          local: {'key': {'$binary': {'base64': 'Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk', 'subType': '00'}}}
+        schemaMap:
+          "default.encryptedCollection": {'properties': {'encrypted_w_altname': {'encrypt': {'keyId': '/altname', 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Random'}}, 'encrypted_string': {'encrypt': {'keyId': [{'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}}], 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'}}, 'random': {'encrypt': {'keyId': [{'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}}], 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Random'}}, 'encrypted_string_equivalent': {'encrypt': {'keyId': [{'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}}], 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'}}}, 'bsonType': 'object'}
+    operations:
+    # Drop to remove a collection that may exist from previous test runs.
+    - name: dropCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+    - name: createCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+    - name: runCommand
+      object: database
+      arguments:
+        command:
+          createIndexes: "encryptedCollection"
+          indexes:
+            - name: "name"
+              key: { name: 1 }
+              partialFilterExpression:
+                encrypted_string: "foo"
+      result:
+        errorContains: "Comparison to encrypted fields not supported"

--- a/test/tools/spec-runner/index.js
+++ b/test/tools/spec-runner/index.js
@@ -86,6 +86,14 @@ function translateClientOptions(options) {
         }
 
         options.autoEncryption.kmsProviders = kmsProviders;
+
+        if (options.autoEncryption.encryptedFieldsMap) {
+          const map = options.autoEncryption.encryptedFieldsMap;
+          if (map['default.encryptedCollection']) {
+            /* eslint no-console: 0 */
+            console.log(map['default.encryptedCollection'].fields[0]);
+          }
+        }
       }
 
       delete options.autoEncryptOpts;
@@ -202,29 +210,31 @@ function generateTopologyTests(testSuites, testContext, filter) {
       if (!shouldRun) this.skip();
     };
 
-    describe(testSuite.name, function () {
-      beforeEach(beforeEachFilter);
-      beforeEach(() => prepareDatabaseForSuite(testSuite, testContext));
-      afterEach(() => testContext.cleanupAfterSuite());
-      for (const spec of testSuite.tests) {
-        const mochaTest = it(spec.description, async function () {
-          if (spec.failPoint) {
-            await testContext.enableFailPoint(spec.failPoint);
-          }
+    if (testSuite.name === 'fle2-CreateCollection') {
+      describe(testSuite.name, function () {
+        beforeEach(beforeEachFilter);
+        beforeEach(() => prepareDatabaseForSuite(testSuite, testContext));
+        afterEach(() => testContext.cleanupAfterSuite());
+        for (const spec of testSuite.tests) {
+          const mochaTest = it(spec.description, async function () {
+            if (spec.failPoint) {
+              await testContext.enableFailPoint(spec.failPoint);
+            }
 
-          // run the actual test
-          await runTestSuiteTest(this.configuration, spec, testContext);
+            // run the actual test
+            await runTestSuiteTest(this.configuration, spec, testContext);
 
-          if (spec.failPoint) {
-            await testContext.disableFailPoint(spec.failPoint);
-          }
+            if (spec.failPoint) {
+              await testContext.disableFailPoint(spec.failPoint);
+            }
 
-          await validateOutcome(spec, testContext);
-        });
-        // Make the spec test available to the beforeEach filter
-        mochaTest.spec = spec;
-      }
-    });
+            await validateOutcome(spec, testContext);
+          });
+          // Make the spec test available to the beforeEach filter
+          mochaTest.spec = spec;
+        }
+      });
+    }
   }
 }
 

--- a/test/tools/spec-runner/index.js
+++ b/test/tools/spec-runner/index.js
@@ -210,31 +210,29 @@ function generateTopologyTests(testSuites, testContext, filter) {
       if (!shouldRun) this.skip();
     };
 
-    if (testSuite.name === 'fle2-CreateCollection') {
-      describe(testSuite.name, function () {
-        beforeEach(beforeEachFilter);
-        beforeEach(() => prepareDatabaseForSuite(testSuite, testContext));
-        afterEach(() => testContext.cleanupAfterSuite());
-        for (const spec of testSuite.tests) {
-          const mochaTest = it(spec.description, async function () {
-            if (spec.failPoint) {
-              await testContext.enableFailPoint(spec.failPoint);
-            }
+    describe(testSuite.name, function () {
+      beforeEach(beforeEachFilter);
+      beforeEach(() => prepareDatabaseForSuite(testSuite, testContext));
+      afterEach(() => testContext.cleanupAfterSuite());
+      for (const spec of testSuite.tests) {
+        const mochaTest = it(spec.description, async function () {
+          if (spec.failPoint) {
+            await testContext.enableFailPoint(spec.failPoint);
+          }
 
-            // run the actual test
-            await runTestSuiteTest(this.configuration, spec, testContext);
+          // run the actual test
+          await runTestSuiteTest(this.configuration, spec, testContext);
 
-            if (spec.failPoint) {
-              await testContext.disableFailPoint(spec.failPoint);
-            }
+          if (spec.failPoint) {
+            await testContext.disableFailPoint(spec.failPoint);
+          }
 
-            await validateOutcome(spec, testContext);
-          });
-          // Make the spec test available to the beforeEach filter
-          mochaTest.spec = spec;
-        }
-      });
-    }
+          await validateOutcome(spec, testContext);
+        });
+        // Make the spec test available to the beforeEach filter
+        mochaTest.spec = spec;
+      }
+    });
   }
 }
 

--- a/test/tools/spec-runner/index.js
+++ b/test/tools/spec-runner/index.js
@@ -102,7 +102,7 @@ function gatherTestSuites(specPath) {
     .map(x =>
       Object.assign(
         EJSON.parse(fs.readFileSync(path.join(specPath, x)), {
-          relaxed: !x.includes('fle2-CreateCollection')
+          relaxed: !x.includes('fle2')
         }),
         {
           name: path.basename(x, '.json')

--- a/test/tools/spec-runner/index.js
+++ b/test/tools/spec-runner/index.js
@@ -655,8 +655,9 @@ const kOperations = new Map([
     (operation, db, context /*, options */) => {
       const collectionName = operation.arguments.collection;
       const encryptedFields = operation.arguments.encryptedFields;
+      const validator = operation.arguments.validator;
       const session = maybeSession(operation, context);
-      return db.createCollection(collectionName, { session, encryptedFields });
+      return db.createCollection(collectionName, { session, encryptedFields, validator });
     }
   ],
   [

--- a/test/tools/spec-runner/index.js
+++ b/test/tools/spec-runner/index.js
@@ -86,14 +86,6 @@ function translateClientOptions(options) {
         }
 
         options.autoEncryption.kmsProviders = kmsProviders;
-
-        if (options.autoEncryption.encryptedFieldsMap) {
-          const map = options.autoEncryption.encryptedFieldsMap;
-          if (map['default.encryptedCollection']) {
-            /* eslint no-console: 0 */
-            console.log(map['default.encryptedCollection'].fields[0]);
-          }
-        }
       }
 
       delete options.autoEncryptOpts;


### PR DESCRIPTION
### Description

Adds list collections assertions in the create spec tests plus tests for create indexes and collmod.

#### What is changing?

Spec test sync. https://github.com/mongodb/specifications/commit/f0d133083c3e68c4d3227426d78b4116acf6382e and https://github.com/mongodb/specifications/commit/2fd6b69c9a0ad58d8c246a852fc389617de6e79d

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-4251/DRIVERS-2309

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
