### PR TITLE
test(NODE-4316): sync latest cmap tests for pool pausing

### DIFF
--- a/test/integration/connection-monitoring-and-pooling/connection_monitoring_and_pooling.spec.test.ts
+++ b/test/integration/connection-monitoring-and-pooling/connection_monitoring_and_pooling.spec.test.ts
@@ -12,17 +12,34 @@ const LB_SKIP_TESTS: SkipDescription[] = [
   skipReason: 'cannot run against a load balanced environment'
 }));
 
-describe('Connection Monitoring and Pooling Spec Tests (Integration)', function () {
+const POOL_PAUSED_SKIP_TESTS: SkipDescription[] = [
+  'clearing pool clears the WaitQueue',
+  'pool clear halts background minPoolSize establishments',
+  'clearing a paused pool emits no events',
+  'after clear, cannot check out connections until pool ready',
+  'error during minPoolSize population clears pool',
+  'readying a ready pool emits no events',
+  'pool starts as cleared and becomes ready'
+].map(description => ({
+  description,
+  skipIfCondition: 'always',
+  skipReason: 'TODO(NODE-2994): implement pool pausing'
+}));
+
+describe.only('Connection Monitoring and Pooling Spec Tests (Integration)', function () {
   const tests: CmapTest[] = loadSpecTests('connection-monitoring-and-pooling');
 
   runCmapTestSuite(tests, {
-    testsToSkip: LB_SKIP_TESTS.concat([
-      {
-        description: 'waiting on maxConnecting is limited by WaitQueueTimeoutMS',
-        skipIfCondition: 'always',
-        skipReason:
-          'not applicable: waitQueueTimeoutMS limits connection establishment time in our driver'
-      }
-    ])
+    testsToSkip: LB_SKIP_TESTS.concat(
+      [
+        {
+          description: 'waiting on maxConnecting is limited by WaitQueueTimeoutMS',
+          skipIfCondition: 'always',
+          skipReason:
+            'not applicable: waitQueueTimeoutMS limits connection establishment time in our driver'
+        }
+      ],
+      POOL_PAUSED_SKIP_TESTS
+    )
   });
 });

--- a/test/integration/connection-monitoring-and-pooling/connection_monitoring_and_pooling.spec.test.ts
+++ b/test/integration/connection-monitoring-and-pooling/connection_monitoring_and_pooling.spec.test.ts
@@ -26,7 +26,7 @@ const POOL_PAUSED_SKIP_TESTS: SkipDescription[] = [
   skipReason: 'TODO(NODE-2994): implement pool pausing'
 }));
 
