### PR TITLE
fix(NODE-4423): better type support for nested objects in query & update

### DIFF
--- a/src/mongo_types.ts
+++ b/src/mongo_types.ts
@@ -531,7 +531,7 @@ export type NestedPaths<Type> = Type extends
           : // child is an array, but it's not a recursive array
             [Key, ...NestedPaths<Type[Key]>]
         : // child is not structured the same as the parent
-          [Key, ...NestedPaths<Type[Key]>];
+          [Key, ...NestedPaths<Type[Key]>] | [Key];
     }[Extract<keyof Type, string>]
   : [];
 

--- a/test/types/community/collection/filterQuery.test-d.ts
+++ b/test/types/community/collection/filterQuery.test-d.ts
@@ -178,7 +178,7 @@ expectNotType<Filter<PetModel>>({ 'regex.dotAll': true });
 collectionT.find({ 'meta.updatedAt': new Date() });
 collectionT.find({ 'meta.deep.nested.level': 123 });
 collectionT.find({ meta: { deep: { nested: { level: 123 } } } }); // no impact on actual nesting
-collectionT.find({ 'meta.deep': { nested: { level: 123 } } }); // no impact on actual nesting
+collectionT.find({ 'meta.deep': { nested: { level: 123 } } });
 collectionT.find({ 'friends.0.name': 'John' });
 collectionT.find({ 'playmates.0.name': 'John' });
 // supports arrays with primitive types

--- a/test/types/community/collection/filterQuery.test-d.ts
+++ b/test/types/community/collection/filterQuery.test-d.ts
@@ -204,7 +204,7 @@ expectNotType<Filter<PetModel>>({ 'friends.0.name': 123 });
 expectNotType<Filter<PetModel>>({ 'playmates.0.name': 123 });
 expectNotType<Filter<PetModel>>({ 'laps.foo': 'string' });
 expectNotType<Filter<PetModel>>({ 'treats.0': 123 });
-expectNotType<Filter<PetModel>>({ meta: { deep: { nested: { level: 'string' } } } }); // no impact on actual nesting
+expectNotType<Filter<PetModel>>({ meta: { deep: { nested: { level: 'string' } } } });
 expectNotType<Filter<PetModel>>({ 'meta.deep': { nested: { level: 'string' } } }); // no impact on actual nesting
 
 /// it should not accept wrong types for nested document array fields

--- a/test/types/community/collection/filterQuery.test-d.ts
+++ b/test/types/community/collection/filterQuery.test-d.ts
@@ -205,7 +205,7 @@ expectNotType<Filter<PetModel>>({ 'playmates.0.name': 123 });
 expectNotType<Filter<PetModel>>({ 'laps.foo': 'string' });
 expectNotType<Filter<PetModel>>({ 'treats.0': 123 });
 expectNotType<Filter<PetModel>>({ meta: { deep: { nested: { level: 'string' } } } });
