### PR TITLE
WIP

### DIFF
--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -76,6 +76,7 @@ const NO_CURSOR_ERROR = 'ChangeStream has no cursor';
 const CHANGESTREAM_CLOSED_ERROR = 'ChangeStream is closed';
 
 /**
+ * @public
  * @deprecated
  *
  * Please use the ChangeStreamCursorOptions instead.

--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -941,11 +941,7 @@ export class ChangeStreamCursor<
       } else {
         options.resumeAfter = this.resumeToken;
       }
-    } else if (
-      this.resumeToken == null &&
-      this.startAtOperationTime != null &&
-      maxWireVersion(this.server) >= 7
-    ) {
+    } else if (this.startAtOperationTime != null && maxWireVersion(this.server) >= 7) {
       options.startAtOperationTime = this.startAtOperationTime;
     }
 

--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -4,12 +4,8 @@ import type { Readable } from 'stream';
 import type { Document, Long, Timestamp } from './bson';
 import { Collection } from './collection';
 import { CHANGE, CLOSE, END, ERROR, INIT, MORE, RESPONSE, RESUME_TOKEN_CHANGED } from './constants';
-import {
-  AbstractCursor,
-  AbstractCursorEvents,
-  AbstractCursorOptions,
-  CursorStreamOptions
-} from './cursor/abstract_cursor';
+import type { AbstractCursorEvents, CursorStreamOptions } from './cursor/abstract_cursor';
+import { ChangeStreamCursor, ChangeStreamCursorOptions } from './cursor/change_stream_cursor';
 import { Db } from './db';
 import {
   AnyError,
@@ -19,13 +15,12 @@ import {
   MongoRuntimeError
 } from './error';
 import { MongoClient } from './mongo_client';
-import { InferIdType, TODO_NODE_3286, TypedEventEmitter } from './mongo_types';
-import { AggregateOperation, AggregateOptions } from './operations/aggregate';
+import { InferIdType, TypedEventEmitter } from './mongo_types';
+import type { AggregateOptions } from './operations/aggregate';
 import type { CollationOptions, OperationParent } from './operations/command';
-import { executeOperation, ExecutionResult } from './operations/execute_operation';
 import type { ReadPreference } from './read_preference';
 import type { Topology } from './sdam/topology';
-import type { ClientSession, ServerSessionId } from './sessions';
+import type { ServerSessionId } from './sessions';
 import {
   calculateDurationInMs,
   Callback,
@@ -869,160 +864,5 @@ export class ChangeStream<
       }
       request(error, this.cursor ?? undefined);
     }
-  }
-}
-
-/** @internal */
-export interface ChangeStreamCursorOptions extends AbstractCursorOptions {
-  startAtOperationTime?: OperationTime;
-  resumeAfter?: ResumeToken;
-  startAfter?: ResumeToken;
-  maxAwaitTimeMS?: number;
-  collation?: CollationOptions;
-  fullDocument?: string;
-}
-
-/** @internal */
-export class ChangeStreamCursor<
-  TSchema extends Document = Document,
-  TChange extends Document = ChangeStreamDocument<TSchema>
-> extends AbstractCursor<TChange, ChangeStreamEvents> {
-  _resumeToken: ResumeToken;
-  startAtOperationTime?: OperationTime;
-  hasReceived?: boolean;
-  resumeAfter: ResumeToken;
-  startAfter: ResumeToken;
-  options: ChangeStreamCursorOptions;
-
-  postBatchResumeToken?: ResumeToken;
-  pipeline: Document[];
-
-  constructor(
-    client: MongoClient,
-    namespace: MongoDBNamespace,
-    pipeline: Document[] = [],
-    options: ChangeStreamCursorOptions = {}
-  ) {
-    super(client, namespace, options);
-
-    this.pipeline = pipeline;
-    this.options = options;
-    this._resumeToken = null;
-    this.startAtOperationTime = options.startAtOperationTime;
-
-    if (options.startAfter) {
-      this.resumeToken = options.startAfter;
-    } else if (options.resumeAfter) {
-      this.resumeToken = options.resumeAfter;
-    }
-  }
-
-  set resumeToken(token: ResumeToken) {
-    this._resumeToken = token;
-    this.emit(ChangeStream.RESUME_TOKEN_CHANGED, token);
-  }
-
-  get resumeToken(): ResumeToken {
-    return this._resumeToken;
-  }
-
-  get resumeOptions(): ChangeStreamCursorOptions {
-    const options: ChangeStreamCursorOptions = {
-      ...this.options
-    };
-
-    for (const key of ['resumeAfter', 'startAfter', 'startAtOperationTime'] as const) {
-      delete options[key];
-    }
-
-    if (this.resumeToken != null) {
-      if (this.options.startAfter && !this.hasReceived) {
-        options.startAfter = this.resumeToken;
-      } else {
-        options.resumeAfter = this.resumeToken;
-      }
-    } else if (this.startAtOperationTime != null && maxWireVersion(this.server) >= 7) {
-      options.startAtOperationTime = this.startAtOperationTime;
-    }
-
-    return options;
-  }
-
-  cacheResumeToken(resumeToken: ResumeToken): void {
-    if (this.bufferedCount() === 0 && this.postBatchResumeToken) {
-      this.resumeToken = this.postBatchResumeToken;
-    } else {
-      this.resumeToken = resumeToken;
-    }
-    this.hasReceived = true;
-  }
-
-  _processBatch(response: ChangeStreamAggregateRawResult<TChange>): void {
-    const cursor = response.cursor;
-    if (cursor.postBatchResumeToken) {
-      this.postBatchResumeToken = response.cursor.postBatchResumeToken;
-
-      const batch =
-        'firstBatch' in response.cursor ? response.cursor.firstBatch : response.cursor.nextBatch;
-      if (batch.length === 0) {
-        this.resumeToken = cursor.postBatchResumeToken;
-      }
-    }
-  }
-
-  clone(): AbstractCursor<TChange> {
-    return new ChangeStreamCursor(this.client, this.namespace, this.pipeline, {
-      ...this.cursorOptions
-    });
-  }
-
-  _initialize(session: ClientSession, callback: Callback<ExecutionResult>): void {
-    const aggregateOperation = new AggregateOperation(this.namespace, this.pipeline, {
-      ...this.cursorOptions,
-      ...this.options,
-      session
-    });
-
-    executeOperation<TODO_NODE_3286, ChangeStreamAggregateRawResult<TChange>>(
-      session.client,
-      aggregateOperation,
-      (err, response) => {
-        if (err || response == null) {
-          return callback(err);
-        }
-
-        const server = aggregateOperation.server;
-        if (
-          this.startAtOperationTime == null &&
-          this.resumeAfter == null &&
-          this.startAfter == null &&
-          maxWireVersion(server) >= 7
-        ) {
-          this.startAtOperationTime = response.operationTime;
-        }
-
-        this._processBatch(response);
-
-        this.emit(ChangeStream.INIT, response);
-        this.emit(ChangeStream.RESPONSE);
-
-        // TODO: NODE-2882
-        callback(undefined, { server, session, response });
-      }
-    );
-  }
-
-  override _getMore(batchSize: number, callback: Callback): void {
-    super._getMore(batchSize, (err, response) => {
-      if (err) {
-        return callback(err);
-      }
-
-      this._processBatch(response as TODO_NODE_3286 as ChangeStreamAggregateRawResult<TChange>);
-
-      this.emit(ChangeStream.MORE, response);
-      this.emit(ChangeStream.RESPONSE);
-      callback(err, response);
-    });
   }
 }

--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -930,19 +930,22 @@ export class ChangeStreamCursor<
       ...this.options
     };
 
