### PR TITLE
test(NODE-4323): add a unit test task with bson-ext installed

### DIFF
--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -837,15 +837,19 @@ functions:
           - "${PROJECT_DIRECTORY}/.evergreen/run-snappy-version-test.sh"
 
   "run bson-ext test":
-    - command: shell.exec
+    - command: subprocess.exec
       type: test
       params:
         working_dir: "src"
         timeout_secs: 60
-        script: |
-          ${PREPARE_SHELL}
+        env:
+          PROJECT_DIRECTORY: ${PROJECT_DIRECTORY}
+          MONGODB_URI: ${MONGODB_URI}
+          TEST_NPM_SCRIPT: ${TEST_NPM_SCRIPT}
+        binary: bash
+        args:
+          - '${PROJECT_DIRECTORY}/.evergreen/run-bson-ext-test.sh'
 
-          MONGODB_URI="${MONGODB_URI}" bash ${PROJECT_DIRECTORY}/.evergreen/run-bson-ext-test.sh
 
   "upload test results":
     # Upload the xunit-format test results.

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -800,15 +800,18 @@ functions:
         args:
           - ${PROJECT_DIRECTORY}/.evergreen/run-snappy-version-test.sh
   run bson-ext test:
-    - command: shell.exec
+    - command: subprocess.exec
       type: test
       params:
         working_dir: src
         timeout_secs: 60
-        script: |
-          ${PREPARE_SHELL}
-
-          MONGODB_URI="${MONGODB_URI}" bash ${PROJECT_DIRECTORY}/.evergreen/run-bson-ext-test.sh
+        env:
+          PROJECT_DIRECTORY: ${PROJECT_DIRECTORY}
+          MONGODB_URI: ${MONGODB_URI}
+          TEST_NPM_SCRIPT: ${TEST_NPM_SCRIPT}
+        binary: bash
+        args:
+          - ${PROJECT_DIRECTORY}/.evergreen/run-bson-ext-test.sh
   upload test results:
     - command: attach.xunit_results
       params:
@@ -1672,7 +1675,7 @@ tasks:
           TOPOLOGY: server
           AUTH: auth
       - func: run custom snappy tests
-  - name: run-bson-ext-test
+  - name: run-bson-ext-integration
     tags:
       - run-custom-dependency-tests
     commands:
@@ -1684,9 +1687,28 @@ tasks:
           VERSION: '5.0'
           TOPOLOGY: server
           AUTH: auth
-      - func: run bson-ext test
+      - name: run-bson-ext-integration
+        func: run bson-ext test
         vars:
           NODE_LTS_NAME: erbium
+          TEST_NPM_SCRIPT: check:test
+  - name: run-bson-ext-unit
+    tags:
+      - run-custom-dependency-tests
+    commands:
+      - func: install dependencies
+        vars:
+          NODE_LTS_NAME: erbium
+      - func: bootstrap mongo-orchestration
+        vars:
+          VERSION: '5.0'
+          TOPOLOGY: server
+          AUTH: auth
+      - name: run-bson-ext-unit
+        func: run bson-ext test
+        vars:
+          NODE_LTS_NAME: erbium
+          TEST_NPM_SCRIPT: check:unit
   - name: run-custom-csfle-tests-mongocryptd-pinned-commit
     tags:
       - run-custom-dependency-tests
@@ -2308,7 +2330,8 @@ buildvariants:
     run_on: ubuntu1804-large
     tasks:
       - run-custom-snappy-tests
-      - run-bson-ext-test
+      - run-bson-ext-integration
+      - run-bson-ext-unit
       - run-custom-csfle-tests-mongocryptd-pinned-commit
       - run-custom-csfle-tests-mongocryptd-master
       - run-custom-csfle-shared-lib-tests-pinned-commit

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -507,15 +507,26 @@ BUILD_VARIANTS.push({
 const oneOffFuncs = [
   { func: 'run custom snappy tests' },
   {
+    name: 'run-bson-ext-integration',
     func: 'run bson-ext test',
     vars: {
-      NODE_LTS_NAME: LOWEST_LTS
+      NODE_LTS_NAME: LOWEST_LTS,
+      TEST_NPM_SCRIPT: 'check:test'
+    }
+  },
+  {
+    name: 'run-bson-ext-unit',
+    func: 'run bson-ext test',
+    vars: {
+      NODE_LTS_NAME: LOWEST_LTS,
+      TEST_NPM_SCRIPT: 'check:unit'
     }
   }
+
 ];
 
 const oneOffFuncAsTasks = oneOffFuncs.map(oneOffFunc => ({
-  name: `${oneOffFunc.func.split(' ').join('-')}`,
+  name: `${oneOffFunc.name ?? oneOffFunc.func.split(' ').join('-')}`,
   tags: ['run-custom-dependency-tests'],
   commands: [
     {

--- a/test/tools/utils.ts
+++ b/test/tools/utils.ts
@@ -489,3 +489,12 @@ export class UnifiedTestSuiteBuilder {
     return JSON.parse(JSON.stringify(this));
   }
 }
+
+export function isBSONExtInstalled() {
+  try {
+    require.resolve('bson-ext');
+    return true;
+  } catch (_) {
+    return false;
+  }
+}

--- a/test/unit/bson.test.js
+++ b/test/unit/bson.test.js
@@ -2,15 +2,7 @@
 
 const { expect } = require('chai');
 const BSON = require('../../src/bson');
-
-function isBSONExtInstalled() {
-  try {
-    require.resolve('bson-ext');
-    return true;
-  } catch (_) {
-    return false;
-  }
-}
+const { isBSONExtInstalled } = require('../tools/utils');
 
 describe('When importing BSON', function () {
   const types = [


### PR DESCRIPTION
### Description

#### What is changing?

bson-ext now has a unit test task

#### What is the motivation for this change?

Adds more utf8 validation behavior coverage

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
