### PR TITLE
test(NODE-3812,NODE-4465): transaction and dns seedlist spec test sync

### DIFF
--- a/test/spec/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-invalid_integer.json
+++ b/test/spec/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-invalid_integer.json
@@ -1,7 +1,0 @@
-{
-  "uri": "mongodb+srv://test1.test.build.10gen.cc/?replicaSet=repl0&srvMaxHosts=-1",
-  "seeds": [],
-  "hosts": [],
-  "error": true,
-  "comment": "Should fail because srvMaxHosts is not greater than or equal to zero"
-}

--- a/test/spec/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-invalid_integer.yml
+++ b/test/spec/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-invalid_integer.yml
@@ -1,5 +1,0 @@
-uri: "mongodb+srv://test1.test.build.10gen.cc/?replicaSet=repl0&srvMaxHosts=-1"
-seeds: []
-hosts: []
-error: true
-comment: Should fail because srvMaxHosts is not greater than or equal to zero

--- a/test/spec/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-invalid_type.json
+++ b/test/spec/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-invalid_type.json
@@ -1,7 +1,0 @@
-{
-  "uri": "mongodb+srv://test1.test.build.10gen.cc/?replicaSet=repl0&srvMaxHosts=foo",
-  "seeds": [],
-  "hosts": [],
-  "error": true,
-  "comment": "Should fail because srvMaxHosts is not an integer"
-}

--- a/test/spec/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-invalid_type.yml
+++ b/test/spec/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-invalid_type.yml
@@ -1,5 +1,0 @@
-uri: "mongodb+srv://test1.test.build.10gen.cc/?replicaSet=repl0&srvMaxHosts=foo"
-seeds: []
-hosts: []
-error: true
-comment: Should fail because srvMaxHosts is not an integer

--- a/test/spec/initial-dns-seedlist-discovery/sharded/srvMaxHosts-invalid_integer.json
+++ b/test/spec/initial-dns-seedlist-discovery/sharded/srvMaxHosts-invalid_integer.json
@@ -1,7 +1,0 @@
-{
-  "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=-1",
-  "seeds": [],
-  "hosts": [],
-  "error": true,
-  "comment": "Should fail because srvMaxHosts is not greater than or equal to zero"
-}

--- a/test/spec/initial-dns-seedlist-discovery/sharded/srvMaxHosts-invalid_integer.yml
+++ b/test/spec/initial-dns-seedlist-discovery/sharded/srvMaxHosts-invalid_integer.yml
@@ -1,5 +1,0 @@
-uri: "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=-1"
-seeds: []
-hosts: []
-error: true
-comment: Should fail because srvMaxHosts is not greater than or equal to zero

--- a/test/spec/initial-dns-seedlist-discovery/sharded/srvMaxHosts-invalid_type.json
+++ b/test/spec/initial-dns-seedlist-discovery/sharded/srvMaxHosts-invalid_type.json
@@ -1,7 +1,0 @@
-{
-  "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=foo",
-  "seeds": [],
-  "hosts": [],
-  "error": true,
-  "comment": "Should fail because srvMaxHosts is not an integer"
-}

--- a/test/spec/initial-dns-seedlist-discovery/sharded/srvMaxHosts-invalid_type.yml
+++ b/test/spec/initial-dns-seedlist-discovery/sharded/srvMaxHosts-invalid_type.yml
@@ -1,5 +1,0 @@
-uri: "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=foo"
-seeds: []
-hosts: []
-error: true
-comment: Should fail because srvMaxHosts is not an integer

--- a/test/spec/transactions/unified/do-not-retry-read-in-transaction.json
+++ b/test/spec/transactions/unified/do-not-retry-read-in-transaction.json
@@ -1,0 +1,115 @@
+{
+  "description": "do not retry read in a transaction",
+  "schemaVersion": "1.4",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "4.0.0",
+      "topologies": [
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.2.0",
+      "topologies": [
+        "sharded",
+        "load-balanced"
+      ]
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": false,
+        "observeEvents": [
+          "commandStartedEvent"
+        ],
+        "uriOptions": {
+          "retryReads": true
+        }
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "retryable-read-in-transaction-test"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll"
+      }
+    },
+    {
+      "session": {
+        "id": "session0",
+        "client": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "find does not retry in a transaction",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "find"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {},
+            "session": "session0"
+          },
+          "expectError": {
+            "isError": true,
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "coll",
+                  "filter": {},
+                  "startTransaction": true
+                },
+                "commandName": "find",
+                "databaseName": "retryable-read-in-transaction-test"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/transactions/unified/do-not-retry-read-in-transaction.yml
+++ b/test/spec/transactions/unified/do-not-retry-read-in-transaction.yml
@@ -1,0 +1,64 @@
+description: "do not retry read in a transaction"
+
+schemaVersion: "1.4"
+
+runOnRequirements:
+  - minServerVersion: "4.0.0"
+    topologies: [ replicaset ]
+  - minServerVersion: "4.2.0"
+    topologies: [ sharded, load-balanced ]
+
+createEntities:
+  - client:
+      id: &client0 client0
+      useMultipleMongoses: false
+      observeEvents: [commandStartedEvent]
+      uriOptions: { retryReads: true }
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &databaseName retryable-read-in-transaction-test
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collectionName coll
+  - session:
+      id: &session0 session0
+      client: *client0
+
+tests:
+  - description: "find does not retry in a transaction"
+    operations:
+
+      - name: startTransaction
+        object: *session0
+
+      - name: failPoint # fail the following find command
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+              failCommands: [find]
+              closeConnection: true
+
+      - name: find
+        object: *collection0
+        arguments:
+          filter: {}
+          session: *session0
+        expectError:
+          isError: true
+          errorLabelsContain: ["TransientTransactionError"]
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                find: *collectionName
+                filter: {}
+                startTransaction: true
+              commandName: find
+              databaseName: *databaseName


### PR DESCRIPTION
### Description
NODE-3812,NODE-4465

#### What is changing?
- New transactions no retry test
- Removing invalid srvMaxHosts tests

##### Is there new documentation needed for these changes?
No

#### What is the motivation for this change?
Keeping up with spec tests

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
