### PR TITLE
chore: remove unusued eslint directives

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,6 +22,7 @@
     "mocha": true,
     "es6": true
   },
+  "reportUnusedDisableDirectives": true,
   "rules": {
     "no-restricted-properties": [
       "error",

--- a/src/mongo_types.ts
+++ b/src/mongo_types.ts
@@ -514,8 +514,7 @@ export type NestedPaths<Type> = Type extends
   ? [] | [number, ...NestedPaths<ArrayType>]
   : Type extends Map<string, any>
   ? [string]
-  : // eslint-disable-next-line @typescript-eslint/ban-types
-  Type extends object
+  : Type extends object
   ? {
       [Key in Extract<keyof Type, string>]: Type[Key] extends Type // type of value extends the parent
         ? [Key]

--- a/src/operations/get_more.ts
+++ b/src/operations/get_more.ts
@@ -8,7 +8,7 @@ import { AbstractOperation, Aspect, defineAspects, OperationOptions } from './op
 /**
  * @public
  */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+
 export interface GetMoreOptions extends OperationOptions {
   /** Set the batchSize for the getMoreCommand when iterating over the query results. */
   batchSize?: number;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -167,7 +167,7 @@ const TO_STRING = (object: unknown) => Object.prototype.toString.call(object);
  * - **NOTE**: the check is based on the `[Symbol.toStringTag]() === 'Object'`
  * @internal
  */
-// eslint-disable-next-line @typescript-eslint/ban-types
+
 export function isObject(arg: unknown): arg is object {
   return '[object Object]' === TO_STRING(arg);
 }

--- a/test/benchmarks/driverBench/common.js
+++ b/test/benchmarks/driverBench/common.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-restricted-modules */
 'use strict';
 
 const fs = require('fs');

--- a/test/integration/server-selection/readpreference.test.js
+++ b/test/integration/server-selection/readpreference.test.js
@@ -97,7 +97,6 @@ describe('ReadPreference', function () {
         collection.mapReduce(map, reduce, { out: { inline: 1 } }, function (/* err */) {
           // expect(err).to.not.exist;
 
-          // eslint-disable-line
           client.topology.command = command;
 
           client.close(done);

--- a/test/tools/unified-spec-runner/match.ts
+++ b/test/tools/unified-spec-runner/match.ts
@@ -90,7 +90,6 @@ export type SpecialOperator =
   | UnsetOrMatchesOperator
   | SessionLsidOperator;
 
-// eslint-disable-next-line @typescript-eslint/ban-types
 type KeysOfUnion<T> = T extends object ? keyof T : never;
 export type SpecialOperatorKey = KeysOfUnion<SpecialOperator>;
 export function isSpecialOperator(value: unknown): value is SpecialOperator {

--- a/test/types/community/client.test-d.ts
+++ b/test/types/community/client.test-d.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-empty-function */
 import { expectType } from 'tsd';
 
 import {

--- a/test/types/enum.test-d.ts
+++ b/test/types/enum.test-d.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { expectAssignable, expectType } from 'tsd';
 
 import {

--- a/test/unit/assorted/server_discovery_and_monitoring.spec.test.ts
+++ b/test/unit/assorted/server_discovery_and_monitoring.spec.test.ts
@@ -207,7 +207,7 @@ describe('Server Discovery and Monitoring (spec)', function () {
         // call to `selectServers` call a fake, and then immediately restore the original behavior.
         topologySelectServers = sinon
           .stub(Topology.prototype, 'selectServer')
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+
           .callsFake(function (selector, options, callback) {
             topologySelectServers.restore();
 


### PR DESCRIPTION
### Description

#### What is changing?

eslint will now tell us if a code change removes a rule disable usage. a la ts-expect-error behavior

#### What is the motivation for this change?

No need to let eslint disables fall out of sync with the code it was referring to below it.

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
