### PR TITLE
test(NODE-4463): download shared lib in evergreen

### DIFF
--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -818,9 +818,16 @@ functions:
           . ./prepare_client_encryption.sh
           rm -f ./prepare_client_encryption.sh
 
+          MONGODB_VERSION=${VERSION}
+          if [ -z "$MONGODB_VERSION" ]; then
+            # default to latest to match behavior of run-orchestration.sh.
+            MONGODB_VERSION=latest
+          fi
+
           . $DRIVERS_TOOLS/.evergreen/download-mongodb.sh
           get_distro
           # get_distro defines $DISTRO.
+          echo "distro='$DISTRO' version='$MONGODB_VERSION'".
           get_mongodb_download_url_for "$DISTRO" "$MONGODB_VERSION"
           # get_mongodb_download_url_for defines $MONGO_CRYPT_SHARED_DOWNLOAD_URL and $EXTRACT.
           if [ -z "$MONGO_CRYPT_SHARED_DOWNLOAD_URL" ]; then

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -798,12 +798,12 @@ functions:
         script: |
           ${PREPARE_SHELL}
           cat <<EOT > prepare_client_encryption.sh
-          export CLIENT_ENCRYPTION=${CLIENT_ENCRYPTION}
+          export CLIENT_ENCRYPTION='${CLIENT_ENCRYPTION}'
           export CSFLE_KMS_PROVIDERS='${CSFLE_KMS_PROVIDERS}'
-          export AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}"
-          export AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}"
-          export CSFLE_GIT_REF="${CSFLE_GIT_REF}"
-          export CDRIVER_GIT_REF="${CDRIVER_GIT_REF}"
+          export AWS_ACCESS_KEY_ID='${AWS_ACCESS_KEY_ID}'
+          export AWS_SECRET_ACCESS_KEY='${AWS_SECRET_ACCESS_KEY}'
+          export CSFLE_GIT_REF='${CSFLE_GIT_REF}'
+          export CDRIVER_GIT_REF='${CDRIVER_GIT_REF}'
           EOT
     - command: shell.exec
       type: test

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -818,40 +818,8 @@ functions:
           . ./prepare_client_encryption.sh
           rm -f ./prepare_client_encryption.sh
 
-          MONGODB_VERSION=${VERSION}
-          if [ -z "$MONGODB_VERSION" ]; then
-            # default to latest to match behavior of run-orchestration.sh.
-            MONGODB_VERSION=latest
-          fi
-
-          . $DRIVERS_TOOLS/.evergreen/download-mongodb.sh
-          get_distro
-          # get_distro defines $DISTRO.
-          echo "distro='$DISTRO' version='$MONGODB_VERSION'".
-          get_mongodb_download_url_for "$DISTRO" "$MONGODB_VERSION"
-          # get_mongodb_download_url_for defines $MONGO_CRYPT_SHARED_DOWNLOAD_URL and $EXTRACT.
-          if [ -z "$MONGO_CRYPT_SHARED_DOWNLOAD_URL" ]; then
-            echo "There is no crypt_shared library for distro='$DISTRO' and version='$MONGODB_VERSION'".
-            exit 1
-          else
-            echo "Downloading crypt_shared package from $MONGO_CRYPT_SHARED_DOWNLOAD_URL"
-            download_and_extract_crypt_shared "$MONGO_CRYPT_SHARED_DOWNLOAD_URL" "$EXTRACT"
-            CRYPT_SHARED_LIB_PATH="$(find $(pwd) -maxdepth 1 -type f \
-              -name 'mongo_crypt_v1.so' -o \
-              -name 'mongo_crypt_v1.dll' -o \
-              -name 'mongo_crypt_v1.dylib')"
-            # Expect that we always find a crypt_shared library file and set the CRYPT_SHARED_LIB_PATH
-            # environment variable. If we didn't, print an error message and exit.
-            if [ -z "$CRYPT_SHARED_LIB_PATH" ]; then
-              echo 'CRYPT_SHARED_LIB_PATH is empty. Exiting.'
-              exit 1
-            fi
-            # If we're on Windows, convert the "cygdrive"  path to Windows-style paths.
-            if [ "Windows_NT" = "$OS" ]; then
-              CRYPT_SHARED_LIB_PATH=$(cygpath -m $CRYPT_SHARED_LIB_PATH)
-            fi
-            echo "CRYPT_SHARED_LIB_PATH: $CRYPT_SHARED_LIB_PATH" > expansion.yml
-          fi
+          VERSION=${VERSION} DRIVERS_TOOLS=${DRIVERS_TOOLS} \
+            bash ${PROJECT_DIRECTORY}/.evergreen/prepare-crypt-shared-lib.sh
 
           MONGODB_URI="${MONGODB_URI}" CRYPT_SHARED_LIB_PATH="${CRYPT_SHARED_LIB_PATH}" \
             bash ${PROJECT_DIRECTORY}/.evergreen/run-custom-csfle-tests.sh

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -789,6 +789,66 @@ functions:
 
           MONGODB_URI="${MONGODB_URI}" bash ${PROJECT_DIRECTORY}/.evergreen/run-custom-csfle-tests.sh
 
