### PR TITLE
feat(NODE-4336): deprecate old write concern options and add missing writeConcern to MongoClientOptions

### DIFF
--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -1188,7 +1188,7 @@ export const OPTIONS = {
 
       throw new MongoParseError(`Invalid WriteConcern cannot parse: ${JSON.stringify(value)}`);
     }
-  } as OptionDescriptor,
+  },
   wtimeout: {
     deprecated: 'Please use wtimeoutMS instead',
     target: 'writeConcern',

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -33,7 +33,7 @@ import {
   ns,
   resolveOptions
 } from './utils';
-import type { W, WriteConcern } from './write_concern';
+import type { W, WriteConcern, WriteConcernSettings } from './write_concern';
 
 /** @public */
 export const ServerApiVersion = Object.freeze({
@@ -183,14 +183,28 @@ export interface MongoClientOptions extends BSONSerializeOptions, SupportedNodeC
   directConnection?: boolean;
   /** Instruct the driver it is connecting to a load balancer fronting a mongos like service */
   loadBalanced?: boolean;
-
-  /** The write concern w value */
+  /**
+   * The write concern w value
+   * @deprecated Please use the `writeConcern` option instead
+   */
   w?: W;
-  /** The write concern timeout */
+  /**
+   * The write concern timeout
+   * @deprecated Please use the `writeConcern` option instead
+   */
   wtimeoutMS?: number;
-  /** The journal write concern */
+  /**
+   * The journal write concern
+   * @deprecated Please use the `writeConcern` option instead
+   */
   journal?: boolean;
-
+  /**
+   * A MongoDB WriteConcern, which describes the level of acknowledgement
+   * requested from MongoDB for write operations.
+   *
+   * @see https://docs.mongodb.com/manual/reference/write-concern/
+   */
+  writeConcern?: WriteConcern | WriteConcernSettings;
   /** Validate mongod server certificate against Certificate Authority */
   sslValidate?: boolean;
   /** SSL Certificate file path. */

--- a/test/types/mongodb.test-d.ts
+++ b/test/types/mongodb.test-d.ts
@@ -1,7 +1,7 @@
 import type { Document } from 'bson';
 import { expectDeprecated, expectError, expectNotDeprecated, expectType } from 'tsd';
 
-import { Db, WithId } from '../../src';
+import { Db, WithId, WriteConcern, WriteConcernSettings } from '../../src';
 import * as MongoDBDriver from '../../src';
 import type { ChangeStreamDocument } from '../../src/change_stream';
 import { Collection } from '../../src/collection';
@@ -22,6 +22,13 @@ expectDeprecated(Topology.prototype.unref);
 expectDeprecated(Db.prototype.unref);
 expectDeprecated(MongoDBDriver.ObjectID);
 expectNotDeprecated(MongoDBDriver.ObjectId);
+
+declare const options: MongoDBDriver.MongoClientOptions;
+expectDeprecated(options.w);
+expectDeprecated(options.journal);
+expectDeprecated(options.wtimeoutMS);
+expectNotDeprecated(options.writeConcern);
+expectType<WriteConcernSettings | WriteConcern | undefined>(options.writeConcern);
 
 interface TSchema extends Document {
   name: string;


### PR DESCRIPTION
### Description

#### What is changing?

- Added writeConcern to MongoClientOptions
- Added deprecation flags to the top level versions of the options
- Added a type test

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
