### PR TITLE
Remove @types/mongodb as it's included in the library

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,12 +65,6 @@ yarn add mongodb
 
 This will download the MongoDB driver and add a dependency entry in your `package.json` file.
 
-If you are a Typescript user, you will need the Node.js type definitions to use the driver's definitions:
-
-```sh
-npm install -D @types/node
-```
-
 ## Troubleshooting
 
 The MongoDB driver depends on several other packages. These are:


### PR DESCRIPTION
There is no need to install the `@types/mongodb` separately as it's already included in the main package

The `@types` is removed from `DefinitelyTyped` already:

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/notNeededPackages.json#L2956-L2958

And also NPM says:

![image](https://user-images.githubusercontent.com/2917613/180630014-65a2cbbc-b32e-4305-8bfa-0c61ec96cd22.png)
