### PR TITLE
test(NODE-4331): add prose test 13

### DIFF
--- a/test/integration/client-side-encryption/client_side_encryption.prose.test.js
+++ b/test/integration/client-side-encryption/client_side_encryption.prose.test.js
@@ -1843,9 +1843,7 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
 
         // 4. Use client_encryption to add a keyAltName "def" to the key created in Step 1 and assert the operation fails due to a duplicate key server error (error code 11000).
         try {
-          await clientEncryption.createDataKey('local', {
-            keyAltNames: ['def']
-          });
+          await clientEncryption.addKeyAltName(_id, 'def');
           expect.fail(
             'Error in step 4) expected clientEncryption.createDataKey to throw duplicate key error but it did not'
           );

--- a/test/integration/client-side-encryption/client_side_encryption.prose.test.js
+++ b/test/integration/client-side-encryption/client_side_encryption.prose.test.js
@@ -1775,28 +1775,28 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
         });
 
         // 2. Repeat Step 1 and assert the operation fails due to a duplicate key server error (error code 11000).
-        const maybeErrorStep2 = await clientEncryption
+        const resultStep2 = await clientEncryption
           .createDataKey('local', {
             keyAltNames: ['abc']
           })
           .catch(e => e);
         expect(
-          maybeErrorStep2,
+          resultStep2,
           'Error in step 2) expected clientEncryption.createDataKey to throw duplicate key error but it did not'
         ).to.be.instanceof(MongoServerError);
-        expect(maybeErrorStep2).have.property('code', 11000);
+        expect(resultStep2).have.property('code', 11000);
 
         // 3. Use client_encryption to create a new local data key with a keyAltName "def" and assert the operation fails due to a duplicate key server error (error code 11000).
-        const maybeErrorStep3 = await clientEncryption
+        const resultStep3 = await clientEncryption
           .createDataKey('local', {
             keyAltNames: ['def']
           })
           .catch(e => e);
         expect(
-          maybeErrorStep3,
+          resultStep3,
           'Error in step 3) expected clientEncryption.createDataKey to throw duplicate key error but it did not'
         ).to.be.instanceof(MongoServerError);
-        expect(maybeErrorStep3).have.property('code', 11000);
+        expect(resultStep3).have.property('code', 11000);
       });
     });
 
@@ -1809,30 +1809,20 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
         await clientEncryption.addKeyAltName(_id, 'abc');
 
         // 3. Repeat Step 2, assert the operation does not fail, and assert the returned key document contains the keyAltName "abc" added in Step 2.
-        const maybeErrorStep3 = await clientEncryption.addKeyAltName(_id, 'abc').catch(e => e);
-        expect(
-          maybeErrorStep3,
-          `Error in step 3) expected clientEncryption.addKeyAltName not to fail, but received ${maybeErrorStep3}`
-        ).not.to.be.instanceof(MongoServerError);
-        expect(maybeErrorStep3).to.have.property('keyAltNames').to.include('abc');
+        const resultStep3 = await clientEncryption.addKeyAltName(_id, 'abc');
+        expect(resultStep3).to.have.property('keyAltNames').to.include('abc');
 
         // 4. Use client_encryption to add a keyAltName "def" to the key created in Step 1 and assert the operation fails due to a duplicate key server error (error code 11000).
-        const maybeErrorStep4 = await clientEncryption.addKeyAltName(_id, 'def').catch(e => e);
+        const resultStep4 = await clientEncryption.addKeyAltName(_id, 'def').catch(e => e);
         expect(
-          maybeErrorStep4,
+          resultStep4,
           'Error in step 4) expected clientEncryption.addKeyAltName to throw duplicate key error but it did not'
         ).to.be.instanceof(MongoServerError);
-        expect(maybeErrorStep4).to.have.property('code', 11000);
+        expect(resultStep4).to.have.property('code', 11000);
 
         // 5. Use client_encryption to add a keyAltName "def" to the existing key, assert the operation does not fail, and assert the returned key document contains the keyAltName "def" added during Setup.
-        const maybeErrorStep5 = await clientEncryption
-          .addKeyAltName(setupKeyId, 'def')
-          .catch(e => e);
-        expect(
-          maybeErrorStep5,
-          `Error in step 4) expected clientEncryption.addKeyAltName not to fail, but received ${maybeErrorStep5}`
-        ).not.to.be.instanceof(MongoServerError);
-        expect(maybeErrorStep5).to.have.property('keyAltNames').to.include('def');
+        const resultStep5 = await clientEncryption.addKeyAltName(setupKeyId, 'def');
+        expect(resultStep5).to.have.property('keyAltNames').to.include('def');
       });
     });
   });

--- a/test/integration/client-side-encryption/client_side_encryption.prose.test.js
+++ b/test/integration/client-side-encryption/client_side_encryption.prose.test.js
@@ -1723,7 +1723,7 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
     });
   });
 
