### PR TITLE
fix(NODE-4425): webpack optional import of FLE issue

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1412,7 +1412,7 @@ export function commandSupportsReadConcern(command: Document, options?: Document
 
 /** A utility function to get the instance of mongodb-client-encryption, if it exists. */
 export function getMongoDBClientEncryption(): {
-  extension: (mdb: typeof import('../src/index')) => {
+  extension: (mdb: unknown) => {
     AutoEncrypter: any;
     ClientEncryption: any;
   };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1426,14 +1426,18 @@ export function getMongoDBClientEncryption(): {
     process.env.MONGODB_CLIENT_ENCRYPTION_OVERRIDE.length > 0
   ) {
     try {
-      // NOTE(NODE-3199): Ensure you always wrap an optional require in the try block
+      // NOTE(NODE-3199): Ensure you always wrap an optional require literally in the try block
+      // Cannot be moved to helper utility function, bundlers search and replace the actual require call
+      // in a way that makes this line throw at bundle time, not runtime, catching here will make bundling succeed
       mongodbClientEncryption = require(process.env.MONGODB_CLIENT_ENCRYPTION_OVERRIDE);
     } catch {
       // ignore
     }
   } else {
     try {
-      // NOTE(NODE-3199): Ensure you always wrap an optional require in the try block
+      // NOTE(NODE-3199): Ensure you always wrap an optional require literally in the try block
+      // Cannot be moved to helper utility function, bundlers search and replace the actual require call
+      // in a way that makes this line throw at bundle time, not runtime, catching here will make bundling succeed
       mongodbClientEncryption = require('mongodb-client-encryption');
     } catch {
       // ignore

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,7 +12,6 @@ import { LEGACY_HELLO_COMMAND } from './constants';
 import type { AbstractCursor } from './cursor/abstract_cursor';
 import type { FindCursor } from './cursor/find_cursor';
 import type { Db } from './db';
-import type { AutoEncrypter } from './deps';
 import {
   AnyError,
   MongoCompatibilityError,

--- a/test/tools/unified-spec-runner/unified-utils.ts
+++ b/test/tools/unified-spec-runner/unified-utils.ts
@@ -206,6 +206,11 @@ export function makeConnectionString(
 export function getClientEncryptionClass(): ClientEncryption {
   try {
     const mongodbClientEncryption = getMongoDBClientEncryption();
+    if (mongodbClientEncryption == null) {
+      throw new MongoMissingDependencyError(
+        'Attempting to import mongodb-client-encryption but it is not installed.'
+      );
+    }
 
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const { ClientEncryption } = mongodbClientEncryption.extension(require('../../../src/index'));


### PR DESCRIPTION
### Description

#### What is changing?

Move FLE require back into a try catch block.

#### What is the motivation for this change?

Webpack needs optional requires to be inside of a try catch. 

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
