### PR TITLE
fix(NODE-4444): use Node.js clear timers

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -42,6 +42,18 @@
     "no-restricted-globals": [
       "error",
       {
+        "name": "clearTimeout",
+        "message": "Use `import { clearTimeout } from 'timers';` instead"
+      },
+      {
+        "name": "clearImmediate",
+        "message": "Use `import { clearImmediate } from 'timers';` instead"
+      },
+      {
+        "name": "clearInterval",
+        "message": "Use `import { clearInterval } from 'timers';` instead"
+      },
+      {
         "name": "setTimeout",
         "message": "Use `import { setTimeout } from 'timers';` instead"
       },

--- a/src/cmap/connection.ts
+++ b/src/cmap/connection.ts
@@ -1,4 +1,4 @@
-import { setTimeout } from 'timers';
+import { clearTimeout, setTimeout } from 'timers';
 
 import type { BSONSerializeOptions, Document, ObjectId } from '../bson';
 import {

--- a/src/cmap/connection_pool.ts
+++ b/src/cmap/connection_pool.ts
@@ -1,5 +1,5 @@
 import Denque = require('denque');
-import { setTimeout } from 'timers';
+import { clearTimeout, setTimeout } from 'timers';
 
 import type { ObjectId } from '../bson';
 import {

--- a/src/sdam/common.ts
+++ b/src/sdam/common.ts
@@ -1,3 +1,5 @@
+import { clearTimeout } from 'timers';
+
 import type { Binary, Long, Timestamp } from '../bson';
 import type { ClientSession } from '../sessions';
 import type { Topology } from './topology';

--- a/src/sdam/monitor.ts
+++ b/src/sdam/monitor.ts
@@ -1,4 +1,4 @@
-import { setTimeout } from 'timers';
+import { clearTimeout, setTimeout } from 'timers';
 
 import { Document, Long } from '../bson';
 import { connect } from '../cmap/connect';

--- a/src/sdam/srv_polling.ts
+++ b/src/sdam/srv_polling.ts
@@ -1,5 +1,5 @@
 import * as dns from 'dns';
-import { setTimeout } from 'timers';
+import { clearTimeout, setTimeout } from 'timers';
 
 import { MongoRuntimeError } from '../error';
 import { Logger, LoggerOptions } from '../logger';

--- a/src/sdam/topology.ts
+++ b/src/sdam/topology.ts
@@ -1,5 +1,5 @@
 import Denque = require('denque');
-import { setTimeout } from 'timers';
+import { clearTimeout, setTimeout } from 'timers';
 import { promisify } from 'util';
 
 import type { BSONSerializeOptions, Document } from '../bson';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,7 @@
 import * as crypto from 'crypto';
 import type { SrvRecord } from 'dns';
 import * as os from 'os';
-import { setTimeout } from 'timers';
+import { clearTimeout, setTimeout } from 'timers';
 import { URL } from 'url';
 
 import { Document, ObjectId, resolveBSONOptions } from './bson';

--- a/test/integration/objectid.test.js
+++ b/test/integration/objectid.test.js
@@ -3,7 +3,7 @@ var test = require('./shared').assert;
 const { expect } = require('chai');
 var setupDatabase = require('./shared').setupDatabase;
 const { ObjectId } = require('../../src');
-const { setInterval } = require('timers');
+const { clearInterval, setInterval } = require('timers');
 const { sleep } = require('../tools/utils');
 
 describe('ObjectId', function () {

--- a/test/unit/sdam/topology.test.js
+++ b/test/unit/sdam/topology.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { setTimeout } = require('timers');
+const { clearTimeout, setTimeout } = require('timers');
 const mock = require('../../tools/mongodb-mock/index');
 const { expect } = require('chai');
 const sinon = require('sinon');


### PR DESCRIPTION
This change follows on from https://github.com/mongodb/node-mongodb-native/pull/3275
which enforced using Node.js timer methods.

However, it didn't enforce using the Node.js _clear_ methods, which
could fall prey to similar issues.

This change adds linter rules for those clear methods, and fixes the
resulting linter errors.

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
