### PR TITLE
test(NODE-3218): Consistent error message for connection string parsing

### DIFF
--- a/test/unit/connection_string.test.ts
+++ b/test/unit/connection_string.test.ts
@@ -384,7 +384,7 @@ describe('Connection String', function () {
     it('should validate compressors options', function () {
       expect(() => parseOptions('mongodb://localhost/?compressors=bunnies')).to.throw(
         MongoInvalidArgumentError,
-        'bunnies is not a valid compression mechanism'
+        'bunnies is not a valid compression mechanism. Must be one of: none,snappy,zlib,zstd.'
       );
     });
 

--- a/test/unit/connection_string.test.ts
+++ b/test/unit/connection_string.test.ts
@@ -382,10 +382,6 @@ describe('Connection String', function () {
 
   describe('validation', function () {
     it('should validate compressors options', function () {
-      /*expect(() => ).to.throw(
-        MongoInvalidArgumentError,
-        'bunnies is not a valid compression mechanism. Must be one of: none,snappy,zlib,zstd.'
-      ); */
       let thrownError;
       try {
         parseOptions('mongodb://localhost/?compressors=bunnies');

--- a/test/unit/connection_string.test.ts
+++ b/test/unit/connection_string.test.ts
@@ -382,8 +382,18 @@ describe('Connection String', function () {
 
   describe('validation', function () {
     it('should validate compressors options', function () {
-      expect(() => parseOptions('mongodb://localhost/?compressors=bunnies')).to.throw(
+      /*expect(() => ).to.throw(
         MongoInvalidArgumentError,
+        'bunnies is not a valid compression mechanism. Must be one of: none,snappy,zlib,zstd.'
+      ); */
+      let thrownError;
+      try {
+        parseOptions('mongodb://localhost/?compressors=bunnies');
+      } catch (error) {
+        thrownError = error;
+      }
+      expect(thrownError).to.be.instanceOf(MongoInvalidArgumentError);
+      expect(thrownError.message).to.equal(
         'bunnies is not a valid compression mechanism. Must be one of: none,snappy,zlib,zstd.'
       );
     });


### PR DESCRIPTION
### Description

#### What is changing?
Change in a unit test so that the error message is tested correctly

##### Is there new documentation needed for these changes?
No

#### What is the motivation for this change?

To include more information in enum option error messages for connection string parsing.

### If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior 
For connection string parsing for the compressors option: Current unit test did not check properly if the correct enum options were provided in the error message, and was giving a false positive.

<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
