### PR TITLE
fix(NODE-4125): change stream resumability

### DIFF
--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -700,7 +700,7 @@ export class ChangeStream<
 
   /** Is the cursor closed */
   get closed(): boolean {
-    return this[kClosed] || (this.cursor.closed ?? false);
+    return this[kClosed] || this.cursor.closed;
   }
 
   /** Close the Change Stream */
@@ -722,9 +722,13 @@ export class ChangeStream<
    * NOTE: When using a Stream to process change stream events, the stream will
    * NOT automatically resume in the case a resumable error is encountered.
    *
-   * @throws MongoDriverError if this.cursor is undefined
+   * @throws MongoChangeStreamError if the underlying cursor or the change stream is closed
    */
   stream(options?: CursorStreamOptions): Readable & AsyncIterable<TChange> {
+    if (this.closed) {
+      throw new MongoChangeStreamError(CHANGESTREAM_CLOSED_ERROR);
+    }
+
     this.streamOptions = options;
     return this.cursor.stream(options);
   }

--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -1,4 +1,3 @@
-import Denque = require('denque');
 import type { Readable } from 'stream';
 import { promisify } from 'util';
 

--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -709,15 +709,6 @@ export class ChangeStream<
     });
   }
 
-  handleChangeCallback(change: TChange | null, callback: Callback): void {
-    try {
-      const processedChange = this._processChange(change);
-      callback(undefined, processedChange);
-    } catch (error) {
-      callback(error);
-    }
-  }
-
   /** Is the cursor closed */
   get closed(): boolean {
     return this[kClosed] || this.cursor.closed;

--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -629,6 +629,9 @@ export class ChangeStream<
   hasNext(callback: Callback<boolean>): void;
   hasNext(callback?: Callback): Promise<boolean> | void {
     this._setIsIterator();
+    // TOOD(NODE-4319): Add eslint rule preventing accidental variable shadowing
+    // Shadowing is intentional here.  We want to override the `callback` variable
+    // from the outer scope so that the inner scope doesn't accidentally call the wrong callback.
     return maybePromise(callback, callback => {
       (async () => {
         try {
@@ -656,6 +659,9 @@ export class ChangeStream<
   next(callback: Callback<TChange>): void;
   next(callback?: Callback<TChange>): Promise<TChange> | void {
     this._setIsIterator();
+    // TOOD(NODE-4319): Add eslint rule preventing accidental variable shadowing
+    // Shadowing is intentional here.  We want to override the `callback` variable
+    // from the outer scope so that the inner scope doesn't accidentally call the wrong callback.
     return maybePromise(callback, callback => {
       (async () => {
         try {
@@ -687,6 +693,9 @@ export class ChangeStream<
   tryNext(callback: Callback<Document | null>): void;
   tryNext(callback?: Callback<Document | null>): Promise<Document | null> | void {
     this._setIsIterator();
+    // TOOD(NODE-4319): Add eslint rule preventing accidental variable shadowing
+    // Shadowing is intentional here.  We want to override the `callback` variable
+    // from the outer scope so that the inner scope doesn't accidentally call the wrong callback.
     return maybePromise(callback, callback => {
       (async () => {
         try {

--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -20,14 +20,7 @@ import type { AggregateOptions } from './operations/aggregate';
 import type { CollationOptions, OperationParent } from './operations/command';
 import type { ReadPreference } from './read_preference';
 import type { ServerSessionId } from './sessions';
-import {
-  Callback,
-  filterOptions,
-  getTopology,
-  maxWireVersion,
-  maybePromise,
-  MongoDBNamespace
-} from './utils';
+import { Callback, filterOptions, getTopology, maybePromise, MongoDBNamespace } from './utils';
 
 /** @internal */
 const kCursorStream = Symbol('cursorStream');
@@ -877,7 +870,7 @@ export class ChangeStream<
     // If the change stream has been closed explicitly, do not process error.
     if (this[kClosed]) return;
 
-    if (this.cursor && isResumableError(error, maxWireVersion(this.cursor.server))) {
+    if (this.cursor && isResumableError(error, this.cursor.maxWireVersion)) {
       this._endStream();
       this.cursor.close();
 
@@ -900,7 +893,7 @@ export class ChangeStream<
       return callback(new MongoAPIError(CHANGESTREAM_CLOSED_ERROR));
     }
 
-    if (this.cursor && isResumableError(error, maxWireVersion(this.cursor.server))) {
+    if (this.cursor && isResumableError(error, this.cursor.maxWireVersion)) {
       this.cursor.close();
 
       const topology = getTopology(this.parent);

--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -704,6 +704,8 @@ export class ChangeStream<
   }
 
   /** Close the Change Stream */
+  close(): Promise<void>;
+  close(callback: Callback): void;
   close(callback?: Callback): Promise<void> | void {
     this[kClosed] = true;
 

--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -735,6 +735,10 @@ export class ChangeStream<
 
   /**
    * Return a modified Readable stream including a possible transform method.
+   *
+   * NOTE: When using a Stream to process change stream events, the stream will
+   * NOT automatically resume in the case a resumable error is encountered.
+   *
    * @throws MongoDriverError if this.cursor is undefined
    */
   stream(options?: CursorStreamOptions): Readable & AsyncIterable<TChange> {

--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -861,6 +861,7 @@ export class ChangeStream<
     return callback(undefined, change);
   }
 
+  /** @internal */
   private _processErrorStreamMode(error: AnyError) {
     // If the change stream has been closed explicitly, do not process error.
     if (this[kClosed]) return;
@@ -879,6 +880,7 @@ export class ChangeStream<
     }
   }
 
+  /** @internal */
   private _processErrorAsync = promisify(this._processErrorIteratorMode);
 
   /** @internal */

--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -906,7 +906,13 @@ export class ChangeStream<
     }
   }
 
-  /** @internal */
+  /**
+   * @internal
+   *
+   * TODO(NODE-4320): promisify selectServer and refactor this code to be async
+   *
+   * we promisify _processErrorIteratorModeCallback until we have a promisifed version of selectServer.
+   */
   private _processErrorIteratorMode = promisify(this._processErrorIteratorModeCallback);
 
   /** @internal */

--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -639,7 +639,7 @@ export class ChangeStream<
           return hasNext;
         } catch (error) {
           try {
-            await this._processErrorAsync(error);
+            await this._processErrorIteratorMode(error);
             const hasNext = await this.cursor.hasNext();
             return hasNext;
           } catch (error) {
@@ -670,7 +670,7 @@ export class ChangeStream<
           return processedChange;
         } catch (error) {
           try {
-            await this._processErrorAsync(error);
+            await this._processErrorIteratorMode(error);
             const change = await this.cursor.next();
             const processedChange = this._processChange(change ?? null);
             return processedChange;
@@ -703,7 +703,7 @@ export class ChangeStream<
           return change ?? null;
         } catch (error) {
           try {
-            await this._processErrorAsync(error);
+            await this._processErrorIteratorMode(error);
             const change = await this.cursor.tryNext();
             return change ?? null;
           } catch (error) {
@@ -907,10 +907,10 @@ export class ChangeStream<
   }
 
   /** @internal */
-  private _processErrorAsync = promisify(this._processErrorIteratorMode);
+  private _processErrorIteratorMode = promisify(this._processErrorIteratorModeCallback);
 
   /** @internal */
-  private _processErrorIteratorMode(error: AnyError, callback: Callback) {
+  private _processErrorIteratorModeCallback(error: AnyError, callback: Callback) {
     if (this[kClosed]) {
       // TODO(NODE-3485): Replace with MongoChangeStreamClosedError
       return callback(new MongoAPIError(CHANGESTREAM_CLOSED_ERROR));

--- a/src/sdam/topology.ts
+++ b/src/sdam/topology.ts
@@ -509,6 +509,9 @@ export class Topology extends TypedEventEmitter<TopologyEvents> {
       .finally(() => callback?.());
   }
 
+  /** @internal */
+  _selectServer = promisify(this.selectServer);
+
   /**
    * Selects a server according to the selection predicate provided
    *

--- a/src/sdam/topology.ts
+++ b/src/sdam/topology.ts
@@ -509,9 +509,6 @@ export class Topology extends TypedEventEmitter<TopologyEvents> {
       .finally(() => callback?.());
   }
 
-  /** @internal */
-  _selectServer = promisify(this.selectServer);
-
   /**
    * Selects a server according to the selection predicate provided
    *

--- a/test/integration/change-streams/change_stream.test.ts
+++ b/test/integration/change-streams/change_stream.test.ts
@@ -2061,7 +2061,7 @@ describe('ChangeStream resumability', function () {
   );
 
   it(
-    'updates the cache3d server version after the first getMore call',
+    'updates the cached server version after the first getMore call',
     { requires: { topology: '!single' } },
     async function () {
       changeStream = collection.watch([], changeStreamResumeOptions);

--- a/test/integration/change-streams/change_stream.test.ts
+++ b/test/integration/change-streams/change_stream.test.ts
@@ -1530,14 +1530,18 @@ describe('ChangeStream resumability', function () {
     gte(serverVersion, '4.2.0') && lt(serverVersion, '4.3.0');
 
   beforeEach(async function () {
-    client = this.configuration.newClient({ monitorCommands: true });
-    client.on('commandStarted', filterForCommands(['aggregate'], aggregateEvents));
+    const utilClient = this.configuration.newClient();
     // 3.6 servers do not support creating a change stream on a database that doesn't exist
-    await client
+    await utilClient
       .db('resumabilty_tests')
       .dropDatabase()
       .catch(e => e);
-    collection = await client.db('resumabilty_tests').createCollection('foo');
+    await utilClient.db('resumabilty_tests').createCollection('foo');
+    await utilClient.close();
+
+    client = this.configuration.newClient({ monitorCommands: true });
+    client.on('commandStarted', filterForCommands(['aggregate'], aggregateEvents));
+    collection = client.db('resumability_test').collection('foo');
   });
 
   afterEach(async function () {

--- a/test/integration/change-streams/change_stream.test.ts
+++ b/test/integration/change-streams/change_stream.test.ts
@@ -17,7 +17,6 @@ import {
   Long,
   MongoChangeStreamError,
   MongoClient,
-  MongoNetworkError,
   MongoServerError,
   ReadPreference,
   ResumeToken
@@ -362,8 +361,8 @@ describe('Change Streams', function () {
           expect(err).to.not.exist;
 
           // Check the cursor is closed
-          assert.equal(changeStream.closed, true);
-          assert.ok(!changeStream.cursor);
+          expect(changeStream.closed).to.be.true;
+          expect(changeStream.cursor.closed).to.be.true;
           done();
         });
       });
@@ -1595,7 +1594,7 @@ describe('ChangeStream resumability', { requires: { topology: '!single' } }, fun
 
             const mock = sinon
               // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-              .stub(changeStream.cursor!.server!, 'getMore')
+              .stub(changeStream.cursor.server!, 'getMore')
               .callsFake((_ns, _cursorId, _options, callback) => {
                 mock.restore();
                 const error = new MongoServerError({ message: 'Something went wrong' });
@@ -1720,7 +1719,7 @@ describe('ChangeStream resumability', { requires: { topology: '!single' } }, fun
 
             const mock = sinon
               // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-              .stub(changeStream.cursor!.server!, 'getMore')
+              .stub(changeStream.cursor.server!, 'getMore')
               .callsFake((_ns, _cursorId, _options, callback) => {
                 mock.restore();
                 const error = new MongoServerError({ message: 'Something went wrong' });
@@ -1844,7 +1843,7 @@ describe('ChangeStream resumability', { requires: { topology: '!single' } }, fun
 
             const mock = sinon
               // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-              .stub(changeStream.cursor!.server!, 'getMore')
+              .stub(changeStream.cursor.server!, 'getMore')
               .callsFake((_ns, _cursorId, _options, callback) => {
                 mock.restore();
                 const error = new MongoServerError({ message: 'Something went wrong' });

--- a/test/integration/change-streams/change_stream.test.ts
+++ b/test/integration/change-streams/change_stream.test.ts
@@ -2058,7 +2058,7 @@ describe('ChangeStream resumability', function () {
       expect(changeStream.cursor.maxWireVersion).to.be.undefined;
       await initIteratorMode(changeStream);
 
-      expect(typeof changeStream.cursor.maxWireVersion).to.equal('number');
+      expect(changeStream.cursor.maxWireVersion).to.be.a('number');
     }
   );
 

--- a/test/integration/change-streams/change_stream.test.ts
+++ b/test/integration/change-streams/change_stream.test.ts
@@ -1530,18 +1530,20 @@ describe('ChangeStream resumability', function () {
     gte(serverVersion, '4.2.0') && lt(serverVersion, '4.3.0');
 
   beforeEach(async function () {
+    const dbName = 'resumabilty_tests';
+    const collectionName = 'foo';
     const utilClient = this.configuration.newClient();
     // 3.6 servers do not support creating a change stream on a database that doesn't exist
     await utilClient
-      .db('resumabilty_tests')
+      .db(dbName)
       .dropDatabase()
       .catch(e => e);
-    await utilClient.db('resumabilty_tests').createCollection('foo');
+    await utilClient.db(dbName).createCollection(collectionName);
     await utilClient.close();
 
     client = this.configuration.newClient({ monitorCommands: true });
     client.on('commandStarted', filterForCommands(['aggregate'], aggregateEvents));
-    collection = client.db('resumability_test').collection('foo');
+    collection = client.db(dbName).collection(collectionName);
   });
 
   afterEach(async function () {

--- a/test/integration/change-streams/change_stream.test.ts
+++ b/test/integration/change-streams/change_stream.test.ts
@@ -2015,4 +2015,25 @@ describe('ChangeStream resumability', { requires: { topology: '!single' } }, fun
       });
     });
   });
+
+  it('caches the server version after the initial aggregate call', async function () {
+    changeStream = collection.watch([], changeStreamResumeOptions);
+    await initIteratorMode(changeStream);
+
+    expect(changeStream.cursor.maxWireVersion).not.to.be.undefined;
+  });
+
+  it('caches the server version after each getMore call', async function () {
+    changeStream = collection.watch([], changeStreamResumeOptions);
+    await initIteratorMode(changeStream);
+
+    const maxWireVersion = changeStream.cursor.maxWireVersion;
+    changeStream.cursor.maxWireVersion = 20;
+
+    await collection.insertOne({ name: 'bailey' });
+
+    await changeStream.next();
+
+    expect(changeStream.cursor.maxWireVersion).equal(maxWireVersion);
+  });
 });

--- a/test/integration/change-streams/change_stream.test.ts
+++ b/test/integration/change-streams/change_stream.test.ts
@@ -1406,7 +1406,7 @@ describe('Change Streams', function () {
 
             const change = await willBeChange;
 
-            expect(typeof change.fullDocument.a).to.equal('number');
+            expect(change.fullDocument.a).to.be.a('number');
           }
         });
       });
@@ -1556,7 +1556,7 @@ describe('ChangeStream resumability', function () {
             changeStream = collection.watch([]);
             await initIteratorMode(changeStream);
 
-            await client.db('admin').command(<FailPoint>{
+            await client.db('admin').command({
               configureFailPoint: is4_2Server(this.configuration.version)
                 ? 'failCommand'
                 : 'failGetMoreAfterCursorCheckout',
@@ -1565,7 +1565,7 @@ describe('ChangeStream resumability', function () {
                 failCommands: ['getMore'],
                 errorCode: code
               }
-            });
+            } as FailPoint);
 
             await collection.insertOne({ name: 'bailey' });
 
@@ -1618,7 +1618,7 @@ describe('ChangeStream resumability', function () {
           changeStream = collection.watch([], changeStreamResumeOptions);
           await initIteratorMode(changeStream);
 
-          await client.db('admin').command(<FailPoint>{
+          await client.db('admin').command({
             configureFailPoint: is4_2Server(this.configuration.version)
               ? 'failCommand'
               : 'failGetMoreAfterCursorCheckout',
@@ -1627,7 +1627,7 @@ describe('ChangeStream resumability', function () {
               failCommands: ['getMore'],
               errorCode: resumableErrorCodes[0].code
             }
-          });
+          } as FailPoint);
 
           expect(changeStream.cursor)
             .to.have.property('options')
@@ -1651,7 +1651,7 @@ describe('ChangeStream resumability', function () {
             changeStream = collection.watch([]);
 
             const unresumableErrorCode = 1000;
-            await client.db('admin').command(<FailPoint>{
+            await client.db('admin').command({
               configureFailPoint: is4_2Server(this.configuration.version)
                 ? 'failCommand'
                 : 'failGetMoreAfterCursorCheckout',
@@ -1660,7 +1660,7 @@ describe('ChangeStream resumability', function () {
                 failCommands: ['getMore'],
                 errorCode: unresumableErrorCode
               }
-            });
+            } as FailPoint);
 
             await initIteratorMode(changeStream);
 
@@ -1684,7 +1684,7 @@ describe('ChangeStream resumability', function () {
             changeStream = collection.watch([]);
             await initIteratorMode(changeStream);
 
-            await client.db('admin').command(<FailPoint>{
+            await client.db('admin').command({
               configureFailPoint: is4_2Server(this.configuration.version)
                 ? 'failCommand'
                 : 'failGetMoreAfterCursorCheckout',
@@ -1693,7 +1693,7 @@ describe('ChangeStream resumability', function () {
                 failCommands: ['getMore'],
                 errorCode: code
               }
-            });
+            } as FailPoint);
 
             await collection.insertOne({ name: 'bailey' });
 
@@ -1747,7 +1747,7 @@ describe('ChangeStream resumability', function () {
           changeStream = collection.watch([], changeStreamResumeOptions);
           await initIteratorMode(changeStream);
 
-          await client.db('admin').command(<FailPoint>{
+          await client.db('admin').command({
             configureFailPoint: is4_2Server(this.configuration.version)
               ? 'failCommand'
               : 'failGetMoreAfterCursorCheckout',
@@ -1756,7 +1756,7 @@ describe('ChangeStream resumability', function () {
               failCommands: ['getMore'],
               errorCode: resumableErrorCodes[0].code
             }
-          });
+          } as FailPoint);
 
           expect(changeStream.cursor)
             .to.have.property('options')
@@ -1780,7 +1780,7 @@ describe('ChangeStream resumability', function () {
             changeStream = collection.watch([]);
 
             const unresumableErrorCode = 1000;
-            await client.db('admin').command(<FailPoint>{
+            await client.db('admin').command({
               configureFailPoint: is4_2Server(this.configuration.version)
                 ? 'failCommand'
                 : 'failGetMoreAfterCursorCheckout',
@@ -1789,7 +1789,7 @@ describe('ChangeStream resumability', function () {
                 failCommands: ['getMore'],
                 errorCode: unresumableErrorCode
               }
-            });
+            } as FailPoint);
 
             await initIteratorMode(changeStream);
 
@@ -1813,7 +1813,7 @@ describe('ChangeStream resumability', function () {
             changeStream = collection.watch([]);
             await initIteratorMode(changeStream);
 
-            await client.db('admin').command(<FailPoint>{
+            await client.db('admin').command({
               configureFailPoint: is4_2Server(this.configuration.version)
                 ? 'failCommand'
                 : 'failGetMoreAfterCursorCheckout',
@@ -1822,7 +1822,7 @@ describe('ChangeStream resumability', function () {
                 failCommands: ['getMore'],
                 errorCode: code
               }
-            });
+            } as FailPoint);
 
             try {
               // tryNext is not blocking and on sharded clusters we don't have control of when
@@ -1890,7 +1890,7 @@ describe('ChangeStream resumability', function () {
           changeStream = collection.watch([], changeStreamResumeOptions);
           await initIteratorMode(changeStream);
 
-          await client.db('admin').command(<FailPoint>{
+          await client.db('admin').command({
             configureFailPoint: is4_2Server(this.configuration.version)
               ? 'failCommand'
               : 'failGetMoreAfterCursorCheckout',
@@ -1899,7 +1899,7 @@ describe('ChangeStream resumability', function () {
               failCommands: ['getMore'],
               errorCode: resumableErrorCodes[0].code
             }
-          });
+          } as FailPoint);
 
           expect(changeStream.cursor)
             .to.have.property('options')
@@ -1923,7 +1923,7 @@ describe('ChangeStream resumability', function () {
             changeStream = collection.watch([]);
 
             const unresumableErrorCode = 1000;
-            await client.db('admin').command(<FailPoint>{
+            await client.db('admin').command({
               configureFailPoint: is4_2Server(this.configuration.version)
                 ? 'failCommand'
                 : 'failGetMoreAfterCursorCheckout',
@@ -1932,7 +1932,7 @@ describe('ChangeStream resumability', function () {
                 failCommands: ['getMore'],
                 errorCode: unresumableErrorCode
               }
-            });
+            } as FailPoint);
 
             await initIteratorMode(changeStream);
 
@@ -1954,7 +1954,7 @@ describe('ChangeStream resumability', function () {
         async function () {
           changeStream = collection.watch([]);
 
-          await client.db('admin').command(<FailPoint>{
+          await client.db('admin').command({
             configureFailPoint: is4_2Server(this.configuration.version)
               ? 'failCommand'
               : 'failGetMoreAfterCursorCheckout',
@@ -1963,7 +1963,7 @@ describe('ChangeStream resumability', function () {
               failCommands: ['getMore'],
               errorCode: code
             }
-          });
+          } as FailPoint);
 
           const changes = once(changeStream, 'change');
           await once(changeStream.cursor, 'init');
@@ -1984,7 +1984,7 @@ describe('ChangeStream resumability', function () {
       async function () {
         changeStream = collection.watch([], changeStreamResumeOptions);
 
-        await client.db('admin').command(<FailPoint>{
+        await client.db('admin').command({
           configureFailPoint: is4_2Server(this.configuration.version)
             ? 'failCommand'
             : 'failGetMoreAfterCursorCheckout',
@@ -1993,7 +1993,7 @@ describe('ChangeStream resumability', function () {
             failCommands: ['getMore'],
             errorCode: resumableErrorCodes[0].code
           }
-        });
+        } as FailPoint);
 
         expect(changeStream.cursor)
           .to.have.property('options')
@@ -2020,7 +2020,7 @@ describe('ChangeStream resumability', function () {
           changeStream = collection.watch([]);
 
           const unresumableErrorCode = 1000;
-          await client.db('admin').command(<FailPoint>{
+          await client.db('admin').command({
             configureFailPoint: is4_2Server(this.configuration.version)
               ? 'failCommand'
               : 'failGetMoreAfterCursorCheckout',
@@ -2029,7 +2029,7 @@ describe('ChangeStream resumability', function () {
               failCommands: ['getMore'],
               errorCode: unresumableErrorCode
             }
-          });
+          } as FailPoint);
 
           const willBeError = once(changeStream, 'change').catch(error => error);
           await once(changeStream.cursor, 'init');

--- a/test/integration/change-streams/change_stream.test.ts
+++ b/test/integration/change-streams/change_stream.test.ts
@@ -1494,7 +1494,7 @@ describe('Change Streams', function () {
   });
 });
 
-describe('ChangeStream resumability', { requires: { topology: '!single' } }, function () {
+describe('ChangeStream resumability', function () {
   let client: MongoClient;
   let collection: Collection;
   let changeStream: ChangeStream;
@@ -1552,7 +1552,7 @@ describe('ChangeStream resumability', { requires: { topology: '!single' } }, fun
       for (const { error, code } of resumableErrorCodes) {
         it(
           `resumes on error code ${code} (${error})`,
-          { requires: { mongodb: '>=4.2' } },
+          { requires: { topology: '!single', mongodb: '>=4.2' } },
           async function () {
             changeStream = collection.watch([]);
             await initIteratorMode(changeStream);
@@ -1580,7 +1580,7 @@ describe('ChangeStream resumability', { requires: { topology: '!single' } }, fun
       for (const { error, code } of resumableErrorCodes) {
         it(
           `resumes on error code ${code} (${error})`,
-          { requires: { mongodb: '<4.2' } },
+          { requires: { topology: '!single', mongodb: '<4.2' } },
           async function () {
             changeStream = collection.watch([]);
             await initIteratorMode(changeStream);
@@ -1614,7 +1614,7 @@ describe('ChangeStream resumability', { requires: { topology: '!single' } }, fun
 
       it(
         'maintains change stream options on resume',
-        { requires: { mongodb: '>=4.2' } },
+        { requires: { topology: '!single', mongodb: '>=4.2' } },
         async function () {
           changeStream = collection.watch([], changeStreamResumeOptions);
           await initIteratorMode(changeStream);
@@ -1645,7 +1645,10 @@ describe('ChangeStream resumability', { requires: { topology: '!single' } }, fun
       );
 
       context('when the error is not a resumable error', function () {
-        it('does not resume', { requires: { mongodb: '>=4.2' } }, async function () {
+        it(
+          'does not resume',
+          { requires: { topology: '!single', mongodb: '>=4.2' } },
+          async function () {
           changeStream = collection.watch([]);
 
           const unresumableErrorCode = 1000;
@@ -1668,7 +1671,8 @@ describe('ChangeStream resumability', { requires: { topology: '!single' } }, fun
 
           expect(error).to.be.instanceOf(MongoServerError);
           expect(aggregateEvents).to.have.lengthOf(1);
-        });
+          }
+        );
       });
     });
 
@@ -1676,7 +1680,7 @@ describe('ChangeStream resumability', { requires: { topology: '!single' } }, fun
       for (const { error, code } of resumableErrorCodes) {
         it(
           `resumes on error code ${code} (${error})`,
-          { requires: { mongodb: '>=4.2' } },
+          { requires: { topology: '!single', mongodb: '>=4.2' } },
           async function () {
             changeStream = collection.watch([]);
             await initIteratorMode(changeStream);
@@ -1705,7 +1709,7 @@ describe('ChangeStream resumability', { requires: { topology: '!single' } }, fun
       for (const { error, code } of resumableErrorCodes) {
         it(
           `resumes on error code ${code} (${error})`,
-          { requires: { mongodb: '<4.2' } },
+          { requires: { topology: '!single', mongodb: '<4.2' } },
           async function () {
             changeStream = collection.watch([]);
             await initIteratorMode(changeStream);
@@ -1739,7 +1743,7 @@ describe('ChangeStream resumability', { requires: { topology: '!single' } }, fun
 
       it(
         'maintains change stream options on resume',
-        { requires: { mongodb: '>=4.2' } },
+        { requires: { topology: '!single', mongodb: '>=4.2' } },
         async function () {
           changeStream = collection.watch([], changeStreamResumeOptions);
           await initIteratorMode(changeStream);
@@ -1770,7 +1774,10 @@ describe('ChangeStream resumability', { requires: { topology: '!single' } }, fun
       );
 
       context('when the error is not a resumable error', function () {
-        it('does not resume', { requires: { mongodb: '>=4.2' } }, async function () {
+        it(
+          'does not resume',
+          { requires: { topology: '!single', mongodb: '>=4.2' } },
+          async function () {
           changeStream = collection.watch([]);
 
           const unresumableErrorCode = 1000;
@@ -1793,7 +1800,8 @@ describe('ChangeStream resumability', { requires: { topology: '!single' } }, fun
 
           expect(error).to.be.instanceOf(MongoServerError);
           expect(aggregateEvents).to.have.lengthOf(1);
-        });
+          }
+        );
       });
     });
 
@@ -1801,7 +1809,7 @@ describe('ChangeStream resumability', { requires: { topology: '!single' } }, fun
       for (const { error, code } of resumableErrorCodes) {
         it(
           `resumes on error code ${code} (${error})`,
-          { requires: { mongodb: '>=4.2' } },
+          { requires: { topology: '!single', mongodb: '>=4.2' } },
           async function () {
             changeStream = collection.watch([]);
             await initIteratorMode(changeStream);
@@ -1829,7 +1837,7 @@ describe('ChangeStream resumability', { requires: { topology: '!single' } }, fun
       for (const { error, code } of resumableErrorCodes) {
         it(
           `resumes on error code ${code} (${error})`,
-          { requires: { mongodb: '<4.2' } },
+          { requires: { topology: '!single', mongodb: '<4.2' } },
           async function () {
             changeStream = collection.watch([]);
             await initIteratorMode(changeStream);
@@ -1863,7 +1871,7 @@ describe('ChangeStream resumability', { requires: { topology: '!single' } }, fun
 
       it(
         'maintains change stream options on resume',
-        { requires: { mongodb: '>=4.2' } },
+        { requires: { topology: '!single', mongodb: '>=4.2' } },
         async function () {
           changeStream = collection.watch([], changeStreamResumeOptions);
           await initIteratorMode(changeStream);
@@ -1894,7 +1902,10 @@ describe('ChangeStream resumability', { requires: { topology: '!single' } }, fun
       );
 
       context('when the error is not a resumable error', function () {
-        it('does not resume', { requires: { mongodb: '>=4.2' } }, async function () {
+        it(
+          'does not resume',
+          { requires: { topology: '!single', mongodb: '>=4.2' } },
+          async function () {
           changeStream = collection.watch([]);
 
           const unresumableErrorCode = 1000;
@@ -1917,7 +1928,8 @@ describe('ChangeStream resumability', { requires: { topology: '!single' } }, fun
 
           expect(error).to.be.instanceOf(MongoServerError);
           expect(aggregateEvents).to.have.lengthOf(1);
-        });
+          }
+        );
       });
     });
   });
@@ -1926,7 +1938,7 @@ describe('ChangeStream resumability', { requires: { topology: '!single' } }, fun
     for (const { error, code } of resumableErrorCodes) {
       it(
         `resumes on error code ${code} (${error})`,
-        { requires: { mongodb: '>=4.2' } },
+        { requires: { topology: '!single', mongodb: '>=4.2' } },
         async function () {
           changeStream = collection.watch([]);
 
@@ -1956,7 +1968,7 @@ describe('ChangeStream resumability', { requires: { topology: '!single' } }, fun
 
     it(
       'maintains the change stream options on resume',
-      { requires: { mongodb: '>=4.2' } },
+      { requires: { topology: '!single', mongodb: '>=4.2' } },
       async function () {
         changeStream = collection.watch([], changeStreamResumeOptions);
 
@@ -1989,7 +2001,10 @@ describe('ChangeStream resumability', { requires: { topology: '!single' } }, fun
     );
 
     context('when the error is not a resumable error', function () {
-      it('does not resume', { requires: { mongodb: '>=4.2' } }, async function () {
+      it(
+        'does not resume',
+        { requires: { topology: '!single', mongodb: '>=4.2' } },
+        async function () {
         changeStream = collection.watch([]);
 
         const unresumableErrorCode = 1000;
@@ -2012,18 +2027,26 @@ describe('ChangeStream resumability', { requires: { topology: '!single' } }, fun
 
         expect(error).to.be.instanceOf(MongoServerError);
         expect(aggregateEvents).to.have.lengthOf(1);
-      });
+        }
+      );
     });
   });
 
-  it('caches the server version after the initial aggregate call', async function () {
+  it(
+    'caches the server version after the initial aggregate call',
+    { requires: { topology: '!single' } },
+    async function () {
     changeStream = collection.watch([], changeStreamResumeOptions);
     await initIteratorMode(changeStream);
 
     expect(changeStream.cursor.maxWireVersion).not.to.be.undefined;
-  });
+    }
+  );
 
-  it('caches the server version after each getMore call', async function () {
+  it(
+    'caches the server version after each getMore call',
+    { requires: { topology: '!single' } },
+    async function () {
     changeStream = collection.watch([], changeStreamResumeOptions);
     await initIteratorMode(changeStream);
 
@@ -2035,5 +2058,6 @@ describe('ChangeStream resumability', { requires: { topology: '!single' } }, fun
     await changeStream.next();
 
     expect(changeStream.cursor.maxWireVersion).equal(maxWireVersion);
-  });
+    }
+  );
 });

--- a/test/integration/change-streams/change_stream.test.ts
+++ b/test/integration/change-streams/change_stream.test.ts
@@ -1532,7 +1532,6 @@ describe('ChangeStream resumability', function () {
   beforeEach(async function () {
     client = this.configuration.newClient({ monitorCommands: true });
     client.on('commandStarted', filterForCommands(['aggregate'], aggregateEvents));
-    await client.connect();
     // 3.6 servers do not support creating a change stream on a database that doesn't exist
     await client
       .db('resumabilty_tests')

--- a/test/tools/unified-spec-runner/operations.ts
+++ b/test/tools/unified-spec-runner/operations.ts
@@ -328,7 +328,7 @@ operations.set('iterateUntilDocumentOrError', async ({ entities, operation }) =>
     return await cursor.next();
   }
 
-  return changeStream.next();
+  return await changeStream.next();
 });
 
 operations.set('listCollections', async ({ entities, operation }) => {

--- a/test/tools/utils.ts
+++ b/test/tools/utils.ts
@@ -279,7 +279,7 @@ export function extractAuthFromConnectionString(connectionString: string | any[]
 }
 
 export interface FailPoint {
-  configureFailPoint: 'failCommand';
+  configureFailPoint: 'failCommand' | 'failGetMoreAfterCursorCheckout';
   mode: { activationProbability: number } | { times: number } | 'alwaysOn' | 'off';
   data: {
     failCommands: string[];


### PR DESCRIPTION
This PR address resumability issues in the iterator-based API for change streams.

As much as I tried to separate the refactor from the code changes, I ended up making a few refactors as a part of this PR.

1. 44635ba30e9dc93559ba1bfe98fcc65ff062e79a makes the cursor property on the change streams always defined (non-optional).  This was primarily to make tests that use the cursor easier to work with.
2. 881dcf2c460a82018b3476262b989c8f24809fb7 breaks apart the error handling for iterator and event emitter modes.  Although this does result in some duplicated code, it did simply each method and allowed the promisifying of iterator-mode resume without modifying event emitter mode resuming.
3. I made each iterator method (tryNext, next and hasNext) internally use async IIFEs.  I did this for two reasons.  First, it made the resume logic a bit simpler to read and write.  Second, once we get to the async/await work, we can simply remove the `maybePromise` wrapper and the IIFE, and we should have the async functionality we need already written for us.
### Relevant Commits

8820ea16e31874a22bfe1ddafc9423d379327a29 is the most important commit in this PR, as it actually fixes the resumability for iterator mode.

94a48533255022d2e02a44552c551d80887f5cad makes a drive-by fix to remove an internal function in favor of server selection in the resume process.

### Note

As it turns out, the stream based change stream API has never been resumable.  I can file a follow up ticket to make our stream resumable, if we want to, but it seemed out of scope for this bug fix work.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