+  "run custom csfle shared lib tests":
+    - command: shell.exec
+      type: test
+      params:
+        silent: true
+        working_dir: "src"
+        script: |
+          ${PREPARE_SHELL}
+          cat <<EOT > prepare_client_encryption.sh
+          export CLIENT_ENCRYPTION=${CLIENT_ENCRYPTION}
+          export CSFLE_KMS_PROVIDERS='${CSFLE_KMS_PROVIDERS}'
+          export AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}"
+          export AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}"
+          export CSFLE_GIT_REF="${CSFLE_GIT_REF}"
+          export CDRIVER_GIT_REF="${CDRIVER_GIT_REF}"
+          EOT
+    - command: shell.exec
+      type: test
+      params:
+        working_dir: "src"
+        timeout_secs: 60
+        script: |
+          ${PREPARE_SHELL}
+
+          # Disable xtrace (just in case it was accidentally set).
+          set +x
+          . ./prepare_client_encryption.sh
+          rm -f ./prepare_client_encryption.sh
+
+          . $DRIVERS_TOOLS/.evergreen/download-mongodb.sh
+          get_distro
+          # get_distro defines $DISTRO.
+          get_mongodb_download_url_for "$DISTRO" "$MONGODB_VERSION"
+          # get_mongodb_download_url_for defines $MONGO_CRYPT_SHARED_DOWNLOAD_URL and $EXTRACT.
+          if [ -z "$MONGO_CRYPT_SHARED_DOWNLOAD_URL" ]; then
+            echo "There is no crypt_shared library for distro='$DISTRO' and version='$MONGODB_VERSION'".
+            exit 1
+          else
+            echo "Downloading crypt_shared package from $MONGO_CRYPT_SHARED_DOWNLOAD_URL"
+            download_and_extract_crypt_shared "$MONGO_CRYPT_SHARED_DOWNLOAD_URL" "$EXTRACT"
+            CRYPT_SHARED_LIB_PATH="$(find $(pwd) -maxdepth 1 -type f \
+              -name 'mongo_crypt_v1.so' -o \
+              -name 'mongo_crypt_v1.dll' -o \
+              -name 'mongo_crypt_v1.dylib')"
+            # Expect that we always find a crypt_shared library file and set the CRYPT_SHARED_LIB_PATH
+            # environment variable. If we didn't, print an error message and exit.
+            if [ -z "$CRYPT_SHARED_LIB_PATH" ]; then
+              echo 'CRYPT_SHARED_LIB_PATH is empty. Exiting.'
+              exit 1
+            fi
+            # If we're on Windows, convert the "cygdrive"  path to Windows-style paths.
+            if [ "Windows_NT" = "$OS" ]; then
+              CRYPT_SHARED_LIB_PATH=$(cygpath -m $CRYPT_SHARED_LIB_PATH)
+            fi
+            echo "CRYPT_SHARED_LIB_PATH: $CRYPT_SHARED_LIB_PATH" > expansion.yml
+          fi
+
+          MONGODB_URI="${MONGODB_URI}" CRYPT_SHARED_LIB_PATH="${CRYPT_SHARED_LIB_PATH}" \
+            bash ${PROJECT_DIRECTORY}/.evergreen/run-custom-csfle-tests.sh
+
   "run custom snappy tests":
     - command: subprocess.exec
       params:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -754,6 +754,65 @@ functions:
           rm -f ./prepare_client_encryption.sh
 
           MONGODB_URI="${MONGODB_URI}" bash ${PROJECT_DIRECTORY}/.evergreen/run-custom-csfle-tests.sh