-expectNotType<Filter<PetModel>>({ 'meta.deep': { nested: { level: 'string' } } }); // no impact on actual nesting
+expectNotType<Filter<PetModel>>({ 'meta.deep': { nested: { level: 'string' } } });
 
 /// it should not accept wrong types for nested document array fields
 expectError<Filter<PetModel>>({

--- a/test/types/community/collection/filterQuery.test-d.ts
+++ b/test/types/community/collection/filterQuery.test-d.ts
@@ -178,6 +178,7 @@ expectNotType<Filter<PetModel>>({ 'regex.dotAll': true });
 collectionT.find({ 'meta.updatedAt': new Date() });
 collectionT.find({ 'meta.deep.nested.level': 123 });
 collectionT.find({ meta: { deep: { nested: { level: 123 } } } }); // no impact on actual nesting
+collectionT.find({ 'meta.deep': { nested: { level: 123 } } }); // no impact on actual nesting
 collectionT.find({ 'friends.0.name': 'John' });
 collectionT.find({ 'playmates.0.name': 'John' });
 // supports arrays with primitive types
@@ -203,6 +204,8 @@ expectNotType<Filter<PetModel>>({ 'friends.0.name': 123 });
 expectNotType<Filter<PetModel>>({ 'playmates.0.name': 123 });
 expectNotType<Filter<PetModel>>({ 'laps.foo': 'string' });
 expectNotType<Filter<PetModel>>({ 'treats.0': 123 });
+expectNotType<Filter<PetModel>>({ meta: { deep: { nested: { level: 'string' } } } }); // no impact on actual nesting
+expectNotType<Filter<PetModel>>({ 'meta.deep': { nested: { level: 'string' } } }); // no impact on actual nesting
 
 /// it should not accept wrong types for nested document array fields
 expectError<Filter<PetModel>>({

--- a/test/types/community/collection/updateX.test-d.ts
+++ b/test/types/community/collection/updateX.test-d.ts
@@ -217,6 +217,9 @@ expectAssignable<UpdateFilter<TestModel>>({
 expectError<UpdateFilter<TestModel>>({
   $set: { 'subInterfaceField.nestedObject': { a: '1' } }
 });
+expectError<UpdateFilter<TestModel>>({
+  $set: { 'subInterfaceField.nestedObject': { a: 1, 'b': '2' } }
+});
 expectError(buildUpdateFilter({ $set: { 'subInterfaceField.field2': 2 } }));
 expectError(buildUpdateFilter({ $set: { 'unknown.field': null } }));
 expectAssignable<UpdateFilter<TestModel>>({ $set: { 'numberArray.$': 40 } });

--- a/test/types/community/collection/updateX.test-d.ts
+++ b/test/types/community/collection/updateX.test-d.ts
@@ -218,7 +218,7 @@ expectError<UpdateFilter<TestModel>>({
   $set: { 'subInterfaceField.nestedObject': { a: '1' } }
 });
 expectError<UpdateFilter<TestModel>>({
-  $set: { 'subInterfaceField.nestedObject': { a: 1, 'b': '2' } }
+  $set: { 'subInterfaceField.nestedObject': { a: 1, b: '2' } }
 });
 expectError(buildUpdateFilter({ $set: { 'subInterfaceField.field2': 2 } }));
 expectError(buildUpdateFilter({ $set: { 'unknown.field': null } }));

--- a/test/types/community/collection/updateX.test-d.ts
+++ b/test/types/community/collection/updateX.test-d.ts
@@ -74,6 +74,10 @@ interface SubTestModel {
   field1: string;
   field2?: string;
   field3?: number;
+  nestedObject?: {
+    a: string;
+    b: string;
+  };
 }
 
 type FruitTypes = 'apple' | 'pear';
@@ -204,6 +208,13 @@ expectAssignable<UpdateFilter<TestModel>>({ $set: { longField: Long.fromString('
 expectAssignable<UpdateFilter<TestModel>>({ $set: { stringField: 'a' } });
 expectError(buildUpdateFilter({ $set: { stringField: 123 } }));
 expectAssignable<UpdateFilter<TestModel>>({ $set: { 'subInterfaceField.field2': '2' } });
+expectAssignable<UpdateFilter<TestModel>>({ $set: { 'subInterfaceField.nestedObject.a': '2' } });
+expectAssignable<UpdateFilter<TestModel>>({
+  $set: { 'subInterfaceField.nestedObject': { a: '1', b: '2' } }
+});
+expectError<UpdateFilter<TestModel>>({
+  $set: { 'subInterfaceField.nestedObject': { a: '1' } }
+});
 expectError(buildUpdateFilter({ $set: { 'subInterfaceField.field2': 2 } }));
 expectError(buildUpdateFilter({ $set: { 'unknown.field': null } }));
 expectAssignable<UpdateFilter<TestModel>>({ $set: { 'numberArray.$': 40 } });

--- a/test/types/community/collection/updateX.test-d.ts
+++ b/test/types/community/collection/updateX.test-d.ts
@@ -101,6 +101,7 @@ interface TestModel {
   subInterfaceField: SubTestModel;
   subInterfaceArray: SubTestModel[];
   timestampField: Timestamp;
+  extras: Record<string, { id: string }>;
 }
 const collectionTType = db.collection<TestModel>('test.update');
 
@@ -205,6 +206,7 @@ expectAssignable<UpdateFilter<TestModel>>({
 expectAssignable<UpdateFilter<TestModel>>({ $set: { doubleField: new Double(1.23) } });
 expectAssignable<UpdateFilter<TestModel>>({ $set: { int32Field: new Int32(10) } });
 expectAssignable<UpdateFilter<TestModel>>({ $set: { longField: Long.fromString('999') } });
+expectAssignable<UpdateFilter<TestModel>>({ $set: { extras: { someExtras: { id: 'someId' } } } });
 expectAssignable<UpdateFilter<TestModel>>({ $set: { stringField: 'a' } });
 expectError(buildUpdateFilter({ $set: { stringField: 123 } }));
 expectAssignable<UpdateFilter<TestModel>>({ $set: { 'subInterfaceField.field2': '2' } });


### PR DESCRIPTION
### Description

#### What is changing?

Better typing for update & query

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

```ts
	interface User {
		pet: {
			name: {
				first: string;
				last: string;
			};
		};
	}
	
	// This works when it shouldn't
	const query: mongodb.Filter<User> = { "pet.name": { first: 1 } };
	// This doesn't work when it should
	const update: mongodb.UpdateFilter<User> = { $set: { "pet.name": { first: "a", last: "b" } } };
```

The second error is a regression. This PR fixes both issues

Tickets:

- https://jira.mongodb.org/browse/NODE-4423
- https://jira.mongodb.org/browse/NODE-4450 (duplicate)

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
