### PR TITLE
refactor(NODE-4125): misc change stream improvements

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -44,6 +44,13 @@ declare global {
       (title: string, metadata: MongoDBMetadataUI, fn: (this: Suite) => void): Mocha.Suite;
     }
 
+    interface ExclusiveSuiteFunction {
+      (title: string, metadata: MongoDBMetadataUI, fn: Mocha.Func): Mocha.Test;
+      (title: string, metadata: MongoDBMetadataUI, fn: Mocha.AsyncFunc): Mocha.Test;
+      (title: string, metadataAndTest: MetadataAndTest<Mocha.Func>): Mocha.Test;
+      (title: string, metadataAndTest: MetadataAndTest<Mocha.AsyncFunc>): Mocha.Test;
+    }
+
     interface TestFunction {
       (title: string, metadata: MongoDBMetadataUI, fn: Mocha.Func): Mocha.Test;
       (title: string, metadata: MongoDBMetadataUI, fn: Mocha.AsyncFunc): Mocha.Test;

--- a/global.d.ts
+++ b/global.d.ts
@@ -51,6 +51,13 @@ declare global {
       (title: string, metadataAndTest: MetadataAndTest<Mocha.AsyncFunc>): Mocha.Test;
     }
 
+    interface ExclusiveTestFunction {
+      (title: string, metadata: MongoDBMetadataUI, fn: Mocha.Func): Mocha.Test;
+      (title: string, metadata: MongoDBMetadataUI, fn: Mocha.AsyncFunc): Mocha.Test;
+      (title: string, metadataAndTest: MetadataAndTest<Mocha.Func>): Mocha.Test;
+      (title: string, metadataAndTest: MetadataAndTest<Mocha.AsyncFunc>): Mocha.Test;
+    }
+
     interface TestFunction {
       (title: string, metadata: MongoDBMetadataUI, fn: Mocha.Func): Mocha.Test;
       (title: string, metadata: MongoDBMetadataUI, fn: Mocha.AsyncFunc): Mocha.Test;

--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -2,7 +2,7 @@ import Denque = require('denque');
 import type { Readable } from 'stream';
 import { setTimeout } from 'timers';
 
-import type { Binary, Document, Long, Timestamp } from './bson';
+import type { Binary, Document, Timestamp } from './bson';
 import { Collection } from './collection';
 import { CHANGE, CLOSE, END, ERROR, INIT, MORE, RESPONSE, RESUME_TOKEN_CHANGED } from './constants';
 import type { AbstractCursorEvents, CursorStreamOptions } from './cursor/abstract_cursor';

--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -106,18 +106,6 @@ export interface PipeOptions {
   end?: boolean;
 }
 
-/** @internal */
-export type ChangeStreamAggregateRawResult<TChange> = {
-  $clusterTime: { clusterTime: Timestamp };
-  cursor: {
-    postBatchResumeToken: ResumeToken;
-    ns: string;
-    id: number | Long;
-  } & ({ firstBatch: TChange[] } | { nextBatch: TChange[] });
-  ok: 1;
-  operationTime: Timestamp;
-};
-
 /**
  * Options that can be passed to a ChangeStream. Note that startAfter, resumeAfter, and startAtOperationTime are all mutually exclusive, and the server will error if more than one is specified.
  * @public
@@ -930,7 +918,7 @@ export class ChangeStream<
       const topology = getTopology(this.parent);
       this._waitForTopologyConnected(topology, { readPreference: cursor.readPreference }, err => {
         // if the topology can't reconnect, close the stream
-        if (err) return this._closeWithError(err);
+        if (err) return this._closeWithError(err, callback);
 
         // create a new cursor, preserving the old cursor's options
         const newCursor = this._createChangeStreamCursor(cursor.resumeOptions);

--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -695,6 +695,21 @@ export class ChangeStream<
     });
   }
 
+  /**
+   * Try to get the next available document from the Change Stream's cursor or `null` if an empty batch is returned
+   */
+  tryNext(): Promise<Document | null>;
+  tryNext(callback: Callback<Document | null>): void;
+  tryNext(callback?: Callback<Document | null>): Promise<Document | null> | void {
+    this._setIsIterator();
+    return maybePromise(callback, cb => {
+      this._getCursor((err, cursor) => {
+        if (err || !cursor) return cb(err); // failed to resume, raise an error
+        return cursor.tryNext(cb);
+      });
+    });
+  }
+
   /** Is the cursor closed */
   get closed(): boolean {
     return this[kClosed] || (this.cursor?.closed ?? false);
@@ -726,21 +741,6 @@ export class ChangeStream<
     this.streamOptions = options;
     if (!this.cursor) throw new MongoChangeStreamError(NO_CURSOR_ERROR);
     return this.cursor.stream(options);
-  }
-
-  /**
-   * Try to get the next available document from the Change Stream's cursor or `null` if an empty batch is returned
-   */
-  tryNext(): Promise<Document | null>;
-  tryNext(callback: Callback<Document | null>): void;
-  tryNext(callback?: Callback<Document | null>): Promise<Document | null> | void {
-    this._setIsIterator();
-    return maybePromise(callback, cb => {
-      this._getCursor((err, cursor) => {
-        if (err || !cursor) return cb(err); // failed to resume, raise an error
-        return cursor.tryNext(cb);
-      });
-    });
   }
 
   /** @internal */

--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -5,12 +5,8 @@ import { setTimeout } from 'timers';
 import type { Binary, Document, Long, Timestamp } from './bson';
 import { Collection } from './collection';
 import { CHANGE, CLOSE, END, ERROR, INIT, MORE, RESPONSE, RESUME_TOKEN_CHANGED } from './constants';
-import {
-  AbstractCursor,
-  AbstractCursorEvents,
-  AbstractCursorOptions,
-  CursorStreamOptions
-} from './cursor/abstract_cursor';
+import type { AbstractCursorEvents, CursorStreamOptions } from './cursor/abstract_cursor';
+import { ChangeStreamCursor, ChangeStreamCursorOptions } from './cursor/change_stream_cursor';
 import { Db } from './db';
 import {
   AnyError,
@@ -20,13 +16,12 @@ import {
   MongoRuntimeError
 } from './error';
 import { MongoClient } from './mongo_client';
-import { InferIdType, TODO_NODE_3286, TypedEventEmitter } from './mongo_types';
-import { AggregateOperation, AggregateOptions } from './operations/aggregate';
+import { InferIdType, TypedEventEmitter } from './mongo_types';
+import type { AggregateOptions } from './operations/aggregate';
 import type { CollationOptions, OperationParent } from './operations/command';
-import { executeOperation, ExecutionResult } from './operations/execute_operation';
 import type { ReadPreference } from './read_preference';
 import type { Topology } from './sdam/topology';
-import type { ClientSession, ServerSessionId } from './sessions';
+import type { ServerSessionId } from './sessions';
 import {
   calculateDurationInMs,
   Callback,
@@ -1008,160 +1003,5 @@ export class ChangeStream<
       }
       request(error, this.cursor ?? undefined);
     }
-  }
-}
-
-/** @internal */
-export interface ChangeStreamCursorOptions extends AbstractCursorOptions {
-  startAtOperationTime?: OperationTime;
-  resumeAfter?: ResumeToken;
-  startAfter?: ResumeToken;
-  maxAwaitTimeMS?: number;
-  collation?: CollationOptions;
-  fullDocument?: string;
-}
-
-/** @internal */
-export class ChangeStreamCursor<
-  TSchema extends Document = Document,
-  TChange extends Document = ChangeStreamDocument<TSchema>
-> extends AbstractCursor<TChange, ChangeStreamEvents> {
-  _resumeToken: ResumeToken;
-  startAtOperationTime?: OperationTime;
-  hasReceived?: boolean;
-  resumeAfter: ResumeToken;
-  startAfter: ResumeToken;
-  options: ChangeStreamCursorOptions;
-
-  postBatchResumeToken?: ResumeToken;
-  pipeline: Document[];
-
-  constructor(
-    client: MongoClient,
-    namespace: MongoDBNamespace,
-    pipeline: Document[] = [],
-    options: ChangeStreamCursorOptions = {}
-  ) {
-    super(client, namespace, options);
-
-    this.pipeline = pipeline;
-    this.options = options;
-    this._resumeToken = null;
-    this.startAtOperationTime = options.startAtOperationTime;
-
-    if (options.startAfter) {
-      this.resumeToken = options.startAfter;
-    } else if (options.resumeAfter) {
-      this.resumeToken = options.resumeAfter;
-    }
-  }
-
-  set resumeToken(token: ResumeToken) {
-    this._resumeToken = token;
-    this.emit(ChangeStream.RESUME_TOKEN_CHANGED, token);
-  }
-
-  get resumeToken(): ResumeToken {
-    return this._resumeToken;
-  }
-
-  get resumeOptions(): ChangeStreamCursorOptions {
-    const options: ChangeStreamCursorOptions = {
-      ...this.options
-    };
-
-    for (const key of ['resumeAfter', 'startAfter', 'startAtOperationTime'] as const) {
-      delete options[key];
-    }
-
-    if (this.resumeToken != null) {
-      if (this.options.startAfter && !this.hasReceived) {
-        options.startAfter = this.resumeToken;
-      } else {
-        options.resumeAfter = this.resumeToken;
-      }
-    } else if (this.startAtOperationTime != null && maxWireVersion(this.server) >= 7) {
-      options.startAtOperationTime = this.startAtOperationTime;
-    }
-
-    return options;
-  }
-
-  cacheResumeToken(resumeToken: ResumeToken): void {
-    if (this.bufferedCount() === 0 && this.postBatchResumeToken) {
-      this.resumeToken = this.postBatchResumeToken;
-    } else {
-      this.resumeToken = resumeToken;
-    }
-    this.hasReceived = true;
-  }
-
-  _processBatch(response: ChangeStreamAggregateRawResult<TChange>): void {
-    const cursor = response.cursor;
-    if (cursor.postBatchResumeToken) {
-      this.postBatchResumeToken = response.cursor.postBatchResumeToken;
-
-      const batch =
-        'firstBatch' in response.cursor ? response.cursor.firstBatch : response.cursor.nextBatch;
-      if (batch.length === 0) {
-        this.resumeToken = cursor.postBatchResumeToken;
-      }
-    }
-  }
-
-  clone(): AbstractCursor<TChange> {
-    return new ChangeStreamCursor(this.client, this.namespace, this.pipeline, {
-      ...this.cursorOptions
-    });
-  }
-
-  _initialize(session: ClientSession, callback: Callback<ExecutionResult>): void {
-    const aggregateOperation = new AggregateOperation(this.namespace, this.pipeline, {
-      ...this.cursorOptions,
-      ...this.options,
-      session
-    });
-
-    executeOperation<TODO_NODE_3286, ChangeStreamAggregateRawResult<TChange>>(
-      session.client,
-      aggregateOperation,
-      (err, response) => {
-        if (err || response == null) {
-          return callback(err);
-        }
-
-        const server = aggregateOperation.server;
-        if (
-          this.startAtOperationTime == null &&
-          this.resumeAfter == null &&
-          this.startAfter == null &&
-          maxWireVersion(server) >= 7
-        ) {
-          this.startAtOperationTime = response.operationTime;
-        }
-
-        this._processBatch(response);
-
-        this.emit(ChangeStream.INIT, response);
-        this.emit(ChangeStream.RESPONSE);
-
-        // TODO: NODE-2882
-        callback(undefined, { server, session, response });
-      }
-    );
-  }
-
-  override _getMore(batchSize: number, callback: Callback): void {
-    super._getMore(batchSize, (err, response) => {
-      if (err) {
-        return callback(err);
-      }
-
-      this._processBatch(response as TODO_NODE_3286 as ChangeStreamAggregateRawResult<TChange>);
-
-      this.emit(ChangeStream.MORE, response);
-      this.emit(ChangeStream.RESPONSE);
-      callback(err, response);
-    });
   }
 }

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -264,7 +264,7 @@ export abstract class AbstractCursor<
   stream(options?: CursorStreamOptions): Readable & AsyncIterable<TSchema> {
     if (options?.transform) {
       const transform = options.transform;
-      const readable = makeCursorStream(this);
+      const readable = new ReadableCursorStream(this);
 
       return readable.pipe(
         new Transform({
@@ -282,7 +282,7 @@ export abstract class AbstractCursor<
       );
     }
 
-    return makeCursorStream(this);
+    return new ReadableCursorStream(this);
   }
 
   hasNext(): Promise<boolean>;
@@ -714,7 +714,11 @@ function nextDocument<T>(cursor: AbstractCursor): T | null {
   return null;
 }
 
-function next<T>(cursor: AbstractCursor<T>, blocking: boolean, callback: Callback<T | null>): void {
+export function next<T>(
+  cursor: AbstractCursor<T>,
+  blocking: boolean,
+  callback: Callback<T | null>
+): void {
   const cursorId = cursor[kId];
   if (cursor.closed) {
     return callback(undefined, null);
@@ -844,41 +848,47 @@ export function assertUninitialized(cursor: AbstractCursor): void {
   }
 }
 
-function makeCursorStream(cursor: AbstractCursor) {
-  const readable = new Readable({
-    objectMode: true,
-    autoDestroy: false,
-    highWaterMark: 1
-  });
+class ReadableCursorStream extends Readable {
+  private _cursor: AbstractCursor;
 
-  let initialized = false;
-  let reading = false;
-  let needToClose = true; // NOTE: we must close the cursor if we never read from it, use `_construct` in future node versions
+  private _initialized = false;
+  private _reading = false;
+  private _needToClose = true; // NOTE: we must close the cursor if we never read from it, use `_construct` in future node versions
 
-  readable._read = function () {
-    if (initialized === false) {
-      needToClose = false;
-      initialized = true;
+  constructor(cursor: AbstractCursor) {
+    super({
+      objectMode: true,
+      autoDestroy: false,
+      highWaterMark: 1
+    });
+    this._cursor = cursor;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  override _read(size: number): void {
+    if (this._initialized === false) {
+      this._needToClose = false;
+      this._initialized = true;
     }
 
-    if (!reading) {
-      reading = true;
-      readNext();
+    if (!this._reading) {
+      this._reading = true;
+      this._readNext();
     }
-  };
+  }
 
-  readable._destroy = function (error, cb) {
-    if (needToClose) {
-      cursor.close(err => process.nextTick(cb, err || error));
+  override _destroy(error: Error | null, callback: (error?: Error | null) => void): void {
+    if (this._needToClose) {
+      this._cursor.close(err => process.nextTick(callback, err || error));
     } else {
-      cb(error);
+      callback(error);
     }
-  };
+  }
 
-  function readNext() {
-    needToClose = false;
-    next(cursor, true, (err, result) => {
-      needToClose = err ? !cursor.closed : result != null;
+  private _readNext() {
+    this._needToClose = false;
+    next(this._cursor, true, (err, result) => {
+      this._needToClose = err ? !this._cursor.closed : result != null;
 
       if (err) {
         // NOTE: This is questionable, but we have a test backing the behavior. It seems the
@@ -886,8 +896,8 @@ function makeCursorStream(cursor: AbstractCursor) {
         //       a client during iteration. Alternatively, we could do the "right" thing and
         //       propagate the error message by removing this special case.
         if (err.message.match(/server is closed/)) {
-          cursor.close();
-          return readable.push(null);
+          this._cursor.close();
+          return this.push(null);
         }
 
         // NOTE: This is also perhaps questionable. The rationale here is that these errors tend
@@ -896,25 +906,23 @@ function makeCursorStream(cursor: AbstractCursor) {
         //       that changed to happen in cleanup legitimate errors would not destroy the
         //       stream. There are change streams test specifically test these cases.
         if (err.message.match(/interrupted/)) {
-          return readable.push(null);
+          return this.push(null);
         }
 
-        return readable.destroy(err);
+        return this.destroy(err);
       }
 
       if (result == null) {
-        readable.push(null);
-      } else if (readable.destroyed) {
-        cursor.close();
+        this.push(null);
+      } else if (this.destroyed) {
+        this._cursor.close();
       } else {
-        if (readable.push(result)) {
-          return readNext();
+        if (this.push(result)) {
+          return this._readNext();
         }
 
-        reading = false;
+        this._reading = false;
       }
     });
   }
-
-  return readable;
 }

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -721,7 +721,7 @@ function nextDocument<T>(cursor: AbstractCursor): T | null {
  *     the cursor has been exhausted.  In certain scenarios (ChangeStreams, tailable await cursors and
  *     `tryNext`, for example) blocking is necessary because a getMore returning no documents does
  *     not indicate the end of the cursor.
- * @param callback - called when
+ * @param callback - callback to return the result to the caller
  * @returns
  */
 export function next<T>(

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -714,6 +714,16 @@ function nextDocument<T>(cursor: AbstractCursor): T | null {
   return null;
 }
 
+/**
+ * @param cursor - the cursor on which to call `next`
+ * @param blocking - a boolean indicating whether or not the cursor should `block` until data
+ *     is available.  Generally, this flag is set to `false` because if the getMore returns no documents,
+ *     the cursor has been exhausted.  In certain scenarios (ChangeStreams, tailable await cursors and
+ *     `tryNext`, for example) blocking is necessary because a getMore returning no documents does
+ *     not indicate the end of the cursor.
+ * @param callback - called when
+ * @returns
+ */
 export function next<T>(
   cursor: AbstractCursor<T>,
   blocking: boolean,

--- a/src/cursor/change_stream_cursor.ts
+++ b/src/cursor/change_stream_cursor.ts
@@ -1,0 +1,174 @@
+import type { Document } from 'bson';
+
+import {
+  type ChangeStreamAggregateRawResult,
+  type ChangeStreamDocument,
+  type ChangeStreamEvents,
+  type OperationTime,
+  type ResumeToken,
+  ChangeStream
+} from '../change_stream';
+import { INIT, RESPONSE } from '../constants';
+import type { MongoClient } from '../mongo_client';
+import type { TODO_NODE_3286 } from '../mongo_types';
+import { AggregateOperation } from '../operations/aggregate';
+import type { CollationOptions } from '../operations/command';
+import { type ExecutionResult, executeOperation } from '../operations/execute_operation';
+import type { ClientSession } from '../sessions';
+import { type Callback, type MongoDBNamespace, maxWireVersion } from '../utils';
+import { type AbstractCursorOptions, AbstractCursor } from './abstract_cursor';
+
+/** @internal */
+export interface ChangeStreamCursorOptions extends AbstractCursorOptions {
+  startAtOperationTime?: OperationTime;
+  resumeAfter?: ResumeToken;
+  startAfter?: ResumeToken;
+  maxAwaitTimeMS?: number;
+  collation?: CollationOptions;
+  fullDocument?: string;
+}
+
+/** @internal */
+export class ChangeStreamCursor<
+  TSchema extends Document = Document,
+  TChange extends Document = ChangeStreamDocument<TSchema>
+> extends AbstractCursor<TChange, ChangeStreamEvents> {
+  _resumeToken: ResumeToken;
+  startAtOperationTime?: OperationTime;
+  hasReceived?: boolean;
+  resumeAfter: ResumeToken;
+  startAfter: ResumeToken;
+  options: ChangeStreamCursorOptions;
+
+  postBatchResumeToken?: ResumeToken;
+  pipeline: Document[];
+
+  constructor(
+    client: MongoClient,
+    namespace: MongoDBNamespace,
+    pipeline: Document[] = [],
+    options: ChangeStreamCursorOptions = {}
+  ) {
+    super(client, namespace, options);
+
+    this.pipeline = pipeline;
+    this.options = options;
+    this._resumeToken = null;
+    this.startAtOperationTime = options.startAtOperationTime;
+
+    if (options.startAfter) {
+      this.resumeToken = options.startAfter;
+    } else if (options.resumeAfter) {
+      this.resumeToken = options.resumeAfter;
+    }
+  }
+
+  set resumeToken(token: ResumeToken) {
+    this._resumeToken = token;
+    this.emit(ChangeStream.RESUME_TOKEN_CHANGED, token);
+  }
+
+  get resumeToken(): ResumeToken {
+    return this._resumeToken;
+  }
+
+  get resumeOptions(): ChangeStreamCursorOptions {
+    const options: ChangeStreamCursorOptions = {
+      ...this.options
+    };
+
+    for (const key of ['resumeAfter', 'startAfter', 'startAtOperationTime'] as const) {
+      delete options[key];
+    }
+
+    if (this.resumeToken != null) {
+      if (this.options.startAfter && !this.hasReceived) {
+        options.startAfter = this.resumeToken;
+      } else {
+        options.resumeAfter = this.resumeToken;
+      }
+    } else if (this.startAtOperationTime != null && maxWireVersion(this.server) >= 7) {
+      options.startAtOperationTime = this.startAtOperationTime;
+    }
+
+    return options;
+  }
+
+  cacheResumeToken(resumeToken: ResumeToken): void {
+    if (this.bufferedCount() === 0 && this.postBatchResumeToken) {
+      this.resumeToken = this.postBatchResumeToken;
+    } else {
+      this.resumeToken = resumeToken;
+    }
+    this.hasReceived = true;
+  }
+
+  _processBatch(response: ChangeStreamAggregateRawResult<TChange>): void {
+    const cursor = response.cursor;
+    if (cursor.postBatchResumeToken) {
+      this.postBatchResumeToken = response.cursor.postBatchResumeToken;
+
+      const batch =
+        'firstBatch' in response.cursor ? response.cursor.firstBatch : response.cursor.nextBatch;
+      if (batch.length === 0) {
+        this.resumeToken = cursor.postBatchResumeToken;
+      }
+    }
+  }
+
+  clone(): AbstractCursor<TChange> {
+    return new ChangeStreamCursor(this.client, this.namespace, this.pipeline, {
+      ...this.cursorOptions
+    });
+  }
+
+  _initialize(session: ClientSession, callback: Callback<ExecutionResult>): void {
+    const aggregateOperation = new AggregateOperation(this.namespace, this.pipeline, {
+      ...this.cursorOptions,
+      ...this.options,
+      session
+    });
+
+    executeOperation<TODO_NODE_3286, ChangeStreamAggregateRawResult<TChange>>(
+      session.client,
+      aggregateOperation,
+      (err, response) => {
+        if (err || response == null) {
+          return callback(err);
+        }
+
+        const server = aggregateOperation.server;
+        if (
+          this.startAtOperationTime == null &&
+          this.resumeAfter == null &&
+          this.startAfter == null &&
+          maxWireVersion(server) >= 7
+        ) {
+          this.startAtOperationTime = response.operationTime;
+        }
+
+        this._processBatch(response);
+
+        this.emit(INIT, response);
+        this.emit(RESPONSE);
+
+        // TODO: NODE-2882
+        callback(undefined, { server, session, response });
+      }
+    );
+  }
+
+  override _getMore(batchSize: number, callback: Callback): void {
+    super._getMore(batchSize, (err, response) => {
+      if (err) {
+        return callback(err);
+      }
+
+      this._processBatch(response as TODO_NODE_3286 as ChangeStreamAggregateRawResult<TChange>);
+
+      this.emit(ChangeStream.MORE, response);
+      this.emit(ChangeStream.RESPONSE);
+      callback(err, response);
+    });
+  }
+}

--- a/src/cursor/change_stream_cursor.ts
+++ b/src/cursor/change_stream_cursor.ts
@@ -1,7 +1,5 @@
-import type { Document } from 'bson';
-
+import type { Document, Long, Timestamp } from '../bson';
 import {
-  type ChangeStreamAggregateRawResult,
   type ChangeStreamDocument,
   type ChangeStreamEvents,
   type OperationTime,
@@ -27,6 +25,18 @@ export interface ChangeStreamCursorOptions extends AbstractCursorOptions {
   collation?: CollationOptions;
   fullDocument?: string;
 }
+
+/** @internal */
+export type ChangeStreamAggregateRawResult<TChange> = {
+  $clusterTime: { clusterTime: Timestamp };
+  cursor: {
+    postBatchResumeToken: ResumeToken;
+    ns: string;
+    id: number | Long;
+  } & ({ firstBatch: TChange[] } | { nextBatch: TChange[] });
+  ok: 1;
+  operationTime: Timestamp;
+};
 
 /** @internal */
 export class ChangeStreamCursor<

--- a/src/index.ts
+++ b/src/index.ts
@@ -171,7 +171,6 @@ export type { OrderedBulkOperation } from './bulk/ordered';
 export type { UnorderedBulkOperation } from './bulk/unordered';
 export type {
   ChangeStream,
-  ChangeStreamAggregateRawResult,
   ChangeStreamCollModDocument,
   ChangeStreamCreateDocument,
   ChangeStreamCreateIndexDocument,
@@ -258,7 +257,10 @@ export type {
 } from './cursor/abstract_cursor';
 export type { InternalAbstractCursorOptions } from './cursor/abstract_cursor';
 export type { AggregationCursorOptions } from './cursor/aggregation_cursor';
-export type { ChangeStreamCursorOptions } from './cursor/change_stream_cursor';
+export type {
+  ChangeStreamAggregateRawResult,
+  ChangeStreamCursorOptions
+} from './cursor/change_stream_cursor';
 export type { DbOptions, DbPrivate } from './db';
 export type { AutoEncrypter, AutoEncryptionOptions, AutoEncryptionTlsOptions } from './deps';
 export type { Encrypter, EncrypterOptions } from './encrypter';

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ export {
   ObjectId,
   Timestamp
 } from './bson';
+export { ChangeStreamCursor } from './cursor/change_stream_cursor';
 /**
  * @public
  * @deprecated Please use `ObjectId`
@@ -174,8 +175,6 @@ export type {
   ChangeStreamCollModDocument,
   ChangeStreamCreateDocument,
   ChangeStreamCreateIndexDocument,
-  ChangeStreamCursor,
-  ChangeStreamCursorOptions,
   ChangeStreamDeleteDocument,
   ChangeStreamDocument,
   ChangeStreamDocumentCollectionUUID,
@@ -259,6 +258,7 @@ export type {
 } from './cursor/abstract_cursor';
 export type { InternalAbstractCursorOptions } from './cursor/abstract_cursor';
 export type { AggregationCursorOptions } from './cursor/aggregation_cursor';
+export type { ChangeStreamCursorOptions } from './cursor/change_stream_cursor';
 export type { DbOptions, DbPrivate } from './db';
 export type { AutoEncrypter, AutoEncryptionOptions, AutoEncryptionTlsOptions } from './deps';
 export type { Encrypter, EncrypterOptions } from './encrypter';

--- a/test/unit/change_stream.test.ts
+++ b/test/unit/change_stream.test.ts
@@ -2,7 +2,7 @@ import { Long, Timestamp } from 'bson';
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 
-import { ChangeStreamCursor } from '../../src/change_stream';
+import { ChangeStreamCursor } from '../../src/cursor/change_stream_cursor';
 import { MongoClient } from '../../src/mongo_client';
 import { MongoDBNamespace } from '../../src/utils';
 


### PR DESCRIPTION
#### What is changing?

As a part of NODE-4125, I made a couple of small refactors.  NODE-4125 isn't done, but I broke these changes into a separate PR.  I made 6 distinct changes:

1. added another overload for `.only` describe blocks to our mocha config
2. moved change stream cursor into its own file in the cursors subdirectory
3. added a doc comment to the `next<T>` function, explaining what the `blocking` parameter does
4. moved the `tryNext` function on the change stream to be grouped with the other iterator methods
5. created a custom readable that extends Readable instead of using the Readable constructor method the Node library provides
6. gets rid of a duplicate function that handled unresumable errors in favor of the existing class method

I think point 5 is probably the only change that will cause contention so I'm happy to revert if it we decide that's what we want to do.

##### Is there new documentation needed for these changes?

No.

#### What is the motivation for this change?

Improved driver code.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
