### PR TITLE
test(NODE-4487, NODE-4390): sync key management tests && bump fle version in tests

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1701,7 +1701,7 @@ tasks:
       - func: bootstrap kms servers
       - func: run custom csfle tests
         vars:
-          CSFLE_GIT_REF: c2712248e9f4909cdad723607ea5291d2eb48b91
+          CSFLE_GIT_REF: 41afd44ca04d246998969c53de4e0f22802b0c8a
   - name: run-custom-csfle-tests-mongocryptd-master
     tags:
       - run-custom-dependency-tests
@@ -1732,7 +1732,7 @@ tasks:
       - func: run custom csfle shared lib tests
         vars:
           VERSION: latest
-          CSFLE_GIT_REF: c2712248e9f4909cdad723607ea5291d2eb48b91
+          CSFLE_GIT_REF: 41afd44ca04d246998969c53de4e0f22802b0c8a
   - name: run-custom-csfle-shared-lib-tests-master
     tags:
       - run-custom-dependency-tests

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -557,7 +557,7 @@ oneOffFuncAsTasks.push({
     {
       func: 'run custom csfle tests',
       vars: {
-        CSFLE_GIT_REF: 'c2712248e9f4909cdad723607ea5291d2eb48b91'
+        CSFLE_GIT_REF: '41afd44ca04d246998969c53de4e0f22802b0c8a'
       }
     }
   ]
@@ -612,7 +612,7 @@ oneOffFuncAsTasks.push({
       func: 'run custom csfle shared lib tests',
       vars: {
         VERSION: 'latest',
-        CSFLE_GIT_REF: 'c2712248e9f4909cdad723607ea5291d2eb48b91'
+        CSFLE_GIT_REF: '41afd44ca04d246998969c53de4e0f22802b0c8a'
       }
     }
   ]

--- a/.evergreen/run-bson-ext-test.sh
+++ b/.evergreen/run-bson-ext-test.sh
@@ -23,7 +23,7 @@ fi
 # run tests
 echo "Running $AUTH tests over $SSL, connecting to $MONGODB_URI"
 
-npm install mongodb-client-encryption@">=2.0.0-beta.4"
+npm install mongodb-client-encryption@">=2.2.0-alpha.6"
 npm install bson-ext
 
 export MONGODB_API_VERSION=${MONGODB_API_VERSION}

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -56,7 +56,7 @@ else
   source "$DRIVERS_TOOLS"/.evergreen/csfle/set-temp-creds.sh
 fi
 
-npm install mongodb-client-encryption@">=2.2.0-alpha.5"
+npm install mongodb-client-encryption@">=2.2.0-alpha.6"
 npm install @mongodb-js/zstd
 npm install snappy
 

--- a/test/spec/client-side-encryption/tests/unified/addKeyAltName.json
+++ b/test/spec/client-side-encryption/tests/unified/addKeyAltName.json
@@ -98,7 +98,9 @@
             },
             "keyAltName": "new_key_alt_name"
           },
