### PR TITLE
chore: fix fle setup script

### DIFF
--- a/.evergreen/run-custom-csfle-tests.sh
+++ b/.evergreen/run-custom-csfle-tests.sh
@@ -41,6 +41,7 @@ pushd libmongocrypt
 git fetch --tags
 git checkout "$CSFLE_GIT_REF" -b csfle-custom
 echo "checked out libmongocrypt at $(git rev-parse HEAD)"
+CSFLE_WORKING_DIR=$(pwd)
 popd # libmongocrypt
 
 git clone https://github.com/mongodb/mongo-c-driver.git
@@ -53,7 +54,7 @@ popd # mongo-c-driver
 pushd libmongocrypt/bindings/node
 
 npm install --production --ignore-scripts
-source ./.evergreen/find_cmake.sh
+source "$CSFLE_WORKING_DIR/.evergreen/find-cmake.sh"
 bash ./etc/build-static.sh
 
 popd # libmongocrypt/bindings/node


### PR DESCRIPTION
### Description

#### What is changing?

#### What is the motivation for this change?

https://github.com/mongodb/libmongocrypt/pull/395 changed the location of the `find-cmake.sh`, used by the custom-csfle task in evergreen to configure the csfle tests.  This PR updates the location of the script we use in our CI.

evergreen patch running just the csfle tests - https://spruce.mongodb.com/version/62c5df0c0305b96e4b828a82/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
