### PR TITLE
fix(NODE-4467): Add back support for `oplogReplay` option as deprecated

### DIFF
--- a/src/operations/find.ts
+++ b/src/operations/find.ts
@@ -63,6 +63,11 @@ export interface FindOptions<TSchema extends Document = Document> extends Comman
   showRecordId?: boolean;
   /** Map of parameter names and values that can be accessed using $$var (requires MongoDB 5.0). */
   let?: Document;
+  /**
+   * Option to enable an optimized code path for queries looking for a particular range of `ts` values in the oplog. Requires `tailable` to be true.
+   * @deprecated Starting from MongoDB 4.4 this flag is not needed and will be ignored.
+   */
+  oplogReplay?: boolean;
 }
 
 const SUPPORTS_WRITE_CONCERN_AND_COLLATION = 5;
@@ -240,6 +245,10 @@ function makeFindCommand(ns: MongoDBNamespace, filter: Document, options: FindOp
 
   if (typeof options.tailable === 'boolean') {
     findCommand.tailable = options.tailable;
+  }
+
+  if (typeof options.oplogReplay === 'boolean') {
+    findCommand.oplogReplay = options.oplogReplay;
   }
 
   if (typeof options.timeout === 'boolean') {


### PR DESCRIPTION
### Description
The option has been deprecated for MongoDB >=4.4 but should still be available to MongoDB <=4.2

#### What is changing?
Oplog tailing for MongoDB server <=4.2 can still use this flag in order to have a better performance.

##### Is there new documentation needed for these changes?
No

#### What is the motivation for this change?
The initial query to tail the oplog on huge MongoDB 4.2 servers was taking too long to complete.

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