-  context.only('13. Unique Index on keyAltNames', function () {
+  context('13. Unique Index on keyAltNames', function () {
     let client, clientEncryption, setupKeyId;
 
     beforeEach(async function () {
@@ -1819,7 +1819,6 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
         expect(maybeErrorStep3).to.have.property('keyAltNames').to.include('abc');
 
         // 4. Use client_encryption to add a keyAltName "def" to the key created in Step 1 and assert the operation fails due to a duplicate key server error (error code 11000).
-
         const maybeErrorStep4 = await clientEncryption.addKeyAltName(_id, 'def').catch(e => e);
         expect(
           maybeErrorStep4,

--- a/test/integration/client-side-encryption/client_side_encryption.prose.test.js
+++ b/test/integration/client-side-encryption/client_side_encryption.prose.test.js
@@ -1782,28 +1782,28 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
         }
 
         // 2. Repeat Step 1 and assert the operation fails due to a duplicate key server error (error code 11000).
-        let maybeError = await clientEncryption
+        const maybeErrorStep2 = await clientEncryption
           .createDataKey('local', {
             keyAltNames: ['abc']
           })
           .catch(e => e);
         expect(
-          maybeError,
+          maybeErrorStep2,
           'Error in step 2) expected clientEncryption.createDataKey to throw duplicate key error but it did not'
         ).to.be.instanceof(MongoServerError);
-        expect(maybeError).have.property('code', 11000);
+        expect(maybeErrorStep2).have.property('code', 11000);
 
         // 3. Use client_encryption to create a new local data key with a keyAltName "def" and assert the operation fails due to a duplicate key server error (error code 11000).
-        maybeError = await clientEncryption
+        const maybeErrorStep3 = await clientEncryption
           .createDataKey('local', {
             keyAltNames: ['def']
           })
           .catch(e => e);
         expect(
-          maybeError,
+          maybeErrorStep3,
           'Error in step 3) expected clientEncryption.createDataKey to throw duplicate key error but it did not'
         ).to.be.instanceof(MongoServerError);
-        expect(maybeError).have.property('code', 11000);
+        expect(maybeErrorStep3).have.property('code', 11000);
       });
     });
 
@@ -1825,35 +1825,39 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
           await clientEncryption.addKeyAltName(_id, 'abc');
         } catch (err) {
           expect.fail(
-            'Error in step 2) expected clientEncryption.createDataKey not to fail, but received',
+            'Error in step 2) expected clientEncryption.addKeyAltName not to fail, but received',
             err
           );
         }
 
         // 3. Repeat Step 2, assert the operation does not fail, and assert the returned key document contains the keyAltName "abc" added in Step 2.
-        let maybeError = await await clientEncryption.addKeyAltName(_id, 'abc').catch(e => e);
+        const maybeErrorStep3 = await await clientEncryption
+          .addKeyAltName(_id, 'abc')
+          .catch(e => e);
         expect(
-          maybeError,
-          `Error in step 3) expected clientEncryption.createDataKey not to fail, but received ${maybeError}`
+          maybeErrorStep3,
+          `Error in step 3) expected clientEncryption.addKeyAltName not to fail, but received ${maybeErrorStep3}`
         ).not.to.be.instanceof(MongoServerError);
-        expect(maybeError).to.have.property('keyAltNames').to.include('abc');
+        expect(maybeErrorStep3).to.have.property('keyAltNames').to.include('abc');
 
         // 4. Use client_encryption to add a keyAltName "def" to the key created in Step 1 and assert the operation fails due to a duplicate key server error (error code 11000).
 
-        maybeError = await clientEncryption.addKeyAltName(_id, 'def').catch(e => e);
+        const maybeErrorStep4 = await clientEncryption.addKeyAltName(_id, 'def').catch(e => e);
         expect(
-          maybeError,
-          'Error in step 4) expected clientEncryption.createDataKey to throw duplicate key error but it did not'
+          maybeErrorStep4,
+          'Error in step 4) expected clientEncryption.addKeyAltName to throw duplicate key error but it did not'
         ).to.be.instanceof(MongoServerError);
-        expect(maybeError).to.have.property('code', 11000);
+        expect(maybeErrorStep4).to.have.property('code', 11000);
 
         // 5. Use client_encryption to add a keyAltName "def" to the existing key, assert the operation does not fail, and assert the returned key document contains the keyAltName "def" added during Setup.
-        maybeError = await clientEncryption.addKeyAltName(setupKeyId, 'def').catch(e => e);
+        const maybeErrorStep5 = await clientEncryption
+          .addKeyAltName(setupKeyId, 'def')
+          .catch(e => e);
         expect(
-          maybeError,
-          `Error in step 4) expected clientEncryption.addKeyAltName not to fail, but received ${maybeError}`
+          maybeErrorStep5,
+          `Error in step 4) expected clientEncryption.addKeyAltName not to fail, but received ${maybeErrorStep5}`
         ).not.to.be.instanceof(MongoServerError);
-        expect(maybeError).to.have.property('keyAltNames').to.include('def');
+        expect(maybeErrorStep5).to.have.property('keyAltNames').to.include('def');
       });
     });
   });

