### PR TITLE
chore: update to latest bson patch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.7.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "bson": "^4.6.4",
+        "bson": "^4.6.5",
         "denque": "^2.0.1",
         "mongodb-connection-string-url": "^2.5.2",
         "socks": "^2.6.2"
@@ -1823,9 +1823,9 @@
       }
     },
     "node_modules/bson": {
-      "version": "4.6.4",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-4.6.4.tgz",
-      "integrity": "sha512-TdQ3FzguAu5HKPPlr0kYQCyrYUYh8tFM+CMTpxjNzVzxeiJY00Rtuj3LXLHSgiGvmaWlZ8PE+4KyM2thqE38pQ==",
+      "version": "4.6.5",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.6.5.tgz",
+      "integrity": "sha512-uqrgcjyOaZsHfz7ea8zLRCLe1u+QGUSzMZmvXqO24CDW7DWoW1qiN9folSwa7hSneTSgM2ykDIzF5kcQQ8cwNw==",
       "dependencies": {
         "buffer": "^5.6.0"
       },
@@ -9525,9 +9525,9 @@
       }
     },
     "bson": {
-      "version": "4.6.4",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-4.6.4.tgz",
-      "integrity": "sha512-TdQ3FzguAu5HKPPlr0kYQCyrYUYh8tFM+CMTpxjNzVzxeiJY00Rtuj3LXLHSgiGvmaWlZ8PE+4KyM2thqE38pQ==",
+      "version": "4.6.5",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.6.5.tgz",
+      "integrity": "sha512-uqrgcjyOaZsHfz7ea8zLRCLe1u+QGUSzMZmvXqO24CDW7DWoW1qiN9folSwa7hSneTSgM2ykDIzF5kcQQ8cwNw==",
       "requires": {
         "buffer": "^5.6.0"
       }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "email": "dbx-node@mongodb.com"
   },
   "dependencies": {
-    "bson": "^4.6.4",
+    "bson": "^4.6.5",
     "denque": "^2.0.1",
     "mongodb-connection-string-url": "^2.5.2",
     "socks": "^2.6.2"


### PR DESCRIPTION
### Description

#### What is changing?

Pulling the latest bson patch

#### What is the motivation for this change?

Pulling in bson bug fixes in the next driver bump.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests