### PR TITLE
test(NODE-4227): add explicit encryption prose tests

### DIFF
--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -56,7 +56,7 @@ else
   source "$DRIVERS_TOOLS"/.evergreen/csfle/set-temp-creds.sh
 fi
 
-npm install mongodb-client-encryption@">=2.2.0-alpha.2"
+npm install mongodb-client-encryption@">=2.2.0-alpha.3"
 npm install @mongodb-js/zstd
 npm install snappy
 

--- a/test/integration/client-side-encryption/client_side_encryption.prose.test.js
+++ b/test/integration/client-side-encryption/client_side_encryption.prose.test.js
@@ -1434,226 +1434,6 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
     });
   });
 
-  context('14. Decryption Events', metadata, function () {
-    let setupClient;
-    let clientEncryption;
-    let keyId;
-    let cipherText;
-    let malformedCiphertext;
-    let encryptedClient;
-    let aggregateSucceeded;
-    let aggregateFailed;
-
-    beforeEach(async function () {
-      const mongodbClientEncryption = this.configuration.mongodbClientEncryption;
-      // Create a MongoClient named ``setupClient``.
-      setupClient = this.configuration.newClient();
-      // Drop and create the collection ``db.decryption_events``.
-      const db = setupClient.db('db');
-      await dropCollection(db, 'decryption_events');
-      await db.createCollection('decryption_events');
-      // Create a ClientEncryption object named ``clientEncryption`` with these options:
-      //   ClientEncryptionOpts {
-      //     keyVaultClient: <setupClient>,
-      //     keyVaultNamespace: "keyvault.datakeys",
-      //     kmsProviders: { "local": { "key": <base64 decoding of LOCAL_MASTERKEY> } }
-      //   }
-      clientEncryption = new mongodbClientEncryption.ClientEncryption(setupClient, {
-        keyVaultNamespace: 'keyvault.datakeys',
-        kmsProviders: getKmsProviders(LOCAL_KEY),
-        bson: BSON
-      });
-      // Create a data key with the "local" KMS provider.
-      // Storing the result in a variable named ``keyID``.
-      keyId = await clientEncryption.createDataKey('local');
-      // Use ``clientEncryption`` to encrypt the string "hello" with the following ``EncryptOpts``:
-      //   EncryptOpts {
-      //     keyId: <keyID>,
-      //     algorithm: "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
-      //   }
-      // Store the result in a variable named ``ciphertext``.
-      cipherText = await clientEncryption.encrypt('hello', {
-        keyId: keyId,
-        algorithm: 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'
-      });
-      // Copy ``ciphertext`` into a variable named ``malformedCiphertext``.
-      // Change the last byte to 0. This will produce an invalid HMAC tag.
-      const buffer = Buffer.from(cipherText.buffer);
-      buffer.writeInt8(0, buffer.length - 1);
-      malformedCiphertext = new Binary(buffer, 6);
-      // Create a MongoClient named ``encryptedClient`` with these ``AutoEncryptionOpts``:
-      //   AutoEncryptionOpts {
-      //     keyVaultNamespace: "keyvault.datakeys";
-      //     kmsProviders: { "local": { "key": <base64 decoding of LOCAL_MASTERKEY> } }
-      //   }
-      // Configure ``encryptedClient`` with "retryReads=false".
-      encryptedClient = this.configuration.newClient(
-        {},
-        {
-          retryReads: false,
-          monitorCommands: true,
-          autoEncryption: {
-            keyVaultNamespace: 'keyvault.datakeys',
-            kmsProviders: getKmsProviders(LOCAL_KEY)
-          }
-        }
-      );
-      // Register a listener for CommandSucceeded events on ``encryptedClient``.
-      encryptedClient.on('commandSucceeded', event => {
-        if (event.commandName === 'aggregate') {
-          aggregateSucceeded = event;
-        }
-      });
-      // The listener must store the most recent CommandFailedEvent error for the "aggregate" command.
-      encryptedClient.on('commandFailed', event => {
-        if (event.commandName === 'aggregate') {
-          aggregateFailed = event;
-        }
-      });
-    });
-
-    afterEach(async function () {
-      aggregateSucceeded = undefined;
-      aggregateFailed = undefined;
-      await setupClient.close();
-      await encryptedClient.close();
-    });
-
-    context('Case 1: Command Error', metadata, function () {
-      beforeEach(async function () {
-        // Use ``setupClient`` to configure the following failpoint:
-        //    {
-        //         "configureFailPoint": "failCommand",
-        //         "mode": {
-        //             "times": 1
-        //         },
-        //         "data": {
-        //             "errorCode": 123,
-        //             "failCommands": [
-        //                 "aggregate"
-        //             ]
-        //         }
-        //     }
-        await setupClient
-          .db()
-          .admin()
-          .command({
-            configureFailPoint: 'failCommand',
-            mode: {
-              times: 1
-            },
-            data: {
-              errorCode: 123,
-              failCommands: ['aggregate']
-            }
-          });
-      });
-
-      it('expects an error and a command failed event', async function () {
-        // Use ``encryptedClient`` to run an aggregate on ``db.decryption_events``.
-        // Expect an exception to be thrown from the command error. Expect a CommandFailedEvent.
-        const collection = encryptedClient.db('db').collection('decryption_events');
-        try {
-          await collection.aggregate([]).toArray();
-          expect.fail('aggregate must fail with error');
-        } catch (error) {
-          expect(error.code).to.equal(123);
-        }
-        expect(aggregateFailed.failure.code).to.equal(123);
-      });
-    });
-
-    context('Case 2: Network Error', metadata, function () {
-      beforeEach(async function () {
-        // Use ``setupClient`` to configure the following failpoint:
-        //    {
-        //         "configureFailPoint": "failCommand",
-        //         "mode": {
-        //             "times": 1
-        //         },
-        //         "data": {
-        //             "errorCode": 123,
-        //             "closeConnection": true,
-        //             "failCommands": [
-        //                 "aggregate"
-        //             ]
-        //         }
-        //     }
-        await setupClient
-          .db()
-          .admin()
-          .command({
-            configureFailPoint: 'failCommand',
-            mode: {
-              times: 1
-            },
-            data: {
-              errorCode: 123,
-              closeConnection: true,
-              failCommands: ['aggregate']
-            }
-          });
-      });
-
-      it('expects an error and a command failed event', async function () {
-        // Use ``encryptedClient`` to run an aggregate on ``db.decryption_events``.
-        // Expect an exception to be thrown from the network error. Expect a CommandFailedEvent.
-        const collection = encryptedClient.db('db').collection('decryption_events');
-        try {
-          await collection.aggregate([]).toArray();
-          expect.fail('aggregate must fail with error');
-        } catch (error) {
-          expect(error).to.be.instanceOf(MongoNetworkError);
-        }
-        expect(aggregateFailed.failure.message).to.include('closed');
-      });
-    });
-
-    context('Case 3: Decrypt Error', metadata, function () {
-      it('errors on decryption but command succeeds', async function () {
-        // Use ``encryptedClient`` to insert the document ``{ "encrypted": <malformedCiphertext> }``
-        // into ``db.decryption_events``.
-        // Use ``encryptedClient`` to run an aggregate on ``db.decryption_events``.
-        // Expect an exception to be thrown from the decryption error.
-        // Expect a CommandSucceededEvent. Expect the CommandSucceededEvent.reply
-        // to contain BSON binary for the field
-        // ``cursor.firstBatch.encrypted``.
-        const collection = encryptedClient.db('db').collection('decryption_events');
-        await collection.insertOne({ encrypted: malformedCiphertext });
-        try {
-          await collection.aggregate([]).toArray();
-          expect.fail('aggregate must fail with error');
-        } catch (error) {
-          expect(error.message).to.include('HMAC validation failure');
-        }
-        const doc = aggregateSucceeded.reply.cursor.firstBatch[0];
-        expect(doc.encrypted).to.be.instanceOf(Binary);
-      });
-    });
-
-    context('Case 4: Decrypt Success', metadata, function () {
-      it('succeeds on decryption and command succeeds', async function () {
-        // Use ``encryptedClient`` to insert the document ``{ "encrypted": <ciphertext> }``
-        // into ``db.decryption_events``.
-        // Use ``encryptedClient`` to run an aggregate on ``db.decryption_events``.
-        // Expect no exception.
-        // Expect a CommandSucceededEvent. Expect the CommandSucceededEvent.reply
-        // to contain BSON binary for the field ``cursor.firstBatch.encrypted``.
-        const collection = encryptedClient.db('db').collection('decryption_events');
-        await collection.insertOne({ encrypted: cipherText });
-        let result;
-        try {
-          result = await collection.aggregate([]).toArray();
-        } catch (error) {
-          expect.fail(`aggregate must not fail, got ${error.message}`);
-        }
-        expect(result[0].encrypted).to.equal('hello');
-        const doc = aggregateSucceeded.reply.cursor.firstBatch[0];
-        expect(doc.encrypted).to.be.instanceOf(Binary);
-      });
-    });
-  });
-
   context('12. Explicit Encryption', eeMetadata, function () {
     const data = path.join(__dirname, '..', '..', 'spec', 'client-side-encryption', 'etc', 'data');
     let encryptedFields;
@@ -1930,6 +1710,226 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
         // equals "encrypted unindexed value".
         const result = await clientEncryption.decrypt(payload);
         expect(result).equals('encrypted unindexed value');
+      });
+    });
+  });
+
+  context('14. Decryption Events', metadata, function () {
+    let setupClient;
+    let clientEncryption;
+    let keyId;
+    let cipherText;
+    let malformedCiphertext;
+    let encryptedClient;
+    let aggregateSucceeded;
+    let aggregateFailed;
+
+    beforeEach(async function () {
+      const mongodbClientEncryption = this.configuration.mongodbClientEncryption;
+      // Create a MongoClient named ``setupClient``.
+      setupClient = this.configuration.newClient();
+      // Drop and create the collection ``db.decryption_events``.
+      const db = setupClient.db('db');
+      await dropCollection(db, 'decryption_events');
+      await db.createCollection('decryption_events');
+      // Create a ClientEncryption object named ``clientEncryption`` with these options:
+      //   ClientEncryptionOpts {
+      //     keyVaultClient: <setupClient>,
+      //     keyVaultNamespace: "keyvault.datakeys",
+      //     kmsProviders: { "local": { "key": <base64 decoding of LOCAL_MASTERKEY> } }
+      //   }
+      clientEncryption = new mongodbClientEncryption.ClientEncryption(setupClient, {
+        keyVaultNamespace: 'keyvault.datakeys',
+        kmsProviders: getKmsProviders(LOCAL_KEY),
+        bson: BSON
+      });
+      // Create a data key with the "local" KMS provider.
+      // Storing the result in a variable named ``keyID``.
+      keyId = await clientEncryption.createDataKey('local');
+      // Use ``clientEncryption`` to encrypt the string "hello" with the following ``EncryptOpts``:
+      //   EncryptOpts {
+      //     keyId: <keyID>,
+      //     algorithm: "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+      //   }
+      // Store the result in a variable named ``ciphertext``.
+      cipherText = await clientEncryption.encrypt('hello', {
+        keyId: keyId,
+        algorithm: 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'
+      });
+      // Copy ``ciphertext`` into a variable named ``malformedCiphertext``.
+      // Change the last byte to 0. This will produce an invalid HMAC tag.
+      const buffer = Buffer.from(cipherText.buffer);
+      buffer.writeInt8(0, buffer.length - 1);
+      malformedCiphertext = new Binary(buffer, 6);
+      // Create a MongoClient named ``encryptedClient`` with these ``AutoEncryptionOpts``:
+      //   AutoEncryptionOpts {
+      //     keyVaultNamespace: "keyvault.datakeys";
+      //     kmsProviders: { "local": { "key": <base64 decoding of LOCAL_MASTERKEY> } }
+      //   }
+      // Configure ``encryptedClient`` with "retryReads=false".
+      encryptedClient = this.configuration.newClient(
+        {},
+        {
+          retryReads: false,
+          monitorCommands: true,
+          autoEncryption: {
+            keyVaultNamespace: 'keyvault.datakeys',
+            kmsProviders: getKmsProviders(LOCAL_KEY)
+          }
+        }
+      );
+      // Register a listener for CommandSucceeded events on ``encryptedClient``.
+      encryptedClient.on('commandSucceeded', event => {
+        if (event.commandName === 'aggregate') {
+          aggregateSucceeded = event;
+        }
+      });
+      // The listener must store the most recent CommandFailedEvent error for the "aggregate" command.
+      encryptedClient.on('commandFailed', event => {
+        if (event.commandName === 'aggregate') {
+          aggregateFailed = event;
+        }
+      });
+    });
+
+    afterEach(async function () {
+      aggregateSucceeded = undefined;
+      aggregateFailed = undefined;
+      await setupClient.close();
+      await encryptedClient.close();
+    });
+
+    context('Case 1: Command Error', metadata, function () {
+      beforeEach(async function () {
+        // Use ``setupClient`` to configure the following failpoint:
+        //    {
+        //         "configureFailPoint": "failCommand",
+        //         "mode": {
+        //             "times": 1
+        //         },
+        //         "data": {
+        //             "errorCode": 123,
+        //             "failCommands": [
+        //                 "aggregate"
+        //             ]
+        //         }
+        //     }
+        await setupClient
+          .db()
+          .admin()
+          .command({
+            configureFailPoint: 'failCommand',
+            mode: {
+              times: 1
+            },
+            data: {
+              errorCode: 123,
+              failCommands: ['aggregate']
+            }
+          });
+      });
+
+      it('expects an error and a command failed event', async function () {
+        // Use ``encryptedClient`` to run an aggregate on ``db.decryption_events``.
+        // Expect an exception to be thrown from the command error. Expect a CommandFailedEvent.
+        const collection = encryptedClient.db('db').collection('decryption_events');
+        try {
+          await collection.aggregate([]).toArray();
+          expect.fail('aggregate must fail with error');
+        } catch (error) {
+          expect(error.code).to.equal(123);
+        }
+        expect(aggregateFailed.failure.code).to.equal(123);
+      });
+    });
+
+    context('Case 2: Network Error', metadata, function () {
+      beforeEach(async function () {
+        // Use ``setupClient`` to configure the following failpoint:
+        //    {
+        //         "configureFailPoint": "failCommand",
+        //         "mode": {
+        //             "times": 1
+        //         },
+        //         "data": {
+        //             "errorCode": 123,
+        //             "closeConnection": true,
+        //             "failCommands": [
+        //                 "aggregate"
+        //             ]
+        //         }
+        //     }
+        await setupClient
+          .db()
+          .admin()
+          .command({
+            configureFailPoint: 'failCommand',
+            mode: {
+              times: 1
+            },
+            data: {
+              errorCode: 123,
+              closeConnection: true,
+              failCommands: ['aggregate']
+            }
+          });
+      });
+
+      it('expects an error and a command failed event', async function () {
+        // Use ``encryptedClient`` to run an aggregate on ``db.decryption_events``.
+        // Expect an exception to be thrown from the network error. Expect a CommandFailedEvent.
+        const collection = encryptedClient.db('db').collection('decryption_events');
+        try {
+          await collection.aggregate([]).toArray();
+          expect.fail('aggregate must fail with error');
+        } catch (error) {
+          expect(error).to.be.instanceOf(MongoNetworkError);
+        }
+        expect(aggregateFailed.failure.message).to.include('closed');
+      });
+    });
+
+    context('Case 3: Decrypt Error', metadata, function () {
+      it('errors on decryption but command succeeds', async function () {
+        // Use ``encryptedClient`` to insert the document ``{ "encrypted": <malformedCiphertext> }``
+        // into ``db.decryption_events``.
+        // Use ``encryptedClient`` to run an aggregate on ``db.decryption_events``.
+        // Expect an exception to be thrown from the decryption error.
+        // Expect a CommandSucceededEvent. Expect the CommandSucceededEvent.reply
+        // to contain BSON binary for the field
+        // ``cursor.firstBatch.encrypted``.
+        const collection = encryptedClient.db('db').collection('decryption_events');
+        await collection.insertOne({ encrypted: malformedCiphertext });
+        try {
+          await collection.aggregate([]).toArray();
+          expect.fail('aggregate must fail with error');
+        } catch (error) {
+          expect(error.message).to.include('HMAC validation failure');
+        }
+        const doc = aggregateSucceeded.reply.cursor.firstBatch[0];
+        expect(doc.encrypted).to.be.instanceOf(Binary);
+      });
+    });
+
+    context('Case 4: Decrypt Success', metadata, function () {
+      it('succeeds on decryption and command succeeds', async function () {
+        // Use ``encryptedClient`` to insert the document ``{ "encrypted": <ciphertext> }``
+        // into ``db.decryption_events``.
+        // Use ``encryptedClient`` to run an aggregate on ``db.decryption_events``.
+        // Expect no exception.
+        // Expect a CommandSucceededEvent. Expect the CommandSucceededEvent.reply
+        // to contain BSON binary for the field ``cursor.firstBatch.encrypted``.
+        const collection = encryptedClient.db('db').collection('decryption_events');
+        await collection.insertOne({ encrypted: cipherText });
+        let result;
+        try {
+          result = await collection.aggregate([]).toArray();
+        } catch (error) {
+          expect.fail(`aggregate must not fail, got ${error.message}`);
+        }
+        expect(result[0].encrypted).to.equal('hello');
+        const doc = aggregateSucceeded.reply.cursor.firstBatch[0];
+        expect(doc.encrypted).to.be.instanceOf(Binary);
       });
     });
   });