-          "expectResult": null
+          "expectResult": {
+            "$$unsetOrMatches": null
+          }
         }
       ],
       "expectEvents": [

--- a/test/spec/client-side-encryption/tests/unified/addKeyAltName.yml
+++ b/test/spec/client-side-encryption/tests/unified/addKeyAltName.yml
@@ -48,7 +48,7 @@ tests:
           # First 3 letters of local_key_id replaced with 'A' (value: "#alkeylocalkey").
           id: &non_existent_id { $binary: { base64: AAAjYWxrZXlsb2NhbGtleQ==, subType: "04" } }
           keyAltName: new_key_alt_name
-        expectResult: null
+        expectResult: { $$unsetOrMatches: null }
     expectEvents:
       - client: *client0
         events:

--- a/test/spec/client-side-encryption/tests/unified/createDataKey-kms_providers-invalid.json
+++ b/test/spec/client-side-encryption/tests/unified/createDataKey-kms_providers-invalid.json
@@ -1,5 +1,5 @@
 {
-  "description": "createDataKey-provider-invalid",
+  "description": "createDataKey-kms_providers-invalid",
   "schemaVersion": "1.8",
   "runOnRequirements": [
     {

--- a/test/spec/client-side-encryption/tests/unified/createDataKey-kms_providers-invalid.yml
+++ b/test/spec/client-side-encryption/tests/unified/createDataKey-kms_providers-invalid.yml
@@ -1,4 +1,4 @@
-description: createDataKey-provider-invalid
+description: createDataKey-kms_providers-invalid
 
 schemaVersion: "1.8"
 

--- a/test/spec/client-side-encryption/tests/unified/getKey.json
+++ b/test/spec/client-side-encryption/tests/unified/getKey.json
@@ -133,7 +133,9 @@
               }
             }
           },
-          "expectResult": null
+          "expectResult": {
+            "$$unsetOrMatches": null
+          }
         }
       ],
       "expectEvents": [

--- a/test/spec/client-side-encryption/tests/unified/getKey.yml
+++ b/test/spec/client-side-encryption/tests/unified/getKey.yml
@@ -59,7 +59,7 @@ tests:
         arguments:
           # *aws_key_id with first three letters replaced with 'A' (value: "3awsawsawsawsa").
           id: &non_existent_id { $binary: { base64: AAAzYXdzYXdzYXdzYXdzYQ==, subType: "04" } }
-        expectResult: null
+        expectResult: { $$unsetOrMatches: null }
     expectEvents:
       - client: *client0
         events:

--- a/test/spec/client-side-encryption/tests/unified/getKeyByAltName.json
+++ b/test/spec/client-side-encryption/tests/unified/getKeyByAltName.json
@@ -128,7 +128,9 @@
           "arguments": {
             "keyAltName": "does_not_exist"
           },
-          "expectResult": null
+          "expectResult": {
+            "$$unsetOrMatches": null
+          }
         }
       ],
       "expectEvents": [

--- a/test/spec/client-side-encryption/tests/unified/getKeyByAltName.yml
+++ b/test/spec/client-side-encryption/tests/unified/getKeyByAltName.yml
@@ -58,7 +58,7 @@ tests:
         object: *clientEncryption0
         arguments:
           keyAltName: does_not_exist
-        expectResult: null
+        expectResult: { $$unsetOrMatches: null }
     expectEvents:
       - client: *client0
         events:

--- a/test/spec/client-side-encryption/tests/unified/removeKeyAltName.json
+++ b/test/spec/client-side-encryption/tests/unified/removeKeyAltName.json
@@ -102,7 +102,9 @@
             },
             "keyAltName": "does_not_exist"
           },
