### PR TITLE
revert(NODE-4414): Improve reliability of SDAM heartbeat error spec tests

### DIFF
--- a/test/spec/server-discovery-and-monitoring/integration/hello-command-error.json
+++ b/test/spec/server-discovery-and-monitoring/integration/hello-command-error.json
@@ -117,7 +117,7 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 4
+                "times": 2
               },
               "data": {
                 "failCommands": [
@@ -161,6 +161,22 @@
                 "_id": 4
               }
             ]
+          }
+        },
+        {
+          "name": "assertEventCount",
+          "object": "testRunner",
+          "arguments": {
+            "event": "ServerMarkedUnknownEvent",
+            "count": 1
+          }
+        },
+        {
+          "name": "assertEventCount",
+          "object": "testRunner",
+          "arguments": {
+            "event": "PoolClearedEvent",
+            "count": 1
           }
         }
       ],

--- a/test/spec/server-discovery-and-monitoring/integration/hello-command-error.yml
+++ b/test/spec/server-discovery-and-monitoring/integration/hello-command-error.yml
@@ -84,16 +84,15 @@ tests:
           documents:
             - _id: 1
             - _id: 2
-      # Configure the next streaming hello check to fail with a command error.
-      # Use "times: 4" to increase the probability that the Monitor check fails
-      # since the RTT hello may trigger this failpoint one or many times as
-      # well.
+      # Configure the next streaming hello check to fail with a command
+      # error.
+      # Use times: 2 so that the RTT hello is blocked as well.
       - name: configureFailPoint
         object: testRunner
         arguments:
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 4 }
+            mode: { times: 2 }
             data:
                 failCommands: ["hello", "isMaster"]
                 appName: commandErrorCheckTest
@@ -120,19 +119,17 @@ tests:
           documents:
             - _id: 3
             - _id: 4
-      # We cannot assert the server was marked Unknown and pool was cleared an
-      # exact number of times because the RTT hello may have triggered this
-      # failpoint one or many times as well.
-      # - name: assertEventCount
-      #   object: testRunner
-      #   arguments:
-      #     event: ServerMarkedUnknownEvent
-      #     count: 1
-      # - name: assertEventCount
-      #   object: testRunner
-      #   arguments:
-      #     event: PoolClearedEvent
-      #     count: 1
+      # Assert the server was marked Unknown and pool was cleared exactly once.
+      - name: assertEventCount
+        object: testRunner
+        arguments:
+          event: ServerMarkedUnknownEvent
+          count: 1
+      - name: assertEventCount
+        object: testRunner
+        arguments:
+          event: PoolClearedEvent
+          count: 1
 
     expectations:
       - command_started_event:

--- a/test/spec/server-discovery-and-monitoring/integration/hello-network-error.json
+++ b/test/spec/server-discovery-and-monitoring/integration/hello-network-error.json
@@ -116,7 +116,7 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 4
+                "times": 2
               },
               "data": {
                 "failCommands": [

--- a/test/spec/server-discovery-and-monitoring/integration/hello-network-error.yml
+++ b/test/spec/server-discovery-and-monitoring/integration/hello-network-error.yml
@@ -84,15 +84,14 @@ tests:
             - _id: 1
             - _id: 2
       # Configure the next streaming hello check to fail with a non-timeout
-      # network error. Use "times: 4" to increase the probability that the
-      # Monitor check fails since the RTT hello may trigger this failpoint one
-      # or many times as well.
+      # network error. Use times: 2 to ensure that the the Monitor check fails
+      # since the RTT hello may trigger this failpoint as well.
       - name: configureFailPoint
         object: testRunner
         arguments:
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 4 }
+            mode: { times: 2 }
             data:
                 failCommands: ["hello", "isMaster"]
                 appName: networkErrorCheckTest
@@ -117,8 +116,8 @@ tests:
             - _id: 3
             - _id: 4
       # We cannot assert the server was marked Unknown and pool was cleared an
-      # exact number of times because the RTT hello may have triggered this
-      # failpoint one or many times as well.
+      # exact number of times because the RTT hello may or may not have
+      # triggered this failpoint as well.
       # - name: assertEventCount
       #   object: testRunner
       #   arguments:

--- a/test/spec/server-discovery-and-monitoring/integration/hello-timeout.json
+++ b/test/spec/server-discovery-and-monitoring/integration/hello-timeout.json
@@ -117,7 +117,7 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 4
+                "times": 2
               },
               "data": {
                 "failCommands": [
@@ -159,6 +159,22 @@
                 "_id": 4
               }
             ]
+          }
+        },
+        {
+          "name": "assertEventCount",
+          "object": "testRunner",
+          "arguments": {
+            "event": "ServerMarkedUnknownEvent",
+            "count": 1
+          }
+        },
+        {
+          "name": "assertEventCount",
+          "object": "testRunner",
+          "arguments": {
+            "event": "PoolClearedEvent",
+            "count": 1
           }
         }
       ],

--- a/test/spec/server-discovery-and-monitoring/integration/hello-timeout.yml
+++ b/test/spec/server-discovery-and-monitoring/integration/hello-timeout.yml
@@ -84,16 +84,14 @@ tests:
           documents:
             - _id: 1
             - _id: 2
-      # Configure the next streaming hello check to fail with a timeout.
-      # Use "times: 4" to increase the probability that the Monitor check times
-      # out since the RTT hello may trigger this failpoint one or many times as
-      # well.
+      # Configure the next streaming hello check to fail with a timeout
+      # Use times: 2 so that the RTT hello is blocked as well.
       - name: configureFailPoint
         object: testRunner
         arguments:
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 4 }
+            mode: { times: 2 }
             data:
                 failCommands: ["hello", "isMaster"]
                 appName: timeoutMonitorCheckTest
@@ -121,19 +119,17 @@ tests:
           documents:
             - _id: 3
             - _id: 4
-      # We cannot assert the server was marked Unknown and pool was cleared an
-      # exact number of times because the RTT hello may have triggered this
-      # failpoint one or many times as well.
-      # - name: assertEventCount
-      #   object: testRunner
-      #   arguments:
-      #     event: ServerMarkedUnknownEvent
-      #     count: 1
-      # - name: assertEventCount
-      #   object: testRunner
-      #   arguments:
-      #     event: PoolClearedEvent
-      #     count: 1
+      # Assert the server was marked Unknown and pool was cleared exactly once.
+      - name: assertEventCount
+        object: testRunner
+        arguments:
+          event: ServerMarkedUnknownEvent
+          count: 1
+      - name: assertEventCount
+        object: testRunner
+        arguments:
+          event: PoolClearedEvent
+          count: 1
 
     expectations:
       - command_started_event:


### PR DESCRIPTION
## Reverts mongodb/node-mongodb-native#3318

### Description

[NODE-4480](https://jira.mongodb.org/browse/NODE-4480)

#### What is changing?

Syncing this test change causes our test runner to leak a 0 timeout socket hanging the process. The test removes two assertions about event counts, possibly the runner isn't correctly awaiting things due to a lack of assertions. `Command error on Monitor check` is the test that would leak the socket. Use TRACE_SOCKETS=true env variable and run the -g filter "SDAM integration spec tests" to reproduce against a 5.0.9 replica_set on linux.

#### What is the motivation for this change?

Undo hanging test issue

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket