### PR TITLE
test(NODE-4395): add csfle master && pinned commit tasks to CI

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1621,7 +1621,7 @@ tasks:
       - func: run bson-ext test
         vars:
           NODE_LTS_NAME: erbium
-  - name: run-custom-csfle-tests
+  - name: run-custom-csfle-tests-pinned-commit
     tags:
       - run-custom-dependency-tests
     commands:
@@ -1634,6 +1634,23 @@ tasks:
           TOPOLOGY: replica_set
       - func: bootstrap kms servers
       - func: run custom csfle tests
+        vars:
+          CSFLE_GIT_REF: e157c35ee4028b292883c4628dc5926f9742b34a
+  - name: run-custom-csfle-tests-master
+    tags:
+      - run-custom-dependency-tests
+    commands:
+      - func: install dependencies
+        vars:
+          NODE_LTS_NAME: erbium
+      - func: bootstrap mongo-orchestration
+        vars:
+          VERSION: latest
+          TOPOLOGY: replica_set
+      - func: bootstrap kms servers
+      - func: run custom csfle tests
+        vars:
+          CSFLE_GIT_REF: master
   - name: test-latest-server-noauth
     tags:
       - latest
@@ -2192,7 +2209,8 @@ buildvariants:
     tasks:
       - run-custom-snappy-tests
       - run-bson-ext-test
-      - run-custom-csfle-tests
+      - run-custom-csfle-tests-pinned-commit
+      - run-custom-csfle-tests-master
   - name: ubuntu1804-test-serverless
     display_name: Serverless Test
     run_on: ubuntu1804-test

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1667,7 +1667,7 @@ tasks:
       - func: bootstrap kms servers
       - func: run custom csfle tests
         vars:
-          CSFLE_GIT_REF: e157c35ee4028b292883c4628dc5926f9742b34a
+          CSFLE_GIT_REF: c2712248e9f4909cdad723607ea5291d2eb48b91
   - name: run-custom-csfle-tests-master
     tags:
       - run-custom-dependency-tests

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -499,7 +499,7 @@ const oneOffFuncAsTasks = oneOffFuncs.map(oneOffFunc => ({
 }));
 
 oneOffFuncAsTasks.push({
-  name: 'run-custom-csfle-tests',
+  name: 'run-custom-csfle-tests-pinned-commit',
   tags: ['run-custom-dependency-tests'],
   commands: [
     {
@@ -516,7 +516,39 @@ oneOffFuncAsTasks.push({
       }
     },
     { func: 'bootstrap kms servers' },
-    { func: 'run custom csfle tests' }
+    {
+      func: 'run custom csfle tests',
+      vars: {
+        CSFLE_GIT_REF: 'e157c35ee4028b292883c4628dc5926f9742b34a'
+      }
+    }
+  ]
+});
+
+oneOffFuncAsTasks.push({
+  name: 'run-custom-csfle-tests-master',
+  tags: ['run-custom-dependency-tests'],
+  commands: [
+    {
+      func: 'install dependencies',
+      vars: {
+        NODE_LTS_NAME: LOWEST_LTS
+      }
+    },
+    {
+      func: 'bootstrap mongo-orchestration',
+      vars: {
+        VERSION: 'latest',
+        TOPOLOGY: 'replica_set'
+      }
+    },
+    { func: 'bootstrap kms servers' },
+    {
+      func: 'run custom csfle tests',
+      vars: {
+        CSFLE_GIT_REF: 'master'
+      }
+    }
   ]
 });
 

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -557,7 +557,7 @@ oneOffFuncAsTasks.push({
     {
       func: 'run custom csfle tests',
       vars: {
-        CSFLE_GIT_REF: 'e157c35ee4028b292883c4628dc5926f9742b34a'
+        CSFLE_GIT_REF: 'c2712248e9f4909cdad723607ea5291d2eb48b91'
       }
     }
   ]

--- a/.evergreen/run-custom-csfle-tests.sh
+++ b/.evergreen/run-custom-csfle-tests.sh
@@ -26,8 +26,7 @@ ABS_PATH_TO_PATCH=$(pwd)
 # Environment Variables:
 # CSFLE_GIT_REF - set the git reference to checkout for a custom CSFLE version
 # CDRIVER_GIT_REF - set the git reference to checkout for a custom CDRIVER version (this is for libbson)
-
-CSFLE_GIT_REF=${CSFLE_GIT_REF:-e157c35ee4028b292883c4628dc5926f9742b34a}
+CSFLE_GIT_REF=${CSFLE_GIT_REF:-master}
 CDRIVER_GIT_REF=${CDRIVER_GIT_REF:-1.17.6}
 
 rm -rf ../csfle-deps-tmp


### PR DESCRIPTION
### Description

#### What is changing?

A new task as been added to the custom dependency tests to test against libmongocrypt master.  The existing task was also renamed to indicate that it tests against a pinned commit, instead of the latest master.