### PR TITLE
test(NODE-4260): add test for csfle bulk write error

### DIFF
--- a/test/integration/client-side-encryption/driver.test.js
+++ b/test/integration/client-side-encryption/driver.test.js
@@ -53,6 +53,49 @@ describe('Client Side Encryption Functional', function () {
     }
   });
 
+  describe('Collection', function () {
+    describe('#bulkWrite()', function () {
+      context('when encryption errors', function () {
+        let client;
+
+        beforeEach(function () {
+          client = this.configuration.newClient({}, {
+            autoEncryption: {
+              keyVaultNamespace: 'test.keyvault',
+              kmsProviders: {
+                local: {
+                  key: 'A'.repeat(128)
+                }
+              },
+              encryptedFieldsMap: {
+                'test.coll': {
+                  fields: [{
+                    path: 'ssn',
+                    keyId: new BSON.UUID('23f786b4-1d39-4c36-ae88-70a663321ec9').toBinary(),
+                    bsonType: 'string'
+                  }]
+                }
+              }
+            }
+          });
+        });
+
+        afterEach(async function () {
+          await client?.close();
+        });
+
+        it('bubbles up the mongocrypt error', async function () {
+          try {
+            await client.db('test').collection('coll').bulkWrite([{insertOne: { ssn: 'foo' }}]);
+            expect.fail('expected error to be thrown');
+          } catch (error) {
+            expect(error.message).to.equal('not all keys requested were satisfied');
+          }
+        });
+      });
+    });
+  });
+
   describe('BSON Options', function () {
     beforeEach(function () {
       this.client = this.configuration.newClient();

--- a/test/integration/client-side-encryption/driver.test.js
+++ b/test/integration/client-side-encryption/driver.test.js
@@ -59,34 +59,42 @@ describe('Client Side Encryption Functional', function () {
         let client;
 
         beforeEach(function () {
-          client = this.configuration.newClient({}, {
-            autoEncryption: {
-              keyVaultNamespace: 'test.keyvault',
-              kmsProviders: {
-                local: {
-                  key: 'A'.repeat(128)
-                }
-              },
-              encryptedFieldsMap: {
-                'test.coll': {
-                  fields: [{
-                    path: 'ssn',
-                    keyId: new BSON.UUID('23f786b4-1d39-4c36-ae88-70a663321ec9').toBinary(),
-                    bsonType: 'string'
-                  }]
+          client = this.configuration.newClient(
+            {},
+            {
+              autoEncryption: {
+                keyVaultNamespace: 'test.keyvault',
+                kmsProviders: {
+                  local: {
+                    key: 'A'.repeat(128)
+                  }
+                },
+                encryptedFieldsMap: {
+                  'test.coll': {
+                    fields: [
+                      {
+                        path: 'ssn',
+                        keyId: new BSON.UUID('23f786b4-1d39-4c36-ae88-70a663321ec9').toBinary(),
+                        bsonType: 'string'
+                      }
+                    ]
+                  }
                 }
               }
             }
-          });
+          );
         });
 
         afterEach(async function () {
-          await client?.close();
+          await client.close();
         });
 
         it('bubbles up the mongocrypt error', async function () {
           try {
-            await client.db('test').collection('coll').bulkWrite([{insertOne: { ssn: 'foo' }}]);
+            await client
+              .db('test')
+              .collection('coll')
+              .bulkWrite([{ insertOne: { ssn: 'foo' } }]);
             expect.fail('expected error to be thrown');
           } catch (error) {
             expect(error.message).to.equal('not all keys requested were satisfied');


### PR DESCRIPTION
### Description

Adds test for NODE-4260

#### What is changing?

Adds new test but requires https://github.com/mongodb/libmongocrypt/pull/383 to pass.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-4260


<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