--- a/test/integration/client-side-encryption/client_side_encryption.prose.test.js
+++ b/test/integration/client-side-encryption/client_side_encryption.prose.test.js
@@ -44,7 +44,7 @@ const eeMetadata = {
   requires: {
     clientSideEncryption: true,
     mongodb: '>=6.0.0',
-    topology: ['replicaset', 'sharded', 'single']
+    topology: ['replicaset', 'sharded']
   }
 };
 
@@ -1545,7 +1545,8 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
         // collection with the filter { "encryptedIndexed": <findPayload> }.
         // Assert one document is returned containing the field
         // { "encryptedIndexed": "encrypted indexed value" }.
-        const result = await encryptedClient.findOne({ encryptedIndexed: findPayload });
+        const collection = encryptedClient.db('db').collection('explicit_encryption');
+        const result = await collection.findOne({ encryptedIndexed: findPayload });
         expect(result.encryptedIndexed).to.equal('encrypted indexed value');
       });
     });
@@ -1613,7 +1614,8 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
           // Assert less than 10 documents are returned. 0 documents may be returned.
           // Assert each returned document contains the field
           // { "encryptedIndexed": "encrypted indexed value" }.
-          const result = await encryptedClient.find({ encryptedIndexed: findPayload }).toArray();
+          const collection = encryptedClient.db('db').collection('explicit_encryption');
+          const result = await collection.find({ encryptedIndexed: findPayload }).toArray();
           expect(result.length).to.be.below(10);
           for (const doc of result) {
             expect(doc.encryptedIndexed).to.equal('encrypted indexed value');
@@ -1625,7 +1627,8 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
           // collection with the filter { "encryptedIndexed": <findPayload2> }.
           // Assert 10 documents are returned. Assert each returned document contains the
           // field { "encryptedIndexed": "encrypted indexed value" }.
-          const result = await encryptedClient.find({ encryptedIndexed: findPayload2 }).toArray();
+          const collection = encryptedClient.db('db').collection('explicit_encryption');
+          const result = await collection.find({ encryptedIndexed: findPayload2 }).toArray();
           expect(result.length).to.equal(10);
           for (const doc of result) {
             expect(doc.encryptedIndexed).to.equal('encrypted indexed value');
@@ -1651,6 +1654,7 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
         // Use encryptedClient to insert the document { "_id": 1, "encryptedUnindexed": <insertPayload> }
         // into db.explicit_encryption.
         await encryptedClient.db('db').collection('explicit_encryption').insertOne({
+          _id: 1,
           encryptedIndexed: insertPayload
         });
       });