--- a/test/integration/client-side-encryption/client_side_encryption.prose.test.js
+++ b/test/integration/client-side-encryption/client_side_encryption.prose.test.js
@@ -1809,9 +1809,7 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
         await clientEncryption.addKeyAltName(_id, 'abc');
 
         // 3. Repeat Step 2, assert the operation does not fail, and assert the returned key document contains the keyAltName "abc" added in Step 2.
-        const maybeErrorStep3 = await await clientEncryption
-          .addKeyAltName(_id, 'abc')
-          .catch(e => e);
+        const maybeErrorStep3 = await clientEncryption.addKeyAltName(_id, 'abc').catch(e => e);
         expect(
           maybeErrorStep3,
           `Error in step 3) expected clientEncryption.addKeyAltName not to fail, but received ${maybeErrorStep3}`

--- a/test/integration/client-side-encryption/client_side_encryption.prose.test.js
+++ b/test/integration/client-side-encryption/client_side_encryption.prose.test.js
@@ -1770,16 +1770,9 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
     context('Case 1', metadata, function () {
       it('createDataKey() handles duplicate key errors on the keyvault collection', async function () {
         // 1. Use client_encryption to create a new local data key with a keyAltName "abc" and assert the operation does not fail.
-        try {
-          await clientEncryption.createDataKey('local', {
-            keyAltNames: ['abc']
-          });
-        } catch (err) {
-          expect.fail(
-            'Error in step 1) expected clientEncryption.createDataKey to not fail, but received',
-            err
-          );
-        }
+        await clientEncryption.createDataKey('local', {
+          keyAltNames: ['abc']
+        });
 
         // 2. Repeat Step 1 and assert the operation fails due to a duplicate key server error (error code 11000).
         const maybeErrorStep2 = await clientEncryption
@@ -1809,26 +1802,11 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
 
     context('Case 2', metadata, function () {
       it('addKeyAltName() handles duplicate key errors on the keyvault collection', async function () {
-        let _id;
         // 1. Use client_encryption to create a new local data key and assert the operation does not fail.
-        try {
-          _id = await clientEncryption.createDataKey('local');
-        } catch (err) {
-          expect.fail(
-            'Error in step 1) expected clientEncryption.createDataKey to not fail, but received',
-            err
-          );
-        }
+        const _id = await clientEncryption.createDataKey('local');
 
         // 2. Use client_encryption to add a keyAltName "abc" to the key created in Step 1 and assert the operation does not fail.
-        try {
-          await clientEncryption.addKeyAltName(_id, 'abc');
-        } catch (err) {
-          expect.fail(
-            'Error in step 2) expected clientEncryption.addKeyAltName not to fail, but received',
-            err
-          );
-        }
+        await clientEncryption.addKeyAltName(_id, 'abc');
 
         // 3. Repeat Step 2, assert the operation does not fail, and assert the returned key document contains the keyAltName "abc" added in Step 2.
         const maybeErrorStep3 = await await clientEncryption

--- a/test/integration/client-side-encryption/client_side_encryption.prose.test.js
+++ b/test/integration/client-side-encryption/client_side_encryption.prose.test.js
@@ -1790,7 +1790,7 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
             'Error in step 2) expected clientEncryption.createDataKey to throw duplicate key error but it did not'
           );
         } catch (err) {
-          expect(err.code).to.equal(11000);
+          expect(err).have.property('code', 11000);
         }
 
         // 3. Use client_encryption to create a new local data key with a keyAltName "def" and assert the operation fails due to a duplicate key server error (error code 11000).
@@ -1802,7 +1802,7 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
             'Error in step 3) expected clientEncryption.createDataKey to throw duplicate key error but it did not'
           );
         } catch (err) {
-          expect(err.code).to.equal(11000);
+          expect(err).to.have.property('code', 11000);
         }
       });
     });
@@ -1848,7 +1848,7 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
             'Error in step 4) expected clientEncryption.createDataKey to throw duplicate key error but it did not'
           );
         } catch (err) {
-          expect(err.code).to.equal(11000);
+          expect(err).to.have.property('code', 11000);
         }
 
         // 5. Use client_encryption to add a keyAltName "def" to the existing key, assert the operation does not fail, and assert the returned key document contains the keyAltName "def" added during Setup.


### PR DESCRIPTION
### Description

#### What is changing?

CSFLE Prose test 13 is implemented, finishing up the key management API work (with the exception of releasing mongodb-client-encryption).

This PR address the following ticket:

- https://jira.mongodb.org/browse/NODE-4331

##### Is there new documentation needed for these changes?

No.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