+  run custom csfle shared lib tests:
+    - command: shell.exec
+      type: test
+      params:
+        silent: true
+        working_dir: src
+        script: |
+          ${PREPARE_SHELL}
+          cat <<EOT > prepare_client_encryption.sh
+          export CLIENT_ENCRYPTION=${CLIENT_ENCRYPTION}
+          export CSFLE_KMS_PROVIDERS='${CSFLE_KMS_PROVIDERS}'
+          export AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}"
+          export AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}"
+          export CSFLE_GIT_REF="${CSFLE_GIT_REF}"
+          export CDRIVER_GIT_REF="${CDRIVER_GIT_REF}"
+          EOT
+    - command: shell.exec
+      type: test
+      params:
+        working_dir: src
+        timeout_secs: 60
+        script: |
+          ${PREPARE_SHELL}
+
+          # Disable xtrace (just in case it was accidentally set).
+          set +x
+          . ./prepare_client_encryption.sh
+          rm -f ./prepare_client_encryption.sh
+
+          . $DRIVERS_TOOLS/.evergreen/download-mongodb.sh
+          get_distro
+          # get_distro defines $DISTRO.
+          get_mongodb_download_url_for "$DISTRO" "$MONGODB_VERSION"
+          # get_mongodb_download_url_for defines $MONGO_CRYPT_SHARED_DOWNLOAD_URL and $EXTRACT.
+          if [ -z "$MONGO_CRYPT_SHARED_DOWNLOAD_URL" ]; then
+            echo "There is no crypt_shared library for distro='$DISTRO' and version='$MONGODB_VERSION'".
+            exit 1
+          else
+            echo "Downloading crypt_shared package from $MONGO_CRYPT_SHARED_DOWNLOAD_URL"
+            download_and_extract_crypt_shared "$MONGO_CRYPT_SHARED_DOWNLOAD_URL" "$EXTRACT"
+            CRYPT_SHARED_LIB_PATH="$(find $(pwd) -maxdepth 1 -type f \
+              -name 'mongo_crypt_v1.so' -o \
+              -name 'mongo_crypt_v1.dll' -o \
+              -name 'mongo_crypt_v1.dylib')"
+            # Expect that we always find a crypt_shared library file and set the CRYPT_SHARED_LIB_PATH
+            # environment variable. If we didn't, print an error message and exit.
+            if [ -z "$CRYPT_SHARED_LIB_PATH" ]; then
+              echo 'CRYPT_SHARED_LIB_PATH is empty. Exiting.'
+              exit 1
+            fi
+            # If we're on Windows, convert the "cygdrive"  path to Windows-style paths.
+            if [ "Windows_NT" = "$OS" ]; then
+              CRYPT_SHARED_LIB_PATH=$(cygpath -m $CRYPT_SHARED_LIB_PATH)
+            fi
+            echo "CRYPT_SHARED_LIB_PATH: $CRYPT_SHARED_LIB_PATH" > expansion.yml
+          fi
+
+          MONGODB_URI="${MONGODB_URI}" CRYPT_SHARED_LIB_PATH="${CRYPT_SHARED_LIB_PATH}" \
+            bash ${PROJECT_DIRECTORY}/.evergreen/run-custom-csfle-tests.sh
   run custom snappy tests:
     - command: subprocess.exec
       params:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -783,40 +783,8 @@ functions:
           . ./prepare_client_encryption.sh
           rm -f ./prepare_client_encryption.sh
 