@@ -1660,7 +1664,8 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
         // collection with the filter { "_id": 1 }.
         // Assert one document is returned containing the field
         // { "encryptedUnindexed": "encrypted unindexed value" }.
-        const result = await encryptedClient.findOne({ _id: 1 });
+        const collection = encryptedClient.db('db').collection('explicit_encryption');
+        const result = await collection.findOne({ _id: 1 });
         expect(result.encryptedIndexed).to.equal('encrypted unindexed value');
       });
     });
@@ -1699,7 +1704,7 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
         //    algorithm: "Unindexed",
         // }
         // Store the result in payload.
-        payload = await clientEncryption.encrypt('encrypted indexed value', {
+        payload = await clientEncryption.encrypt('encrypted unindexed value', {
           keyId: key1Id,
           algorithm: 'Unindexed'
         });

--- a/test/integration/client-side-encryption/client_side_encryption.prose.test.js
+++ b/test/integration/client-side-encryption/client_side_encryption.prose.test.js
@@ -40,6 +40,14 @@ const metadata = {
   }
 };
 
+const eeMetadata = {
+  requires: {
+    clientSideEncryption: true,
+    mongodb: '>=6.0.0',
+    topology: ['replicaset', 'sharded', 'single']
+  }
+};
+
 // Tests for the ClientEncryption type are not included as part of the YAML tests.
 
 // In the prose tests LOCAL_MASTERKEY refers to the following base64:
@@ -1642,6 +1650,286 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
         expect(result[0].encrypted).to.equal('hello');
         const doc = aggregateSucceeded.reply.cursor.firstBatch[0];
         expect(doc.encrypted).to.be.instanceOf(Binary);
+      });
+    });
+  });
+
+  context('12. Explicit Encryption', eeMetadata, function () {
+    const data = path.join(__dirname, '..', '..', 'spec', 'client-side-encryption', 'etc', 'data');
+    let encryptedFields;
+    let key1Document;
+    let key1Id;
+    let setupClient;
+    let keyVaultClient;
+    let clientEncryption;
+    let encryptedClient;
+
+    beforeEach(async function () {
+      const mongodbClientEncryption = this.configuration.mongodbClientEncryption;
+      // Load the file encryptedFields.json as encryptedFields.
+      encryptedFields = EJSON.parse(
+        await fs.promises.readFile(path.join(data, 'encryptedFields.json')),
+        { relaxed: false }
+      );
+      // Load the file key1-document.json as key1Document.
+      key1Document = EJSON.parse(
+        await fs.promises.readFile(path.join(data, 'keys', 'key1-document.json')),
+        { relaxed: false }
+      );
+      // Read the "_id" field of key1Document as key1ID.
+      key1Id = key1Document._id;
+      setupClient = this.configuration.newClient();
+      // Drop and create the collection db.explicit_encryption using encryptedFields as an option.
+      const db = setupClient.db('db');
+      await dropCollection(db, 'explicit_encryption', { encryptedFields });
+      await db.createCollection('explicit_encryption', { encryptedFields });
+      // Drop and create the collection keyvault.datakeys.
+      const kdb = setupClient.db('keyvault');
+      await dropCollection(kdb, 'datakeys');
+      await kdb.createCollection('datakeys');
+      // Insert key1Document in keyvault.datakeys with majority write concern.
+      await kdb.collection('datakeys').insertOne(key1Document, { writeConcern: { w: 'majority' } });
+      // Create a MongoClient named keyVaultClient.
+      keyVaultClient = this.configuration.newClient();
+      // Create a ClientEncryption object named clientEncryption with these options:
+      //   ClientEncryptionOpts {
+      //      keyVaultClient: <keyVaultClient>;
+      //      keyVaultNamespace: "keyvault.datakeys";
+      //      kmsProviders: { "local": { "key": <base64 decoding of LOCAL_MASTERKEY> } }
+      //   }
+      clientEncryption = new mongodbClientEncryption.ClientEncryption(keyVaultClient, {
+        keyVaultNamespace: 'keyvault.datakeys',
+        kmsProviders: getKmsProviders(LOCAL_KEY),
+        bson: BSON
+      });
+      // Create a MongoClient named ``encryptedClient`` with these ``AutoEncryptionOpts``:
+      //   AutoEncryptionOpts {
+      //     keyVaultNamespace: "keyvault.datakeys";
+      //     kmsProviders: { "local": { "key": <base64 decoding of LOCAL_MASTERKEY> } },
+      //     bypassQueryAnalysis: true
+      //   }
+      encryptedClient = this.configuration.newClient(
+        {},
+        {
+          bypassQueryAnalysis: true,
+          autoEncryption: {
+            keyVaultNamespace: 'keyvault.datakeys',
+            kmsProviders: getKmsProviders(LOCAL_KEY)
+          }
+        }
+      );
+    });
+
+    afterEach(async function () {
+      await setupClient.close();
+      await keyVaultClient.close();
+      await encryptedClient.close();
+    });
+
+    context('Case 1: can insert encrypted indexed and find', eeMetadata, function () {
+      let insertPayload;
+      let findPayload;
+
+      beforeEach(async function () {
+        // Use clientEncryption to encrypt the value "encrypted indexed value" with these EncryptOpts:
+        // class EncryptOpts {
+        //   keyId : <key1ID>
+        //   algorithm: "Indexed",
+        // }
+        // Store the result in insertPayload.
+        insertPayload = await clientEncryption.encrypt('encrypted indexed value', {
+          keyId: key1Id,
+          algorithm: 'Indexed'
+        });
+        // Use encryptedClient to insert the document { "encryptedIndexed": <insertPayload> }
+        // into db.explicit_encryption.
+        await encryptedClient.db('db').collection('explicit_encryption').insertOne({
+          encryptedIndexed: insertPayload
+        });
+        // Use clientEncryption to encrypt the value "encrypted indexed value" with these EncryptOpts:
+        // class EncryptOpts {
+        //    keyId : <key1ID>
+        //    algorithm: "Indexed",
+        //    queryType: Equality
+        // }
+        // Store the result in findPayload.
+        findPayload = await clientEncryption.encrypt('encrypted indexed value', {
+          keyId: key1Id,
+          algorithm: 'Indexed',
+          queryType: 'equality'
+        });
+      });
+
+      it('returns the decrypted value', async function () {
+        // Use encryptedClient to run a "find" operation on the db.explicit_encryption
+        // collection with the filter { "encryptedIndexed": <findPayload> }.
+        // Assert one document is returned containing the field
+        // { "encryptedIndexed": "encrypted indexed value" }.
+        const result = await encryptedClient.findOne({ encryptedIndexed: findPayload });
+        expect(result.encryptedIndexed).to.equal('encrypted indexed value');
+      });
+    });
+
+    context(
+      'Case 2: can insert encrypted indexed and find with non-zero contention',
+      eeMetadata,
+      function () {
+        let findPayload;
+        let findPayload2;
+
+        beforeEach(async function () {
+          for (let i = 0; i < 10; i++) {
+            // Use clientEncryption to encrypt the value "encrypted indexed value" with these EncryptOpts:
+            // class EncryptOpts {
+            //    keyId : <key1ID>
+            //    algorithm: "Indexed",
+            //    contentionFactor: 10
+            // }
+            // Store the result in insertPayload.
+            const insertPayload = await clientEncryption.encrypt('encrypted indexed value', {
+              keyId: key1Id,
+              algorithm: 'Indexed',
+              contentionFactor: 10
+            });
+            // Use encryptedClient to insert the document { "encryptedIndexed": <insertPayload> }
+            // into db.explicit_encryption.
+            await encryptedClient.db('db').collection('explicit_encryption').insertOne({
+              encryptedIndexed: insertPayload
+            });
+            // Repeat the above steps 10 times to insert 10 total documents.
+            // The insertPayload must be regenerated each iteration.
+          }
+          // Use clientEncryption to encrypt the value "encrypted indexed value" with these EncryptOpts:
+          // class EncryptOpts {
+          //    keyId : <key1ID>
+          //    algorithm: "Indexed",
+          //    queryType: Equality
+          // }
+          // Store the result in findPayload.
+          findPayload = await clientEncryption.encrypt('encrypted indexed value', {
+            keyId: key1Id,
+            algorithm: 'Indexed',
+            queryType: 'equality'
+          });
+          // Use clientEncryption to encrypt the value "encrypted indexed value" with these EncryptOpts:
+          // class EncryptOpts {
+          //    keyId : <key1ID>
+          //    algorithm: "Indexed",
+          //    queryType: Equality,
+          //    contentionFactor: 10
+          // }
+          // Store the result in findPayload2.
+          findPayload2 = await clientEncryption.encrypt('encrypted indexed value', {
+            keyId: key1Id,
+            algorithm: 'Indexed',
+            queryType: 'equality',
+            contentionFactor: 10
+          });
+        });
+
+        it('returns less than the total documents with no contention', async function () {
+          // Use encryptedClient to run a "find" operation on the db.explicit_encryption
+          // collection with the filter { "encryptedIndexed": <findPayload> }.
+          // Assert less than 10 documents are returned. 0 documents may be returned.
+          // Assert each returned document contains the field
+          // { "encryptedIndexed": "encrypted indexed value" }.
+          const result = await encryptedClient.find({ encryptedIndexed: findPayload }).toArray();
+          expect(result.length).to.be.below(10);
+          for (const doc of result) {
+            expect(doc.encryptedIndexed).to.equal('encrypted indexed value');
+          }
+        });
+
+        it('returns all documents with contention', async function () {
+          // Use encryptedClient to run a "find" operation on the db.explicit_encryption
+          // collection with the filter { "encryptedIndexed": <findPayload2> }.
+          // Assert 10 documents are returned. Assert each returned document contains the
+          // field { "encryptedIndexed": "encrypted indexed value" }.
+          const result = await encryptedClient.find({ encryptedIndexed: findPayload2 }).toArray();
+          expect(result.length).to.equal(10);
+          for (const doc of result) {
+            expect(doc.encryptedIndexed).to.equal('encrypted indexed value');
+          }
+        });
+      }
+    );
+
+    context('Case 3: can insert encrypted unindexed', eeMetadata, function () {
+      let insertPayload;
+
+      beforeEach(async function () {
+        // Use clientEncryption to encrypt the value "encrypted unindexed value" with these EncryptOpts:
+        // class EncryptOpts {
+        //    keyId : <key1ID>
+        //    algorithm: "Unindexed"
+        // }
+        // Store the result in insertPayload.
+        insertPayload = await clientEncryption.encrypt('encrypted unindexed value', {
+          keyId: key1Id,
+          algorithm: 'Unindexed'
+        });
+        // Use encryptedClient to insert the document { "_id": 1, "encryptedUnindexed": <insertPayload> }
+        // into db.explicit_encryption.
+        await encryptedClient.db('db').collection('explicit_encryption').insertOne({
+          encryptedIndexed: insertPayload
+        });
+      });
+
+      it('returns unindexed documents', async function () {
+        // Use encryptedClient to run a "find" operation on the db.explicit_encryption
+        // collection with the filter { "_id": 1 }.
+        // Assert one document is returned containing the field
+        // { "encryptedUnindexed": "encrypted unindexed value" }.
+        const result = await encryptedClient.findOne({ _id: 1 });
+        expect(result.encryptedIndexed).to.equal('encrypted unindexed value');
+      });
+    });
+
+    context('Case 4: can roundtrip encrypted indexed', eeMetadata, function () {
+      let payload;
+
+      beforeEach(async function () {
+        // Use clientEncryption to encrypt the value "encrypted indexed value" with these EncryptOpts:
+        // class EncryptOpts {
+        //    keyId : <key1ID>
+        //    algorithm: "Indexed",
+        // }
+        // Store the result in payload.
+        payload = await clientEncryption.encrypt('encrypted indexed value', {
+          keyId: key1Id,
+          algorithm: 'Indexed'
+        });
+      });
+
+      it('decrypts the value', async function () {
+        // Use clientEncryption to decrypt payload. Assert the returned value
+        // equals "encrypted indexed value".
+        const result = await clientEncryption.decrypt(payload);
+        expect(result).equals('encrypted indexed value');
+      });
+    });
+
+    context('Case 5: can roundtrip encrypted unindexed', eeMetadata, function () {
+      let payload;
+
+      beforeEach(async function () {
+        // Use clientEncryption to encrypt the value "encrypted unindexed value" with these EncryptOpts:
+        // class EncryptOpts {
+        //    keyId : <key1ID>
+        //    algorithm: "Unindexed",
+        // }
+        // Store the result in payload.
+        payload = await clientEncryption.encrypt('encrypted indexed value', {
+          keyId: key1Id,
+          algorithm: 'Unindexed'
+        });
+      });
+
+      it('decrypts the value', async function () {
+        // Use clientEncryption to decrypt payload. Assert the returned value
+        // equals "encrypted unindexed value".
+        const result = await clientEncryption.decrypt(payload);
+        expect(result).equals('encrypted unindexed value');
       });
     });
   });

