### PR TITLE
test(NODE-4434): sync skipped StaleShardVersion change stream unifed tests

### DIFF
--- a/test/integration/change-streams/change_streams.spec.test.ts
+++ b/test/integration/change-streams/change_streams.spec.test.ts
@@ -1,15 +1,8 @@
 import * as path from 'path';
-import { gte } from 'semver';
 
 import { loadSpecTests } from '../../spec';
 import { runUnifiedSuite } from '../../tools/unified-spec-runner/runner';
 
 describe('Change Streams Spec - Unified', function () {
-  runUnifiedSuite(
-    loadSpecTests(path.join('change-streams', 'unified')),
-    ({ description }, { version }) =>
-      description === 'change stream resumes after StaleShardVersion' && gte(version, '6.0.0')
-        ? 'TODO(NODE-4434): fix StaleShardVersion resumability tests'
-        : false
-  );
+  runUnifiedSuite(loadSpecTests(path.join('change-streams', 'unified')));
 });

--- a/test/spec/change-streams/unified/change-streams-resume-errorLabels.json
+++ b/test/spec/change-streams/unified/change-streams-resume-errorLabels.json
@@ -1477,6 +1477,11 @@
     },
     {
       "description": "change stream resumes after StaleShardVersion",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "6.0.99"
+        }
+      ],
       "operations": [
         {
           "name": "failPoint",

--- a/test/spec/change-streams/unified/change-streams-resume-errorLabels.yml
+++ b/test/spec/change-streams/unified/change-streams-resume-errorLabels.yml
@@ -739,6 +739,9 @@ tests:
               databaseName: *database0
 
   - description: change stream resumes after StaleShardVersion
+    runOnRequirements:
+      # StaleShardVersion is obsolete as of 6.1 and is no longer marked as resumable.
+      - maxServerVersion: "6.0.99"
     operations:
       - name: failPoint
         object: testRunner


### PR DESCRIPTION
### Description

#### What is changing?

This PR skips `StaleShardVersion` change stream resumibility tests on server versions 6.1.0+.  

#### What is the reason for this change?

In 6.1+ servers, StaleShardVersion is no longer sent as a resumable error (StaleConfig is sent instead, which is also resumable). 

##### Is there new documentation needed for these changes?

No.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
