### PR TITLE
test(NODE-4296): add csfle decryption events prose tests

### DIFF
--- a/test/integration/client-side-encryption/client_side_encryption.prose.test.js
+++ b/test/integration/client-side-encryption/client_side_encryption.prose.test.js
@@ -1626,7 +1626,6 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
         // to contain BSON binary for the field
         // ``cursor.firstBatch.encrypted``.
         const collection = encryptedClient.db('').collection('decryption_events');
-        await collection.drop();
         await collection.insertOne({ encrypted: malformedCiphertext });
         let result;
         try {
@@ -1650,7 +1649,6 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
         // Expect a CommandSucceededEvent. Expect the CommandSucceededEvent.reply
         // to contain BSON binary for the field ``cursor.firstBatch.encrypted``.
         const collection = encryptedClient.db('').collection('decryption_events');
-        await collection.drop();
         await collection.insertOne({ encrypted: cipherText });
         let result;
         try {

--- a/test/integration/client-side-encryption/client_side_encryption.prose.test.js
+++ b/test/integration/client-side-encryption/client_side_encryption.prose.test.js
@@ -1434,7 +1434,6 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
     let malformedCiphertext;
     let encryptedClient;
     let aggregateSucceeded;
-    let aggregateStarted;
     let aggregateFailed;
 
     beforeEach(async function () {
@@ -1497,12 +1496,6 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
           aggregateSucceeded = event;
         }
       });
-      // The listener must store the most recent CommandStartedEvent reply for the "aggregate" command.
-      encryptedClient.on('commandStarted', event => {
-        if (event.commandName === 'aggregate') {
-          aggregateStarted = event;
-        }
-      });
       // The listener must store the most recent CommandFailedEvent error for the "aggregate" command.
       encryptedClient.on('commandFailed', event => {
         if (event.commandName === 'aggregate') {
@@ -1513,7 +1506,6 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
 
     afterEach(async function () {
       aggregateSucceeded = undefined;
-      aggregateStarted = undefined;
       aggregateFailed = undefined;
       await setupClient.close();
       await encryptedClient.close();
@@ -1560,7 +1552,6 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
           expect(error.code).to.equal(123);
         }
         expect(aggregateFailed.failure.code).to.equal(123);
-        expect(aggregateStarted).to.exist;
       });
     });
 
@@ -1607,7 +1598,6 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
           expect(error.message).to.be.instanceOf(MongoNetworkError);
         }
         expect(aggregateFailed.failure.message).to.include('closed');
-        expect(aggregateStarted).to.exist;
       });
     });
 
@@ -1630,7 +1620,6 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
         }
         const doc = aggregateSucceeded.reply.cursor.firstBatch[0];
         expect(doc.encrypted).to.be.instanceOf(Binary);
-        expect(aggregateStarted).to.exist;
       });
     });
 
@@ -1653,7 +1642,6 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
         expect(result[0].encrypted).to.equal('hello');
         const doc = aggregateSucceeded.reply.cursor.firstBatch[0];
         expect(doc.encrypted).to.be.instanceOf(Binary);
-        expect(aggregateStarted).to.exist;
       });
     });
   });

--- a/test/integration/client-side-encryption/client_side_encryption.prose.test.js
+++ b/test/integration/client-side-encryption/client_side_encryption.prose.test.js
@@ -1595,7 +1595,7 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
           await collection.aggregate([]).toArray();
           expect.fail('aggregate must fail with error');
         } catch (error) {
-          expect(error.message).to.be.instanceOf(MongoNetworkError);
+          expect(error).to.be.instanceOf(MongoNetworkError);
         }
         expect(aggregateFailed.failure.message).to.include('closed');
       });

--- a/test/integration/client-side-encryption/client_side_encryption.prose.test.js
+++ b/test/integration/client-side-encryption/client_side_encryption.prose.test.js
@@ -1426,7 +1426,7 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
     });
   });
 
-  context('14. Decryption Events', function () {
+  context('14. Decryption Events', metadata, function () {
     let setupClient;
     let clientEncryption;
     let keyId;
@@ -1511,7 +1511,7 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
       await encryptedClient.close();
     });
 
-    context('Case 1: Command Error', function () {
+    context('Case 1: Command Error', metadata, function () {
       beforeEach(async function () {
         // Use ``setupClient`` to configure the following failpoint:
         //    {
@@ -1555,7 +1555,7 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
       });
     });
 
-    context('Case 2: Network Error', function () {
+    context('Case 2: Network Error', metadata, function () {
       beforeEach(async function () {
         // Use ``setupClient`` to configure the following failpoint:
         //    {
@@ -1601,7 +1601,7 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
       });
     });
 
-    context('Case 3: Decrypt Error', function () {
+    context('Case 3: Decrypt Error', metadata, function () {
       it('errors on decryption but command succeeds', async function () {
         // Use ``encryptedClient`` to insert the document ``{ "encrypted": <malformedCiphertext> }``
         // into ``db.decryption_events``.
@@ -1623,7 +1623,7 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
       });
     });
 
-    context('Case 4: Decrypt Success', function () {
+    context('Case 4: Decrypt Success', metadata, function () {
       it('succeeds on decryption and command succeeds', async function () {
         // Use ``encryptedClient`` to insert the document ``{ "encrypted": <ciphertext> }``
         // into ``db.decryption_events``.

--- a/test/integration/client-side-encryption/client_side_encryption.prose.test.js
+++ b/test/integration/client-side-encryption/client_side_encryption.prose.test.js
@@ -1637,7 +1637,7 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
         try {
           result = await collection.aggregate([]).toArray();
         } catch (error) {
-          expect(error).to.not.exist;
+          expect.fail(`aggregate must not fail, got ${error.message}`);
         }
         expect(result[0].encrypted).to.equal('hello');
         const doc = aggregateSucceeded.reply.cursor.firstBatch[0];


### PR DESCRIPTION
### Description

Add the decryption events prose tests for CSFLE.

#### What is changing?

4 new prose tests have been added to test command monitoring when using CSFLE in various cases. I've copied and pasted the prose tests as comments in the code. The new prose tests language can also be referenced here: https://github.com/mongodb/specifications/commit/f9cbedafe53faffd62f15bcb2e952d1e016934e9

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-4296

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