--- a/test/integration/client-side-encryption/client_side_encryption.prose.test.js
+++ b/test/integration/client-side-encryption/client_side_encryption.prose.test.js
@@ -1547,7 +1547,7 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
         // { "encryptedIndexed": "encrypted indexed value" }.
         const collection = encryptedClient.db('db').collection('explicit_encryption');
         const result = await collection.findOne({ encryptedIndexed: findPayload });
-        expect(result.encryptedIndexed).to.equal('encrypted indexed value');
+        expect(result).to.have.property('encryptedIndexed', 'encrypted indexed value')
       });
     });
 
@@ -1618,7 +1618,7 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
           const result = await collection.find({ encryptedIndexed: findPayload }).toArray();
           expect(result.length).to.be.below(10);
           for (const doc of result) {
-            expect(doc.encryptedIndexed).to.equal('encrypted indexed value');
+            expect(doc).to.have.property('encryptedIndexed', 'encrypted indexed value')
           }
         });
 
@@ -1631,7 +1631,7 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
           const result = await collection.find({ encryptedIndexed: findPayload2 }).toArray();
           expect(result.length).to.equal(10);
           for (const doc of result) {
-            expect(doc.encryptedIndexed).to.equal('encrypted indexed value');
+            expect(doc).to.have.property('encryptedIndexed', 'encrypted indexed value')
           }
         });
       }