-          MONGODB_VERSION=${VERSION}
-          if [ -z "$MONGODB_VERSION" ]; then
-            # default to latest to match behavior of run-orchestration.sh.
-            MONGODB_VERSION=latest
-          fi
-
-          . $DRIVERS_TOOLS/.evergreen/download-mongodb.sh
-          get_distro
-          # get_distro defines $DISTRO.
-          echo "distro='$DISTRO' version='$MONGODB_VERSION'".
-          get_mongodb_download_url_for "$DISTRO" "$MONGODB_VERSION"
-          # get_mongodb_download_url_for defines $MONGO_CRYPT_SHARED_DOWNLOAD_URL and $EXTRACT.
-          if [ -z "$MONGO_CRYPT_SHARED_DOWNLOAD_URL" ]; then
-            echo "There is no crypt_shared library for distro='$DISTRO' and version='$MONGODB_VERSION'".
-            exit 1
-          else
-            echo "Downloading crypt_shared package from $MONGO_CRYPT_SHARED_DOWNLOAD_URL"
-            download_and_extract_crypt_shared "$MONGO_CRYPT_SHARED_DOWNLOAD_URL" "$EXTRACT"
-            CRYPT_SHARED_LIB_PATH="$(find $(pwd) -maxdepth 1 -type f \
-              -name 'mongo_crypt_v1.so' -o \
-              -name 'mongo_crypt_v1.dll' -o \
-              -name 'mongo_crypt_v1.dylib')"
-            # Expect that we always find a crypt_shared library file and set the CRYPT_SHARED_LIB_PATH
-            # environment variable. If we didn't, print an error message and exit.
-            if [ -z "$CRYPT_SHARED_LIB_PATH" ]; then
-              echo 'CRYPT_SHARED_LIB_PATH is empty. Exiting.'
-              exit 1
-            fi
-            # If we're on Windows, convert the "cygdrive"  path to Windows-style paths.
-            if [ "Windows_NT" = "$OS" ]; then
-              CRYPT_SHARED_LIB_PATH=$(cygpath -m $CRYPT_SHARED_LIB_PATH)
-            fi
-            echo "CRYPT_SHARED_LIB_PATH: $CRYPT_SHARED_LIB_PATH" > expansion.yml
-          fi
+          VERSION=${VERSION} DRIVERS_TOOLS=${DRIVERS_TOOLS} \
+            bash ${PROJECT_DIRECTORY}/.evergreen/prepare-crypt-shared-lib.sh
 
           MONGODB_URI="${MONGODB_URI}" CRYPT_SHARED_LIB_PATH="${CRYPT_SHARED_LIB_PATH}" \
             bash ${PROJECT_DIRECTORY}/.evergreen/run-custom-csfle-tests.sh

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1719,7 +1719,7 @@ tasks:
       - func: run bson-ext test
         vars:
           NODE_LTS_NAME: erbium
-  - name: run-custom-csfle-tests-pinned-commit
+  - name: run-custom-csfle-tests-pinned-commit-mongocryptd
     tags:
       - run-custom-dependency-tests
     commands:
@@ -1734,7 +1734,7 @@ tasks:
       - func: run custom csfle tests
         vars:
           CSFLE_GIT_REF: c2712248e9f4909cdad723607ea5291d2eb48b91
-  - name: run-custom-csfle-tests-master
+  - name: run-custom-csfle-tests-master-mongocryptd
     tags:
       - run-custom-dependency-tests
     commands:
@@ -1748,6 +1748,38 @@ tasks:
       - func: bootstrap kms servers
       - func: run custom csfle tests
         vars:
+          CSFLE_GIT_REF: master
+  - name: run-custom-csfle-shared-lib-tests-pinned-commit
+    tags:
+      - run-custom-dependency-tests
+    commands:
+      - func: install dependencies
+        vars:
+          NODE_LTS_NAME: erbium
+      - func: bootstrap mongo-orchestration
+        vars:
+          VERSION: latest
+          TOPOLOGY: replica_set
+      - func: bootstrap kms servers
+      - func: run custom csfle shared lib tests
+        vars:
+          VERSION: latest
+          CSFLE_GIT_REF: c2712248e9f4909cdad723607ea5291d2eb48b91
+  - name: run-custom-csfle-shared-lib-tests-master
+    tags:
+      - run-custom-dependency-tests
+    commands:
+      - func: install dependencies
+        vars:
+          NODE_LTS_NAME: erbium
+      - func: bootstrap mongo-orchestration
+        vars:
+          VERSION: latest
+          TOPOLOGY: replica_set
+      - func: bootstrap kms servers
+      - func: run custom csfle shared lib tests
+        vars:
+          VERSION: latest
           CSFLE_GIT_REF: master
   - name: test-latest-server-noauth
     tags:
@@ -2309,8 +2341,10 @@ buildvariants:
     tasks:
       - run-custom-snappy-tests
       - run-bson-ext-test
