### PR TITLE
test(NODE-4469): unskip all key management tests

### DIFF
--- a/.evergreen/run-custom-csfle-tests.sh
+++ b/.evergreen/run-custom-csfle-tests.sh
@@ -27,7 +27,7 @@ ABS_PATH_TO_PATCH=$(pwd)
 # CSFLE_GIT_REF - set the git reference to checkout for a custom CSFLE version
 # CDRIVER_GIT_REF - set the git reference to checkout for a custom CDRIVER version (this is for libbson)
 
-CSFLE_GIT_REF=${CSFLE_GIT_REF:-b14d06000535e55be0c619e936972805cac24d37}
+CSFLE_GIT_REF=${CSFLE_GIT_REF:-c2712248e9f4909cdad723607ea5291d2eb48b91}
 CDRIVER_GIT_REF=${CDRIVER_GIT_REF:-1.17.6}
 
 rm -rf ../csfle-deps-tmp

--- a/.evergreen/run-custom-csfle-tests.sh
+++ b/.evergreen/run-custom-csfle-tests.sh
@@ -27,7 +27,7 @@ ABS_PATH_TO_PATCH=$(pwd)
 # CSFLE_GIT_REF - set the git reference to checkout for a custom CSFLE version
 # CDRIVER_GIT_REF - set the git reference to checkout for a custom CDRIVER version (this is for libbson)
 
-CSFLE_GIT_REF=${CSFLE_GIT_REF:-master}
+CSFLE_GIT_REF=${CSFLE_GIT_REF:-b14d06000535e55be0c619e936972805cac24d37}
 CDRIVER_GIT_REF=${CDRIVER_GIT_REF:-1.17.6}
 
 rm -rf ../csfle-deps-tmp

--- a/.evergreen/run-custom-csfle-tests.sh
+++ b/.evergreen/run-custom-csfle-tests.sh
@@ -27,7 +27,7 @@ ABS_PATH_TO_PATCH=$(pwd)
 # CSFLE_GIT_REF - set the git reference to checkout for a custom CSFLE version
 # CDRIVER_GIT_REF - set the git reference to checkout for a custom CDRIVER version (this is for libbson)
 
-CSFLE_GIT_REF=${CSFLE_GIT_REF:-e157c35ee4028b292883c4628dc5926f9742b34a}
+CSFLE_GIT_REF=${CSFLE_GIT_REF:-master}
 CDRIVER_GIT_REF=${CDRIVER_GIT_REF:-1.17.6}
 
 rm -rf ../csfle-deps-tmp

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -56,7 +56,7 @@ else
   source "$DRIVERS_TOOLS"/.evergreen/csfle/set-temp-creds.sh
 fi
 
-npm install mongodb-client-encryption@">=2.2.0-alpha.4"
+npm install mongodb-client-encryption@">=2.2.0-alpha.5"
 npm install @mongodb-js/zstd
 npm install snappy
 

--- a/test/integration/client-side-encryption/client_side_encryption.spec.test.ts
+++ b/test/integration/client-side-encryption/client_side_encryption.spec.test.ts
@@ -7,7 +7,6 @@ import {
   TestRunnerContext
 } from '../../tools/spec-runner';
 import { runUnifiedSuite } from '../../tools/unified-spec-runner/runner';
-import { TestFilter } from '../../tools/unified-spec-runner/schema';
 
 const isAuthEnabled = process.env.AUTH === 'auth';
 
@@ -81,19 +80,5 @@ describe('Client Side Encryption (Legacy)', function () {
 });
 
 describe('Client Side Encryption (Unified)', function () {
-  const filter: TestFilter = ({ description }) => {
-    if (
-      description.includes('create datakey with') ||
-      description.includes('create data key with') ||
-      description.includes('rewrap')
-    ) {
-      if (description === 'no keys to rewrap due to no filter matches') {
-        return 'TODO(NODE-4330): implement the key management API';
-      }
-      return false;
-    }
-
-    return 'TODO(NODE-4330): implement the key management API';
-  };
-  runUnifiedSuite(loadSpecTests(path.join('client-side-encryption', 'tests', 'unified')), filter);
+  runUnifiedSuite(loadSpecTests(path.join('client-side-encryption', 'tests', 'unified')));
 });

--- a/test/tools/unified-spec-runner/operations.ts
+++ b/test/tools/unified-spec-runner/operations.ts
@@ -510,7 +510,7 @@ operations.set('getKey', async ({ entities, operation }) => {
 operations.set('getKeys', async ({ entities, operation }) => {
   const clientEncryption = entities.getEntity('clientEncryption', operation.object);
 
-  return clientEncryption.getKeys();
+  return clientEncryption.getKeys().toArray();
 });
 
 operations.set('addKeyAltName', async ({ entities, operation }) => {

--- a/test/tools/unified-spec-runner/schema.ts
+++ b/test/tools/unified-spec-runner/schema.ts
@@ -1,4 +1,4 @@
-import { MongoClient, ServerApiVersion } from '../../../src';
+import { FindCursor, MongoClient, ServerApiVersion } from '../../../src';
 import type { Document, ObjectId } from '../../../src/bson';
 import type { ReadConcernLevel } from '../../../src/read_concern';
 import type { ReadPreferenceMode } from '../../../src/read_preference';
@@ -303,7 +303,7 @@ export interface ClientEncryption {
   rewrapManyDataKey(filter, options): Promise<any>;
   deleteKey(id): Promise<any>;
   getKey(id): Promise<any>;
-  getKeys(): Promise<any>;
+  getKeys(): FindCursor;
   addKeyAltName(id, keyAltName): Promise<any>;
   removeKeyAltName(id, keyAltName): Promise<any>;
   getKeyByAltName(keyAltName): Promise<any>;

--- a/test/tools/unified-spec-runner/unified-utils.ts
+++ b/test/tools/unified-spec-runner/unified-utils.ts
@@ -1,7 +1,6 @@
 import { EJSON } from 'bson';
 import { expect } from 'chai';
 import ConnectionString from 'mongodb-connection-string-url';
-import { versions } from 'process';
 import { gte as semverGte, lte as semverLte } from 'semver';
 import { isDeepStrictEqual } from 'util';
 


### PR DESCRIPTION
https://jira.mongodb.org/browse/NODE-4330

### Description
#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

This PR unskips all the key management API tests for the new key management API functions added in https://github.com/mongodb/libmongocrypt/pull/414.  

Before this PR merges, we need to

1. ~~merge https://github.com/mongodb/libmongocrypt/pull/414 into libmongocrypt~~
2. ~~update the supported commit hash in run-custom-csfle-test.sh to the new commit~~
3. ~~release another alpha of mongodb-client-encryption~~
4. ~~update to the newest version of mongodb-client-encryption for the regular tests in CI~~