-    if (this.resumeToken || this.startAtOperationTime) {
-      for (const key of ['resumeAfter', 'startAfter', 'startAtOperationTime'] as const) {
-        delete options[key];
-      }
+    for (const key of ['resumeAfter', 'startAfter', 'startAtOperationTime'] as const) {
+      delete options[key];
+    }
 
-      if (this.resumeToken) {
-        const resumeKey =
-          this.options.startAfter && !this.hasReceived ? 'startAfter' : 'resumeAfter';
-
-        options[resumeKey] = this.resumeToken;
-      } else if (this.startAtOperationTime && maxWireVersion(this.server) >= 7) {
-        options.startAtOperationTime = this.startAtOperationTime;
+    if (this.resumeToken != null) {
+      if (this.options.startAfter && !this.hasReceived) {
+        options.startAfter = this.resumeToken;
+      } else {
+        options.resumeAfter = this.resumeToken;
       }
+    } else if (
+      this.resumeToken == null &&
+      this.startAtOperationTime != null &&
+      maxWireVersion(this.server) >= 7
+    ) {
+      options.startAtOperationTime = this.startAtOperationTime;
     }
 
     return options;

--- a/src/cursor/change_stream_cursor.ts
+++ b/src/cursor/change_stream_cursor.ts
@@ -1,0 +1,173 @@
+import type { Document } from 'bson';
+
+import type {
+  ChangeStreamAggregateRawResult,
+  ChangeStreamDocument,
+  ChangeStreamEvents,
+  OperationTime,
+  ResumeToken
+} from '../change_stream';
+import { INIT, MORE, RESPONSE, RESUME_TOKEN_CHANGED } from '../constants';
+import type { MongoClient } from '../mongo_client';
+import type { TODO_NODE_3286 } from '../mongo_types';
+import { AggregateOperation } from '../operations/aggregate';
+import type { CollationOptions } from '../operations/command';
+import { executeOperation, ExecutionResult } from '../operations/execute_operation';
+import type { ClientSession } from '../sessions';
+import { Callback, maxWireVersion, MongoDBNamespace } from '../utils';
+import { AbstractCursor, AbstractCursorOptions } from './abstract_cursor';
+
+/** @internal */
+export interface ChangeStreamCursorOptions extends AbstractCursorOptions {
+  startAtOperationTime?: OperationTime;
+  resumeAfter?: ResumeToken;
+  startAfter?: ResumeToken;
+  maxAwaitTimeMS?: number;
+  collation?: CollationOptions;
+  fullDocument?: string;
+}
+
+/** @internal */
+export class ChangeStreamCursor<
+  TSchema extends Document = Document,
+  TChange extends Document = ChangeStreamDocument<TSchema>
+> extends AbstractCursor<TChange, ChangeStreamEvents> {
+  _resumeToken: ResumeToken;
+  startAtOperationTime?: OperationTime;
+  hasReceived?: boolean;
+  resumeAfter: ResumeToken;
+  startAfter: ResumeToken;
+  options: ChangeStreamCursorOptions;
+
+  postBatchResumeToken?: ResumeToken;
+  pipeline: Document[];
+
+  constructor(
+    client: MongoClient,
+    namespace: MongoDBNamespace,
+    pipeline: Document[] = [],
+    options: ChangeStreamCursorOptions = {}
+  ) {
+    super(client, namespace, options);
+
+    this.pipeline = pipeline;
+    this.options = options;
+    this._resumeToken = null;
+    this.startAtOperationTime = options.startAtOperationTime;
+
+    if (options.startAfter) {
+      this.resumeToken = options.startAfter;
+    } else if (options.resumeAfter) {
+      this.resumeToken = options.resumeAfter;
+    }
+  }
+
+  set resumeToken(token: ResumeToken) {
+    this._resumeToken = token;
+    this.emit(RESUME_TOKEN_CHANGED, token);
+  }
+
+  get resumeToken(): ResumeToken {
+    return this._resumeToken;
+  }
+
+  get resumeOptions(): ChangeStreamCursorOptions {
+    const options: ChangeStreamCursorOptions = {
+      ...this.options
+    };
+
+    for (const key of ['resumeAfter', 'startAfter', 'startAtOperationTime'] as const) {
+      delete options[key];
+    }
+
+    if (this.resumeToken != null) {
+      if (this.options.startAfter && !this.hasReceived) {
+        options.startAfter = this.resumeToken;
+      } else {
+        options.resumeAfter = this.resumeToken;
+      }
+    } else if (this.startAtOperationTime != null && maxWireVersion(this.server) >= 7) {
+      options.startAtOperationTime = this.startAtOperationTime;
+    }
+
+    return options;
+  }
+
+  cacheResumeToken(resumeToken: ResumeToken): void {
+    if (this.bufferedCount() === 0 && this.postBatchResumeToken) {
+      this.resumeToken = this.postBatchResumeToken;
+    } else {
+      this.resumeToken = resumeToken;
+    }
+    this.hasReceived = true;
+  }
+
+  _processBatch(response: ChangeStreamAggregateRawResult<TChange>): void {
+    const cursor = response.cursor;
+    if (cursor.postBatchResumeToken) {
+      this.postBatchResumeToken = response.cursor.postBatchResumeToken;
+
+      const batch =
+        'firstBatch' in response.cursor ? response.cursor.firstBatch : response.cursor.nextBatch;
+      if (batch.length === 0) {
+        this.resumeToken = cursor.postBatchResumeToken;
+      }
+    }
+  }
+
+  clone(): AbstractCursor<TChange> {
+    return new ChangeStreamCursor(this.client, this.namespace, this.pipeline, {
+      ...this.cursorOptions
+    });
+  }
+
+  _initialize(session: ClientSession, callback: Callback<ExecutionResult>): void {
+    const aggregateOperation = new AggregateOperation(this.namespace, this.pipeline, {
+      ...this.cursorOptions,
+      ...this.options,
+      session
+    });
+
+    executeOperation<TODO_NODE_3286, ChangeStreamAggregateRawResult<TChange>>(
+      session.client,
+      aggregateOperation,
+      (err, response) => {
+        if (err || response == null) {
+          return callback(err);
+        }
+
+        const server = aggregateOperation.server;
+        if (
+          this.startAtOperationTime == null &&
+          this.resumeAfter == null &&
+          this.startAfter == null &&
+          maxWireVersion(server) >= 7
+        ) {
+          this.startAtOperationTime = response.operationTime;
+        }
+
+        this._processBatch(response);
+
+        this.emit(INIT, response);
+        this.emit(RESPONSE);
+
+        // TODO: NODE-2882
+        callback(undefined, { server, session, response });
+      }
+    );
+  }
+
+  override _getMore(batchSize: number, callback: Callback): void {
+    super._getMore(batchSize, (err, response) => {
+      if (err) {
+        return callback(err);
+      }
+
+      this._processBatch(response as TODO_NODE_3286 as ChangeStreamAggregateRawResult<TChange>);
+
+      this.emit(MORE, response);
+      this.emit(RESPONSE);
+      callback(err, response);
+    });
+  }
+}

--- a/test/integration/change-streams/change_stream.test.ts
+++ b/test/integration/change-streams/change_stream.test.ts
@@ -1,168 +1,36 @@
 import { strict as assert } from 'assert';
 import { expect } from 'chai';
 import * as crypto from 'crypto';
-import { once } from 'events';
-import * as sinon from 'sinon';
+import { on, once } from 'events';
 import { PassThrough, Transform } from 'stream';
+import { promisify } from 'util';
 
 import {
+  AbstractCursor,
   ChangeStream,
   ChangeStreamOptions,
   Collection,
   Db,
   Long,
+  MongoChangeStreamError,
   MongoClient,
   MongoNetworkError,
-  ReadPreference
+  MongoServerError,
+  ReadPreference,
+  ResumeToken
 } from '../../../src';
 import { isHello } from '../../../src/utils';
 import * as mock from '../../tools/mongodb-mock/index';
-import { skipBrokenAuthTestBeforeEachHook } from '../../tools/runner/hooks/configuration';
-import {
-  EventCollector,
-  getSymbolFrom,
-  TestBuilder,
-  UnifiedTestSuiteBuilder
-} from '../../tools/utils';
-import { delay, filterForCommands, setupDatabase, withClient, withCursor } from '../shared';
+import { getSymbolFrom, sleep, TestBuilder, UnifiedTestSuiteBuilder } from '../../tools/utils';
+import { delay, filterForCommands } from '../shared';
 
-function withChangeStream(
-  callback: (collection: Collection, changeStream: ChangeStream, done: Mocha.Done) => void
-): Mocha.Func {
-  const dbName = 'changestream_integration_test';
-  const collectionName = 'test';
-
-  // TODO(NODE-2764): remove withClient and withChangeStream usage, use mocha hooks
-  const withClientTyped: (cb: (client: MongoClient, done: Mocha.Done) => void) => Mocha.Func =
-    withClient as any;
-
-  return withClientTyped((client, done) => {
-    const db = client.db(dbName);
-    db.dropCollection(collectionName, () => {
-      db.createCollection(
-        collectionName,
-        { writeConcern: { w: 'majority' } },
-        (err, collection) => {
-          if (err) return done(err);
-          withCursor(
-            collection.watch(),
-            (cursor, done) => callback(collection, cursor, done),
-            err => collection.drop(dropErr => done(err || dropErr))
-          );
-        }
-      );
-    });
-  });
-}
-
-/**
- * Triggers a fake resumable error on a change stream
- * changeStream
- * [delay] optional delay before triggering error
- * onClose callback when cursor closed due this error
- */
-function triggerResumableError(changeStream: ChangeStream, onClose?: () => void);
-function triggerResumableError(changeStream: ChangeStream, delay: number, onClose?: () => void);
-function triggerResumableError(
-  changeStream: ChangeStream,
-  delay: number | (() => void),
-  onClose?: () => void
-) {
-  if (typeof delay === 'function') {
-    onClose = delay;
-    delay = undefined;
-  }
-
-  const stub = sinon.stub(changeStream.cursor, 'close');
-  stub.callsFake(function () {
-    stub.wrappedMethod.call(this);
-    stub.restore();
-    onClose();
-  });
-
-  function triggerError() {
-    const cursorStream = changeStream.cursorStream;
-    if (cursorStream) {
-      cursorStream.emit('error', new MongoNetworkError('error triggered from test'));
-      return;
-    }
-
-    const nextStub = sinon.stub(changeStream.cursor, 'next').callsFake(function (callback) {
-      callback(new MongoNetworkError('error triggered from test'));
-      nextStub.restore();
-    });
-
-    changeStream.next(() => {
-      // ignore
-    });
-  }
-
-  if (typeof delay === 'number') {
-    setTimeout(triggerError, delay);
-    return;
-  }
-
-  triggerError();
-}
-
-/** Waits for a change stream to start */
-function waitForStarted(changeStream: ChangeStream, callback: () => void) {
-  changeStream.cursor.once('init', () => {
-    callback();
-  });
-}
-
-/**
- * Iterates the next discrete batch of a change stream non-eagerly. This
- * will return `null` if the next bach is empty, rather than waiting forever
- * for a non-empty batch.
- */
-function tryNext(changeStream, callback) {
-  let complete = false;
-  function done(err, result) {
-    if (complete) return;
-    // if the arity is 1 then this a callback for `more`
-    if (arguments.length === 1) {
-      result = err;
-      const batch = result.cursor.firstBatch || result.cursor.nextBatch;
-      if (batch.length === 0) {
-        complete = true;
-        callback(null, null);
-      }
-
-      return;
-    }
-
-    // otherwise, this a normal response to `next`
-    complete = true;
-    changeStream.removeListener('more', done);
-    if (err) return callback(err);
-    callback(err, result);
-  }
-
-  // race the two requests
-  changeStream.next(done);
-  changeStream.cursor.once('more', done);
-}
-
-/**
- * Exhausts a change stream aggregating all responses until the first
- * empty batch into a returned array of events.
- */
-function exhaust(changeStream, bag, callback) {
-  if (typeof bag === 'function') {
-    callback = bag;
-    bag = [];
-  }
-
-  tryNext(changeStream, (err, doc) => {
-    if (err) return callback(err);
-    if (doc === null) return callback(undefined, bag);
-
-    bag.push(doc);
-    exhaust(changeStream, bag, callback);
-  });
-}
+const initIteratorMode = async (cs: ChangeStream) => {
+  const init = getSymbolFrom(AbstractCursor.prototype, 'kInit');
+  const initEvent = once(cs.cursor, 'init');
+  await promisify(cs.cursor[init].bind(cs.cursor))();
+  await initEvent;
+  return;
+};
 
 // Define the pipeline processing changes
 const pipeline = [
@@ -171,26 +39,32 @@ const pipeline = [
   { $addFields: { comment: 'The documentKey field has been projected out of this document.' } }
 ];
 
-describe('Change Streams', function () {
-  before(async function () {
-    return await setupDatabase(this.configuration, ['integration_tests']);
-  });
+describe('Change Streams', { sessions: { skipLeakTests: true } }, function () {
+  let client: MongoClient;
+  let collection: Collection;
+  let changeStream: ChangeStream;
+  let db: Db;
 
   beforeEach(async function () {
     const configuration = this.configuration;
-    const client = configuration.newClient();
+    client = configuration.newClient();
 
     await client.connect();
-    const db = client.db('integration_tests');
-    try {
-      await db.createCollection('test');
-    } catch {
-      // ns already exists, don't care
-    } finally {
-      await client.close();
-    }
+    db = client.db('integration_tests');
+    await db.createCollection('test').catch(() => null);
+
+    const csDb = client.db('changestream_integration_test');
+    await csDb.dropDatabase().catch(() => null);
+    await csDb.createCollection('test').catch(() => null);
+    collection = csDb.collection('test');
+    changeStream = collection.watch();
   });
-  afterEach(async () => await mock.cleanup());
+
+  afterEach(async () => {
+    await changeStream.close();
+    await client.close();
+    await mock.cleanup();
+  });
 
   context('ChangeStreamCursor options', function () {
     let client, db, collection;
@@ -217,7 +91,7 @@ describe('Change Streams', function () {
         );
       });
 
-      it('does not validate the value passed in for the `fullDocument` property', function () {
+      it('does not validate the value passed in for the fullDocument property', function () {
         const changeStream = client.watch([], { fullDocument: 'invalid value' });
 
         expect(changeStream).to.have.nested.property(
@@ -226,7 +100,7 @@ describe('Change Streams', function () {
         );
       });
 
-      it('assigns `fullDocument` to the correct value if it is passed as an option', function () {
+      it('assigns fullDocument to the correct value if it is passed as an option', function () {
         const changeStream = client.watch([], { fullDocument: 'updateLookup' });
 
         expect(changeStream).to.have.nested.property(
@@ -237,7 +111,7 @@ describe('Change Streams', function () {
     });
 
     context('allChangesForCluster', () => {
-      it('assigns `allChangesForCluster` to `true` if the ChangeStream.type is Cluster', function () {
+      it('assigns allChangesForCluster to true if the ChangeStream.type is Cluster', function () {
         const changeStream = client.watch();
 
         expect(changeStream).to.have.nested.property(
@@ -246,7 +120,7 @@ describe('Change Streams', function () {
         );
       });
 
-      it('does not assign `allChangesForCluster` if the ChangeStream.type is Db', function () {
+      it('does not assign allChangesForCluster if the ChangeStream.type is Db', function () {
         const changeStream = db.watch();
 
         expect(changeStream).not.to.have.nested.property(
@@ -254,7 +128,7 @@ describe('Change Streams', function () {
         );
       });
 
-      it('does not assign `allChangesForCluster` if the ChangeStream.type is Collection', function () {
+      it('does not assign allChangesForCluster if the ChangeStream.type is Collection', function () {
         const changeStream = collection.watch();
 
         expect(changeStream).not.to.have.nested.property(
@@ -273,92 +147,56 @@ describe('Change Streams', function () {
   });
 
   it('should close the listeners after the cursor is closed', {
-    metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
+    metadata: { requires: { topology: 'replicaset' } },
+    async test() {
+      const willBeChanges = on(changeStream, 'change');
+      await once(changeStream.cursor, 'init');
+      await collection.insertOne({ a: 1 });
 
-    test: function (done) {
-      let closed = false;
-      function close(err) {
-        if (closed) return;
-        closed = true;
-        done(err);
-      }
+      await willBeChanges.next();
+      expect(changeStream.cursorStream.listenerCount('data')).to.equal(1);
 
-      const configuration = this.configuration;
-      const client = configuration.newClient();
-
-      client.connect((err, client) => {
-        expect(err).to.not.exist;
-        this.defer(() => client.close());
-
-        const coll = client.db('integration_tests').collection('listenertest');
-        const changeStream = coll.watch();
-        this.defer(() => changeStream.close());
-
-        changeStream.on('change', () => {
-          expect(changeStream.cursorStream.listenerCount('data')).to.equal(1);
-          changeStream.close(err => {
-            expect(changeStream.cursorStream).to.not.exist;
-            expect(err).to.not.exist;
-            close(err);
-          });
-        });
-
-        waitForStarted(changeStream, () => this.defer(coll.insertOne({ x: 1 })));
-        changeStream.on('error', err => close(err));
-      });
+      await changeStream.close();
+      expect(changeStream.cursorStream).to.not.exist;
     }
   });
 
-  it('should create a ChangeStream on a collection and emit `change` events', {
-    metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
+  it('should create a ChangeStream on a collection and emit change events', {
+    metadata: { requires: { topology: 'replicaset' } },
+    async test() {
+      const collection = db.collection('docsDataEvent');
+      const changeStream = collection.watch(pipeline);
 
-    test: function (done) {
-      const configuration = this.configuration;
-      const client = configuration.newClient();
+      const willBeChanges = on(changeStream, 'change');
+      await once(changeStream.cursor, 'init');
 
-      client.connect((err, client) => {
-        expect(err).to.not.exist;
-        this.defer(() => client.close());
+      await collection.insertOne({ d: 4 });
+      await collection.updateOne({ d: 4 }, { $inc: { d: 2 } });
 
-        const collection = client.db('integration_tests').collection('docsDataEvent');
-        const changeStream = collection.watch(pipeline);
-        this.defer(() => changeStream.close());
+      const changes = [
+        (await willBeChanges.next()).value[0],
+        (await willBeChanges.next()).value[0]
+      ];
 
-        const collector = new EventCollector(changeStream, ['init', 'change']);
-        waitForStarted(changeStream, () => {
-          // Trigger the first database event
-          collection.insertOne({ d: 4 }, err => {
-            expect(err).to.not.exist;
-            // Trigger the second database event
-            collection.updateOne({ d: 4 }, { $inc: { d: 2 } }, err => {
-              expect(err).to.not.exist;
+      await changeStream.close();
 
-              collector.waitForEvent('change', 2, (err, changes) => {
-                expect(err).to.not.exist;
-                expect(changes).to.have.length(2);
-                expect(changes[0]).to.not.have.property('documentKey');
-                expect(changes[0]).to.containSubset({
-                  operationType: 'insert',
-                  fullDocument: { d: 4 },
-                  ns: {
-                    db: 'integration_tests',
-                    coll: 'docsDataEvent'
-                  },
-                  comment: 'The documentKey field has been projected out of this document.'
-                });
+      expect(changes).to.have.length(2);
+      expect(changes[0]).to.not.have.property('documentKey');
+      expect(changes[0]).to.containSubset({
+        operationType: 'insert',
+        fullDocument: { d: 4 },
+        ns: {
+          db: 'integration_tests',
+          coll: 'docsDataEvent'
+        },
+        comment: 'The documentKey field has been projected out of this document.'
+      });
 
-                expect(changes[1]).to.containSubset({
-                  operationType: 'update',
-                  updateDescription: {
-                    updatedFields: { d: 6 }
-                  }
-                });
-
-                done();
-              });
-            });
-          });
-        });
+      expect(changes[1]).to.containSubset({
+        operationType: 'update',
+        updateDescription: {
+          updatedFields: { d: 6 }
+        }
       });
     }
   });
@@ -366,7 +204,7 @@ describe('Change Streams', function () {
   it(
     'should create a ChangeStream on a collection and get change events through imperative callback form',
     {
-      metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
+      metadata: { requires: { topology: 'replicaset' } },
 
       test: function (done) {
         const configuration = this.configuration;
@@ -424,7 +262,7 @@ describe('Change Streams', function () {
   );
 
   it('should support creating multiple simultaneous ChangeStreams', {
-    metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
+    metadata: { requires: { topology: 'replicaset' } },
 
     test: function (done) {
       const configuration = this.configuration;
@@ -494,7 +332,7 @@ describe('Change Streams', function () {
   });
 
   it('should properly close ChangeStream cursor', {
-    metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
+    metadata: { requires: { topology: 'replicaset' } },
 
     test: function (done) {
       const configuration = this.configuration;
@@ -526,7 +364,7 @@ describe('Change Streams', function () {
   it(
     'should error when attempting to create a ChangeStream with a forbidden aggregation pipeline stage',
     {
-      metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
+      metadata: { requires: { topology: 'replicaset' } },
 
       test: function (done) {
         const configuration = this.configuration;
@@ -558,109 +396,35 @@ describe('Change Streams', function () {
     }
   );
 
-  it('should cache the change stream resume token using imperative callback form', {
-    metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
+  it('should cache the change stream resume token using iterator form', {
+    metadata: { requires: { topology: 'replicaset' } },
 
-    test: function (done) {
-      const configuration = this.configuration;
-      const client = configuration.newClient();
+    async test() {
+      await initIteratorMode(changeStream);
+      collection.insertOne({ a: 1 });
 
-      client.connect((err, client) => {
-        expect(err).to.not.exist;
-        this.defer(() => client.close());
+      const hasNext = await changeStream.hasNext();
+      expect(hasNext).to.be.true;
 
-        const database = client.db('integration_tests');
-        const changeStream = database.collection('cacheResumeTokenCallback').watch(pipeline);
-        this.defer(() => changeStream.close());
-
-        // Trigger the first database event
-        waitForStarted(changeStream, () => {
-          this.defer(database.collection('cacheResumeTokenCallback').insertMany([{ b: 2 }]));
-        });
-
-        // Fetch the change notification
-        changeStream.hasNext(function (err, hasNext) {
-          expect(err).to.not.exist;
-          assert.equal(true, hasNext);
-          changeStream.next(function (err, change) {
-            expect(err).to.not.exist;
-            assert.deepEqual(changeStream.resumeToken, change._id);
-            done();
-          });
-        });
-      });
+      const change = await changeStream.next();
+      expect(change).to.have.property('_id').that.deep.equals(changeStream.resumeToken);
     }
   });
 
-  // TODO: NODE-3819: Unskip flaky MacOS tests.
-  const maybeIt = process.platform === 'darwin' ? it.skip : it;
-  maybeIt('should cache the change stream resume token using promises', {
-    metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
-    test: function () {
-      const configuration = this.configuration;
-      const client = configuration.newClient();
+  it('should cache the change stream resume token using event listener form', {
+    metadata: { requires: { topology: 'replicaset' } },
+    async test() {
+      const willBeChange = once(changeStream, 'change');
+      await once(changeStream.cursor, 'init');
+      collection.insertOne({ a: 1 });
 
-      return client.connect().then(() => {
-        this.defer(() => client.close());
-
-        const database = client.db('integration_tests');
-        const changeStream = database.collection('cacheResumeTokenPromise').watch(pipeline);
-        this.defer(() => changeStream.close());
-
-        // trigger the first database event
-        waitForStarted(changeStream, () => {
-          this.defer(database.collection('cacheResumeTokenPromise').insertMany([{ b: 2 }]));
-        });
-
-        return changeStream
-          .hasNext()
-          .then(hasNext => {
-            assert.equal(true, hasNext);
-            return changeStream.next();
-          })
-          .then(change => {
-            assert.deepEqual(changeStream.resumeToken, change._id);
-          });
-      });
-    }
-  });
-
-  it('should cache the change stream resume token using event listeners', {
-    metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
-
-    test: function (done) {
-      const configuration = this.configuration;
-      const client = configuration.newClient();
-
-      client.connect((err, client) => {
-        expect(err).to.not.exist;
-        this.defer(() => client.close());
-
-        const db = client.db('integration_tests');
-        const changeStream = db.collection('cacheResumeTokenListener').watch(pipeline);
-        this.defer(() => changeStream.close());
-
-        const collector = new EventCollector(changeStream, ['change']);
-        waitForStarted(changeStream, () => {
-          // Trigger the first database event
-          db.collection('cacheResumeTokenListener').insertMany([{ b: 2 }], (err, result) => {
-            expect(err).to.not.exist;
-            expect(result).property('insertedCount').to.equal(1);
-
-            collector.waitForEvent('change', (err, events) => {
-              expect(err).to.not.exist;
-              expect(changeStream).property('resumeToken').to.eql(events[0]._id);
-
-              done();
-            });
-          });
-        });
-      });
+      const [change] = await willBeChange;
+      expect(change).to.have.property('_id').that.deep.equals(changeStream.resumeToken);
     }
   });
 
   it('should error if resume token projected out of change stream document using iterator', {
-    metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
+    metadata: { requires: { topology: 'replicaset' } },
     test(done) {
       const configuration = this.configuration;
       const client = configuration.newClient();
@@ -696,392 +460,244 @@ describe('Change Streams', function () {
   });
 
   it('should error if resume token projected out of change stream document using event listeners', {
-    metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
+    metadata: { requires: { topology: 'replicaset' } },
+    async test() {
+      const changeStream = collection.watch([{ $project: { _id: false } }]);
 
-    test: function (done) {
-      const configuration = this.configuration;
-      const client = configuration.newClient();
+      const willBeChangeOrError = once(changeStream, 'change').catch(error => error);
+      await once(changeStream.cursor, 'init');
 
-      client.connect((err, client) => {
-        expect(err).to.not.exist;
-        this.defer(() => client.close());
+      await collection.insertOne({ a: 1 });
 
-        const db = client.db('integration_tests');
-        const collection = db.collection('resumetokenProjectedOutListener');
-        const changeStream = collection.watch([{ $project: { _id: false } }]);
-        this.defer(() => changeStream.close());
+      const error = await willBeChangeOrError;
 
-        const collector = new EventCollector(changeStream, ['change', 'error']);
-        waitForStarted(changeStream, () => {
-          collection.insertMany([{ b: 2 }], (err, result) => {
-            expect(err).to.not.exist;
-            expect(result).property('insertedCount').to.equal(1);
+      await changeStream.close();
 
-            collector.waitForEvent('error', (err, events) => {
-              expect(err).to.not.exist;
-              expect(events).to.have.lengthOf.at.least(1);
-              done();
-            });
-          });
-        });
-      });
+      if (error instanceof MongoServerError) {
+        // Newer servers
+        expect(error).to.be.instanceOf(MongoServerError);
+        expect(error).to.have.property('code', 280); // ChangeStreamFatalError code
+      } else if (error instanceof MongoChangeStreamError) {
+        // Older servers do not error, but the driver will
+        expect(error).to.be.instanceOf(MongoChangeStreamError);
+        expect(error.message).to.match(/that lacks a resume token/);
+      } else {
+        expect.fail(`error needs to be a known instance, got ${error.constructor.name}`);
+      }
     }
   });
 
   it('should invalidate change stream on collection rename using event listeners', {
-    metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
-    test: function (done) {
-      const configuration = this.configuration;
-      const client = configuration.newClient();
+    metadata: { requires: { topology: 'replicaset', mongodb: '>3.6' } },
+    async test() {
+      const willBeChange = once(changeStream, 'change');
+      await once(changeStream.cursor, 'init');
 
-      client.connect((err, client) => {
-        expect(err).to.not.exist;
-        this.defer(() => client.close());
+      collection.insertOne({ a: 1 });
 
-        const database = client.db('integration_tests');
-        const changeStream = database
-          .collection('invalidateListeners')
-          .watch(pipeline, { batchSize: 1 });
-        this.defer(() => changeStream.close());
+      const [change] = await willBeChange;
+      expect(change).to.have.property('operationType', 'insert');
+      expect(change).to.have.nested.property('fullDocument.a', 1);
 
-        // Attach first event listener
-        changeStream.once('change', change => {
+      const willBeClose = once(changeStream, 'close');
+
+      const changes = on(changeStream, 'change');
+
+      await collection.rename('renamedDocs', { dropTarget: true });
+
+      const [renameChange] = (await changes.next()).value;
+      expect(renameChange).to.have.property('operationType', 'rename');
+
+      const [invalidateChange] = (await changes.next()).value;
+      expect(invalidateChange).to.have.property('operationType', 'invalidate');
+
+      await willBeClose; // Server will close this changestream
+    }
+  });
+
+  it('should invalidate change stream on database drop using iterator form', {
+    metadata: { requires: { topology: 'replicaset', mongodb: '>3.6' } },
+    async test() {
+      const db = client.db('droppableDb');
+      const collection = db.collection('invalidateCallback');
+
+      // ensure ns exists before making cs
+      await collection.insertOne({ random: Math.random() });
+
+      const changeStream = collection.watch(pipeline);
+      await initIteratorMode(changeStream);
+
+      await collection.insertOne({ a: 1 });
+
+      const insertChange = await changeStream.next();
+      expect(insertChange).to.have.property('operationType', 'insert');
+
+      await db.dropDatabase();
+
+      const dropChange = await changeStream.next();
+      expect(dropChange).to.have.property('operationType', 'drop');
+
+      const invalidateChange = await changeStream.next();
+      expect(invalidateChange).to.have.property('operationType', 'invalidate');
+
+      const hasNext = await changeStream.hasNext();
+      expect(hasNext).to.be.false;
+
+      expect(changeStream.closed).to.be.true;
+    }
+  });
+
+  it('should resume from point in time using user-provided resumeAfter', {
+    metadata: { requires: { topology: 'replicaset' } },
+
+    async test() {
+      const collection = db.collection('resumeAfterTest2');
+
+      await collection.drop().catch(() => null);
+
+      let resumeToken;
+      const docs = [{ a: 0 }, { a: 1 }, { a: 2 }];
+
+      let secondChangeStream;
+      const firstChangeStream = collection.watch(pipeline);
+      this.defer(() => firstChangeStream.close());
+
+      return initIteratorMode(firstChangeStream)
+        .then(() =>
+          collection
+            .insertMany([docs[0]])
+            .then(() => collection.insertOne(docs[1]))
+            .then(() => collection.insertOne(docs[2]))
+        )
+        .then(() => firstChangeStream.hasNext())
+        .then(hasNext => {
+          assert.equal(true, hasNext);
+          return firstChangeStream.next();
+        })
+        .then(change => {
           expect(change).to.have.property('operationType', 'insert');
-          expect(change).to.have.nested.property('fullDocument.a', 1);
-          expect(change).to.have.nested.property('ns.db', 'integration_tests');
-          expect(change).to.have.nested.property('ns.coll', 'invalidateListeners');
+          expect(change).to.have.nested.property('fullDocument.a', docs[0].a);
+
+          // Save the resumeToken
+          resumeToken = change._id;
+          return firstChangeStream.next();
+        })
+        .then(change => {
+          expect(change).to.have.property('operationType', 'insert');
+          expect(change).to.have.nested.property('fullDocument.a', docs[1].a);
+
+          return firstChangeStream.next();
+        })
+        .then(change => {
+          expect(change).to.have.property('operationType', 'insert');
+          expect(change).to.have.nested.property('fullDocument.a', docs[2].a);
+
+          return firstChangeStream.close();
+        })
+        .then(() => {
+          secondChangeStream = collection.watch(pipeline, {
+            resumeAfter: resumeToken
+          });
+          this.defer(() => secondChangeStream.close());
+
+          return initIteratorMode(secondChangeStream).then(() => delay(200));
+        })
+        .then(() => secondChangeStream.hasNext())
+        .then(hasNext => {
+          assert.equal(true, hasNext);
+          return secondChangeStream.next();
+        })
+        .then(change => {
+          assert.equal(change.operationType, 'insert');
+          assert.equal(change.fullDocument.a, docs[1].a);
+          return secondChangeStream.next();
+        })
+        .then(change => {
+          assert.equal(change.operationType, 'insert');
+          assert.equal(change.fullDocument.a, docs[2].a);
+          return secondChangeStream.close();
+        });
+    }
+  });
+
+  it('should support full document lookup', {
+    metadata: { requires: { topology: 'replicaset' } },
+    async test() {
+      const collection = db.collection('fullDocumentLookup');
+      const changeStream = collection.watch([], { fullDocument: 'updateLookup' });
+
+      await initIteratorMode(changeStream);
+
+      const { insertedId: _id } = await collection.insertOne({ f: 128 });
+
+      const insertChange = await changeStream.next();
+
+      expect(insertChange).to.have.property('operationType', 'insert');
+      expect(insertChange).to.have.nested.property('fullDocument.f', 128);
+      expect(insertChange).to.not.have.nested.property('fullDocument.c');
+
+      await collection.updateOne({ _id }, { $set: { c: 2 } });
+
+      const updateChange = await changeStream.next();
+
+      expect(updateChange).to.have.property('operationType', 'update');
+
+      expect(updateChange).to.have.property('fullDocument').that.is.a('object');
+      expect(updateChange).to.have.nested.property('fullDocument.f', 128);
+      expect(updateChange).to.have.nested.property('fullDocument.c', 2);
+      expect(updateChange).to.have.nested.property('updateDescription.updatedFields.c', 2);
+
+      await changeStream.close();
+    }
+  });
+
+  it('should support full document lookup with deleted documents', {
+    metadata: { requires: { topology: 'replicaset' } },
+
+    test: function () {
+      const database = client.db('integration_tests');
+      const collection = database.collection('fullLookupTest');
+      const changeStream = collection.watch(pipeline, { fullDocument: 'updateLookup' });
+
+      return initIteratorMode(changeStream)
+        .then(() =>
+          collection.insertMany([{ i: 128 }]).then(() => collection.deleteOne({ i: 128 }))
+        )
+        .then(() => changeStream.hasNext())
+        .then(function (hasNext) {
+          assert.equal(true, hasNext);
+          return changeStream.next();
+        })
+        .then(function (change) {
+          expect(change).to.have.property('operationType', 'insert');
+          expect(change).to.have.nested.property('fullDocument.i', 128);
+          expect(change).to.have.nested.property('ns.db', database.databaseName);
+          expect(change).to.have.nested.property('ns.coll', collection.collectionName);
           expect(change).to.not.have.property('documentKey');
           expect(change).to.have.property(
             'comment',
             'The documentKey field has been projected out of this document.'
           );
-
-          // Attach second event listener
-          changeStream.on('change', change => {
-            if (change.operationType === 'invalidate') {
-              // now expect the server to close the stream
-              changeStream.once('close', () => done());
-            }
-          });
-
           // Trigger the second database event
-          setTimeout(() => {
-            this.defer(
-              database.collection('invalidateListeners').rename('renamedDocs', { dropTarget: true })
-            );
-          }, 250);
+          return collection.updateOne({ i: 128 }, { $set: { c: 2 } });
+        })
+        .then(() => changeStream.hasNext())
+        .then(function (hasNext) {
+          assert.equal(true, hasNext);
+          return changeStream.next();
+        })
+        .then(function (change) {
+          expect(change).to.have.property('operationType', 'delete');
+          expect(change).to.not.have.property('lookedUpDocument');
+        })
+        .finally(() => {
+          return changeStream.close();
         });
-
-        // Trigger the first database event
-        waitForStarted(changeStream, () => {
-          this.defer(database.collection('invalidateListeners').insertMany([{ a: 1 }]));
-        });
-      });
-    }
-  });
-
-  it('should invalidate change stream on database drop using imperative callback form', {
-    metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
-
-    test: function (done) {
-      const configuration = this.configuration;
-      const client = configuration.newClient();
-
-      client.connect((err, client) => {
-        expect(err).to.not.exist;
-        this.defer(() => client.close());
-
-        const database = client.db('integration_tests');
-        const changeStream = database.collection('invalidateCallback').watch(pipeline);
-        this.defer(() => changeStream.close());
-
-        // Trigger the first database event
-        waitForStarted(changeStream, () => {
-          this.defer(database.collection('invalidateCallback').insertMany([{ a: 1 }]));
-        });
-
-        changeStream.next((err, change) => {
-          expect(err).to.not.exist;
-          assert.equal(change.operationType, 'insert');
-
-          database.dropDatabase(err => {
-            expect(err).to.not.exist;
-
-            function completeStream() {
-              changeStream.hasNext(function (err, hasNext) {
-                expect(err).to.not.exist;
-                assert.equal(hasNext, false);
-                assert.equal(changeStream.closed, true);
-                done();
-              });
-            }
-
-            function checkInvalidate() {
-              changeStream.next(function (err, change) {
-                expect(err).to.not.exist;
-
-                // Check the cursor invalidation has occured
-                if (change.operationType === 'invalidate') {
-                  return completeStream();
-                }
-
-                checkInvalidate();
-              });
-            }
-
-            checkInvalidate();
-          });
-        });
-      });
-    }
-  });
-
-  it('should invalidate change stream on collection drop using promises', {
-    metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
-
-    test: function (done) {
-      const configuration = this.configuration;
-      const client = configuration.newClient();
-
-      function checkInvalidate(changeStream) {
-        return changeStream.next().then(change => {
-          if (change.operationType === 'invalidate') {
-            return Promise.resolve();
-          }
-
-          return checkInvalidate(changeStream);
-        });
-      }
-
-      client.connect((err, client) => {
-        expect(err).to.not.exist;
-        this.defer(() => client.close());
-
-        const database = client.db('integration_tests');
-        const changeStream = database
-          .collection('invalidateCollectionDropPromises')
-          .watch(pipeline);
-        this.defer(() => changeStream.close());
-
-        // Trigger the first database event
-        waitForStarted(changeStream, () => {
-          this.defer(
-            database.collection('invalidateCollectionDropPromises').insertMany([{ a: 1 }])
-          );
-        });
-
-        return changeStream
-          .next()
-          .then(function (change) {
-            assert.equal(change.operationType, 'insert');
-            return database.dropCollection('invalidateCollectionDropPromises');
-          })
-          .then(() => checkInvalidate(changeStream))
-          .then(() => changeStream.hasNext())
-          .then(function (hasNext) {
-            assert.equal(hasNext, false);
-            assert.equal(changeStream.closed, true);
-            done();
-          });
-      });
-    }
-  });
-
-  it('should resume from point in time using user-provided resumeAfter', {
-    metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
-
-    test: function () {
-      const configuration = this.configuration;
-      const client = configuration.newClient();
-
-      return client.connect().then(client => {
-        this.defer(() => client.close());
-
-        const database = client.db('integration_tests');
-        const collection = database.collection('resumeAfterTest2');
-
-        let resumeToken;
-        const docs = [{ a: 0 }, { a: 1 }, { a: 2 }];
-
-        let secondChangeStream;
-        const firstChangeStream = collection.watch(pipeline);
-        this.defer(() => firstChangeStream.close());
-
-        // Trigger the first database event
-        waitForStarted(firstChangeStream, () => {
-          this.defer(
-            collection
-              .insertMany([docs[0]])
-              .then(() => collection.insertOne(docs[1]))
-              .then(() => collection.insertOne(docs[2]))
-          );
-        });
-
-        return firstChangeStream
-          .hasNext()
-          .then(hasNext => {
-            assert.equal(true, hasNext);
-            return firstChangeStream.next();
-          })
-          .then(change => {
-            expect(change).to.have.property('operationType', 'insert');
-            expect(change).to.have.nested.property('fullDocument.a', docs[0].a);
-
-            // Save the resumeToken
-            resumeToken = change._id;
-            return firstChangeStream.next();
-          })
-          .then(change => {
-            expect(change).to.have.property('operationType', 'insert');
-            expect(change).to.have.nested.property('fullDocument.a', docs[1].a);
-
-            return firstChangeStream.next();
-          })
-          .then(change => {
-            expect(change).to.have.property('operationType', 'insert');
-            expect(change).to.have.nested.property('fullDocument.a', docs[2].a);
-
-            return firstChangeStream.close();
-          })
-          .then(() => {
-            secondChangeStream = collection.watch(pipeline, {
-              resumeAfter: resumeToken
-            });
-            this.defer(() => secondChangeStream.close());
-
-            return delay(200);
-          })
-          .then(() => secondChangeStream.hasNext())
-          .then(hasNext => {
-            assert.equal(true, hasNext);
-            return secondChangeStream.next();
-          })
-          .then(change => {
-            assert.equal(change.operationType, 'insert');
-            assert.equal(change.fullDocument.a, docs[1].a);
-            return secondChangeStream.next();
-          })
-          .then(change => {
-            assert.equal(change.operationType, 'insert');
-            assert.equal(change.fullDocument.a, docs[2].a);
-            return secondChangeStream.close();
-          });
-      });
-    }
-  });
-
-  it('should support full document lookup', {
-    metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
-
-    test: function () {
-      const configuration = this.configuration;
-      const client = configuration.newClient();
-
-      return client.connect().then(client => {
-        this.defer(() => client.close());
-
-        const database = client.db('integration_tests');
-        const collection = database.collection('fullDocumentLookup');
-        const changeStream = collection.watch(pipeline, {
-          fullDocument: 'updateLookup'
-        });
-        this.defer(() => changeStream.close());
-
-        waitForStarted(changeStream, () => {
-          this.defer(collection.insertOne({ f: 128 }));
-        });
-
-        return changeStream
-          .hasNext()
-          .then(function (hasNext) {
-            assert.equal(true, hasNext);
-            return changeStream.next();
-          })
-          .then(function (change) {
-            expect(change).to.have.property('operationType', 'insert');
-            expect(change).to.have.nested.property('fullDocument.f', 128);
-            expect(change).to.have.nested.property('ns.db', database.databaseName);
-            expect(change).to.have.nested.property('ns.coll', collection.collectionName);
-            expect(change).to.not.have.property('documentKey');
-            expect(change).to.have.property(
-              'comment',
-              'The documentKey field has been projected out of this document.'
-            );
-            return collection.updateOne({ f: 128 }, { $set: { c: 2 } });
-          })
-          .then(function () {
-            return changeStream.next();
-          })
-          .then(function (change) {
-            assert.equal(change.operationType, 'update');
-
-            // Check the correct fullDocument is present
-            expect(change).to.have.property('fullDocument').that.is.a('object');
-            expect(change).to.have.nested.property('fullDocument.f', 128);
-            expect(change).to.have.nested.property('fullDocument.c', 2);
-          });
-      });
-    }
-  });
-
-  it('should support full document lookup with deleted documents', {
-    metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
-
-    test: function () {
-      const configuration = this.configuration;
-      const client = configuration.newClient();
-
-      return client.connect().then(client => {
-        this.defer(() => client.close());
-
-        const database = client.db('integration_tests');
-        const collection = database.collection('fullLookupTest');
-        const changeStream = collection.watch(pipeline, {
-          fullDocument: 'updateLookup'
-        });
-        this.defer(() => changeStream.close());
-
-        // Trigger the first database event
-        waitForStarted(changeStream, () => {
-          this.defer(
-            collection.insertMany([{ i: 128 }]).then(() => collection.deleteOne({ i: 128 }))
-          );
-        });
-
-        return changeStream
-          .hasNext()
-          .then(function (hasNext) {
-            assert.equal(true, hasNext);
-            return changeStream.next();
-          })
-          .then(function (change) {
-            expect(change).to.have.property('operationType', 'insert');
-            expect(change).to.have.nested.property('fullDocument.i', 128);
-            expect(change).to.have.nested.property('ns.db', database.databaseName);
-            expect(change).to.have.nested.property('ns.coll', collection.collectionName);
-            expect(change).to.not.have.property('documentKey');
-            expect(change).to.have.property(
-              'comment',
-              'The documentKey field has been projected out of this document.'
-            );
-            // Trigger the second database event
-            return collection.updateOne({ i: 128 }, { $set: { c: 2 } });
-          })
-          .then(() => changeStream.hasNext())
-          .then(function (hasNext) {
-            assert.equal(true, hasNext);
-            return changeStream.next();
-          })
-          .then(function (change) {
-            expect(change).to.have.property('operationType', 'delete');
-            expect(change).to.not.have.property('lookedUpDocument');
-          });
-      });
     }
   });
 
   it('should create Change Streams with correct read preferences', {
-    metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
+    metadata: { requires: { topology: 'replicaset' } },
 
     test: function () {
       const configuration = this.configuration;
@@ -1127,108 +743,70 @@ describe('Change Streams', function () {
   });
 
   it('should support piping of Change Streams', {
-    metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
+    metadata: { requires: { topology: 'replicaset' } },
 
-    test: function (done) {
-      const configuration = this.configuration;
-      const client = configuration.newClient();
+    async test() {
+      await initIteratorMode(changeStream);
 
-      client.connect((err, client) => {
-        expect(err).to.not.exist;
-        this.defer(() => client.close());
+      const outStream = new PassThrough({ objectMode: true });
 
-        const database = client.db('integration_tests');
-        const collection = database.collection('pipeTest');
-        const changeStream = collection.watch(pipeline);
-        this.defer(() => changeStream.close());
+      // @ts-expect-error: transform requires a Document return type
+      changeStream.stream({ transform: JSON.stringify }).pipe(outStream);
 
-        const outStream = new PassThrough({ objectMode: true });
+      const willBeData = once(outStream, 'data');
 
-        // Make a stream transforming to JSON and piping to the file
-        // @ts-expect-error: NODE-XXXX This is a type bug!!
-        changeStream.stream({ transform: JSON.stringify }).pipe(outStream);
+      await collection.insertMany([{ a: 1 }]);
 
-        outStream
-          .on('data', data => {
-            try {
-              const parsedEvent = JSON.parse(data);
-              assert.equal(parsedEvent.fullDocument.a, 1);
-              done();
-            } catch (e) {
-              done(e);
-            }
-          })
-          .on('error', done);
-
-        waitForStarted(changeStream, () => {
-          this.defer(collection.insertMany([{ a: 1 }]));
-        });
-      });
+      const [data] = await willBeData;
+      const parsedEvent = JSON.parse(data);
+      expect(parsedEvent).to.have.nested.property('fullDocument.a', 1);
     }
   });
 
-  it('should support piping of Change Streams through multiple pipes', {
-    metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
-    test: function (done) {
-      const configuration = this.configuration;
-      const client = configuration.newClient(configuration.url(), { maxPoolSize: 1 });
+  it.skip('should support piping of Change Streams through multiple pipes', {
+    metadata: { requires: { topology: 'replicaset' } },
+    async test() {
+      const cipher = crypto.createCipher('aes192', 'a password');
+      const decipher = crypto.createDecipher('aes192', 'a password');
 
-      client.connect((err, client) => {
-        expect(err).to.not.exist;
-        this.defer(() => client.close());
+      // Make a stream transforming to JSON and piping to the file
+      const stream = changeStream.stream();
+      const basicStream = stream.pipe(
+        new Transform({
+          transform: (data, encoding, callback) => callback(null, JSON.stringify(data)),
+          objectMode: true
+        })
+      );
+      const pipedStream = basicStream.pipe(cipher).pipe(decipher);
+      pipedStream.setEncoding('utf8');
 
-        const cipher = crypto.createCipher('aes192', 'a password');
-        const decipher = crypto.createDecipher('aes192', 'a password');
+      const dataIterator = on(pipedStream, 'data');
+      const willBeEnd = once(pipedStream, 'end');
 
-        const database = client.db('integration_tests');
-        const collection = database.collection('multiPipeTest');
-        const changeStream = collection.watch(pipeline);
-        this.defer(() => changeStream.close());
+      await collection.insertMany([{ a: 1407 }]);
+      let dataEmitted = '';
+      let parsedData;
+      for await (const data of dataIterator) {
+        dataEmitted += data;
+        try {
+          parsedData = JSON.parse(dataEmitted);
+          break;
+        } catch {
+          continue;
+        }
+      }
 
-        // Make a stream transforming to JSON and piping to the file
-        const stream = changeStream.stream();
-        const basicStream = stream.pipe(
-          new Transform({
-            transform: (data, encoding, callback) => callback(null, JSON.stringify(data)),
-            objectMode: true
-          })
-        );
-        const pipedStream = basicStream.pipe(cipher).pipe(decipher);
+      stream.emit('end');
+      await willBeEnd;
 
-        let dataEmitted = '';
-        pipedStream.on('data', function (data) {
-          dataEmitted += data.toString();
-
-          // Work around poor compatibility with crypto cipher
-          stream.emit('end');
-        });
-
-        pipedStream.on('end', function () {
-          const parsedData = JSON.parse(dataEmitted.toString());
-          assert.equal(parsedData.operationType, 'insert');
-          assert.equal(parsedData.fullDocument.a, 1407);
-
-          basicStream.emit('close');
-          done();
-        });
-
-        pipedStream.on('error', err => {
-          done(err);
-        });
-
-        waitForStarted(changeStream, () => {
-          this.defer(collection.insertMany([{ a: 1407 }]));
-        });
-      });
+      expect(parsedData).to.have.nested.property('operationType', 'insert');
+      expect(parsedData).to.have.nested.property('fullDocument.a', 1407);
     }
-  });
+  }).skipReason = 'I am unable to get the data event to emit';
 
   it('should maintain change stream options on resume', {
-    metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
-    test: function () {
-      const configuration = this.configuration;
-      const client = configuration.newClient();
-
+    metadata: { requires: { topology: 'replicaset' } },
+    async test() {
       const collectionName = 'resumeAfterKillCursor';
       const changeStreamOptions: ChangeStreamOptions = {
         fullDocument: 'updateLookup',
@@ -1237,21 +815,21 @@ describe('Change Streams', function () {
         batchSize: 200
       };
 
-      return client.connect().then(() => {
-        this.defer(() => client.close());
+      const db = client.db('integration_tests');
+      const coll = db.collection(collectionName);
+      const changeStream = coll.watch([], changeStreamOptions);
 
-        const db = client.db('integration_tests');
-        const coll = db.collection(collectionName);
-        const changeStream = coll.watch([], changeStreamOptions);
-        this.defer(() => changeStream.close());
+      await initIteratorMode(changeStream);
+      await changeStream.tryNext();
 
-        expect(changeStream.cursor.resumeOptions).to.containSubset(changeStreamOptions);
-      });
+      expect(changeStream.cursor.resumeOptions).to.containSubset(changeStreamOptions);
+
+      await changeStream.close();
     }
   });
 
   describe('should error when used as iterator and emitter concurrently', function () {
-    let client, coll, changeStream, kMode, initPromise;
+    let client, coll, changeStream, kMode;
 
     beforeEach(async function () {
       client = this.configuration.newClient();
@@ -1260,44 +838,23 @@ describe('Change Streams', function () {
       coll = client.db(this.configuration.db).collection('tester');
       changeStream = coll.watch();
       kMode = getSymbolFrom(changeStream, 'mode');
-      initPromise = new Promise<void>(resolve => waitForStarted(changeStream, resolve));
     });
 
     afterEach(async function () {
-      let err;
-      if (changeStream) {
-        try {
-          if (changeStream[kMode] === 'emitter') {
-            // shutting down the client will end the session, if this happens before
-            // the stream initialization aggregate operation is processed, it will throw
-            // a session ended error, which can't be caught if we end the stream, so
-            // we need to wait for the stream to initialize before closing all the things
-            await initPromise;
-          }
-          await changeStream.close();
-        } catch (error) {
-          // don't throw before closing the client
-          err = error;
-        }
-      }
-
-      if (client) {
-        await client.close();
-      }
-
-      if (err) {
-        throw err;
-      }
+      await changeStream.close();
+      await client?.close();
     });
 
-    it(`should throw when mixing event listeners with iterator methods`, {
-      metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
+    it('should throw when mixing event listeners with iterator methods', {
+      metadata: { requires: { topology: 'replicaset' } },
       async test() {
         expect(changeStream).to.have.property(kMode, false);
         changeStream.on('change', () => {
           // ChangeStream detects emitter usage via 'newListener' event
           // so this covers all emitter methods
         });
+
+        await once(changeStream.cursor, 'init');
         expect(changeStream).to.have.property(kMode, 'emitter');
 
         const errRegex = /ChangeStream cannot be used as an iterator/;
@@ -1315,9 +872,10 @@ describe('Change Streams', function () {
       }
     });
 
-    it(`should throw when mixing iterator methods with event listeners`, {
-      metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
+    it('should throw when mixing iterator methods with event listeners', {
+      metadata: { requires: { topology: 'replicaset' } },
       async test() {
+        await initIteratorMode(changeStream);
         expect(changeStream).to.have.property(kMode, false);
         const res = await changeStream.tryNext();
         expect(res).to.not.exist;
@@ -1346,12 +904,6 @@ describe('Change Streams', function () {
     function lastWrite() {
       return coll.insertOne({ c: 3 });
     }
-
-    beforeEach(
-      skipBrokenAuthTestBeforeEachHook({
-        skippedTests: ['when invoked using eventEmitter API']
-      })
-    );
 
     beforeEach(function () {
       client = this.configuration.newClient();
@@ -1382,7 +934,7 @@ describe('Change Streams', function () {
     });
 
     it('when invoked with promises', {
-      metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
+      metadata: { requires: { topology: 'replicaset' } },
       test: function () {
         const read = () => {
           return Promise.resolve()
@@ -1403,7 +955,7 @@ describe('Change Streams', function () {
     });
 
     it('when invoked with callbacks', {
-      metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
+      metadata: { requires: { topology: 'replicaset' } },
       test: function (done) {
         const ops = [];
         changeStream.next(() => {
@@ -1434,240 +986,180 @@ describe('Change Streams', function () {
       }
     });
 
-    it('when invoked using eventEmitter API', {
+    it.skip('when invoked using eventEmitter API', {
       metadata: {
-        requires: { topology: 'replicaset', mongodb: '>=3.6', auth: 'disabled' }
+        requires: { topology: 'replicaset' }
       },
-      test: function (done) {
-        let closed = false;
-        const close = _err => {
-          if (closed) {
-            return;
-          }
-          closed = true;
-          return done(_err);
-        };
+      async test() {
+        const changes = on(changeStream, 'change');
+        await once(changeStream.cursor, 'init');
+
+        await write();
+        await lastWrite().catch(() => null);
 
         let counter = 0;
-        changeStream.on('change', () => {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        for await (const _ of changes) {
           counter += 1;
           if (counter === 2) {
-            changeStream.close(close);
-          } else if (counter >= 3) {
-            close(new Error('Should not have received more than 2 events'));
+            await changeStream.close();
+            break;
           }
-        });
-        changeStream.on('error', err => close(err));
+        }
 
-        waitForStarted(changeStream, () =>
-          write()
-            .then(() => lastWrite())
-            .catch(() => {
-              // ignore
-            })
-        );
+        const result = await Promise.race([changes.next(), sleep(800).then(() => 42)]);
+        expect(result, 'should not have recieved a third event').to.equal(42);
+      }
+    }).skipReason =
+      'This test only worked because of timing, changeStream.close does not remove the change listener';
+  });
+
+  describe('#tryNext()', function () {
+    it('should return null on single iteration of empty cursor', {
+      metadata: { requires: { topology: 'replicaset' } },
+      async test() {
+        const doc = await changeStream.tryNext();
+        expect(doc).to.be.null;
+      }
+    });
+
+    it('should iterate a change stream until first empty batch', {
+      metadata: { requires: { topology: 'replicaset' } },
+      async test() {
+        // tryNext doesn't send the initial agg, just checks the driver document batch cache
+        const firstTry = await changeStream.tryNext();
+        expect(firstTry).to.be.null;
+
+        await initIteratorMode(changeStream);
+        await collection.insertOne({ a: 42 });
+
+        const secondTry = await changeStream.tryNext();
+        expect(secondTry).to.be.an('object');
+
+        const thirdTry = await changeStream.tryNext();
+        expect(thirdTry).to.be.null;
       }
     });
   });
 
-  describe('tryNext', function () {
-    it('should return null on single iteration of empty cursor', {
-      metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
-      test: withChangeStream((collection, changeStream, done) => {
-        tryNext(changeStream, (err, doc) => {
-          expect(err).to.not.exist;
-          expect(doc).to.not.exist;
-          done();
-        });
-      })
-    });
-
-    it('should iterate a change stream until first empty batch', {
-      metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
-      test: withChangeStream((collection, changeStream, done) => {
-        waitForStarted(changeStream, () => {
-          collection.insertOne({ a: 42 }, err => {
-            expect(err).to.not.exist;
-
-            collection.insertOne({ b: 24 }, err => {
-              expect(err).to.not.exist;
-            });
-          });
-        });
-
-        tryNext(changeStream, (err, doc) => {
-          expect(err).to.not.exist;
-          expect(doc).to.exist;
-
-          tryNext(changeStream, (err, doc) => {
-            expect(err).to.not.exist;
-            expect(doc).to.exist;
-
-            tryNext(changeStream, (err, doc) => {
-              expect(err).to.not.exist;
-              expect(doc).to.not.exist;
-
-              done();
-            });
-          });
-        });
-      })
-    });
-  });
-
   describe('startAfter', function () {
-    let client;
-    let coll;
-    let startAfter;
+    let client: MongoClient;
+    let collection: Collection;
+    let startAfter: ResumeToken;
+    let changeStream;
 
-    beforeEach(function (done) {
-      const configuration = this.configuration;
-      client = configuration.newClient({ monitorCommands: true });
-      client.connect(err => {
-        expect(err).to.not.exist;
-        coll = client.db('integration_tests').collection('setupAfterTest');
-        const changeStream = coll.watch();
-        waitForStarted(changeStream, () => {
-          coll.insertOne({ x: 1 }, { writeConcern: { w: 'majority', j: true } }, err => {
-            expect(err).to.not.exist;
+    beforeEach(async function () {
+      client = this.configuration.newClient();
+      collection = db.collection('setupAfterTest');
+      const changeStreamForResumeToken = collection.watch();
 
-            coll.drop(err => {
-              expect(err).to.not.exist;
-            });
-          });
-        });
+      const changes = on(changeStreamForResumeToken, 'change');
+      await once(changeStreamForResumeToken.cursor, 'init');
 
-        changeStream.on('change', change => {
-          if (change.operationType === 'invalidate') {
-            startAfter = change._id;
-            changeStream.close(done);
-          }
-        });
-      });
+      await collection.insertOne({ x: 1 }); // ensure ns exists
+      await collection.drop(); // invalidate this change stream
+
+      for await (const [change] of changes) {
+        if (change.operationType === 'invalidate') {
+          startAfter = change._id;
+          break;
+        }
+      }
+
+      await changeStreamForResumeToken.close();
+      changeStream = collection.watch([], { startAfter });
     });
 
-    afterEach(function (done) {
-      client.close(done);
+    afterEach(async function () {
+      await changeStream.close();
+      await client?.close();
     });
 
     it('should work with events', {
       metadata: { requires: { topology: 'replicaset', mongodb: '>=4.1.1' } },
-      test: function (done) {
-        const changeStream = coll.watch([], { startAfter });
-        this.defer(() => changeStream.close());
+      async test() {
+        const willBeChange = once(changeStream, 'change');
+        await once(changeStream.cursor, 'init');
+        await collection.insertOne({ x: 2 });
 
-        coll.insertOne({ x: 2 }, { writeConcern: { w: 'majority', j: true } }, err => {
-          expect(err).to.not.exist;
-          changeStream.once('change', change => {
-            expect(change).to.containSubset({
-              operationType: 'insert',
-              fullDocument: { x: 2 }
-            });
-
-            done();
-          });
-        });
+        const [change] = await willBeChange;
+        expect(change).to.have.property('operationType', 'insert');
+        expect(change).to.have.nested.property('fullDocument.x', 2);
       }
     });
 
     it('should work with callbacks', {
       metadata: { requires: { topology: 'replicaset', mongodb: '>=4.1.1' } },
-      test: function (done) {
-        const changeStream = coll.watch([], { startAfter });
-        this.defer(() => changeStream.close());
+      async test() {
+        await initIteratorMode(changeStream);
 
-        coll.insertOne({ x: 2 }, { writeConcern: { w: 'majority', j: true } }, err => {
-          expect(err).to.not.exist;
-          exhaust(changeStream, [], (err, bag) => {
-            expect(err).to.not.exist;
-            const finalOperation = bag.pop();
-            expect(finalOperation).to.containSubset({
-              operationType: 'insert',
-              fullDocument: { x: 2 }
-            });
+        await collection.insertOne({ x: 2 });
 
-            done();
-          });
-        });
+        const change = await changeStream.next();
+        expect(change).to.have.property('operationType', 'insert');
+        expect(change).to.have.nested.property('fullDocument.x', 2);
       }
     });
   });
 
   describe('Change Stream Resume Error Tests', function () {
     it('should continue emitting change events after a resumable error', {
-      metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
-      test: withChangeStream((collection, changeStream, done) => {
-        const docs = [];
-        changeStream.on('change', change => {
-          expect(change).to.exist;
-          docs.push(change);
-          if (docs.length === 2) {
-            expect(docs[0]).to.containSubset({
-              operationType: 'insert',
-              fullDocument: { a: 42 }
-            });
-            expect(docs[1]).to.containSubset({
-              operationType: 'insert',
-              fullDocument: { b: 24 }
-            });
-            done();
-          }
-        });
+      metadata: { requires: { topology: 'replicaset', mongodb: '>3.6' } },
+      async test() {
+        const changes = on(changeStream, 'change');
+        await once(changeStream.cursor, 'init');
 
-        waitForStarted(changeStream, () => {
-          collection.insertOne({ a: 42 }, err => {
-            expect(err).to.not.exist;
-            triggerResumableError(changeStream, 1000, () => {
-              collection.insertOne({ b: 24 }, err => {
-                expect(err).to.not.exist;
-              });
-            });
-          });
-        });
-      })
+        await collection.insertOne({ a: 42 });
+
+        changeStream.cursorStream.emit('error', new MongoNetworkError('error triggered from test'));
+
+        await collection.insertOne({ b: 24 });
+
+        const changesCollected = [];
+        for await (const [change] of changes) {
+          changesCollected.push(change);
+          if (changesCollected.length === 2) {
+            break;
+          }
+        }
+
+        expect(changesCollected[0]).to.have.nested.property('fullDocument.a');
+        expect(changesCollected[1]).to.have.nested.property('fullDocument.b');
+      }
     });
 
     it('should continue iterating changes after a resumable error', {
-      metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
-      test: withChangeStream((collection, changeStream, done) => {
-        waitForStarted(changeStream, () => {
-          collection.insertOne({ a: 42 }, err => {
-            expect(err).to.not.exist;
-            triggerResumableError(changeStream, 250, () => {
-              changeStream.hasNext((err1, hasNext) => {
-                expect(err1).to.not.exist;
-                expect(hasNext).to.be.true;
-                changeStream.next((err, change) => {
-                  expect(err).to.not.exist;
-                  expect(change).to.containSubset({
-                    operationType: 'insert',
-                    fullDocument: { b: 24 }
-                  });
-                  done();
-                });
-              });
-              collection.insertOne({ b: 24 });
-            });
-          });
-        });
+      metadata: { requires: { topology: 'replicaset', mongodb: '>3.6' } },
+      async test() {
+        await initIteratorMode(changeStream);
+        await collection.insertOne({ a: 42 });
 
-        changeStream.hasNext((err, hasNext) => {
-          expect(err).to.not.exist;
-          expect(hasNext).to.be.true;
-          changeStream.next((err, change) => {
-            expect(err).to.not.exist;
-            expect(change).to.containSubset({
-              operationType: 'insert',
-              fullDocument: { a: 42 }
-            });
-          });
-        });
-      })
+        // NOTE the error comes from cursor.next. ChangeStream squashes it
+        const oldNext = changeStream.cursor.next.bind(changeStream.cursor);
+
+        // @ts-expect-error: simulating network error
+        changeStream.cursor.next = function (callback) {
+          changeStream.cursor.next = oldNext;
+          return callback(new MongoNetworkError('error triggered from test'));
+        };
+
+        await changeStream.hasNext();
+        const changeA = await changeStream.next();
+        expect(changeA).to.have.property('operationType', 'insert');
+        expect(changeA).to.have.nested.property('fullDocument.a', 42);
+
+        await collection.insertOne({ b: 24 });
+
+        await changeStream.hasNext();
+        const changeB = await changeStream.next();
+        expect(changeB).to.have.property('operationType', 'insert');
+        expect(changeB).to.have.nested.property('fullDocument.b', 24);
+      }
     });
 
     it.skip('should continue piping changes after a resumable error', {
-      metadata: { requires: { topology: 'replicaset', mongodb: '>=3.6' } },
-      test: withChangeStream((collection, changeStream, done) => {
+      metadata: { requires: { topology: 'replicaset' } },
+      test: done => {
         const d = new PassThrough({ objectMode: true });
         const bucket = [];
         d.on('data', data => {
@@ -1679,19 +1171,19 @@ describe('Change Streams', function () {
           }
         });
         changeStream.stream().pipe(d);
-        waitForStarted(changeStream, () => {
-          collection.insertOne({ x: 1 }, (err, result) => {
-            expect(err).to.not.exist;
-            expect(result).to.exist;
-            triggerResumableError(changeStream, 250, () => {
-              collection.insertOne({ x: 2 }, (err, result) => {
-                expect(err).to.not.exist;
-                expect(result).to.exist;
-              });
-            });
-          });
-        });
-      })
+        // waitForStarted(changeStream, () => {
+        //   collection.insertOne({ x: 1 }, (err, result) => {
+        //     expect(err).to.not.exist;
+        //     expect(result).to.exist;
+        //     triggerResumableError(changeStream, 250, () => {
+        //       collection.insertOne({ x: 2 }, (err, result) => {
+        //         expect(err).to.not.exist;
+        //         expect(result).to.exist;
+        //       });
+        //     });
+        //   });
+        // });
+      }
     }).skipReason = 'TODO(NODE-3884): Fix when implementing prose case #3';
 
     describe('NODE-2626 - handle null changes without error', function () {
@@ -2077,6 +1569,7 @@ describe('Change Streams', function () {
 
           client.on('commandStarted', filterForCommands(['aggregate'], started));
           const doc = { invalidBSONOption: true };
+          // @ts-expect-error: checking for invalid options
           cs = collection.watch([], doc);
 
           const willBeChange = once(cs, 'change').then(args => args[0]);
@@ -2097,6 +1590,7 @@ describe('Change Streams', function () {
 
           client.on('commandStarted', filterForCommands(['aggregate'], started));
           const doc = { invalidBSONOption: true };
+          // @ts-expect-error: checking for invalid options
           cs = collection.watch([], doc);
 
           const willBeChange = once(cs, 'change').then(args => args[0]);

--- a/test/integration/change-streams/change_streams.spec.test.ts
+++ b/test/integration/change-streams/change_streams.spec.test.ts
@@ -7,31 +7,8 @@ import { loadSpecTests } from '../../spec';
 import { runUnifiedSuite } from '../../tools/unified-spec-runner/runner';
 import { delay, setupDatabase } from '../shared';
 
-// TODO(NODE-4126): Fix change stream resumabilty in iterator mode
-const skippedResumabilityTests = [
-  'change stream resumes after HostUnreachable',
-  'change stream resumes after HostNotFound',
-  'change stream resumes after NetworkTimeout',
-  'change stream resumes after ShutdownInProgress',
-  'change stream resumes after PrimarySteppedDown',
-  'change stream resumes after ExceededTimeLimit',
-  'change stream resumes after SocketException',
-  'change stream resumes after NotWritablePrimary',
-  'change stream resumes after InterruptedAtShutdown',
-  'change stream resumes after InterruptedDueToReplStateChange',
-  'change stream resumes after NotPrimaryNoSecondaryOk',
-  'change stream resumes after NotPrimaryOrSecondary',
-  'change stream resumes after StaleShardVersion',
-  'change stream resumes after StaleEpoch',
-  'change stream resumes after RetryChangeStream',
-  'change stream resumes after FailedToSatisfyReadPreference',
-  'change stream resumes if error contains ResumableChangeStreamError',
-  'change stream resumes after a network error',
-  'change stream resumes after CursorNotFound',
-  'Test consecutive resume'
-];
 describe('Change Streams Spec - Unified', function () {
-  runUnifiedSuite(loadSpecTests(path.join('change-streams', 'unified')), skippedResumabilityTests);
+  runUnifiedSuite(loadSpecTests(path.join('change-streams', 'unified')));
 });
 
 // TODO(NODE-3819): Unskip flaky MacOS tests.

--- a/test/tools/unified-spec-runner/operations.ts
+++ b/test/tools/unified-spec-runner/operations.ts
@@ -322,7 +322,7 @@ operations.set('iterateUntilDocumentOrError', async ({ entities, operation }) =>
     return await cursor.next();
   }
 
-  return changeStream.cursor.next();
+  return changeStream.next();
 });
 
 operations.set('listCollections', async ({ entities, operation }) => {

--- a/test/unit/change_stream.test.ts
+++ b/test/unit/change_stream.test.ts
@@ -7,7 +7,10 @@ import { MongoClient } from '../../src/mongo_client';
 import { MongoDBNamespace } from '../../src/utils';
 
 describe('class ChangeStreamCursor', function () {
-  afterEach(() => sinon.restore());
+  afterEach(function () {
+    sinon.restore();
+  });
+
   describe('get resumeOptions()', function () {
     context('non-resume related options', function () {
       it('copies all options from the original cursor', function () {
@@ -25,9 +28,11 @@ describe('class ChangeStreamCursor', function () {
         });
       });
     });
+
     context('when there is a cached resumeToken', function () {
       context('when the cursor was started with startAfter', function () {
         let cursor: ChangeStreamCursor;
+
         beforeEach(function () {
           cursor = new ChangeStreamCursor(
             new MongoClient('mongodb://localhost:27027'),
@@ -37,6 +42,7 @@ describe('class ChangeStreamCursor', function () {
           );
           cursor.resumeToken = 'resume token';
         });
+
         context('when the cursor has not yet returned a document', function () {
           beforeEach(function () {
             cursor.hasReceived = false;
@@ -103,6 +109,7 @@ describe('class ChangeStreamCursor', function () {
           );
           cursor.resumeToken = 'resume token';
         });
+
         it('sets the resumeAfter option to the cached resumeToken', function () {
           expect(cursor.resumeOptions).to.haveOwnProperty('resumeAfter', 'resume token');
         });
@@ -132,7 +139,6 @@ describe('class ChangeStreamCursor', function () {
       context('when the cursor has a saved operation time', function () {
         context('when the maxWireVersion >= 7', function () {
           let cursor: ChangeStreamCursor;
-
           beforeEach(function () {
             cursor = new ChangeStreamCursor(
               new MongoClient('mongodb://localhost:27027'),
@@ -144,17 +150,18 @@ describe('class ChangeStreamCursor', function () {
                 startAtOperationTime: new Timestamp(Long.ZERO)
               }
             );
-
             cursor.resumeToken = null;
-
             sinon.stub(cursor, 'server').get(() => ({ hello: { maxWireVersion: 7 } }));
           });
+
           it('does NOT set the resumeAfter option', function () {
             expect(cursor.resumeOptions).not.to.haveOwnProperty('resumeAfter');
           });
+
           it('does NOT set the startAfter option', function () {
             expect(cursor.resumeOptions).not.to.haveOwnProperty('startAfter');
           });
+
           it('does set the startAtOperationTime option', function () {
             expect(cursor.resumeOptions).to.haveOwnProperty('startAtOperationTime');
           });
@@ -162,7 +169,6 @@ describe('class ChangeStreamCursor', function () {
 
         context('when the maxWireVersion < 7', function () {
           let cursor: ChangeStreamCursor;
-
           beforeEach(function () {
             cursor = new ChangeStreamCursor(
               new MongoClient('mongodb://localhost:27027'),
@@ -174,17 +180,18 @@ describe('class ChangeStreamCursor', function () {
                 startAtOperationTime: new Timestamp(Long.ZERO)
               }
             );
-
             cursor.resumeToken = null;
-
             sinon.stub(cursor, 'server').get(() => ({ hello: { maxWireVersion: 6 } }));
           });
+
           it('does NOT set the resumeAfter option', function () {
             expect(cursor.resumeOptions).not.to.haveOwnProperty('resumeAfter');
           });
+
           it('does NOT set the startAfter option', function () {
             expect(cursor.resumeOptions).not.to.haveOwnProperty('startAfter');
           });
+
           it('does NOT set the startAtOperationTime option', function () {
             expect(cursor.resumeOptions).not.to.haveOwnProperty('startAtOperationTime');
           });
@@ -194,7 +201,6 @@ describe('class ChangeStreamCursor', function () {
       context('when the cursor does NOT have a saved operation time', function () {
         context('when the maxWireVersion >= 7', function () {
           let cursor: ChangeStreamCursor;
-
           beforeEach(function () {
             cursor = new ChangeStreamCursor(
               new MongoClient('mongodb://localhost:27027'),
@@ -205,17 +211,18 @@ describe('class ChangeStreamCursor', function () {
                 resumeAfter: 'resume after'
               }
             );
-
             cursor.resumeToken = null;
-
             sinon.stub(cursor, 'server').get(() => ({ hello: { maxWireVersion: 7 } }));
           });
+
           it('does NOT set the resumeAfter option', function () {
             expect(cursor.resumeOptions).not.to.haveOwnProperty('resumeAfter');
           });
+
           it('does NOT set the startAfter option', function () {
             expect(cursor.resumeOptions).not.to.haveOwnProperty('startAfter');
           });
+
           it('does NOT set the startAtOperationTime option', function () {
             expect(cursor.resumeOptions).not.to.haveOwnProperty('startAtOperationTime');
           });
@@ -223,7 +230,6 @@ describe('class ChangeStreamCursor', function () {
 
         context('when the maxWireVersion < 7', function () {
           let cursor: ChangeStreamCursor;
-
           beforeEach(function () {
             cursor = new ChangeStreamCursor(
               new MongoClient('mongodb://localhost:27027'),
@@ -235,17 +241,18 @@ describe('class ChangeStreamCursor', function () {
                 startAtOperationTime: new Timestamp(Long.ZERO)
               }
             );
-
             cursor.resumeToken = null;
-
             sinon.stub(cursor, 'server').get(() => ({ hello: { maxWireVersion: 6 } }));
           });
+
           it('does NOT set the resumeAfter option', function () {
             expect(cursor.resumeOptions).not.to.haveOwnProperty('resumeAfter');
           });
+
           it('does NOT set the startAfter option', function () {
             expect(cursor.resumeOptions).not.to.haveOwnProperty('startAfter');
           });
+
           it('does NOT set the startAtOperationTime option', function () {
             expect(cursor.resumeOptions).not.to.haveOwnProperty('startAtOperationTime');
           });

--- a/test/unit/change_stream.test.ts
+++ b/test/unit/change_stream.test.ts
@@ -6,7 +6,7 @@ import { ChangeStreamCursor } from '../../src/change_stream';
 import { MongoClient } from '../../src/mongo_client';
 import { MongoDBNamespace } from '../../src/utils';
 
-describe('class ChangeStreamCursor', function () {
+describe('ChangeStreamCursor', function () {
   afterEach(function () {
     sinon.restore();
   });

--- a/test/unit/change_stream.test.ts
+++ b/test/unit/change_stream.test.ts
@@ -4,13 +4,9 @@ import * as sinon from 'sinon';
 
 import { ChangeStreamCursor } from '../../src/change_stream';
 import { MongoClient } from '../../src/mongo_client';
-import { Server } from '../../src/sdam/server';
-import { ServerDescription } from '../../src/sdam/server_description';
-import { Topology } from '../../src/sdam/topology';
 import { MongoDBNamespace } from '../../src/utils';
-import { getSymbolFrom } from '../tools/utils';
 
-describe.only('class ChangeStreamCursor', function () {
+describe('class ChangeStreamCursor', function () {
   afterEach(() => sinon.restore());
   describe('get resumeOptions()', function () {
     context('non-resume related options', function () {

--- a/test/unit/change_stream.test.ts
+++ b/test/unit/change_stream.test.ts
@@ -26,7 +26,7 @@ describe('class ChangeStreamCursor', function () {
       });
     });
     context('when there is a cached resumeToken', function () {
-      context('when startAfter is set', function () {
+      context('when the cursor was started with startAfter', function () {
         let cursor: ChangeStreamCursor;
         beforeEach(function () {
           cursor = new ChangeStreamCursor(
@@ -37,42 +37,69 @@ describe('class ChangeStreamCursor', function () {
           );
           cursor.resumeToken = 'resume token';
         });
-        it('sets the startAfter option to the cached resumeToken', function () {
-          expect(cursor.resumeOptions).to.haveOwnProperty('startAfter', 'resume token');
-        });
-        it('does NOT set the resumeAfter option', function () {
-          expect(cursor.resumeOptions).not.to.haveOwnProperty('resumeAfter');
-        });
+        context('when the cursor has not yet returned a document', function () {
+          beforeEach(function () {
+            cursor.hasReceived = false;
+          });
 
-        context('when the startAtOperationTime option is NOT set', function () {
-          it('does not set the startAtOperationTime option', function () {
-            expect(cursor.resumeOptions).not.to.haveOwnProperty('startAtOperationTime');
+          it('sets the startAfter option to the cached resumeToken', function () {
+            expect(cursor.resumeOptions).to.haveOwnProperty('startAfter', 'resume token');
+          });
+
+          it('does NOT set the resumeAfter option', function () {
+            expect(cursor.resumeOptions).not.to.haveOwnProperty('resumeAfter');
+          });
+
+          context('when the startAtOperationTime option is NOT set', function () {
+            it('does NOT set the startAtOperationTime option', function () {
+              expect(cursor.resumeOptions).not.to.haveOwnProperty('startAtOperationTime');
+            });
+          });
+
+          context('when the startAtOperationTime option is set', function () {
+            it('does NOT set the startAtOperationTime option', function () {
+              cursor.startAtOperationTime = new Timestamp(Long.ZERO);
+              expect(cursor.resumeOptions).not.to.haveOwnProperty('startAtOperationTime');
+            });
           });
         });
 
-        context('when the startAtOperationTime option is set', function () {
-          it('does not set the startAtOperationTime option', function () {
-            const cursor = new ChangeStreamCursor(
-              new MongoClient('mongodb://localhost:27027'),
-              new MongoDBNamespace('db', 'collection'),
-              [],
-              { startAfter: 'start after', startAtOperationTime: new Timestamp(Long.ZERO) }
-            );
-            cursor.resumeToken = 'resume token';
+        context('when the cursor has returned a document', function () {
+          beforeEach(function () {
+            cursor.hasReceived = true;
+          });
 
-            expect(cursor.resumeOptions).not.to.haveOwnProperty('startAtOperationTime');
+          it('does NOT set the startAfter option', function () {
+            expect(cursor.resumeOptions).not.to.haveOwnProperty('startAfter');
+          });
+
+          it('sets the resumeAFter option to the cached resumeToken', function () {
+            expect(cursor.resumeOptions).to.haveOwnProperty('resumeAfter', 'resume token');
+          });
+
+          context('when the startAtOperationTime option is NOT set', function () {
+            it('does NOT set the startAtOperationTime option', function () {
+              expect(cursor.resumeOptions).not.to.haveOwnProperty('startAtOperationTime');
+            });
+          });
+
+          context('when the startAtOperationTime option is set', function () {
+            it('does NOT set the startAtOperationTime option', function () {
+              cursor.startAtOperationTime = new Timestamp(Long.ZERO);
+              expect(cursor.resumeOptions).not.to.haveOwnProperty('startAtOperationTime');
+            });
           });
         });
       });
 
-      context('when resumeAfter is set', function () {
+      context('when the cursor was not initialized with startAfter set', function () {
         let cursor: ChangeStreamCursor;
         beforeEach(function () {
           cursor = new ChangeStreamCursor(
             new MongoClient('mongodb://localhost:27027'),
             new MongoDBNamespace('db', 'collection'),
             [],
-            { resumeAfter: 'resume after' }
+            {}
           );
           cursor.resumeToken = 'resume token';
         });
@@ -84,31 +111,20 @@ describe('class ChangeStreamCursor', function () {
           expect(cursor.resumeOptions).not.to.haveOwnProperty('startAfter');
         });
 
-        context(
-          'when the startAtOperationTime option is NOT set on the aggregation pipeline',
-          function () {
-            it('does not set the startAtOperationTime option', function () {
-              expect(cursor.resumeOptions).not.to.haveOwnProperty('startAtOperationTime');
-            });
-          }
-        );
+        context('when the startAtOperationTime option is NOT set', function () {
+          it('does NOT set the startAtOperationTime option', function () {
+            expect(cursor.resumeOptions).not.to.haveOwnProperty('startAtOperationTime');
+          });
+        });
 
-        context(
-          'when the startAtOperationTime option is set on the aggregation pipeline',
-          function () {
-            it('does not set the startAtOperationTime option', function () {
-              const cursor = new ChangeStreamCursor(
-                new MongoClient('mongodb://localhost:27027'),
-                new MongoDBNamespace('db', 'collection'),
-                [],
-                { resumeAfter: 'resume after', startAtOperationTime: new Timestamp(Long.ZERO) }
-              );
-              cursor.resumeToken = 'resume token';
+        context('when the startAtOperationTime option is set', function () {
+          it('does NOT set the startAtOperationTime option', function () {
+            cursor.startAtOperationTime = new Timestamp(Long.ZERO);
+            cursor.resumeToken = 'resume token';
 
-              expect(cursor.resumeOptions).not.to.haveOwnProperty('startAtOperationTime');
-            });
-          }
-        );
+            expect(cursor.resumeOptions).not.to.haveOwnProperty('startAtOperationTime');
+          });
+        });
       });
     });
 
@@ -175,7 +191,7 @@ describe('class ChangeStreamCursor', function () {
         });
       });
 
-      context('when the cursor does not have a saved operation time', function () {
+      context('when the cursor does NOT have a saved operation time', function () {
         context('when the maxWireVersion >= 7', function () {
           let cursor: ChangeStreamCursor;
 

--- a/test/unit/change_stream.test.ts
+++ b/test/unit/change_stream.test.ts
@@ -1,0 +1,244 @@
+import { Long, Timestamp } from 'bson';
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+
+import { ChangeStreamCursor } from '../../src/change_stream';
+import { MongoClient } from '../../src/mongo_client';
+import { Server } from '../../src/sdam/server';
+import { ServerDescription } from '../../src/sdam/server_description';
+import { Topology } from '../../src/sdam/topology';
+import { MongoDBNamespace } from '../../src/utils';
+import { getSymbolFrom } from '../tools/utils';
+
+describe.only('class ChangeStreamCursor', function () {
+  afterEach(() => sinon.restore());
+  describe('get resumeOptions()', function () {
+    context('non-resume related options', function () {
+      it('copies all options from the original cursor', function () {
+        const cursor = new ChangeStreamCursor(
+          new MongoClient('mongodb://localhost:27027'),
+          new MongoDBNamespace('db', 'collection'),
+          [],
+          { promoteBuffers: true, promoteLongs: false, maxAwaitTimeMS: 5000 }
+        );
+
+        expect(cursor.resumeOptions).to.deep.equal({
+          promoteBuffers: true,
+          promoteLongs: false,
+          maxAwaitTimeMS: 5000
+        });
+      });
+    });
+    context('when there is a cached resumeToken', function () {
+      context('when startAfter is set', function () {
+        let cursor: ChangeStreamCursor;
+        beforeEach(function () {
+          cursor = new ChangeStreamCursor(
+            new MongoClient('mongodb://localhost:27027'),
+            new MongoDBNamespace('db', 'collection'),
+            [],
+            { startAfter: 'start after' }
+          );
+          cursor.resumeToken = 'resume token';
+        });
+        it('sets the startAfter option to the cached resumeToken', function () {
+          expect(cursor.resumeOptions).to.haveOwnProperty('startAfter', 'resume token');
+        });
+        it('does NOT set the resumeAfter option', function () {
+          expect(cursor.resumeOptions).not.to.haveOwnProperty('resumeAfter');
+        });
+
+        context('when the startAtOperationTime option is NOT set', function () {
+          it('does not set the startAtOperationTime option', function () {
+            expect(cursor.resumeOptions).not.to.haveOwnProperty('startAtOperationTime');
+          });
+        });
+
+        context('when the startAtOperationTime option is set', function () {
+          it('does not set the startAtOperationTime option', function () {
+            const cursor = new ChangeStreamCursor(
+              new MongoClient('mongodb://localhost:27027'),
+              new MongoDBNamespace('db', 'collection'),
+              [],
+              { startAfter: 'start after', startAtOperationTime: new Timestamp(Long.ZERO) }
+            );
+            cursor.resumeToken = 'resume token';
+
+            expect(cursor.resumeOptions).not.to.haveOwnProperty('startAtOperationTime');
+          });
+        });
+      });
+
+      context('when resumeAfter is set', function () {
+        let cursor: ChangeStreamCursor;
+        beforeEach(function () {
+          cursor = new ChangeStreamCursor(
+            new MongoClient('mongodb://localhost:27027'),
+            new MongoDBNamespace('db', 'collection'),
+            [],
+            { resumeAfter: 'resume after' }
+          );
+          cursor.resumeToken = 'resume token';
+        });
+        it('sets the resumeAfter option to the cached resumeToken', function () {
+          expect(cursor.resumeOptions).to.haveOwnProperty('resumeAfter', 'resume token');
+        });
+
+        it('does NOT set the startAfter option', function () {
+          expect(cursor.resumeOptions).not.to.haveOwnProperty('startAfter');
+        });
+
+        context(
+          'when the startAtOperationTime option is NOT set on the aggregation pipeline',
+          function () {
+            it('does not set the startAtOperationTime option', function () {
+              expect(cursor.resumeOptions).not.to.haveOwnProperty('startAtOperationTime');
+            });
+          }
+        );
+
+        context(
+          'when the startAtOperationTime option is set on the aggregation pipeline',
+          function () {
+            it('does not set the startAtOperationTime option', function () {
+              const cursor = new ChangeStreamCursor(
+                new MongoClient('mongodb://localhost:27027'),
+                new MongoDBNamespace('db', 'collection'),
+                [],
+                { resumeAfter: 'resume after', startAtOperationTime: new Timestamp(Long.ZERO) }
+              );
+              cursor.resumeToken = 'resume token';
+
+              expect(cursor.resumeOptions).not.to.haveOwnProperty('startAtOperationTime');
+            });
+          }
+        );
+      });
+    });
+
+    context('when there is no cached resumeToken', function () {
+      context('when the cursor has a saved operation time', function () {
+        context('when the maxWireVersion >= 7', function () {
+          let cursor: ChangeStreamCursor;
+
+          beforeEach(function () {
+            cursor = new ChangeStreamCursor(
+              new MongoClient('mongodb://localhost:27027'),
+              new MongoDBNamespace('db', 'collection'),
+              [],
+              {
+                startAfter: 'start after',
+                resumeAfter: 'resume after',
+                startAtOperationTime: new Timestamp(Long.ZERO)
+              }
+            );
+
+            cursor.resumeToken = null;
+
+            sinon.stub(cursor, 'server').get(() => ({ hello: { maxWireVersion: 7 } }));
+          });
+          it('does NOT set the resumeAfter option', function () {
+            expect(cursor.resumeOptions).not.to.haveOwnProperty('resumeAfter');
+          });
+          it('does NOT set the startAfter option', function () {
+            expect(cursor.resumeOptions).not.to.haveOwnProperty('startAfter');
+          });
+          it('does set the startAtOperationTime option', function () {
+            expect(cursor.resumeOptions).to.haveOwnProperty('startAtOperationTime');
+          });
+        });
+
+        context('when the maxWireVersion < 7', function () {
+          let cursor: ChangeStreamCursor;
+
+          beforeEach(function () {
+            cursor = new ChangeStreamCursor(
+              new MongoClient('mongodb://localhost:27027'),
+              new MongoDBNamespace('db', 'collection'),
+              [],
+              {
+                startAfter: 'start after',
+                resumeAfter: 'resume after',
+                startAtOperationTime: new Timestamp(Long.ZERO)
+              }
+            );
+
+            cursor.resumeToken = null;
+
+            sinon.stub(cursor, 'server').get(() => ({ hello: { maxWireVersion: 6 } }));
+          });
+          it('does NOT set the resumeAfter option', function () {
+            expect(cursor.resumeOptions).not.to.haveOwnProperty('resumeAfter');
+          });
+          it('does NOT set the startAfter option', function () {
+            expect(cursor.resumeOptions).not.to.haveOwnProperty('startAfter');
+          });
+          it('does NOT set the startAtOperationTime option', function () {
+            expect(cursor.resumeOptions).not.to.haveOwnProperty('startAtOperationTime');
+          });
+        });
+      });
+
+      context('when the cursor does not have a saved operation time', function () {
+        context('when the maxWireVersion >= 7', function () {
+          let cursor: ChangeStreamCursor;
+
+          beforeEach(function () {
+            cursor = new ChangeStreamCursor(
+              new MongoClient('mongodb://localhost:27027'),
+              new MongoDBNamespace('db', 'collection'),
+              [],
+              {
+                startAfter: 'start after',
+                resumeAfter: 'resume after'
+              }
+            );
+
+            cursor.resumeToken = null;
+
+            sinon.stub(cursor, 'server').get(() => ({ hello: { maxWireVersion: 7 } }));
+          });
+          it('does NOT set the resumeAfter option', function () {
+            expect(cursor.resumeOptions).not.to.haveOwnProperty('resumeAfter');
+          });
+          it('does NOT set the startAfter option', function () {
+            expect(cursor.resumeOptions).not.to.haveOwnProperty('startAfter');
+          });
+          it('does NOT set the startAtOperationTime option', function () {
+            expect(cursor.resumeOptions).not.to.haveOwnProperty('startAtOperationTime');
+          });
+        });
+
+        context('when the maxWireVersion < 7', function () {
+          let cursor: ChangeStreamCursor;
+
+          beforeEach(function () {
+            cursor = new ChangeStreamCursor(
+              new MongoClient('mongodb://localhost:27027'),
+              new MongoDBNamespace('db', 'collection'),
+              [],
+              {
+                startAfter: 'start after',
+                resumeAfter: 'resume after',
+                startAtOperationTime: new Timestamp(Long.ZERO)
+              }
+            );
+
+            cursor.resumeToken = null;
+
+            sinon.stub(cursor, 'server').get(() => ({ hello: { maxWireVersion: 6 } }));
+          });
+          it('does NOT set the resumeAfter option', function () {
+            expect(cursor.resumeOptions).not.to.haveOwnProperty('resumeAfter');
+          });
+          it('does NOT set the startAfter option', function () {
+            expect(cursor.resumeOptions).not.to.haveOwnProperty('startAfter');
+          });
+          it('does NOT set the startAtOperationTime option', function () {
+            expect(cursor.resumeOptions).not.to.haveOwnProperty('startAtOperationTime');
+          });
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
- remove calls to Reflect from the resume options getter
- deprecate the ResumeOptions interface
- make use of ChangeStreamCursorOptions instead of ResumeOptions internally### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
