### PR TITLE
refactor(NODE-4415): 

### DIFF
--- a/src/cmap/connection_pool.ts
+++ b/src/cmap/connection_pool.ts
@@ -399,7 +399,10 @@ export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
       this[kGeneration] += 1;
     }
 
-    this.emit('connectionPoolCleared', new ConnectionPoolClearedEvent(this, serviceId));
+    this.emit(
+      ConnectionPool.CONNECTION_POOL_CLEARED,
+      new ConnectionPoolClearedEvent(this, serviceId)
+    );
   }
 
   /** Close the pool */

--- a/src/cmap/connection_pool.ts
+++ b/src/cmap/connection_pool.ts
@@ -668,7 +668,6 @@ function processWaitQueue(pool: ConnectionPool) {
 
     if (!isPerished(pool, connection)) {
       pool[kCheckedOut]++;
-      console.log('DEBUG: checkout() succeeded', pool.id);
       pool.emit(
         ConnectionPool.CONNECTION_CHECKED_OUT,
         new ConnectionCheckedOutEvent(pool, connection)

--- a/src/cmap/connection_pool.ts
+++ b/src/cmap/connection_pool.ts
@@ -89,7 +89,7 @@ export interface WaitQueueMember {
 }
 
 /** @internal */
-const PoolState = Object.freeze({
+export const PoolState = Object.freeze({
   paused: 'paused',
   ready: 'ready',
   closed: 'closed'

--- a/src/index.ts
+++ b/src/index.ts
@@ -235,6 +235,7 @@ export type {
   ConnectionPool,
   ConnectionPoolEvents,
   ConnectionPoolOptions,
+  PoolState,
   WaitQueueMember,
   WithConnectionCallback
 } from './cmap/connection_pool';


### PR DESCRIPTION
### Description
NODE-4415 as a subtask of NODE-2994

#### What is changing?

- Make event handlers consistently use a const instead of plain string
- Moving helper methods that take the connection pool as a parameter into class methods

##### Is there new documentation needed for these changes?
No

#### What is the motivation for this change?
Makes it easier to implement pool paused specification that requires similar behavior for pool pausing and closing, and also requires connection pruning as part of the min pool population thread task.

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
