### PR TITLE
fix(NODE-4441): correct `UpdateResult.upsertedId` type to include null

### DIFF
--- a/src/operations/update.ts
+++ b/src/operations/update.ts
@@ -40,7 +40,7 @@ export interface UpdateResult {
   /** The number of documents that were upserted */
   upsertedCount: number;
   /** The identifier of the inserted document if an upsert took place */
-  upsertedId: ObjectId;
+  upsertedId: ObjectId | null;
 }
 
 /** @public */


### PR DESCRIPTION
### Description

`upsertedId` can be `null`, but the types don't reflect this

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
