### PR TITLE
chore(NODE-4321): add typescript to eslint rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -182,6 +182,29 @@
       }
     },
     {
+      // Settings for typescript test files
+      "files": [
+        "src/**/*.ts"
+      ],
+      "parser": "@typescript-eslint/parser",
+      "parserOptions": {
+        "project": ["./tsconfig.json"]
+      },
+      "extends": [
+        "plugin:@typescript-eslint/recommended-requiring-type-checking"
+      ],
+      "rules": {
+        "@typescript-eslint/no-unsafe-member-access": "off",
+        "@typescript-eslint/no-unsafe-argument": "off",
+        "@typescript-eslint/no-unsafe-assignment": "off",
+        "@typescript-eslint/no-unsafe-return": "off",
+        "@typescript-eslint/no-unsafe-call": "off",
+
+        "@typescript-eslint/restrict-plus-operands": "off",
+        "@typescript-eslint/restrict-template-expressions": "off"
+      }
+    },
+    {
       // Settings for typescript type test files
       "files": [
         "*.test-d.ts"

--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -894,10 +894,7 @@ export class ChangeStream<
 
     if (isResumableError(changeStreamError, this.cursor.maxWireVersion)) {
       this._endStream();
-      this.cursor.close().then(
-        () => null,
-        () => null
-      ); // Ignoring the result of close is intentional
+      this.cursor.close().catch(() => null);
 
       const topology = getTopology(this.parent);
       topology.selectServer(this.cursor.readPreference, {}, serverSelectionError => {
@@ -927,10 +924,7 @@ export class ChangeStream<
     }
 
     if (isResumableError(changeStreamError, this.cursor.maxWireVersion)) {
-      this.cursor.close().then(
-        () => null,
-        () => null
-      ); // Ignoring the result of close is intentional
+      this.cursor.close().catch(() => null);
 
       const topology = getTopology(this.parent);
       topology.selectServer(this.cursor.readPreference, {}, serverSelectionError => {

--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -897,7 +897,7 @@ export class ChangeStream<
       this.cursor.close().then(
         () => null,
         () => null
-      ); // TODO(NODE-XXX): Is this correct?
+      ); // Ignoring the result of close is intentional
 
       const topology = getTopology(this.parent);
       topology.selectServer(this.cursor.readPreference, {}, serverSelectionError => {
@@ -930,7 +930,7 @@ export class ChangeStream<
       this.cursor.close().then(
         () => null,
         () => null
-      ); // TODO(NODE-XXX): Is this correct?;
+      ); // Ignoring the result of close is intentional
 
       const topology = getTopology(this.parent);
       topology.selectServer(this.cursor.readPreference, {}, serverSelectionError => {

--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -894,7 +894,10 @@ export class ChangeStream<
 
     if (isResumableError(changeStreamError, this.cursor.maxWireVersion)) {
       this._endStream();
-      this.cursor.close();
+      this.cursor.close().then(
+        () => null,
+        () => null
+      ); // TODO(NODE-XXX): Is this correct?
 
       const topology = getTopology(this.parent);
       topology.selectServer(this.cursor.readPreference, {}, serverSelectionError => {
@@ -913,6 +916,7 @@ export class ChangeStream<
    *
    * we promisify _processErrorIteratorModeCallback until we have a promisifed version of selectServer.
    */
+  // eslint-disable-next-line @typescript-eslint/unbound-method
   private _processErrorIteratorMode = promisify(this._processErrorIteratorModeCallback);
 
   /** @internal */
@@ -923,7 +927,10 @@ export class ChangeStream<
     }
 
     if (isResumableError(changeStreamError, this.cursor.maxWireVersion)) {
-      this.cursor.close();
+      this.cursor.close().then(
+        () => null,
+        () => null
+      ); // TODO(NODE-XXX): Is this correct?;
 
       const topology = getTopology(this.parent);
       topology.selectServer(this.cursor.readPreference, {}, serverSelectionError => {

--- a/src/cmap/command_monitoring_events.ts
+++ b/src/cmap/command_monitoring_events.ts
@@ -248,9 +248,8 @@ function extractCommand(command: WriteProtocolMessageType): Document {
     });
 
     OP_QUERY_KEYS.forEach(key => {
-      const opKey = key as typeof OP_QUERY_KEYS[number];
-      if (command[opKey]) {
-        result[opKey] = command[opKey];
+      if (command[key]) {
+        result[key] = command[key];
       }
     });
 

--- a/src/cmap/connect.ts
+++ b/src/cmap/connect.ts
@@ -490,11 +490,7 @@ function makeSocks5Connection(options: MakeConnectionOptions, callback: Callback
             callback
           );
         },
-        error => {
-          if (error) {
-            return callback(connectionFailureError('error', error));
-          }
-        }
+        error => callback(connectionFailureError('error', error))
       );
     }
   );

--- a/src/cmap/connect.ts
+++ b/src/cmap/connect.ts
@@ -8,7 +8,6 @@ import type { Document } from '../bson';
 import { Int32 } from '../bson';
 import { LEGACY_HELLO_COMMAND } from '../constants';
 import {
-  AnyError,
   MongoCompatibilityError,
   MongoError,
   MongoErrorLabel,
@@ -462,39 +461,39 @@ function makeSocks5Connection(options: MakeConnectionOptions, callback: Callback
       }
 
       // Then, establish the Socks5 proxy connection:
-      SocksClient.createConnection(
-        {
-          existing_socket: rawSocket,
-          timeout: options.connectTimeoutMS,
-          command: 'connect',
-          destination: {
-            host: destination.host,
-            port: destination.port
-          },
-          proxy: {
-            // host and port are ignored because we pass existing_socket
-            host: 'iLoveJavaScript',
-            port: 0,
-            type: 5,
-            userId: options.proxyUsername || undefined,
-            password: options.proxyPassword || undefined
-          }
+      SocksClient.createConnection({
+        existing_socket: rawSocket,
+        timeout: options.connectTimeoutMS,
+        command: 'connect',
+        destination: {
+          host: destination.host,
+          port: destination.port
         },
-        (err: AnyError, info: { socket: Stream }) => {
-          if (err) {
-            return callback(connectionFailureError('error', err));
-          }
-
+        proxy: {
+          // host and port are ignored because we pass existing_socket
+          host: 'iLoveJavaScript',
+          port: 0,
+          type: 5,
+          userId: options.proxyUsername || undefined,
+          password: options.proxyPassword || undefined
+        }
+      }).then(
+        ({ socket }) => {
           // Finally, now treat the resulting duplex stream as the
           // socket over which we send and receive wire protocol messages:
           makeConnection(
             {
               ...options,
-              existingSocket: info.socket,
+              existingSocket: socket,
               proxyHost: undefined
             },
             callback
           );
+        },
+        error => {
+          if (error) {
+            return callback(connectionFailureError('error', error));
+          }
         }
       );
     }

--- a/src/cmap/connection.ts
+++ b/src/cmap/connection.ts
@@ -533,7 +533,7 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
         clusterTime = session.clusterTime;
       }
 
-      const err = applySession(session, finalCmd, options as CommandOptions);
+      const err = applySession(session, finalCmd, options);
       if (err) {
         return callback(err);
       }

--- a/src/cmap/wire_protocol/compression.ts
+++ b/src/cmap/wire_protocol/compression.ts
@@ -52,9 +52,10 @@ export function compress(
       if (Snappy[PKG_VERSION].major <= 6) {
         Snappy.compress(dataToBeCompressed, callback);
       } else {
-        Snappy.compress(dataToBeCompressed)
-          .then(buffer => callback(undefined, buffer))
-          .catch(error => callback(error));
+        Snappy.compress(dataToBeCompressed).then(
+          buffer => callback(undefined, buffer),
+          error => callback(error)
+        );
       }
       break;
     }
@@ -102,9 +103,10 @@ export function decompress(
       if (Snappy[PKG_VERSION].major <= 6) {
         Snappy.uncompress(compressedData, { asBuffer: true }, callback);
       } else {
-        Snappy.uncompress(compressedData, { asBuffer: true })
-          .then(buffer => callback(undefined, buffer))
-          .catch(error => callback(error));
+        Snappy.uncompress(compressedData, { asBuffer: true }).then(
+          buffer => callback(undefined, buffer),
+          error => callback(error)
+        );
       }
       break;
     }

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -725,7 +725,7 @@ export class Collection<TSchema extends Document = Document> {
     }
 
     if (typeof filter === 'function') {
-      callback = filter as Callback<WithId<TSchema> | null>;
+      callback = filter;
       filter = {};
       options = {};
     }
@@ -1128,7 +1128,7 @@ export class Collection<TSchema extends Document = Document> {
       this.s.db.s.client,
       new CountDocumentsOperation(
         this as TODO_NODE_3286,
-        filter as Document,
+        filter,
         resolveOptions(this, options as CountDocumentsOptions)
       ),
       callback
@@ -1191,7 +1191,7 @@ export class Collection<TSchema extends Document = Document> {
     callback?: Callback<any[]>
   ): Promise<any[]> | void {
     if (typeof filter === 'function') {
-      (callback = filter as Callback<any[]>), (filter = {}), (options = {});
+      (callback = filter), (filter = {}), (options = {});
     } else {
       if (arguments.length === 3 && typeof options === 'function') {
         (callback = options), (options = {});
@@ -1667,7 +1667,7 @@ export class Collection<TSchema extends Document = Document> {
     callback?: Callback<number>
   ): Promise<number> | void {
     if (typeof filter === 'function') {
-      (callback = filter as Callback<number>), (filter = {}), (options = {});
+      (callback = filter), (filter = {}), (options = {});
     } else {
       if (typeof options === 'function') (callback = options), (options = {});
     }

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -67,7 +67,7 @@ export interface CursorCloseOptions {
 /** @public */
 export interface CursorStreamOptions {
   /** A transformation method applied to each document emitted by the stream */
-  transform?(doc: Document): Document;
+  transform?(this: void, doc: Document): Document;
 }
 
 /** @public */
@@ -883,7 +883,10 @@ class ReadableCursorStream extends Readable {
         //       a client during iteration. Alternatively, we could do the "right" thing and
         //       propagate the error message by removing this special case.
         if (err.message.match(/server is closed/)) {
-          this._cursor.close();
+          this._cursor.close().then(
+            () => null,
+            () => null
+          ); // TODO(NODE-XXXX): is this correct?
           return this.push(null);
         }
 
@@ -902,7 +905,10 @@ class ReadableCursorStream extends Readable {
       if (result == null) {
         this.push(null);
       } else if (this.destroyed) {
-        this._cursor.close();
+        this._cursor.close().then(
+          () => null,
+          () => null
+        ); // TODO(NODE-XXXX): is this correct?
       } else {
         if (this.push(result)) {
           return this._readNext();

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -886,7 +886,7 @@ class ReadableCursorStream extends Readable {
           this._cursor.close().then(
             () => null,
             () => null
-          ); // TODO(NODE-XXXX): is this correct?
+          ); // Ignoring the result of close is intentional
           return this.push(null);
         }
 
@@ -908,7 +908,7 @@ class ReadableCursorStream extends Readable {
         this._cursor.close().then(
           () => null,
           () => null
-        ); // TODO(NODE-XXXX): is this correct?
+        ); // Ignoring the result of close is intentional
       } else {
         if (this.push(result)) {
           return this._readNext();

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -597,7 +597,7 @@ export abstract class AbstractCursor<
       // We only want to end this session if we created it, and it hasn't ended yet
       if (session.explicit === false) {
         if (!session.hasEnded) {
-          session.endSession(() => null);
+          session.endSession().catch(() => null);
         }
         this[kSession] = this.client.startSession({ owner: this, explicit: false });
       }
@@ -883,10 +883,7 @@ class ReadableCursorStream extends Readable {
         //       a client during iteration. Alternatively, we could do the "right" thing and
         //       propagate the error message by removing this special case.
         if (err.message.match(/server is closed/)) {
-          this._cursor.close().then(
-            () => null,
-            () => null
-          ); // Ignoring the result of close is intentional
+          this._cursor.close().catch(() => null);
           return this.push(null);
         }
 
@@ -905,10 +902,7 @@ class ReadableCursorStream extends Readable {
       if (result == null) {
         this.push(null);
       } else if (this.destroyed) {
-        this._cursor.close().then(
-          () => null,
-          () => null
-        ); // Ignoring the result of close is intentional
+        this._cursor.close().catch(() => null);
       } else {
         if (this.push(result)) {
           return this._readNext();

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -35,13 +35,12 @@ try {
 } catch {} // eslint-disable-line
 
 export interface KerberosClient {
-  step: (challenge: string, callback?: Callback<string>) => Promise<string> | void;
-  wrap: (
-    challenge: string,
-    options?: { user: string },
-    callback?: Callback<string>
-  ) => Promise<string> | void;
-  unwrap: (challenge: string, callback?: Callback<string>) => Promise<string> | void;
+  step(challenge: string): Promise<string>;
+  step(challenge: string, callback: Callback<string>): void;
+  wrap(challenge: string, options: { user: string }): Promise<string>;
+  wrap(challenge: string, options: { user: string }, callback: Callback<string>): void;
+  unwrap(challenge: string): Promise<string>;
+  unwrap(challenge: string, callback: Callback<string>): void;
 }
 
 type ZStandardLib = {
@@ -80,11 +79,7 @@ type SnappyLib = {
    * @param callback - ONLY USED IN SNAPPY 6.x
    */
   compress(buf: Buffer): Promise<Buffer>;
-  compress(buf: Buffer, callback: (error?: Error, buffer?: Buffer) => void): Promise<Buffer> | void;
-  compress(
-    buf: Buffer,
-    callback?: (error?: Error, buffer?: Buffer) => void
-  ): Promise<Buffer> | void;
+  compress(buf: Buffer, callback: (error?: Error, buffer?: Buffer) => void): void;
 
   /**
    * - Snappy 6.x takes a callback and returns void
@@ -99,12 +94,7 @@ type SnappyLib = {
     buf: Buffer,
     opt: { asBuffer: true },
     callback: (error?: Error, buffer?: Buffer) => void
-  ): Promise<Buffer> | void;
-  uncompress(
-    buf: Buffer,
-    opt: { asBuffer: true },
-    callback?: (error?: Error, buffer?: Buffer) => void
-  ): Promise<Buffer> | void;
+  ): void;
 };
 
 export let Snappy: SnappyLib | { kModuleError: MongoMissingDependencyError } = makeErrorModule(
@@ -141,6 +131,7 @@ interface AWS4 {
    * @param credentials - AWS credential details, sessionToken should be omitted entirely if its false-y
    */
   sign(
+    this: void,
     options: {
       path: '/';
       body: string;

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -493,7 +493,6 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> {
               { endSessions },
               { readPreference: ReadPreference.primaryPreferred, noResponse: true }
             )
-            .then(() => null) // outcome does not matter
             .catch(() => null); // outcome does not matter
         })
         .then(() => {
@@ -639,10 +638,7 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> {
         // Do not return the result of callback
       })
       .finally(() => {
-        session.endSession().then(
-          () => null,
-          () => null
-        );
+        session.endSession().catch(() => null);
       });
   }
 

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -638,7 +638,12 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> {
       .then(() => {
         // Do not return the result of callback
       })
-      .finally(() => session.endSession());
+      .finally(() => {
+        session.endSession().then(
+          () => null,
+          () => null
+        );
+      });
   }
 
   /**

--- a/src/operations/common_functions.ts
+++ b/src/operations/common_functions.ts
@@ -34,7 +34,7 @@ export function indexInformation(
   let options = _optionsOrCallback as IndexInformationOptions;
   let callback = _callback as Callback;
   if ('function' === typeof _optionsOrCallback) {
-    callback = _optionsOrCallback as Callback;
+    callback = _optionsOrCallback;
     options = {};
   }
   // If we specified full information

--- a/src/operations/execute_operation.ts
+++ b/src/operations/execute_operation.ts
@@ -144,10 +144,7 @@ export function executeOperation<
       });
     } catch (error) {
       if (session?.owner != null && session.owner === owner) {
-        session.endSession().then(
-          () => null,
-          () => null
-        ); // Ignoring the result of endSession is intentional
+        session.endSession().catch(() => null);
       }
 
       throw error;

--- a/src/operations/execute_operation.ts
+++ b/src/operations/execute_operation.ts
@@ -144,8 +144,12 @@ export function executeOperation<
       });
     } catch (error) {
       if (session?.owner != null && session.owner === owner) {
-        session.endSession();
+        session.endSession().then(
+          () => null,
+          () => null
+        );
       }
+
       throw error;
     }
   });

--- a/src/operations/execute_operation.ts
+++ b/src/operations/execute_operation.ts
@@ -147,7 +147,7 @@ export function executeOperation<
         session.endSession().then(
           () => null,
           () => null
-        );
+        ); // Ignoring the result of endSession is intentional
       }
 
       throw error;

--- a/src/read_preference.ts
+++ b/src/read_preference.ts
@@ -163,14 +163,10 @@ export class ReadPreference {
     } else if (!(readPreference instanceof ReadPreference) && typeof readPreference === 'object') {
       const mode = readPreference.mode || readPreference.preference;
       if (mode && typeof mode === 'string') {
-        return new ReadPreference(
-          mode as ReadPreferenceMode,
-          readPreference.tags ?? readPreferenceTags,
-          {
-            maxStalenessSeconds: readPreference.maxStalenessSeconds,
-            hedge: options.hedge
-          }
-        );
+        return new ReadPreference(mode, readPreference.tags ?? readPreferenceTags, {
+          maxStalenessSeconds: readPreference.maxStalenessSeconds,
+          hedge: options.hedge
+        });
       }
     }
 
@@ -193,7 +189,7 @@ export class ReadPreference {
     } else if (r && !(r instanceof ReadPreference) && typeof r === 'object') {
       const mode = r.mode || r.preference;
       if (mode && typeof mode === 'string') {
-        options.readPreference = new ReadPreference(mode as ReadPreferenceMode, r.tags, {
+        options.readPreference = new ReadPreference(mode, r.tags, {
           maxStalenessSeconds: r.maxStalenessSeconds
         });
       }

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -616,10 +616,7 @@ function attemptTransaction<TSchema>(
   }
 
   if (!isPromiseLike(promise)) {
-    session.abortTransaction().then(
-      () => null,
-      () => null
-    ); // TODO(NODE-XXXX): is this correct?
+    session.abortTransaction().catch(() => null);
     throw new MongoInvalidArgumentError(
       'Function provided to `withTransaction` must return a Promise'
     );

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -616,7 +616,10 @@ function attemptTransaction<TSchema>(
   }
 
   if (!isPromiseLike(promise)) {
-    session.abortTransaction();
+    session.abortTransaction().then(
+      () => null,
+      () => null
+    ); // TODO(NODE-XXXX): is this correct?
     throw new MongoInvalidArgumentError(
       'Function provided to `withTransaction` must return a Promise'
     );

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -161,6 +161,7 @@ export function parseIndexOptions(indexSpec: IndexSpecification): IndexOptions {
   };
 }
 
+const TO_STRING = (object: unknown) => Object.prototype.toString.call(object);
 /**
  * Checks if arg is an Object:
  * - **NOTE**: the check is based on the `[Symbol.toStringTag]() === 'Object'`
@@ -168,7 +169,7 @@ export function parseIndexOptions(indexSpec: IndexSpecification): IndexOptions {
  */
 // eslint-disable-next-line @typescript-eslint/ban-types
 export function isObject(arg: unknown): arg is object {
-  return '[object Object]' === Object.prototype.toString.call(arg);
+  return '[object Object]' === TO_STRING(arg);
 }
 
 /** @internal */
@@ -380,7 +381,7 @@ export interface DeprecateOptionsConfig {
   /** index of options object in function arguments array */
   optionsIndex: number;
   /** optional custom message handler to generate warnings */
-  msgHandler?(name: string, option: string): string;
+  msgHandler?(this: void, name: string, option: string): string;
 }
 
 /**
@@ -1024,6 +1025,9 @@ export function setDifference<T>(setA: Iterable<T>, setB: Iterable<T>): Set<T> {
   return difference;
 }
 
+const HAS_OWN = (object: unknown, prop: string) =>
+  Object.prototype.hasOwnProperty.call(object, prop);
+
 export function isRecord<T extends readonly string[]>(
   value: unknown,
   requiredKeys: T
@@ -1033,9 +1037,6 @@ export function isRecord(
   value: unknown,
   requiredKeys: string[] | undefined = undefined
 ): value is Record<string, any> {
-  const toString = Object.prototype.toString;
-  const hasOwnProperty = Object.prototype.hasOwnProperty;
-  const isObject = (v: unknown) => toString.call(v) === '[object Object]';
   if (!isObject(value)) {
     return false;
   }
@@ -1047,7 +1048,7 @@ export function isRecord(
     }
 
     // Check to see if some method exists from the Object exists
-    if (!hasOwnProperty.call(ctor.prototype, 'isPrototypeOf')) {
+    if (!HAS_OWN(ctor.prototype, 'isPrototypeOf')) {
       return false;
     }
   }
@@ -1261,7 +1262,7 @@ export class HostAddress {
     return `${this.socketPath}`;
   }
 
-  static fromString(s: string): HostAddress {
+  static fromString(this: void, s: string): HostAddress {
     return new HostAddress(s);
   }
 


### PR DESCRIPTION
### Description

#### What is changing?

Adds `@typescript-eslint/recommended-requiring-type-checking` rules which include enforcing promise returning functions are awaited.

Skips the following:
- @typescript-eslint/no-unsafe-member-access
- @typescript-eslint/no-unsafe-argument
- @typescript-eslint/no-unsafe-assignment
- @typescript-eslint/no-unsafe-return
- @typescript-eslint/no-unsafe-call
- @typescript-eslint/restrict-plus-operands
- @typescript-eslint/restrict-template-expressions

I'll file follow up tickets for us to address these.

There are outstanding TODOs that need discussion.

#### What is the motivation for this change?

We can use async await internally as long as we pass the result through our callback / maybePromise handling logic. We want this lint rule to help us catch any mistakes where we might forget to await a promise returning funciton.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