@@ -1655,7 +1655,7 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
         // into db.explicit_encryption.
         await encryptedClient.db('db').collection('explicit_encryption').insertOne({
           _id: 1,
-          encryptedIndexed: insertPayload
+          encryptedUnindexed: insertPayload
         });
       });
 
@@ -1666,7 +1666,7 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
         // { "encryptedUnindexed": "encrypted unindexed value" }.
         const collection = encryptedClient.db('db').collection('explicit_encryption');
         const result = await collection.findOne({ _id: 1 });
-        expect(result.encryptedIndexed).to.equal('encrypted unindexed value');
+        expect(result).to.have.property('encryptedUnindexed', 'encrypted unindexed value')
       });
     });
 

--- a/test/integration/client-side-encryption/client_side_encryption.prose.test.js
+++ b/test/integration/client-side-encryption/client_side_encryption.prose.test.js
@@ -1547,7 +1547,7 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
         // { "encryptedIndexed": "encrypted indexed value" }.
         const collection = encryptedClient.db('db').collection('explicit_encryption');
         const result = await collection.findOne({ encryptedIndexed: findPayload });
-        expect(result).to.have.property('encryptedIndexed', 'encrypted indexed value')
+        expect(result).to.have.property('encryptedIndexed', 'encrypted indexed value');
       });
     });
 