-describe.only('Connection Monitoring and Pooling Spec Tests (Integration)', function () {
+describe('Connection Monitoring and Pooling Spec Tests (Integration)', function () {
   const tests: CmapTest[] = loadSpecTests('connection-monitoring-and-pooling');
 
   runCmapTestSuite(tests, {

--- a/test/spec/connection-monitoring-and-pooling/connection-must-have-id.json
+++ b/test/spec/connection-monitoring-and-pooling/connection-must-have-id.json
@@ -4,6 +4,9 @@
   "description": "must have an ID number associated with it",
   "operations": [
     {
+      "name": "ready"
+    },
+    {
       "name": "checkOut"
     },
     {
@@ -42,6 +45,7 @@
   ],
   "ignore": [
     "ConnectionPoolCreated",
+    "ConnectionPoolReady",
     "ConnectionPoolClosed",
     "ConnectionReady"
   ]

--- a/test/spec/connection-monitoring-and-pooling/connection-must-have-id.yml
+++ b/test/spec/connection-monitoring-and-pooling/connection-must-have-id.yml
@@ -2,6 +2,7 @@ version: 1
 style: unit
 description: must have an ID number associated with it
 operations:
+  - name: ready
   - name: checkOut
   - name: checkOut
 events:
@@ -23,5 +24,6 @@ events:
     address: 42
 ignore:
   - ConnectionPoolCreated
+  - ConnectionPoolReady
   - ConnectionPoolClosed
   - ConnectionReady

--- a/test/spec/connection-monitoring-and-pooling/pool-checkin-destroy-closed.json
+++ b/test/spec/connection-monitoring-and-pooling/pool-checkin-destroy-closed.json
@@ -4,6 +4,9 @@
   "description": "must destroy checked in connection if pool has been closed",
   "operations": [
     {
+      "name": "ready"
+    },
+    {
       "name": "checkOut",
       "label": "conn"
     },
@@ -39,6 +42,7 @@
   ],
   "ignore": [
     "ConnectionPoolCreated",
+    "ConnectionPoolReady",
     "ConnectionCreated",
     "ConnectionReady",
     "ConnectionCheckOutStarted"

--- a/test/spec/connection-monitoring-and-pooling/pool-checkin-destroy-closed.yml
+++ b/test/spec/connection-monitoring-and-pooling/pool-checkin-destroy-closed.yml
@@ -2,6 +2,7 @@ version: 1
 style: unit
 description: must destroy checked in connection if pool has been closed
 operations:
+  - name: ready
   - name: checkOut
     label: conn
   - name: close
@@ -22,6 +23,7 @@ events:
     address: 42
 ignore:
   - ConnectionPoolCreated
+  - ConnectionPoolReady
   - ConnectionCreated
   - ConnectionReady
   - ConnectionCheckOutStarted

--- a/test/spec/connection-monitoring-and-pooling/pool-checkin-destroy-stale.json
+++ b/test/spec/connection-monitoring-and-pooling/pool-checkin-destroy-stale.json
@@ -4,6 +4,9 @@
   "description": "must destroy checked in connection if it is stale",
   "operations": [
     {
+      "name": "ready"
+    },
+    {
       "name": "checkOut",
       "label": "conn"
     },
@@ -39,6 +42,7 @@
   ],
   "ignore": [
     "ConnectionPoolCreated",
+    "ConnectionPoolReady",
     "ConnectionCreated",
     "ConnectionReady",
     "ConnectionCheckOutStarted"

--- a/test/spec/connection-monitoring-and-pooling/pool-checkin-destroy-stale.yml
+++ b/test/spec/connection-monitoring-and-pooling/pool-checkin-destroy-stale.yml
@@ -2,6 +2,7 @@ version: 1
 style: unit
 description: must destroy checked in connection if it is stale
 operations:
+  - name: ready
   - name: checkOut
     label: conn
   - name: clear
@@ -22,6 +23,7 @@ events:
     address: 42
 ignore:
   - ConnectionPoolCreated
+  - ConnectionPoolReady
   - ConnectionCreated
   - ConnectionReady
   - ConnectionCheckOutStarted

--- a/test/spec/connection-monitoring-and-pooling/pool-checkin-make-available.json
+++ b/test/spec/connection-monitoring-and-pooling/pool-checkin-make-available.json
@@ -4,6 +4,9 @@
   "description": "must make valid checked in connection available",
   "operations": [
     {
+      "name": "ready"
+    },
+    {
       "name": "checkOut",
       "label": "conn"
     },
@@ -34,6 +37,7 @@
   ],
   "ignore": [
     "ConnectionPoolCreated",
+    "ConnectionPoolReady",
     "ConnectionCreated",
     "ConnectionReady",
     "ConnectionCheckOutStarted"

--- a/test/spec/connection-monitoring-and-pooling/pool-checkin-make-available.yml
+++ b/test/spec/connection-monitoring-and-pooling/pool-checkin-make-available.yml
@@ -2,6 +2,7 @@ version: 1
 style: unit
 description: must make valid checked in connection available
 operations:
+  - name: ready
   - name: checkOut
     label: conn
   - name: checkIn
@@ -19,6 +20,7 @@ events:
     address: 42
 ignore:
   - ConnectionPoolCreated
+  - ConnectionPoolReady
   - ConnectionCreated
   - ConnectionReady
   - ConnectionCheckOutStarted

--- a/test/spec/connection-monitoring-and-pooling/pool-checkin.json
+++ b/test/spec/connection-monitoring-and-pooling/pool-checkin.json
@@ -4,6 +4,9 @@
   "description": "must have a method of allowing the driver to check in a connection",
   "operations": [
     {
+      "name": "ready"
+    },
+    {
       "name": "checkOut",
       "label": "conn"
     },
@@ -21,6 +24,7 @@
   ],
   "ignore": [
     "ConnectionPoolCreated",
+    "ConnectionPoolReady",
     "ConnectionCreated",
     "ConnectionReady",
     "ConnectionClosed",

--- a/test/spec/connection-monitoring-and-pooling/pool-checkin.yml
+++ b/test/spec/connection-monitoring-and-pooling/pool-checkin.yml
@@ -2,6 +2,7 @@ version: 1
 style: unit
 description: must have a method of allowing the driver to check in a connection
 operations:
+  - name: ready
   - name: checkOut
     label: conn
   - name: checkIn
@@ -12,6 +13,7 @@ events:
     address: 42
 ignore:
   - ConnectionPoolCreated
+  - ConnectionPoolReady
   - ConnectionCreated
   - ConnectionReady
   - ConnectionClosed

--- a/test/spec/connection-monitoring-and-pooling/pool-checkout-connection.json
+++ b/test/spec/connection-monitoring-and-pooling/pool-checkout-connection.json
@@ -4,6 +4,9 @@
   "description": "must be able to check out a connection",
   "operations": [
     {
+      "name": "ready"
+    },
+    {
       "name": "checkOut"
     }
   ],
@@ -29,6 +32,7 @@
     }
   ],
   "ignore": [
+    "ConnectionPoolReady",
     "ConnectionPoolCreated"
   ]
 }

--- a/test/spec/connection-monitoring-and-pooling/pool-checkout-connection.yml
+++ b/test/spec/connection-monitoring-and-pooling/pool-checkout-connection.yml
@@ -2,6 +2,7 @@ version: 1
 style: unit
 description: must be able to check out a connection
 operations:
+  - name: ready
   - name: checkOut
 events:
   - type: ConnectionCheckOutStarted
@@ -16,4 +17,5 @@ events:
     connectionId: 1
     address: 42
 ignore:
+  - ConnectionPoolReady
   - ConnectionPoolCreated

--- a/test/spec/connection-monitoring-and-pooling/pool-checkout-error-closed.json
+++ b/test/spec/connection-monitoring-and-pooling/pool-checkout-error-closed.json
@@ -4,6 +4,9 @@
   "description": "must throw error if checkOut is called on a closed pool",
   "operations": [
     {
+      "name": "ready"
+    },
+    {
       "name": "checkOut",
       "label": "conn1"
     },
@@ -57,6 +60,7 @@
     }
   ],
   "ignore": [
+    "ConnectionPoolReady",
     "ConnectionCreated",
     "ConnectionReady",
     "ConnectionClosed"

--- a/test/spec/connection-monitoring-and-pooling/pool-checkout-error-closed.yml
+++ b/test/spec/connection-monitoring-and-pooling/pool-checkout-error-closed.yml
@@ -2,6 +2,7 @@ version: 1
 style: unit
 description: must throw error if checkOut is called on a closed pool
 operations:
+  - name: ready
   - name: checkOut
     label: conn1
   - name: checkIn
@@ -31,6 +32,7 @@ events:
     address: 42
     reason: poolClosed
 ignore:
+  - ConnectionPoolReady
   - ConnectionCreated
   - ConnectionReady
   - ConnectionClosed

--- a/test/spec/connection-monitoring-and-pooling/pool-checkout-maxConnecting-is-enforced.json
+++ b/test/spec/connection-monitoring-and-pooling/pool-checkout-maxConnecting-is-enforced.json
@@ -28,6 +28,9 @@
   },
   "operations": [
     {
+      "name": "ready"
+    },
+    {
       "name": "start",
       "target": "thread1"
     },
@@ -99,6 +102,7 @@
     "ConnectionCheckedIn",
     "ConnectionCheckedOut",
     "ConnectionClosed",
-    "ConnectionPoolCreated"
+    "ConnectionPoolCreated",
+    "ConnectionPoolReady"
   ]
 }

--- a/test/spec/connection-monitoring-and-pooling/pool-checkout-maxConnecting-is-enforced.yml
+++ b/test/spec/connection-monitoring-and-pooling/pool-checkout-maxConnecting-is-enforced.yml
@@ -18,6 +18,7 @@ poolOptions:
   maxPoolSize: 10
   waitQueueTimeoutMS: 5000
 operations:
+  - name: ready
   # start 3 threads
   - name: start
     target: thread1
@@ -75,3 +76,4 @@ ignore:
   - ConnectionCheckedOut
   - ConnectionClosed
   - ConnectionPoolCreated
+  - ConnectionPoolReady

--- a/test/spec/connection-monitoring-and-pooling/pool-checkout-maxConnecting-timeout.json
+++ b/test/spec/connection-monitoring-and-pooling/pool-checkout-maxConnecting-timeout.json
@@ -28,6 +28,9 @@
   },
   "operations": [
     {
+      "name": "ready"
+    },
+    {
       "name": "start",
       "target": "thread1"
     },
@@ -94,6 +97,7 @@
     "ConnectionCheckedIn",
     "ConnectionCheckedOut",
     "ConnectionClosed",
-    "ConnectionPoolCreated"
+    "ConnectionPoolCreated",
+    "ConnectionPoolReady"
   ]
 }

--- a/test/spec/connection-monitoring-and-pooling/pool-checkout-maxConnecting-timeout.yml
+++ b/test/spec/connection-monitoring-and-pooling/pool-checkout-maxConnecting-timeout.yml
@@ -21,6 +21,7 @@ poolOptions:
   # it will soon be deprecated, so it is easier for those drivers to just skip this test.
   waitQueueTimeoutMS: 50
 operations:
+  - name: ready
   # start creating two connections simultaneously.
   - name: start
     target: thread1
@@ -65,3 +66,4 @@ ignore:
   - ConnectionCheckedOut
   - ConnectionClosed
   - ConnectionPoolCreated
+  - ConnectionPoolReady

--- a/test/spec/connection-monitoring-and-pooling/pool-checkout-multiple.json
+++ b/test/spec/connection-monitoring-and-pooling/pool-checkout-multiple.json
@@ -4,6 +4,9 @@
   "description": "must be able to check out multiple connections at the same time",
   "operations": [
     {
+      "name": "ready"
+    },
+    {
       "name": "start",
       "target": "thread1"
     },
@@ -59,6 +62,7 @@
   ],
   "ignore": [
     "ConnectionCreated",
+    "ConnectionPoolReady",
     "ConnectionReady",
     "ConnectionPoolCreated",
     "ConnectionCheckOutStarted"

--- a/test/spec/connection-monitoring-and-pooling/pool-checkout-multiple.yml
+++ b/test/spec/connection-monitoring-and-pooling/pool-checkout-multiple.yml
@@ -2,6 +2,7 @@ version: 1
 style: unit
 description: must be able to check out multiple connections at the same time
 operations:
+  - name: ready
   - name: start
     target: thread1
   - name: start
@@ -32,6 +33,7 @@ events:
     address: 42
 ignore:
   - ConnectionCreated
+  - ConnectionPoolReady
   - ConnectionReady
   - ConnectionPoolCreated
   - ConnectionCheckOutStarted

--- a/test/spec/connection-monitoring-and-pooling/pool-checkout-no-idle.json
+++ b/test/spec/connection-monitoring-and-pooling/pool-checkout-no-idle.json
@@ -3,9 +3,13 @@
   "style": "unit",
   "description": "must destroy and must not check out an idle connection if found while iterating available connections",
   "poolOptions": {
-    "maxIdleTimeMS": 10
+    "maxIdleTimeMS": 10,
+    "backgroundThreadIntervalMS": -1
   },
   "operations": [
+    {
+      "name": "ready"
+    },
     {
       "name": "checkOut",
       "label": "conn"
@@ -20,6 +24,11 @@
     },
     {
       "name": "checkOut"
+    },
+    {
+      "name": "waitForEvent",
+      "event": "ConnectionCheckedOut",
+      "count": 2
     }
   ],
   "events": [
@@ -52,6 +61,7 @@
   ],
   "ignore": [
     "ConnectionReady",
+    "ConnectionPoolReady",
     "ConnectionCreated",
     "ConnectionCheckOutStarted"
   ]

--- a/test/spec/connection-monitoring-and-pooling/pool-checkout-no-idle.yml
+++ b/test/spec/connection-monitoring-and-pooling/pool-checkout-no-idle.yml
@@ -3,7 +3,9 @@ style: unit
 description: must destroy and must not check out an idle connection if found while iterating available connections
 poolOptions:
   maxIdleTimeMS: 10
+  backgroundThreadIntervalMS: -1
 operations:
+  - name: ready
   - name: checkOut
     label: conn
   - name: checkIn
@@ -11,6 +13,9 @@ operations:
   - name: wait
     ms: 50
   - name: checkOut
+  - name: waitForEvent
+    event: ConnectionCheckedOut
+    count: 2
 events:
   - type: ConnectionPoolCreated
     address: 42
@@ -31,5 +36,6 @@ events:
     address: 42
 ignore:
   - ConnectionReady
+  - ConnectionPoolReady
   - ConnectionCreated
   - ConnectionCheckOutStarted

--- a/test/spec/connection-monitoring-and-pooling/pool-checkout-no-stale.json
+++ b/test/spec/connection-monitoring-and-pooling/pool-checkout-no-stale.json
@@ -2,7 +2,13 @@
   "version": 1,
   "style": "unit",
   "description": "must destroy and must not check out a stale connection if found while iterating available connections",
+  "poolOptions": {
+    "backgroundThreadIntervalMS": -1
+  },
   "operations": [
+    {
+      "name": "ready"
+    },
     {
       "name": "checkOut",
       "label": "conn"
@@ -15,7 +21,15 @@
       "name": "clear"
     },
     {
+      "name": "ready"
+    },
+    {
       "name": "checkOut"
+    },
+    {
+      "name": "waitForEvent",
+      "event": "ConnectionCheckedOut",
+      "count": 2
     }
   ],
   "events": [
@@ -52,6 +66,7 @@
   ],
   "ignore": [
     "ConnectionReady",
+    "ConnectionPoolReady",
     "ConnectionCreated",
     "ConnectionCheckOutStarted"
   ]

--- a/test/spec/connection-monitoring-and-pooling/pool-checkout-no-stale.yml
+++ b/test/spec/connection-monitoring-and-pooling/pool-checkout-no-stale.yml
@@ -1,13 +1,20 @@
 version: 1
 style: unit
 description: must destroy and must not check out a stale connection if found while iterating available connections
+poolOptions:
+  backgroundThreadIntervalMS: -1
 operations:
+  - name: ready
   - name: checkOut
     label: conn
   - name: checkIn
     connection: conn
   - name: clear
+  - name: ready
   - name: checkOut
+  - name: waitForEvent
+    event: ConnectionCheckedOut
+    count: 2
 events:
   - type: ConnectionPoolCreated
     address: 42
@@ -29,5 +36,6 @@ events:
     address: 42
 ignore:
   - ConnectionReady
+  - ConnectionPoolReady
   - ConnectionCreated
   - ConnectionCheckOutStarted

--- a/test/spec/connection-monitoring-and-pooling/pool-checkout-returned-connection-maxConnecting.json
+++ b/test/spec/connection-monitoring-and-pooling/pool-checkout-returned-connection-maxConnecting.json
@@ -28,6 +28,9 @@
   },
   "operations": [
     {
+      "name": "ready"
+    },
+    {
       "name": "checkOut",
       "label": "conn0"
     },
@@ -112,6 +115,7 @@
     }
   ],
   "ignore": [
+    "ConnectionPoolReady",
     "ConnectionClosed",
     "ConnectionReady",
     "ConnectionPoolCreated",

--- a/test/spec/connection-monitoring-and-pooling/pool-checkout-returned-connection-maxConnecting.yml
+++ b/test/spec/connection-monitoring-and-pooling/pool-checkout-returned-connection-maxConnecting.yml
@@ -18,6 +18,7 @@ poolOptions:
   maxPoolSize: 10
   waitQueueTimeoutMS: 5000
 operations:
+  - name: ready
   # check out a connection and hold on to it.
   - name: checkOut
     label: conn0
@@ -78,6 +79,7 @@ events:
   - type: ConnectionCheckedOut
     address: 42
 ignore:
+  - ConnectionPoolReady
   - ConnectionClosed
   - ConnectionReady
   - ConnectionPoolCreated

--- a/test/spec/connection-monitoring-and-pooling/pool-clear-clears-waitqueue.json
+++ b/test/spec/connection-monitoring-and-pooling/pool-clear-clears-waitqueue.json
@@ -1,0 +1,101 @@
+{
+  "version": 1,
+  "style": "unit",
+  "description": "clearing pool clears the WaitQueue",
+  "poolOptions": {
+    "maxPoolSize": 1,
+    "waitQueueTimeoutMS": 30000
+  },
+  "operations": [
+    {
+      "name": "ready"
+    },
+    {
+      "name": "checkOut"
+    },
+    {
+      "name": "start",
+      "target": "thread1"
+    },
+    {
+      "name": "checkOut",
+      "thread": "thread1"
+    },
+    {
+      "name": "start",
+      "target": "thread2"
+    },
+    {
+      "name": "checkOut",
+      "thread": "thread2"
+    },
+    {
+      "name": "start",
+      "target": "thread3"
+    },
+    {
+      "name": "checkOut",
+      "thread": "thread3"
+    },
+    {
+      "name": "waitForEvent",
+      "event": "ConnectionCheckOutStarted",
+      "count": 4
+    },
+    {
+      "name": "clear"
+    },
+    {
+      "name": "waitForEvent",
+      "event": "ConnectionCheckOutFailed",
+      "count": 3,
+      "timeout": 1000
+    }
+  ],
+  "events": [
+    {
+      "type": "ConnectionCheckOutStarted",
+      "address": 42
+    },
+    {
+      "type": "ConnectionCheckedOut",
+      "address": 42
+    },
+    {
+      "type": "ConnectionCheckOutStarted",
+      "address": 42
+    },
+    {
+      "type": "ConnectionCheckOutStarted",
+      "address": 42
+    },
+    {
+      "type": "ConnectionCheckOutStarted",
+      "address": 42
+    },
+    {
+      "type": "ConnectionCheckOutFailed",
+      "reason": "connectionError",
+      "address": 42
+    },
+    {
+      "type": "ConnectionCheckOutFailed",
+      "reason": "connectionError",
+      "address": 42
+    },
+    {
+      "type": "ConnectionCheckOutFailed",
+      "reason": "connectionError",
+      "address": 42
+    }
+  ],
+  "ignore": [
+    "ConnectionPoolReady",
+    "ConnectionPoolCleared",
+    "ConnectionPoolCreated",
+    "ConnectionCreated",
+    "ConnectionReady",
+    "ConnectionCheckedIn",
+    "ConnectionClosed"
+  ]
+}

--- a/test/spec/connection-monitoring-and-pooling/pool-clear-clears-waitqueue.yml
+++ b/test/spec/connection-monitoring-and-pooling/pool-clear-clears-waitqueue.yml
@@ -1,0 +1,63 @@
+version: 1
+style: unit
+description: clearing pool clears the WaitQueue
+poolOptions:
+  maxPoolSize: 1
+  waitQueueTimeoutMS: 30000
+operations:
+  - name: ready
+  # check out only connection in the pool
+  - name: checkOut
+  # start a few threads that all will enter
+  # the wait queue
+  - name: start
+    target: thread1
+  - name: checkOut
+    thread: thread1
+  - name: start
+    target: thread2
+  - name: checkOut
+    thread: thread2
+  - name: start
+    target: thread3 
+  - name: checkOut
+    thread: thread3
+  # wait for the 3 threads to start checking out a connection
+  - name: waitForEvent
+    event: ConnectionCheckOutStarted
+    count: 4
+  # clear the pool, ejecting the previous three threads
+  # from the WaitQueue
+  - name: clear
+  - name: waitForEvent
+    event: ConnectionCheckOutFailed
+    count: 3
+    timeout: 1000
+events:
+  - type: ConnectionCheckOutStarted
+    address: 42
+  - type: ConnectionCheckedOut
+    address: 42
+  - type: ConnectionCheckOutStarted
+    address: 42
+  - type: ConnectionCheckOutStarted
+    address: 42
+  - type: ConnectionCheckOutStarted
+    address: 42
+  - type: ConnectionCheckOutFailed
+    reason: connectionError
+    address: 42
+  - type: ConnectionCheckOutFailed
+    reason: connectionError
+    address: 42
+  - type: ConnectionCheckOutFailed
+    reason: connectionError
+    address: 42
+ignore:
+  - ConnectionPoolReady
+  - ConnectionPoolCleared
+  - ConnectionPoolCreated
+  - ConnectionCreated
+  - ConnectionReady
+  - ConnectionCheckedIn
+  - ConnectionClosed

--- a/test/spec/connection-monitoring-and-pooling/pool-clear-min-size.json
+++ b/test/spec/connection-monitoring-and-pooling/pool-clear-min-size.json
@@ -1,0 +1,68 @@
+{
+  "version": 1,
+  "style": "unit",
+  "description": "pool clear halts background minPoolSize establishments",
+  "poolOptions": {
+    "minPoolSize": 1,
+    "backgroundThreadIntervalMS": 50
+  },
+  "operations": [
+    {
+      "name": "ready"
+    },
+    {
+      "name": "waitForEvent",
+      "event": "ConnectionReady",
+      "count": 1
+    },
+    {
+      "name": "clear"
+    },
+    {
+      "name": "wait",
+      "ms": 200
+    },
+    {
+      "name": "ready"
+    },
+    {
+      "name": "waitForEvent",
+      "event": "ConnectionReady",
+      "count": 2
+    }
+  ],
+  "events": [
+    {
+      "type": "ConnectionPoolReady",
+      "address": 42
+    },
+    {
+      "type": "ConnectionCreated",
+      "address": 42
+    },
+    {
+      "type": "ConnectionReady",
+      "address": 42
+    },
+    {
+      "type": "ConnectionPoolCleared",
+      "address": 42
+    },
+    {
+      "type": "ConnectionPoolReady",
+      "address": 42
+    },
+    {
+      "type": "ConnectionCreated",
+      "address": 42
+    },
+    {
+      "type": "ConnectionReady",
+      "address": 42
+    }
+  ],
+  "ignore": [
+    "ConnectionPoolCreated",
+    "ConnectionClosed"
+  ]
+}

--- a/test/spec/connection-monitoring-and-pooling/pool-clear-min-size.yml
+++ b/test/spec/connection-monitoring-and-pooling/pool-clear-min-size.yml
@@ -1,0 +1,37 @@
+version: 1
+style: unit
+description: pool clear halts background minPoolSize establishments
+poolOptions:
+  minPoolSize: 1
+  backgroundThreadIntervalMS: 50
+operations:
+  - name: ready
+  - name: waitForEvent
+    event: ConnectionReady
+    count: 1
+  - name: clear
+  # ensure no connections created after clear
+  - name: wait
+    ms: 200
+  - name: ready
+  - name: waitForEvent
+    event: ConnectionReady
+    count: 2
+events:
+  - type: ConnectionPoolReady
+    address: 42
+  - type: ConnectionCreated
+    address: 42
+  - type: ConnectionReady
+    address: 42
+  - type: ConnectionPoolCleared
+    address: 42
+  - type: ConnectionPoolReady
+    address: 42
+  - type: ConnectionCreated
+    address: 42
+  - type: ConnectionReady
+    address: 42
+ignore:
+  - ConnectionPoolCreated
+  - ConnectionClosed

--- a/test/spec/connection-monitoring-and-pooling/pool-clear-paused.json
+++ b/test/spec/connection-monitoring-and-pooling/pool-clear-paused.json
@@ -1,0 +1,32 @@
+{
+  "version": 1,
+  "style": "unit",
+  "description": "clearing a paused pool emits no events",
+  "operations": [
+    {
+      "name": "clear"
+    },
+    {
+      "name": "ready"
+    },
+    {
+      "name": "clear"
+    },
+    {
+      "name": "clear"
+    }
+  ],
+  "events": [
+    {
+      "type": "ConnectionPoolReady",
+      "address": 42
+    },
+    {
+      "type": "ConnectionPoolCleared",
+      "address": 42
+    }
+  ],
+  "ignore": [
+    "ConnectionPoolCreated"
+  ]
+}

--- a/test/spec/connection-monitoring-and-pooling/pool-clear-paused.yml
+++ b/test/spec/connection-monitoring-and-pooling/pool-clear-paused.yml
@@ -1,0 +1,15 @@
+version: 1
+style: unit
+description: clearing a paused pool emits no events
+operations:
+  - name: clear
+  - name: ready
+  - name: clear
+  - name: clear
+events:
+  - type: ConnectionPoolReady
+    address: 42
+  - type: ConnectionPoolCleared
+    address: 42
+ignore:
+  - ConnectionPoolCreated

--- a/test/spec/connection-monitoring-and-pooling/pool-clear-ready.json
+++ b/test/spec/connection-monitoring-and-pooling/pool-clear-ready.json
@@ -1,0 +1,69 @@
+{
+  "version": 1,
+  "style": "unit",
+  "description": "after clear, cannot check out connections until pool ready",
+  "operations": [
+    {
+      "name": "ready"
+    },
+    {
+      "name": "checkOut"
+    },
+    {
+      "name": "clear"
+    },
+    {
+      "name": "start",
+      "target": "thread1"
+    },
+    {
+      "name": "checkOut",
+      "thread": "thread1"
+    },
+    {
+      "name": "waitForEvent",
+      "event": "ConnectionCheckOutFailed",
+      "count": 1
+    },
+    {
+      "name": "ready"
+    },
+    {
+      "name": "checkOut"
+    }
+  ],
+  "events": [
+    {
+      "type": "ConnectionPoolReady",
+      "address": 42
+    },
+    {
+      "type": "ConnectionCheckedOut",
+      "address": 42,
+      "connectionId": 42
+    },
+    {
+      "type": "ConnectionPoolCleared",
+      "address": 42
+    },
+    {
+      "type": "ConnectionCheckOutFailed",
+      "address": 42,
+      "reason": "connectionError"
+    },
+    {
+      "type": "ConnectionPoolReady",
+      "address": 42
+    },
+    {
+      "type": "ConnectionCheckedOut",
+      "address": 42
+    }
+  ],
+  "ignore": [
+    "ConnectionPoolCreated",
+    "ConnectionReady",
+    "ConnectionCheckOutStarted",
+    "ConnectionCreated"
+  ]
+}

--- a/test/spec/connection-monitoring-and-pooling/pool-clear-ready.yml
+++ b/test/spec/connection-monitoring-and-pooling/pool-clear-ready.yml
@@ -1,0 +1,36 @@
+version: 1
+style: unit
+description: after clear, cannot check out connections until pool ready
+operations:
+  - name: ready
+  - name: checkOut
+  - name: clear
+  - name: start
+    target: thread1
+  - name: checkOut
+    thread: thread1
+  - name: waitForEvent
+    event: ConnectionCheckOutFailed
+    count: 1
+  - name: ready
+  - name: checkOut
+events:
+  - type: ConnectionPoolReady
+    address: 42
+  - type: ConnectionCheckedOut
+    address: 42
+    connectionId: 42
+  - type: ConnectionPoolCleared
+    address: 42
+  - type: ConnectionCheckOutFailed
+    address: 42
+    reason: connectionError
+  - type: ConnectionPoolReady
+    address: 42
+  - type: ConnectionCheckedOut
+    address: 42
+ignore:
+  - ConnectionPoolCreated
+  - ConnectionReady
+  - ConnectionCheckOutStarted
+  - ConnectionCreated

--- a/test/spec/connection-monitoring-and-pooling/pool-close-destroy-conns.json
+++ b/test/spec/connection-monitoring-and-pooling/pool-close-destroy-conns.json
@@ -4,6 +4,9 @@
   "description": "When a pool is closed, it MUST first destroy all available connections in that pool",
   "operations": [
     {
+      "name": "ready"
+    },
+    {
       "name": "checkOut"
     },
     {
@@ -40,6 +43,7 @@
   ],
   "ignore": [
     "ConnectionCreated",
+    "ConnectionPoolReady",
     "ConnectionReady",
     "ConnectionPoolCreated",
     "ConnectionCheckOutStarted",

--- a/test/spec/connection-monitoring-and-pooling/pool-close-destroy-conns.yml
+++ b/test/spec/connection-monitoring-and-pooling/pool-close-destroy-conns.yml
@@ -2,6 +2,7 @@ version: 1
 style: unit
 description: When a pool is closed, it MUST first destroy all available connections in that pool
 operations:
+  - name: ready
   - name: checkOut
   - name: checkOut
     label: conn
@@ -21,6 +22,7 @@ events:
     address: 42
 ignore:
   - ConnectionCreated
+  - ConnectionPoolReady
   - ConnectionReady
   - ConnectionPoolCreated
   - ConnectionCheckOutStarted

--- a/test/spec/connection-monitoring-and-pooling/pool-create-max-size.json
+++ b/test/spec/connection-monitoring-and-pooling/pool-create-max-size.json
@@ -7,6 +7,9 @@
   },
   "operations": [
     {
+      "name": "ready"
+    },
+    {
       "name": "checkOut",
       "label": "conn1"
     },
@@ -124,6 +127,7 @@
     }
   ],
   "ignore": [
-    "ConnectionReady"
+    "ConnectionReady",
+    "ConnectionPoolReady"
   ]
 }

--- a/test/spec/connection-monitoring-and-pooling/pool-create-max-size.yml
+++ b/test/spec/connection-monitoring-and-pooling/pool-create-max-size.yml
@@ -4,6 +4,7 @@ description: must never exceed maxPoolSize total connections
 poolOptions:
   maxPoolSize: 3
 operations:
+  - name: ready
   - name: checkOut
     label: conn1
   - name: checkOut
@@ -69,3 +70,4 @@ events:
     address: 42
 ignore:
   - ConnectionReady
+  - ConnectionPoolReady

--- a/test/spec/connection-monitoring-and-pooling/pool-create-min-size-error.json
+++ b/test/spec/connection-monitoring-and-pooling/pool-create-min-size-error.json
@@ -1,0 +1,66 @@
+{
+  "version": 1,
+  "style": "integration",
+  "description": "error during minPoolSize population clears pool",
+  "runOn": [
+    {
+      "minServerVersion": "4.9.0"
+    }
+  ],
+  "failPoint": {
+    "configureFailPoint": "failCommand",
+    "mode": {
+      "times": 50
+    },
+    "data": {
+      "failCommands": [
+        "isMaster",
+        "hello"
+      ],
+      "closeConnection": true,
+      "appName": "poolCreateMinSizeErrorTest"
+    }
+  },
+  "poolOptions": {
+    "minPoolSize": 1,
+    "backgroundThreadIntervalMS": 50,
+    "appName": "poolCreateMinSizeErrorTest"
+  },
+  "operations": [
+    {
+      "name": "ready"
+    },
+    {
+      "name": "waitForEvent",
+      "event": "ConnectionPoolCleared",
+      "count": 1
+    },
+    {
+      "name": "wait",
+      "ms": 200
+    }
+  ],
+  "events": [
+    {
+      "type": "ConnectionPoolReady",
+      "address": 42
+    },
+    {
+      "type": "ConnectionCreated",
+      "address": 42
+    },
+    {
+      "type": "ConnectionClosed",
+      "address": 42,
+      "connectionId": 42,
+      "reason": "error"
+    },
+    {
+      "type": "ConnectionPoolCleared",
+      "address": 42
+    }
+  ],
+  "ignore": [
+    "ConnectionPoolCreated"
+  ]
+}

--- a/test/spec/connection-monitoring-and-pooling/pool-create-min-size-error.yml
+++ b/test/spec/connection-monitoring-and-pooling/pool-create-min-size-error.yml
@@ -1,0 +1,40 @@
+version: 1
+style: integration
+description: error during minPoolSize population clears pool
+runOn:
+  -
+    # required for appName in fail point
+    minServerVersion: "4.9.0"
+failPoint:
+  configureFailPoint: failCommand
+  # high amount to ensure not interfered with by monitor checks.
+  mode: { times: 50 }
+  data:
+    failCommands: ["isMaster","hello"]
+    closeConnection: true
+    appName: "poolCreateMinSizeErrorTest"
+poolOptions:
+  minPoolSize: 1
+  backgroundThreadIntervalMS: 50
+  appName: "poolCreateMinSizeErrorTest"
+operations:
+  - name: ready
+  - name: waitForEvent
+    event: ConnectionPoolCleared
+    count: 1
+  # ensure pool doesn't start making new connections
+  - name: wait
+    ms: 200
+events:
+  - type: ConnectionPoolReady
+    address: 42
+  - type: ConnectionCreated
+    address: 42
+  - type: ConnectionClosed
+    address: 42
+    connectionId: 42
+    reason: error
+  - type: ConnectionPoolCleared
+    address: 42
+ignore:
+  - ConnectionPoolCreated

--- a/test/spec/connection-monitoring-and-pooling/pool-create-min-size.json
+++ b/test/spec/connection-monitoring-and-pooling/pool-create-min-size.json
@@ -7,6 +7,13 @@
   },
   "operations": [
     {
+      "name": "wait",
+      "ms": 200
+    },
+    {
+      "name": "ready"
+    },
+    {
       "name": "waitForEvent",
       "event": "ConnectionCreated",
       "count": 3
@@ -25,6 +32,10 @@
       "type": "ConnectionPoolCreated",
       "address": 42,
       "options": 42
+    },
+    {
+      "type": "ConnectionPoolReady",
+      "address": 42
     },
     {
       "type": "ConnectionCreated",

--- a/test/spec/connection-monitoring-and-pooling/pool-create-min-size.yml
+++ b/test/spec/connection-monitoring-and-pooling/pool-create-min-size.yml
@@ -4,6 +4,10 @@ description: must be able to start a pool with minPoolSize connections
 poolOptions:
   minPoolSize: 3
 operations:
+  # ensure no connections are created until this pool is ready
+  - name: wait
+    ms: 200
+  - name: ready
   - name: waitForEvent
     event: ConnectionCreated
     count: 3
@@ -15,6 +19,8 @@ events:
   - type: ConnectionPoolCreated
     address: 42
     options: 42
+  - type: ConnectionPoolReady
+    address: 42
   - type: ConnectionCreated
     connectionId: 42
     address: 42

--- a/test/spec/connection-monitoring-and-pooling/pool-ready-ready.json
+++ b/test/spec/connection-monitoring-and-pooling/pool-ready-ready.json
@@ -1,0 +1,39 @@
+{
+  "version": 1,
+  "style": "unit",
+  "description": "readying a ready pool emits no events",
+  "operations": [
+    {
+      "name": "ready"
+    },
+    {
+      "name": "ready"
+    },
+    {
+      "name": "ready"
+    },
+    {
+      "name": "clear"
+    },
+    {
+      "name": "ready"
+    }
+  ],
+  "events": [
+    {
+      "type": "ConnectionPoolReady",
+      "address": 42
+    },
+    {
+      "type": "ConnectionPoolCleared",
+      "address": 42
+    },
+    {
+      "type": "ConnectionPoolReady",
+      "address": 42
+    }
+  ],
+  "ignore": [
+    "ConnectionPoolCreated"
+  ]
+}

--- a/test/spec/connection-monitoring-and-pooling/pool-ready-ready.yml
+++ b/test/spec/connection-monitoring-and-pooling/pool-ready-ready.yml
@@ -1,0 +1,19 @@
+version: 1
+style: unit
+description: readying a ready pool emits no events
+operations:
+  - name: ready
+  - name: ready
+  - name: ready
+  # the first ready after this clear should emit an event
+  - name: clear
+  - name: ready
+events:
+  - type: ConnectionPoolReady
+    address: 42
+  - type: ConnectionPoolCleared
+    address: 42
+  - type: ConnectionPoolReady
+    address: 42
+ignore:
+  - ConnectionPoolCreated

--- a/test/spec/connection-monitoring-and-pooling/pool-ready.json
+++ b/test/spec/connection-monitoring-and-pooling/pool-ready.json
@@ -1,13 +1,23 @@
 {
   "version": 1,
   "style": "unit",
-  "description": "must have IDs assigned in order of creation",
+  "description": "pool starts as cleared and becomes ready",
   "operations": [
     {
-      "name": "ready"
+      "name": "start",
+      "target": "thread1"
     },
     {
-      "name": "checkOut"
+      "name": "checkOut",
+      "thread": "thread1"
+    },
+    {
+      "name": "waitForEvent",
+      "event": "ConnectionCheckOutFailed",
+      "count": 1
+    },
+    {
+      "name": "ready"
     },
     {
       "name": "checkOut"
@@ -19,13 +29,12 @@
       "address": 42
     },
     {
-      "type": "ConnectionCreated",
-      "connectionId": 1,
+      "type": "ConnectionCheckOutFailed",
+      "reason": "connectionError",
       "address": 42
     },
     {
-      "type": "ConnectionCheckedOut",
-      "connectionId": 1,
+      "type": "ConnectionPoolReady",
       "address": 42
     },
     {
@@ -34,19 +43,15 @@
     },
     {
       "type": "ConnectionCreated",
-      "connectionId": 2,
       "address": 42
     },
     {
       "type": "ConnectionCheckedOut",
-      "connectionId": 2,
       "address": 42
     }
   ],
   "ignore": [
     "ConnectionPoolCreated",
-    "ConnectionPoolReady",
-    "ConnectionPoolClosed",
     "ConnectionReady"
   ]
 }

--- a/test/spec/connection-monitoring-and-pooling/pool-ready.yml
+++ b/test/spec/connection-monitoring-and-pooling/pool-ready.yml
@@ -1,29 +1,30 @@
 version: 1
 style: unit
-description: must have IDs assigned in order of creation
+description: pool starts as cleared and becomes ready
 operations:
-  - name: ready
+  - name: start
+    target: thread1
   - name: checkOut
+    thread: thread1
+  - name: waitForEvent
+    event: ConnectionCheckOutFailed
+    count: 1
+  - name: ready
   - name: checkOut
 events:
   - type: ConnectionCheckOutStarted
     address: 42
-  - type: ConnectionCreated
-    connectionId: 1
+  - type: ConnectionCheckOutFailed
+    reason: connectionError
     address: 42
-  - type: ConnectionCheckedOut
-    connectionId: 1
+  - type: ConnectionPoolReady
     address: 42
   - type: ConnectionCheckOutStarted
     address: 42
   - type: ConnectionCreated
-    connectionId: 2
     address: 42
   - type: ConnectionCheckedOut
-    connectionId: 2
     address: 42
 ignore:
   - ConnectionPoolCreated
-  - ConnectionPoolReady
-  - ConnectionPoolClosed
   - ConnectionReady

--- a/test/spec/connection-monitoring-and-pooling/wait-queue-fairness.json
+++ b/test/spec/connection-monitoring-and-pooling/wait-queue-fairness.json
@@ -8,6 +8,9 @@
   },
   "operations": [
     {
+      "name": "ready"
+    },
+    {
       "name": "checkOut",
       "label": "conn0"
     },
@@ -187,6 +190,7 @@
     "ConnectionCreated",
     "ConnectionReady",
     "ConnectionClosed",
+    "ConnectionPoolReady",
     "ConnectionPoolCreated"
   ]
 }

--- a/test/spec/connection-monitoring-and-pooling/wait-queue-fairness.yml
+++ b/test/spec/connection-monitoring-and-pooling/wait-queue-fairness.yml
@@ -5,6 +5,7 @@ poolOptions:
   maxPoolSize: 1
   waitQueueTimeoutMS: 5000
 operations:
+  - name: ready
     # Check out sole connection in pool
   - name: checkOut
     label: conn0
@@ -121,4 +122,5 @@ ignore:
   - ConnectionCreated
   - ConnectionReady
   - ConnectionClosed
+  - ConnectionPoolReady
   - ConnectionPoolCreated

--- a/test/spec/connection-monitoring-and-pooling/wait-queue-timeout.json
+++ b/test/spec/connection-monitoring-and-pooling/wait-queue-timeout.json
@@ -4,9 +4,12 @@
   "description": "must aggressively timeout threads enqueued longer than waitQueueTimeoutMS",
   "poolOptions": {
     "maxPoolSize": 1,
-    "waitQueueTimeoutMS": 20
+    "waitQueueTimeoutMS": 50
   },
   "operations": [
+    {
+      "name": "ready"
+    },
     {
       "name": "checkOut",
       "label": "conn0"
@@ -66,6 +69,7 @@
     "ConnectionCreated",
     "ConnectionReady",
     "ConnectionClosed",
-    "ConnectionPoolCreated"
+    "ConnectionPoolCreated",
+    "ConnectionPoolReady"
   ]
 }

--- a/test/spec/connection-monitoring-and-pooling/wait-queue-timeout.yml
+++ b/test/spec/connection-monitoring-and-pooling/wait-queue-timeout.yml
@@ -3,8 +3,9 @@ style: unit
 description: must aggressively timeout threads enqueued longer than waitQueueTimeoutMS
 poolOptions:
   maxPoolSize: 1
-  waitQueueTimeoutMS: 20
+  waitQueueTimeoutMS: 50
 operations:
+  - name: ready
   # Check out only possible connection
   - name: checkOut
     label: conn0
@@ -44,3 +45,4 @@ ignore:
   - ConnectionReady
   - ConnectionClosed
   - ConnectionPoolCreated
+  - ConnectionPoolReady


### PR DESCRIPTION
### Description
NODE-4316
fully covers NODE-3254, NODE-3257, NODE-3259
as well as the test sync changes needed for NODE-3255 and NODE-2994

#### What is changing?
- cmap spec tests are synced with latest
- new pool pause tests are added and skipped
- existing tests have ready operation added (currently no-op)
- one existing test has backgroundThreadIntervalMS option added, the runner types were updated with this new option and the runner itself was updated to check pool options against the known list of options
- another test had a ConnectionPoolReady event added to its list of expected events, which we cannot handle until pool pausing is implemented, so temporary logic was added to filter it out from the expected event list

*Note to reviewers:* 
- verify that existing cmap tests run and pass as before on all configurations of interest (i.e., server, rs, sharded, and lb) and the newly added tests appear in the logs with the expected skip reason
- implementation of handling for appName and timeout in waitForEvent test options is intentionally deferred to NODE-2994 since no running tests currently use them

##### Is there new documentation needed for these changes?
No

#### What is the motivation for this change?
Have tests readily available for the core work of pool pausing

### Double check the following

- [x] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket