### PR TITLE
chore(NODE-4285): rename csfle shared library references

### DIFF
--- a/src/deps.ts
+++ b/src/deps.ts
@@ -324,7 +324,7 @@ export interface AutoEncryptionOptions {
     /** Command line arguments to use when auto-spawning a mongocryptd */
     mongocryptdSpawnArgs?: string[];
     /**
-     * Full path to a CSFLE shared library to be used (instead of mongocryptd).
+     * Full path to a MongoDB Crypt shared library to be used (instead of mongocryptd).
      *
      * This needs to be the path to the file itself, not a directory.
      * It can be an absolute or relative path. If the path is relative and
@@ -332,32 +332,32 @@ export interface AutoEncryptionOptions {
      * containing the mongodb-client-encryption native addon file. Otherwise,
      * the path will be interpreted relative to the current working directory.
      *
-     * Currently, loading different CSFLE shared library files from different
+     * Currently, loading different MongoDB Crypt shared library files from different
      * MongoClients in the same process is not supported.
      *
-     * If this option is provided and no CSFLE shared library could be loaded
+     * If this option is provided and no MongoDB Crypt shared library could be loaded
      * from the specified location, creating the MongoClient will fail.
      *
-     * If this option is not provided and `csfleRequired` is not specified,
+     * If this option is not provided and `cryptSharedLibRequired` is not specified,
      * the AutoEncrypter will attempt to spawn and/or use mongocryptd according
      * to the mongocryptd-specific `extraOptions` options.
      *
      * Specifying a path prevents mongocryptd from being used as a fallback.
      */
-    csflePath?: string;
+    cryptSharedLibPath?: string;
     /**
-     * If specified, never use mongocryptd and instead fail when the CSFLE shared library
-     * could not be loaded.
+     * If specified, never use mongocryptd and instead fail when the MongoDB Crypt
+     * shared library could not be loaded.
      *
-     * This is always true when `csflePath` is specified.
+     * This is always true when `cryptSharedLibPath` is specified.
      */
-    csfleRequired?: boolean;
+    cryptSharedLibRequired?: boolean;
     /**
-     * Search paths for a CSFLE shared library to be used (instead of mongocryptd)
+     * Search paths for a MongoDB Crypt shared library to be used (instead of mongocryptd)
      * Only for driver testing!
      * @internal
      */
-    csfleSearchPaths?: string[];
+    cryptSharedLibSearchPaths?: string[];
   };
   proxyOptions?: ProxyOptions;
   /** The TLS options to use connecting to the KMS provider */
@@ -378,5 +378,5 @@ export interface AutoEncrypter {
   teardown(force: boolean, callback: Callback): void;
   encrypt(ns: string, cmd: Document, options: any, callback: Callback<Document>): void;
   decrypt(cmd: Document, options: any, callback: Callback<Document>): void;
-  readonly csfleVersionInfo: { version: bigint; versionStr: string } | null;
+  readonly cryptSharedLibVersionInfo: { version: bigint; versionStr: string } | null;
 }

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -344,7 +344,7 @@ export interface AutoEncryptionOptions {
      *
      * Specifying a path prevents mongocryptd from being used as a fallback.
      *
-     * Requires the MongoDB Crypt shared library, available in MongoDB 6.0 or higher.
+     * @experimental Requires the MongoDB Crypt shared library, available in MongoDB 6.0 or higher.
      */
     cryptSharedLibPath?: string;
     /**
@@ -353,7 +353,7 @@ export interface AutoEncryptionOptions {
      *
      * This is always true when `cryptSharedLibPath` is specified.
      *
-     * Requires the MongoDB Crypt shared library, available in MongoDB 6.0 or higher.
+     * @experimental Requires the MongoDB Crypt shared library, available in MongoDB 6.0 or higher.
      */
     cryptSharedLibRequired?: boolean;
     /**

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -382,5 +382,6 @@ export interface AutoEncrypter {
   teardown(force: boolean, callback: Callback): void;
   encrypt(ns: string, cmd: Document, options: any, callback: Callback<Document>): void;
   decrypt(cmd: Document, options: any, callback: Callback<Document>): void;
+  /** @experimental */
   readonly cryptSharedLibVersionInfo: { version: bigint; versionStr: string } | null;
 }

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -343,6 +343,8 @@ export interface AutoEncryptionOptions {
      * to the mongocryptd-specific `extraOptions` options.
      *
      * Specifying a path prevents mongocryptd from being used as a fallback.
+     *
+     * Requires the MongoDB Crypt shared library, available in MongoDB 6.0 or higher.
      */
     cryptSharedLibPath?: string;
     /**
@@ -350,6 +352,8 @@ export interface AutoEncryptionOptions {
      * shared library could not be loaded.
      *
      * This is always true when `cryptSharedLibPath` is specified.
+     *
+     * Requires the MongoDB Crypt shared library, available in MongoDB 6.0 or higher.
      */
     cryptSharedLibRequired?: boolean;
     /**


### PR DESCRIPTION
Adjust the AutoEncryption typings as indicated in the updated spec.

(Changes to libmongocrypt are in https://github.com/mongodb/libmongocrypt/pull/352)

### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
