### PR TITLE
feat(NODE-4301): remove shared lib experimental tags

### DIFF
--- a/src/deps.ts
+++ b/src/deps.ts
@@ -344,7 +344,7 @@ export interface AutoEncryptionOptions {
      *
      * Specifying a path prevents mongocryptd from being used as a fallback.
      *
-     * @experimental Requires the MongoDB Crypt shared library, available in MongoDB 6.0 or higher.
+     * Requires the MongoDB Crypt shared library, available in MongoDB 6.0 or higher.
      */
     cryptSharedLibPath?: string;
     /**
@@ -353,7 +353,7 @@ export interface AutoEncryptionOptions {
      *
      * This is always true when `cryptSharedLibPath` is specified.
      *
-     * @experimental Requires the MongoDB Crypt shared library, available in MongoDB 6.0 or higher.
+     * Requires the MongoDB Crypt shared library, available in MongoDB 6.0 or higher.
      */
     cryptSharedLibRequired?: boolean;
     /**


### PR DESCRIPTION
### Description

Removes the experimental tags for the shared csfle library.

#### What is changing?

The `extraOptions.cryptSharedLibPath` and `extraOptions.cryptSharedLibRequired` provided as auto encryption options are GA and no longer experimental.

No changes to mongodb-client-encryption.

##### Is there new documentation needed for these changes?

Update release notes on next release to note this.

#### What is the motivation for this change?

NODE-4301

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