-      - run-custom-csfle-tests-pinned-commit
-      - run-custom-csfle-tests-master
+      - run-custom-csfle-tests-pinned-commit-mongocryptd
+      - run-custom-csfle-tests-master-mongocryptd
+      - run-custom-csfle-shared-lib-tests-pinned-commit
+      - run-custom-csfle-shared-lib-tests-master
   - name: ubuntu1804-test-serverless
     display_name: Serverless Test
     run_on: ubuntu1804-test

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1687,7 +1687,7 @@ tasks:
       - func: run bson-ext test
         vars:
           NODE_LTS_NAME: erbium
-  - name: run-custom-csfle-tests-pinned-commit-mongocryptd
+  - name: run-custom-csfle-tests-mongocryptd-pinned-commit
     tags:
       - run-custom-dependency-tests
     commands:
@@ -1702,7 +1702,7 @@ tasks:
       - func: run custom csfle tests
         vars:
           CSFLE_GIT_REF: c2712248e9f4909cdad723607ea5291d2eb48b91
-  - name: run-custom-csfle-tests-master-mongocryptd
+  - name: run-custom-csfle-tests-mongocryptd-master
     tags:
       - run-custom-dependency-tests
     commands:
@@ -2309,8 +2309,8 @@ buildvariants:
     tasks:
       - run-custom-snappy-tests
       - run-bson-ext-test
-      - run-custom-csfle-tests-pinned-commit-mongocryptd
-      - run-custom-csfle-tests-master-mongocryptd
+      - run-custom-csfle-tests-mongocryptd-pinned-commit
+      - run-custom-csfle-tests-mongocryptd-master
       - run-custom-csfle-shared-lib-tests-pinned-commit
       - run-custom-csfle-shared-lib-tests-master
   - name: ubuntu1804-test-serverless

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -763,12 +763,12 @@ functions:
         script: |
           ${PREPARE_SHELL}
           cat <<EOT > prepare_client_encryption.sh
-          export CLIENT_ENCRYPTION=${CLIENT_ENCRYPTION}
+          export CLIENT_ENCRYPTION='${CLIENT_ENCRYPTION}'
           export CSFLE_KMS_PROVIDERS='${CSFLE_KMS_PROVIDERS}'
-          export AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}"
-          export AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}"
-          export CSFLE_GIT_REF="${CSFLE_GIT_REF}"
-          export CDRIVER_GIT_REF="${CDRIVER_GIT_REF}"
+          export AWS_ACCESS_KEY_ID='${AWS_ACCESS_KEY_ID}'
+          export AWS_SECRET_ACCESS_KEY='${AWS_SECRET_ACCESS_KEY}'
+          export CSFLE_GIT_REF='${CSFLE_GIT_REF}'
+          export CDRIVER_GIT_REF='${CDRIVER_GIT_REF}'
           EOT
     - command: shell.exec
       type: test

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -783,9 +783,16 @@ functions:
           . ./prepare_client_encryption.sh
           rm -f ./prepare_client_encryption.sh
 
+          MONGODB_VERSION=${VERSION}
+          if [ -z "$MONGODB_VERSION" ]; then
+            # default to latest to match behavior of run-orchestration.sh.
+            MONGODB_VERSION=latest
+          fi
+
           . $DRIVERS_TOOLS/.evergreen/download-mongodb.sh
           get_distro
           # get_distro defines $DISTRO.
