### PR TITLE
test: fix aws auth tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "check:ts": "node ./node_modules/typescript/bin/tsc -v && node ./node_modules/typescript/bin/tsc --noEmit",
     "check:atlas": "mocha --config test/manual/mocharc.json test/manual/atlas_connectivity.test.js",
     "check:adl": "mocha --config test/mocha_mongodb.json test/manual/atlas-data-lake-testing",
-    "check:aws": "mocha --config test/mocha_mongodb.json test/integration/auth/mongodb_aws.test.js",
+    "check:aws": "mocha --config test/mocha_mongodb.json test/integration/auth/mongodb_aws.test.ts",
     "check:ocsp": "mocha --config test/manual/mocharc.json test/manual/ocsp_support.test.js",
     "check:kerberos": "mocha --config test/manual/mocharc.json test/manual/kerberos.test.js",
     "check:tls": "mocha --config test/manual/mocharc.json test/manual/tls_support.test.js",

--- a/test/integration/auth/mongodb_aws.test.ts
+++ b/test/integration/auth/mongodb_aws.test.ts
@@ -1,12 +1,13 @@
-'use strict';
-const { expect } = require('chai');
-const { removeAuthFromConnectionString } = require('../../tools/utils');
-const sinon = require('sinon');
-const http = require('http');
-const { performance } = require('perf_hooks');
-const { MongoAWSError } = require('../../../src');
+import { expect } from 'chai';
+import * as http from 'http';
+import { performance } from 'perf_hooks';
+import * as sinon from 'sinon';
+
+import { MongoAWSError, MongoClient, MongoServerError } from '../../../src';
+import { removeAuthFromConnectionString } from '../../tools/utils';
 
 describe('MONGODB-AWS', function () {
+  let client: MongoClient;
   beforeEach(function () {
     const MONGODB_URI = process.env.MONGODB_URI;
     if (!MONGODB_URI || MONGODB_URI.indexOf('MONGODB-AWS') === -1) {
@@ -15,32 +16,40 @@ describe('MONGODB-AWS', function () {
     }
   });
 
+  afterEach(async () => {
+    await client?.close();
+  });
+
   it('should not authorize when not authenticated', async function () {
     const url = removeAuthFromConnectionString(this.configuration.url());
-    const client = this.configuration.newClient(url); // strip provided URI of credentials
+    client = this.configuration.newClient(url); // strip provided URI of credentials
+    console.log('\n'.repeat(3) + url + '\n'.repeat(3));
 
     const error = await client
       .db('aws')
-      .command({ ping: 1 })
+      .collection('aws_test')
+      .estimatedDocumentCount()
       .catch(error => error);
 
-    expect(error).to.be.instanceOf(MongoAWSError);
+    expect(error).to.be.instanceOf(MongoServerError);
+    expect(error).to.have.property('code', 13);
   });
 
   it('should authorize when successfully authenticated', async function () {
-    const client = this.configuration.newClient(process.env.MONGODB_URI); // use the URI built by the test environment
+    client = this.configuration.newClient(process.env.MONGODB_URI); // use the URI built by the test environment
 
     const result = await client
       .db('aws')
-      .command({ ping: 1 })
+      .collection('aws_test')
+      .estimatedDocumentCount()
       .catch(error => error);
 
-    expect(result).to.not.be.instanceOf(MongoAWSError);
-    expect(result).to.have.property('ok', 1);
+    expect(result).to.not.be.instanceOf(MongoServerError);
+    expect(result).to.be.a('number');
   });
 
   it('should allow empty string in authMechanismProperties.AWS_SESSION_TOKEN to override AWS_SESSION_TOKEN environment variable', function () {
-    const client = this.configuration.newClient(this.configuration.url(), {
+    client = this.configuration.newClient(this.configuration.url(), {
       authMechanismProperties: { AWS_SESSION_TOKEN: '' }
     });
     expect(client)
@@ -56,18 +65,21 @@ describe('MONGODB-AWS', function () {
         this.currentTest.skipReason = 'requires an AWS EC2 environment';
         this.skip();
       }
-      sinon.stub(http, 'request').callsFake(function () {
-        arguments[0].hostname = 'www.example.com';
-        arguments[0].port = 81;
-        return http.request.wrappedMethod.apply(this, arguments);
+      sinon.stub(http, 'request').callsFake(function (...args) {
+        // We pass in a legacy object that has the same properties as a URL
+        // but it is not an instanceof URL.
+        expect(args[0]).to.be.an('object');
+        if (typeof args[0] === 'object') {
+          args[0].hostname = 'www.example.com';
+          args[0].port = '81';
+        }
+        return http.request.wrappedMethod.apply(this, args);
       });
     });
 
     afterEach(async () => {
       sinon.restore();
-      if (client) {
-        await client.close();
-      }
+      await client?.close();
     });
 
     it('should respect the default timeout of 10000ms', async function () {

--- a/test/integration/auth/mongodb_aws.test.ts
+++ b/test/integration/auth/mongodb_aws.test.ts
@@ -23,7 +23,6 @@ describe('MONGODB-AWS', function () {
   it('should not authorize when not authenticated', async function () {
     const url = removeAuthFromConnectionString(this.configuration.url());
     client = this.configuration.newClient(url); // strip provided URI of credentials
-    console.log('\n'.repeat(3) + url + '\n'.repeat(3));
 
     const error = await client
       .db('aws')


### PR DESCRIPTION
### Description

#### What is changing?

We erroneously changed the aws auth test to use ping instead of count. We need to use a command that requires both authentication and authorization.

#### What is the motivation for this change?

Green CI.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