-          "expectResult": null
+          "expectResult": {
+            "$$unsetOrMatches": null
+          }
         }
       ],
       "expectEvents": [

--- a/test/spec/client-side-encryption/tests/unified/removeKeyAltName.yml
+++ b/test/spec/client-side-encryption/tests/unified/removeKeyAltName.yml
@@ -49,7 +49,7 @@ tests:
           # First 3 letters of local_key_id replaced with 'A' (value: "#alkeylocalkey").
           id: &non_existent_id { $binary: { base64: AAAjYWxrZXlsb2NhbGtleQ==, subType: "04" } }
           keyAltName: does_not_exist
-        expectResult: null
+        expectResult: { $$unsetOrMatches: null }
     expectEvents:
       - client: *client0
         events:

--- a/test/spec/client-side-encryption/tests/unified/rewrapManyDataKey.json
+++ b/test/spec/client-side-encryption/tests/unified/rewrapManyDataKey.json
@@ -1,5 +1,5 @@
 {
-  "description": "rewrapManyDataKey-kms_providers",
+  "description": "rewrapManyDataKey",
   "schemaVersion": "1.8",
   "runOnRequirements": [
     {
@@ -128,7 +128,7 @@
           ],
           "keyMaterial": {
             "$binary": {
-              "base64": "AQICAHhQNmWG2CzOm1dq3kWLM+iDUZhEqnhJwH9wZVpuZ94A8gEGkNTybTc7Eyif0f+qqE0lAAAAwjCBvwYJKoZIhvcNAQcGoIGxMIGuAgEAMIGoBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDB2j78AeuIQxcRh8cQIBEIB7vj9buHEaT7XHFIsKBJiyzZRmNnjvqMK5LSdzonKdx97jlqauvPvTDXSsdQDcspUs5oLrGmAXpbFResscxmbwZoKgUtWiuIOpeAcYuszCiMKt15s1WIMLDXUhYtfCmhRhekvgHnRAaK4HJMlGE+lKJXYI84E0b86Cd/g+",
+              "base64": "pr01l7qDygUkFE/0peFwpnNlv3iIy8zrQK38Q9i12UCN2jwZHDmfyx8wokiIKMb9kAleeY+vnt3Cf1MKu9kcDmI+KxbNDd+V3ytAAGzOVLDJr77CiWjF9f8ntkXRHrAY9WwnVDANYkDwXlyU0Y2GQFTiW65jiQhUtYLYH63Tk48SsJuQvnWw1Q+PzY8ga+QeVec8wbcThwtm+r2IHsCFnc72Gv73qq7weISw+O4mN08z3wOp5FOS2ZM3MK7tBGmPdBcktW7F8ODGsOQ1FU53OrWUnyX2aTi2ftFFFMWVHqQo7EYuBZHru8RRODNKMyQk0BFfKovAeTAVRv9WH9QU7g==",
               "subType": "00"
             }
           },
@@ -196,7 +196,7 @@
           ],
           "keyMaterial": {
             "$binary": {
-              "base64": "VoI9J8HusQ3u2gT9i8Awgg/6W4/igvLwRzn3SRDGx0Dl/1ayDMubphOw0ONPVKfuvS6HL3e4gAoCJ/uEz2KLFTVsEqYCpMhfAhgXxm8Ena8vDcOkCzFX+euvN/N2ES3wpzAD18b3qIH0MbBwKJP82d5GQ4pVfGnPW8Ujp9aO1qC/s0EqNqYyzJ1SyzhV9lAjHHGIENYJx+bBrekg2EeZBA==",
+              "base64": "CklVctHzke4mcytd0TxGqvepkdkQN8NUF4+jV7aZQITAKdz6WjdDpq3lMt9nSzWGG2vAEfvRb3mFEVjV57qqGqxjq2751gmiMRHXz0btStbIK3mQ5xbY9kdye4tsixlCryEwQONr96gwlwKKI9Nubl9/8+uRF6tgYjje7Q7OjauEf1SrJwKcoQ3WwnjZmEqAug0kImCpJ/irhdqPzivRiA==",
               "subType": "00"
             }
           },

--- a/test/spec/client-side-encryption/tests/unified/rewrapManyDataKey.yml
+++ b/test/spec/client-side-encryption/tests/unified/rewrapManyDataKey.yml
@@ -2,7 +2,7 @@
 # commands sort the resulting documents in ascending order by the single-element
 # keyAltNames array to ensure alphabetic order by original KMS provider as
 # defined in initialData.
-description: rewrapManyDataKey-kms_providers
+description: rewrapManyDataKey
 
 schemaVersion: "1.8"
 
@@ -50,7 +50,7 @@ initialData:
           region: us-east-1
       - _id: &azure_key_id { $binary: { base64: YXp1cmVhenVyZWF6dXJlYQ==, subType: "04" } }
         keyAltNames: ["azure_key"]
-        keyMaterial: { $binary: { base64: AQICAHhQNmWG2CzOm1dq3kWLM+iDUZhEqnhJwH9wZVpuZ94A8gEGkNTybTc7Eyif0f+qqE0lAAAAwjCBvwYJKoZIhvcNAQcGoIGxMIGuAgEAMIGoBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDB2j78AeuIQxcRh8cQIBEIB7vj9buHEaT7XHFIsKBJiyzZRmNnjvqMK5LSdzonKdx97jlqauvPvTDXSsdQDcspUs5oLrGmAXpbFResscxmbwZoKgUtWiuIOpeAcYuszCiMKt15s1WIMLDXUhYtfCmhRhekvgHnRAaK4HJMlGE+lKJXYI84E0b86Cd/g+, subType: "00" } }
+        keyMaterial: { $binary: { base64: pr01l7qDygUkFE/0peFwpnNlv3iIy8zrQK38Q9i12UCN2jwZHDmfyx8wokiIKMb9kAleeY+vnt3Cf1MKu9kcDmI+KxbNDd+V3ytAAGzOVLDJr77CiWjF9f8ntkXRHrAY9WwnVDANYkDwXlyU0Y2GQFTiW65jiQhUtYLYH63Tk48SsJuQvnWw1Q+PzY8ga+QeVec8wbcThwtm+r2IHsCFnc72Gv73qq7weISw+O4mN08z3wOp5FOS2ZM3MK7tBGmPdBcktW7F8ODGsOQ1FU53OrWUnyX2aTi2ftFFFMWVHqQo7EYuBZHru8RRODNKMyQk0BFfKovAeTAVRv9WH9QU7g==, subType: "00" } }
         creationDate: { $date: { $numberLong: "1641024000000" } }
         updateDate: { $date: { $numberLong: "1641024000000" } }
         status: 1
@@ -72,7 +72,7 @@ initialData:
           keyName: key-name-csfle
       - _id: &kmip_key_id { $binary: { base64: a21pcGttaXBrbWlwa21pcA==, subType: "04" } }
         keyAltNames: ["kmip_key"]
-        keyMaterial: { $binary: { base64: VoI9J8HusQ3u2gT9i8Awgg/6W4/igvLwRzn3SRDGx0Dl/1ayDMubphOw0ONPVKfuvS6HL3e4gAoCJ/uEz2KLFTVsEqYCpMhfAhgXxm8Ena8vDcOkCzFX+euvN/N2ES3wpzAD18b3qIH0MbBwKJP82d5GQ4pVfGnPW8Ujp9aO1qC/s0EqNqYyzJ1SyzhV9lAjHHGIENYJx+bBrekg2EeZBA==, subType: "00" } }
+        keyMaterial: { $binary: { base64: CklVctHzke4mcytd0TxGqvepkdkQN8NUF4+jV7aZQITAKdz6WjdDpq3lMt9nSzWGG2vAEfvRb3mFEVjV57qqGqxjq2751gmiMRHXz0btStbIK3mQ5xbY9kdye4tsixlCryEwQONr96gwlwKKI9Nubl9/8+uRF6tgYjje7Q7OjauEf1SrJwKcoQ3WwnjZmEqAug0kImCpJ/irhdqPzivRiA==, subType: "00" } }
         creationDate: { $date: { $numberLong: "1641024000000" } }
         updateDate: { $date: { $numberLong: "1641024000000" } }
         status: 1


### PR DESCRIPTION
### Description

#### What is changing?

- bump fle tests to use https://github.com/mongodb/libmongocrypt/commit/41afd44ca04d246998969c53de4e0f22802b0c8a (2.2.0-alpha.6 release)
- bump bson-ext tests and regular CI tests to use mongodb-client-encryption@2.2.0-alpha.6
- syncs spec tests from [NODE-4487](https://jira.mongodb.org/browse/NODE-4487)
- syncs spec tests from [NODE-4390](https://jira.mongodb.org/browse/NODE-4390)

There will be a follow up PR for https://jira.mongodb.org/browse/NODE-4489.

##### Is there new documentation needed for these changes?

No.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