@@ -1618,7 +1618,7 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
           const result = await collection.find({ encryptedIndexed: findPayload }).toArray();
           expect(result.length).to.be.below(10);
           for (const doc of result) {
-            expect(doc).to.have.property('encryptedIndexed', 'encrypted indexed value')
+            expect(doc).to.have.property('encryptedIndexed', 'encrypted indexed value');
           }
         });
 
@@ -1631,7 +1631,7 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
           const result = await collection.find({ encryptedIndexed: findPayload2 }).toArray();
           expect(result.length).to.equal(10);
           for (const doc of result) {
-            expect(doc).to.have.property('encryptedIndexed', 'encrypted indexed value')
+            expect(doc).to.have.property('encryptedIndexed', 'encrypted indexed value');
           }
         });
       }
@@ -1666,7 +1666,7 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
         // { "encryptedUnindexed": "encrypted unindexed value" }.
         const collection = encryptedClient.db('db').collection('explicit_encryption');
         const result = await collection.findOne({ _id: 1 });
-        expect(result).to.have.property('encryptedUnindexed', 'encrypted unindexed value')
+        expect(result).to.have.property('encryptedUnindexed', 'encrypted unindexed value');
       });
     });
 

--- a/test/integration/client-side-encryption/client_side_encryption.prose.test.js
+++ b/test/integration/client-side-encryption/client_side_encryption.prose.test.js
@@ -1711,8 +1711,8 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
       encryptedClient = this.configuration.newClient(
         {},
         {
-          bypassQueryAnalysis: true,
           autoEncryption: {
+            bypassQueryAnalysis: true,
             keyVaultNamespace: 'keyvault.datakeys',
             kmsProviders: getKmsProviders(LOCAL_KEY)
           }

--- a/test/integration/shared.js
+++ b/test/integration/shared.js
@@ -38,8 +38,8 @@ function delay(timeout) {
   });
 }
 