+          echo "distro='$DISTRO' version='$MONGODB_VERSION'".
           get_mongodb_download_url_for "$DISTRO" "$MONGODB_VERSION"
           # get_mongodb_download_url_for defines $MONGO_CRYPT_SHARED_DOWNLOAD_URL and $EXTRACT.
           if [ -z "$MONGO_CRYPT_SHARED_DOWNLOAD_URL" ]; then

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -537,7 +537,7 @@ const oneOffFuncAsTasks = oneOffFuncs.map(oneOffFunc => ({
 }));
 
 oneOffFuncAsTasks.push({
-  name: 'run-custom-csfle-tests-pinned-commit',
+  name: 'run-custom-csfle-tests-pinned-commit-mongocryptd',
   tags: ['run-custom-dependency-tests'],
   commands: [
     {
@@ -564,7 +564,7 @@ oneOffFuncAsTasks.push({
 });
 
 oneOffFuncAsTasks.push({
-  name: 'run-custom-csfle-tests-master',
+  name: 'run-custom-csfle-tests-master-mongocryptd',
   tags: ['run-custom-dependency-tests'],
   commands: [
     {
@@ -584,6 +584,62 @@ oneOffFuncAsTasks.push({
     {
       func: 'run custom csfle tests',
       vars: {
+        CSFLE_GIT_REF: 'master'
+      }
+    }
+  ]
+});
+
+oneOffFuncAsTasks.push({
+  name: 'run-custom-csfle-shared-lib-tests-pinned-commit',
+  tags: ['run-custom-dependency-tests'],
+  commands: [
+    {
+      func: 'install dependencies',
+      vars: {
+        NODE_LTS_NAME: LOWEST_LTS
+      }
+    },
+    {
+      func: 'bootstrap mongo-orchestration',
+      vars: {
+        VERSION: 'latest',
+        TOPOLOGY: 'replica_set'
+      }
+    },
+    { func: 'bootstrap kms servers' },
+    {
+      func: 'run custom csfle shared lib tests',
+      vars: {
+        VERSION: 'latest',
+        CSFLE_GIT_REF: 'c2712248e9f4909cdad723607ea5291d2eb48b91'
+      }
+    }
+  ]
+});
+
+oneOffFuncAsTasks.push({
+  name: 'run-custom-csfle-shared-lib-tests-master',
+  tags: ['run-custom-dependency-tests'],
+  commands: [
+    {
+      func: 'install dependencies',
+      vars: {
+        NODE_LTS_NAME: LOWEST_LTS
+      }
+    },
+    {
+      func: 'bootstrap mongo-orchestration',
+      vars: {
+        VERSION: 'latest',
+        TOPOLOGY: 'replica_set'
+      }
+    },
+    { func: 'bootstrap kms servers' },
+    {
+      func: 'run custom csfle shared lib tests',
+      vars: {
+        VERSION: 'latest',
         CSFLE_GIT_REF: 'master'
       }
     }

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -537,7 +537,7 @@ const oneOffFuncAsTasks = oneOffFuncs.map(oneOffFunc => ({
 }));
 
 oneOffFuncAsTasks.push({
-  name: 'run-custom-csfle-tests-pinned-commit-mongocryptd',
+  name: 'run-custom-csfle-tests-mongocryptd-pinned-commit',
   tags: ['run-custom-dependency-tests'],
   commands: [
     {

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -564,7 +564,7 @@ oneOffFuncAsTasks.push({
 });
 
 oneOffFuncAsTasks.push({
-  name: 'run-custom-csfle-tests-master-mongocryptd',
+  name: 'run-custom-csfle-tests-mongocryptd-master',
   tags: ['run-custom-dependency-tests'],
   commands: [
     {

--- a/.evergreen/prepare-crypt-shared-lib.sh
+++ b/.evergreen/prepare-crypt-shared-lib.sh
@@ -1,0 +1,35 @@
+MONGODB_VERSION=${VERSION}
+if [ -z "$MONGODB_VERSION" ]; then
+  # default to latest to match behavior of run-orchestration.sh.
+  MONGODB_VERSION=latest
+fi
+
+. $DRIVERS_TOOLS/.evergreen/download-mongodb.sh
+get_distro
+# get_distro defines $DISTRO.
+echo "distro='$DISTRO' version='$MONGODB_VERSION'".
+get_mongodb_download_url_for "$DISTRO" "$MONGODB_VERSION"
+# get_mongodb_download_url_for defines $MONGO_CRYPT_SHARED_DOWNLOAD_URL and $EXTRACT.
+if [ -z "$MONGO_CRYPT_SHARED_DOWNLOAD_URL" ]; then
+  echo "There is no crypt_shared library for distro='$DISTRO' and version='$MONGODB_VERSION'".
+  exit 1
+else
+  echo "Downloading crypt_shared package from $MONGO_CRYPT_SHARED_DOWNLOAD_URL"
+  download_and_extract_crypt_shared "$MONGO_CRYPT_SHARED_DOWNLOAD_URL" "$EXTRACT"
+  CRYPT_SHARED_LIB_PATH="$(find $(pwd) -maxdepth 1 -type f \
+    -name 'mongo_crypt_v1.so' -o \
+    -name 'mongo_crypt_v1.dll' -o \
+    -name 'mongo_crypt_v1.dylib')"
+  # Expect that we always find a crypt_shared library file and set the CRYPT_SHARED_LIB_PATH
+  # environment variable. If we didn't, print an error message and exit.
+  if [ -z "$CRYPT_SHARED_LIB_PATH" ]; then
+    echo 'CRYPT_SHARED_LIB_PATH is empty. Exiting.'
+    exit 1
+  fi
+  # If we're on Windows, convert the "cygdrive"  path to Windows-style paths.
+  if [ "Windows_NT" = "$OS" ]; then
+    CRYPT_SHARED_LIB_PATH=$(cygpath -m $CRYPT_SHARED_LIB_PATH)
+  fi
+  echo "CRYPT_SHARED_LIB_PATH: $CRYPT_SHARED_LIB_PATH"
+  export CRYPT_SHARED_LIB_PATH=${CRYPT_SHARED_LIB_PATH}
+fi

--- a/.evergreen/run-custom-csfle-tests.sh
+++ b/.evergreen/run-custom-csfle-tests.sh
@@ -65,6 +65,11 @@ export MONGODB_URI=${MONGODB_URI}
 export KMIP_TLS_CA_FILE="${DRIVERS_TOOLS}/.evergreen/x509gen/ca.pem"
 export KMIP_TLS_CERT_FILE="${DRIVERS_TOOLS}/.evergreen/x509gen/client.pem"
 export TEST_CSFLE=true
+
+if [ -n "$CRYPT_SHARED_LIB_PATH" ]; then
+  export CRYPT_SHARED_LIB_PATH=${CRYPT_SHARED_LIB_PATH}
+fi
+
 set +o errexit # We want to run both test suites even if the first fails
 npm run check:csfle
 DRIVER_CSFLE_TEST_RESULT=$?

--- a/test/readme.md
+++ b/test/readme.md
@@ -416,7 +416,7 @@ The following steps will walk you through how to run the tests for CSFLE.
 
    The output of the tests will include sections like "Client Side Encryption Corpus," "Client Side Encryption Functional," "Client Side Encryption Prose Tests," and "Client Side Encryption."
 
-  To run the functional tests using the crypt shared lirary instead of mongocryptd, download the appropriate version of the crypt shared library for the enterprise server version [here](https://www.mongodb.com/download-center/enterprise/releases) and then set the location of it in the environment variable `CRYPT_SHARED_LIB_PATH`.
+  To run the functional tests using the crypt shared library instead of mongocryptd, download the appropriate version of the crypt shared library for the enterprise server version [here](https://www.mongodb.com/download-center/enterprise/releases) and then set the location of it in the environment variable `CRYPT_SHARED_LIB_PATH`.
 
 #### KMIP FLE support tests
 

--- a/test/readme.md
+++ b/test/readme.md
@@ -416,6 +416,8 @@ The following steps will walk you through how to run the tests for CSFLE.
 
    The output of the tests will include sections like "Client Side Encryption Corpus," "Client Side Encryption Functional," "Client Side Encryption Prose Tests," and "Client Side Encryption."
 
+  To run the functional tests using the crypt shared lirary instead of mongocryptd, download the appropriate version of the crypt shared library for the enterprise server version [here](https://www.mongodb.com/download-center/enterprise/releases) and then set the location of it in the environment variable `CRYPT_SHARED_LIB_PATH`.
+
 #### KMIP FLE support tests
 
 1. Install virtualenv: `pip install virtualenv`


### PR DESCRIPTION
### Description

Downloads the crypt shared lib for the appropriate version and sets its path in the environment.

#### What is changing?

Adds a new evergreen task that will download the crypt shared lib before running the csfle custom tests. This does not include the changes to the test runner to use it - that is the next subtask.

https://evergreen.mongodb.com/task_log_raw/mongo_node_driver_next_ubuntu1804_custom_dependency_tests_run_custom_csfle_tests_patch_8ecbabcc4dec6c77db4e5ce5ef4a2ca5629c4608_62e12ede2a60ed018c89d3bc_22_07_27_12_26_07/0?type=T#L1437

##### Is there new documentation needed for these changes?

None.

#### What is the motivation for this change?

NODE-4463/NODE-4089

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
