### PR TITLE
docs(NODE-4263): document initialize bulk op function require connection

### DIFF
--- a/src/collection.ts
+++ b/src/collection.ts
@@ -1547,8 +1547,10 @@ export class Collection<TSchema extends Document = Document> {
   /**
    * Initiate an Out of order batch write operation. All operations will be buffered into insert/update/remove commands executed out of order.
    *
+   * @throws MongoNotConnectedError
    * @remarks
-   * **NOTE:** MongoClient must be connected prior to calling this API.
+   * **NOTE:** MongoClient must be connected prior to calling this method due to a known limitation in this legacy implemenation.
+   * However, `collection.bulkWrite()` provides an equivalent API that does not require prior connecting.
    */
   initializeUnorderedBulkOp(options?: BulkWriteOptions): UnorderedBulkOperation {
     return new UnorderedBulkOperation(this as TODO_NODE_3286, resolveOptions(this, options));
@@ -1557,8 +1559,10 @@ export class Collection<TSchema extends Document = Document> {
   /**
    * Initiate an In order bulk write operation. Operations will be serially executed in the order they are added, creating a new operation for each switch in types.
    *
+   * @throws MongoNotConnectedError
    * @remarks
-   * **NOTE:** MongoClient must be connected prior to calling this API.
+   * **NOTE:** MongoClient must be connected prior to calling this method due to a known limitation in this legacy implemenation.
+   * However, `collection.bulkWrite()` provides an equivalent API that does not require prior connecting.
    */
   initializeOrderedBulkOp(options?: BulkWriteOptions): OrderedBulkOperation {
     return new OrderedBulkOperation(this as TODO_NODE_3286, resolveOptions(this, options));

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -1544,12 +1544,22 @@ export class Collection<TSchema extends Document = Document> {
     );
   }
 
-  /** Initiate an Out of order batch write operation. All operations will be buffered into insert/update/remove commands executed out of order. */
+  /**
+   * Initiate an Out of order batch write operation. All operations will be buffered into insert/update/remove commands executed out of order.
+   *
+   * @remarks
+   * **NOTE:** MongoClient must be connected prior to calling this API.
+   */
   initializeUnorderedBulkOp(options?: BulkWriteOptions): UnorderedBulkOperation {
     return new UnorderedBulkOperation(this as TODO_NODE_3286, resolveOptions(this, options));
   }
 
-  /** Initiate an In order bulk write operation. Operations will be serially executed in the order they are added, creating a new operation for each switch in types. */
+  /**
+   * Initiate an In order bulk write operation. Operations will be serially executed in the order they are added, creating a new operation for each switch in types.
+   *
+   * @remarks
+   * **NOTE:** MongoClient must be connected prior to calling this API.
+   */
   initializeOrderedBulkOp(options?: BulkWriteOptions): OrderedBulkOperation {
     return new OrderedBulkOperation(this as TODO_NODE_3286, resolveOptions(this, options));
   }


### PR DESCRIPTION
### Description

#### What is changing?

API documentation calling out that `initializeUnorderedBulkOp` and `initializeOrderedBulkOp` require a connected client.

#### What is the motivation for this change?

These APIs rely on information obtained from the hello response from the server. Restructuring the code to run batching logic after a hello has been exchanged would be a significant amount of effort. We defer to a future project to make this possible. 

NODE-4263
Follow up: https://jira.mongodb.org/browse/NODE-4360

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`