-function dropCollection(dbObj, collectionName) {
-  return dbObj.dropCollection(collectionName).catch(ignoreNsNotFound);
+function dropCollection(dbObj, collectionName, options = {}) {
+  return dbObj.dropCollection(collectionName, options).catch(ignoreNsNotFound);
 }
 
 function filterForCommands(commands, bag) {

--- a/test/spec/client-side-encryption/etc/data/encryptedFields.json
+++ b/test/spec/client-side-encryption/etc/data/encryptedFields.json
@@ -1,0 +1,33 @@
+{
+  "escCollection": "enxcol_.default.esc",
+  "eccCollection": "enxcol_.default.ecc",
+  "ecocCollection": "enxcol_.default.ecoc",
+  "fields": [
+    {
+      "keyId": {
+        "$binary": {
+          "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+          "subType": "04"
+        }
+      },
+      "path": "encryptedIndexed",
+      "bsonType": "string",
+      "queries": {
+        "queryType": "equality",
+        "contention": {
+          "$numberLong": "0"
+        }
+      }
+    },
+    {
+      "keyId": {
+        "$binary": {
+          "base64": "q83vqxI0mHYSNBI0VniQEg==",
+          "subType": "04"
+        }
+      },
+      "path": "encryptedUnindexed",
+      "bsonType": "string"
+    }
+  ]
+}

--- a/test/spec/client-side-encryption/etc/data/keys/key1-document.json
+++ b/test/spec/client-side-encryption/etc/data/keys/key1-document.json
@@ -1,0 +1,30 @@
+{
+    "_id": {
+        "$binary": {
+            "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+            "subType": "04"
+        }
+    },
+    "keyMaterial": {
+        "$binary": {
+            "base64": "sHe0kz57YW7v8g9VP9sf/+K1ex4JqKc5rf/URX3n3p8XdZ6+15uXPaSayC6adWbNxkFskuMCOifDoTT+rkqMtFkDclOy884RuGGtUysq3X7zkAWYTKi8QAfKkajvVbZl2y23UqgVasdQu3OVBQCrH/xY00nNAs/52e958nVjBuzQkSb1T8pKJAyjZsHJ60+FtnfafDZSTAIBJYn7UWBCwQ==",
+            "subType": "00"
+        }
+    },
+    "creationDate": {
+        "$date": {
+            "$numberLong": "1648914851981"
+        }
+    },
+    "updateDate": {
+        "$date": {
+            "$numberLong": "1648914851981"
+        }
+    },
+    "status": {
+        "$numberInt": "0"
+    },
+    "masterKey": {
+        "provider": "local"
+    }
+}


### PR DESCRIPTION
### Description

Adds explicit encryption prose tests

#### What is changing?

Adds 5 new prose tests for #12 in the client side encryption spec. https://github.com/mongodb/specifications/blob/7f37c9325b423223edf54d795afed444e6989b98/source/client-side-encryption/tests/README.rst#explicit-encryption

I've also included the spec prose test language in code comments in the test here for easier following.

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

NODE-4227

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
