### PR TITLE
fix(NODE-4159,NODE-4512): remove servers with incorrect setName from topology and fix unix socket parsing

### DIFF
--- a/src/sdam/server.ts
+++ b/src/sdam/server.ts
@@ -29,6 +29,7 @@ import {
   MongoNetworkError,
   MongoNetworkTimeoutError,
   MongoServerClosedError,
+  MongoServerError,
   MongoUnexpectedServerResponseError,
   needsRetryableWriteLabel
 } from '../error';
@@ -385,7 +386,7 @@ function calculateRoundTripTime(oldRtt: number, duration: number): number {
   return alpha * duration + (1 - alpha) * oldRtt;
 }
 
-function markServerUnknown(server: Server, error?: MongoError) {
+function markServerUnknown(server: Server, error?: MongoServerError) {
   // Load balancer servers can never be marked unknown.
   if (server.loadBalanced) {
     return;
@@ -397,11 +398,7 @@ function markServerUnknown(server: Server, error?: MongoError) {
 
   server.emit(
     Server.DESCRIPTION_RECEIVED,
-    new ServerDescription(server.description.hostAddress, undefined, {
-      error,
-      topologyVersion:
-        error && error.topologyVersion ? error.topologyVersion : server.description.topologyVersion
-    })
+    new ServerDescription(server.description.hostAddress, undefined, { error })
   );
 }
 

--- a/src/sdam/server_description.ts
+++ b/src/sdam/server_description.ts
@@ -1,5 +1,5 @@
 import { Document, Long, ObjectId } from '../bson';
-import { MongoInvalidArgumentError, MongoRuntimeError, MongoServerError } from '../error';
+import { MongoRuntimeError, MongoServerError } from '../error';
 import { arrayStrictEqual, compareObjectId, errorStrictEqual, HostAddress, now } from '../utils';
 import type { ClusterTime } from './common';
 import { ServerType } from './common';

--- a/src/sdam/server_description.ts
+++ b/src/sdam/server_description.ts
@@ -1,5 +1,5 @@
 import { Document, Long, ObjectId } from '../bson';
-import type { MongoServerError } from '../error';
+import { MongoInvalidArgumentError, MongoServerError } from '../error';
 import { arrayStrictEqual, compareObjectId, errorStrictEqual, HostAddress, now } from '../utils';
 import type { ClusterTime } from './common';
 import { ServerType } from './common';
@@ -82,6 +82,12 @@ export class ServerDescription {
     hello?: Document,
     options: ServerDescriptionOptions = {}
   ) {
+    if (address == null || address === '') {
+      throw new MongoInvalidArgumentError(
+        'ServerDescription must be provided with a non-empty address'
+      );
+    }
+
     this.address =
       typeof address === 'string'
         ? HostAddress.fromString(address).toString(false) // Use HostAddress to normalize

--- a/src/sdam/server_description.ts
+++ b/src/sdam/server_description.ts
@@ -53,21 +53,19 @@ export class ServerDescription {
   passives: string[];
   arbiters: string[];
   tags: TagSet;
-
   error: MongoServerError | null;
-  topologyVersion?: TopologyVersion;
+  topologyVersion: TopologyVersion | null;
   minWireVersion: number;
   maxWireVersion: number;
   roundTripTime: number;
   lastUpdateTime: number;
   lastWriteDate: number;
-
-  me?: string;
-  primary?: string;
-  setName?: string;
-  setVersion?: number;
-  electionId?: ObjectId;
-  logicalSessionTimeoutMinutes?: number;
+  me: string | null;
+  primary: string | null;
+  setName: string | null;
+  setVersion: number | null;
+  electionId: ObjectId | null;
+  logicalSessionTimeoutMinutes: number | null;
 
   // NOTE: does this belong here? It seems we should gossip the cluster time at the CMAP level
   $clusterTime?: ClusterTime;
@@ -238,8 +236,8 @@ function tagsStrictEqual(tags: TagSet, tags2: TagSet): boolean {
  * ```
  */
 export function compareTopologyVersion(
-  currentTv?: TopologyVersion,
-  newTv?: TopologyVersion
+  currentTv?: TopologyVersion | null,
+  newTv?: TopologyVersion | null
 ): 0 | -1 | 1 {
   if (currentTv == null || newTv == null) {
     return -1;

--- a/src/sdam/server_description.ts
+++ b/src/sdam/server_description.ts
@@ -1,5 +1,5 @@
 import { Document, Long, ObjectId } from '../bson';
-import { MongoInvalidArgumentError, MongoServerError } from '../error';
+import { MongoInvalidArgumentError, MongoRuntimeError, MongoServerError } from '../error';
 import { arrayStrictEqual, compareObjectId, errorStrictEqual, HostAddress, now } from '../utils';
 import type { ClusterTime } from './common';
 import { ServerType } from './common';
@@ -83,9 +83,7 @@ export class ServerDescription {
     options: ServerDescriptionOptions = {}
   ) {
     if (address == null || address === '') {
-      throw new MongoInvalidArgumentError(
-        'ServerDescription must be provided with a non-empty address'
-      );
+      throw new MongoRuntimeError('ServerDescription must be provided with a non-empty address');
     }
 
     this.address =

--- a/src/sdam/server_description.ts
+++ b/src/sdam/server_description.ts
@@ -146,7 +146,8 @@ export class ServerDescription {
    * in the {@link https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst#serverdescription|SDAM spec}
    */
   equals(other?: ServerDescription | null): boolean {
-    // TODO(NODE-4510): Check ServerDescription equality logic for nullish topologyVersion meaning "greater than"
+    // Despite using the comparator that would determine a nullish topologyVersion as greater than
+    // for equality we should only always perform direct equality comparison
     const topologyVersionsEqual =
       this.topologyVersion === other?.topologyVersion ||
       compareTopologyVersion(this.topologyVersion, other?.topologyVersion) === 0;

--- a/src/sdam/topology.ts
+++ b/src/sdam/topology.ts
@@ -724,7 +724,7 @@ export class Topology extends TypedEventEmitter<TopologyEvents> {
     return this.description.commonWireVersion;
   }
 
-  get logicalSessionTimeoutMinutes(): number | undefined {
+  get logicalSessionTimeoutMinutes(): number | null {
     return this.description.logicalSessionTimeoutMinutes;
   }
 

--- a/src/sdam/topology_description.ts
+++ b/src/sdam/topology_description.ts
@@ -32,29 +32,29 @@ export interface TopologyDescriptionOptions {
  */
 export class TopologyDescription {
   type: TopologyType;
-  setName?: string;
-  maxSetVersion?: number;
-  maxElectionId?: ObjectId;
+  setName: string | null;
+  maxSetVersion: number | null;
+  maxElectionId: ObjectId | null;
   servers: Map<string, ServerDescription>;
   stale: boolean;
   compatible: boolean;
   compatibilityError?: string;
-  logicalSessionTimeoutMinutes?: number;
+  logicalSessionTimeoutMinutes: number | null;
   heartbeatFrequencyMS: number;
   localThresholdMS: number;
-  commonWireVersion?: number;
+  commonWireVersion: number;
 
   /**
    * Create a TopologyDescription
    */
   constructor(
     topologyType: TopologyType,
-    serverDescriptions?: Map<string, ServerDescription>,
-    setName?: string,
-    maxSetVersion?: number,
-    maxElectionId?: ObjectId,
-    commonWireVersion?: number,
-    options?: TopologyDescriptionOptions
+    serverDescriptions: Map<string, ServerDescription> | null = null,
+    setName: string | null = null,
+    maxSetVersion: number | null = null,
+    maxElectionId: ObjectId | null = null,
+    commonWireVersion: number | null = null,
+    options: TopologyDescriptionOptions | null = null
   ) {
     options = options ?? {};
 
@@ -64,22 +64,10 @@ export class TopologyDescription {
     this.compatible = true;
     this.heartbeatFrequencyMS = options.heartbeatFrequencyMS ?? 0;
     this.localThresholdMS = options.localThresholdMS ?? 15;
-
-    if (setName) {
-      this.setName = setName;
-    }
-
-    if (maxSetVersion) {
-      this.maxSetVersion = maxSetVersion;
-    }
-
-    if (maxElectionId) {
-      this.maxElectionId = maxElectionId;
-    }
-
-    if (commonWireVersion) {
-      this.commonWireVersion = commonWireVersion;
-    }
+    this.setName = setName ?? null;
+    this.maxElectionId = maxElectionId ?? null;
+    this.maxSetVersion = maxSetVersion ?? null;
+    this.commonWireVersion = commonWireVersion ?? 0;
 
     // determine server compatibility
     for (const serverDescription of this.servers.values()) {
@@ -108,12 +96,12 @@ export class TopologyDescription {
     // value among ServerDescriptions of all data-bearing server types. If any have a null
     // logicalSessionTimeoutMinutes, then TopologyDescription.logicalSessionTimeoutMinutes MUST be
     // set to null.
-    this.logicalSessionTimeoutMinutes = undefined;
+    this.logicalSessionTimeoutMinutes = null;
     for (const [, server] of this.servers) {
       if (server.isReadable) {
         if (server.logicalSessionTimeoutMinutes == null) {
           // If any of the servers have a null logicalSessionsTimeout, then the whole topology does
-          this.logicalSessionTimeoutMinutes = undefined;
+          this.logicalSessionTimeoutMinutes = null;
           break;
         }
 
@@ -375,10 +363,10 @@ function topologyTypeForServerType(serverType: ServerType): TopologyType {
 function updateRsFromPrimary(
   serverDescriptions: Map<string, ServerDescription>,
   serverDescription: ServerDescription,
-  setName?: string,
-  maxSetVersion?: number,
-  maxElectionId?: ObjectId
-): [TopologyType, string?, number?, ObjectId?] {
+  setName: string | null = null,
+  maxSetVersion: number | null = null,
+  maxElectionId: ObjectId | null = null
+): [TopologyType, string | null, number | null, ObjectId | null] {
   setName = setName || serverDescription.setName;
   if (setName !== serverDescription.setName) {
     serverDescriptions.delete(serverDescription.address);
@@ -445,7 +433,7 @@ function updateRsFromPrimary(
 function updateRsWithPrimaryFromMember(
   serverDescriptions: Map<string, ServerDescription>,
   serverDescription: ServerDescription,
-  setName?: string
+  setName: string | null = null
 ): TopologyType {
   if (setName == null) {
     // TODO(NODE-3483): should be an appropriate runtime error
@@ -465,10 +453,10 @@ function updateRsWithPrimaryFromMember(
 function updateRsNoPrimaryFromMember(
   serverDescriptions: Map<string, ServerDescription>,
   serverDescription: ServerDescription,
-  setName?: string
-): [TopologyType, string?] {
+  setName: string | null = null
+): [TopologyType, string | null] {
   const topologyType = TopologyType.ReplicaSetNoPrimary;
-  setName = setName || serverDescription.setName;
+  setName = setName ?? serverDescription.setName;
   if (setName !== serverDescription.setName) {
     serverDescriptions.delete(serverDescription.address);
     return [topologyType, setName];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -627,7 +627,7 @@ export function arrayStrictEqual(arr: unknown[], arr2: unknown[]): boolean {
 }
 
 /** @internal */
-export function errorStrictEqual(lhs?: AnyError, rhs?: AnyError): boolean {
+export function errorStrictEqual(lhs?: AnyError | null, rhs?: AnyError | null): boolean {
   if (lhs === rhs) {
     return true;
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1153,9 +1153,9 @@ export class HostAddress {
     const escapedHost = hostString.split(' ').join('%20'); // escape spaces, for socket path hosts
     const { hostname, port } = new URL(`mongodb://${escapedHost}`);
 
-    if (hostname.endsWith('.sock')) {
+    if (escapedHost.endsWith('.sock')) {
       // heuristically determine if we're working with a domain socket
-      this.socketPath = decodeURIComponent(hostname);
+      this.socketPath = decodeURIComponent(escapedHost);
     } else if (typeof hostname === 'string') {
       this.isIPv6 = false;
 

--- a/test/unit/assorted/server_discovery_and_monitoring.spec.test.ts
+++ b/test/unit/assorted/server_discovery_and_monitoring.spec.test.ts
@@ -51,6 +51,8 @@ const SDAM_EVENT_CLASSES = {
   ServerHeartbeatFailedEvent
 } as const;
 
+const WIRE_VERSION_KEYS = new Set(['minWireVersion', 'maxWireVersion']);
+
 const specDir = path.resolve(__dirname, '../../spec/server-discovery-and-monitoring');
 function collectTests(): Record<string, SDAMTest[]> {
   const testTypes = fs
@@ -263,21 +265,6 @@ function convertOutcomeEvents(events) {
   });
 }
 
-// iterates through expectation building a path of keys that should not exist (null), and
-// removes them from the expectation (NOTE: this mutates the expectation)
-function findOmittedFields(expected) {
-  const result = [];
-  for (const key of Object.keys(expected)) {
-    if (expected[key] == null) {
-      result.push(key);
-      // TODO(NODE-4159): remove this delete
-      delete expected[key];
-    }
-  }
-
-  return result;
-}
-
 function normalizeServerDescription(serverDescription) {
   if (serverDescription.type === 'PossiblePrimary') {
     // Some single-threaded drivers care a lot about ordering potential primary
@@ -470,27 +457,39 @@ function assertTopologyDescriptionOutcomeExpectations(
   expect(actualServers).to.be.instanceOf(Map);
 
   // TODO(NODE-4159): The node driver keeps unknown servers where it should discard
-  // expect(actualServers.size).to.equal(expectedServers.size);
+  expect(actualServers).to.have.lengthOf(expectedServers.size);
 
   for (const serverName of expectedServers.keys()) {
     expect(actualServers).to.include.keys(serverName);
     const expectedServer = expectedServers.get(serverName);
+    if (expectedServer == null) expect.fail(`Must have server defined for ${serverName}`);
 
     if (expectedServer.pool != null) {
-      const expectedPool = expectedServers.get(serverName).pool;
-      const actualPoolGeneration = topology.s.servers.get(serverName).s.pool;
+      const expectedPool = expectedServer.pool;
+      const actualServer = topology.s.servers.get(serverName);
+      if (actualServer == null) expect.fail(`Must have server defined for ${serverName}`);
+      const actualPoolGeneration = actualServer.s.pool;
       expect(actualPoolGeneration).to.have.property('generation', expectedPool.generation);
       delete expectedServer.pool;
     }
 
     const normalizedExpectedServer = normalizeServerDescription(expectedServer);
-    const omittedFields = findOmittedFields(normalizedExpectedServer);
+    // const omittedFields = findOmittedFields(normalizedExpectedServer);
     const actualServer = actualServers.get(serverName);
-    expect(actualServer).to.matchMongoSpec(normalizedExpectedServer);
-
-    if (omittedFields.length !== 0) {
-      // TODO(NODE-4159): There are properties that should be nulled out when the server transitions to Unknown
-      // instead of looking for keys to be omitted, null them out
+    // expect(actualServer).to.matchMongoSpec(normalizedExpectedServer);
+    const entriesOnExpectedServer = Object.entries(normalizedExpectedServer);
+    expect(entriesOnExpectedServer).to.not.be.empty;
+    for (const [expectedKey, expectedValue] of entriesOnExpectedServer) {
+      if (WIRE_VERSION_KEYS.has(expectedKey)) {
+        if (expectedValue === null) {
+          // For wireVersion keys we default to zero instead of null
+          expect(actualServer).to.have.property(expectedKey, 0);
+        } else {
+          expect(actualServer).to.have.deep.property(expectedKey, expectedValue);
+        }
+      } else {
+        expect(actualServer).to.have.deep.property(expectedKey, expectedValue);
+      }
     }
   }
 

--- a/test/unit/assorted/server_discovery_and_monitoring.spec.test.ts
+++ b/test/unit/assorted/server_discovery_and_monitoring.spec.test.ts
@@ -493,37 +493,21 @@ function assertTopologyDescriptionOutcomeExpectations(
     }
   }
 
-  if (outcome.setName != null) {
-    expect(description).to.have.property('setName', outcome.setName);
-  } else {
-    expect(description).to.not.have.property('setName');
-  }
-
-  if (outcome.maxSetVersion != null) {
-    expect(description).to.have.property('maxSetVersion', outcome.maxSetVersion);
-  } else {
-    expect(description).to.not.have.property('maxSetVersion');
-  }
-
   if (outcome.maxElectionId != null) {
     expect(description).to.have.property('maxElectionId').that.is.instanceOf(ObjectId);
-    const driverMaxId = description.maxElectionId.toString('hex');
+    const driverMaxId = description.maxElectionId?.toString('hex');
     const testMaxId = outcome.maxElectionId.toString('hex');
     // Much easier to debug a hex string mismatch
     expect(driverMaxId).to.equal(testMaxId);
   } else {
-    expect(description).to.not.have.property('maxElectionId');
+    expect(description).to.have.property('maxElectionId', null);
   }
 
-  if (outcome.compatible != null) {
-    expect(description).to.have.property('compatible', outcome.compatible);
-  } else {
-    expect(description).to.have.property('compatible', true);
-  }
-
-  // logicalSessionTimeoutMinutes is always defined
+  expect(description).to.have.property('setName', outcome.setName ?? null);
+  expect(description).to.have.property('maxSetVersion', outcome.maxSetVersion ?? null);
+  expect(description).to.have.property('compatible', outcome.compatible ?? true);
   expect(description).to.have.property(
     'logicalSessionTimeoutMinutes',
-    outcome.logicalSessionTimeoutMinutes ?? undefined
+    outcome.logicalSessionTimeoutMinutes ?? null
   );
 }

--- a/test/unit/assorted/server_discovery_and_monitoring.spec.test.ts
+++ b/test/unit/assorted/server_discovery_and_monitoring.spec.test.ts
@@ -456,7 +456,6 @@ function assertTopologyDescriptionOutcomeExpectations(
   const actualServers = description.servers;
   expect(actualServers).to.be.instanceOf(Map);
 
-  // TODO(NODE-4159): The node driver keeps unknown servers where it should discard
   expect(actualServers).to.have.lengthOf(expectedServers.size);
 
   for (const serverName of expectedServers.keys()) {
@@ -474,19 +473,14 @@ function assertTopologyDescriptionOutcomeExpectations(
     }
 
     const normalizedExpectedServer = normalizeServerDescription(expectedServer);
-    // const omittedFields = findOmittedFields(normalizedExpectedServer);
     const actualServer = actualServers.get(serverName);
-    // expect(actualServer).to.matchMongoSpec(normalizedExpectedServer);
+
     const entriesOnExpectedServer = Object.entries(normalizedExpectedServer);
     expect(entriesOnExpectedServer).to.not.be.empty;
     for (const [expectedKey, expectedValue] of entriesOnExpectedServer) {
-      if (WIRE_VERSION_KEYS.has(expectedKey)) {
-        if (expectedValue === null) {
-          // For wireVersion keys we default to zero instead of null
-          expect(actualServer).to.have.property(expectedKey, 0);
-        } else {
-          expect(actualServer).to.have.deep.property(expectedKey, expectedValue);
-        }
+      if (WIRE_VERSION_KEYS.has(expectedKey) && expectedValue === null) {
+        // For wireVersion keys we default to zero instead of null
+        expect(actualServer).to.have.property(expectedKey, 0);
       } else {
         expect(actualServer).to.have.deep.property(expectedKey, expectedValue);
       }

--- a/test/unit/operations/find.test.ts
+++ b/test/unit/operations/find.test.ts
@@ -40,7 +40,11 @@ describe('FindOperation', function () {
   describe('#execute', function () {
     context('command construction', () => {
       const namespace = ns('db.collection');
-      const server = new Server(new Topology([], {} as any), new ServerDescription(''), {} as any);
+      const server = new Server(
+        new Topology([], {} as any),
+        new ServerDescription('a:1'),
+        {} as any
+      );
 
       it('should build basic find command with filter', async () => {
         const findOperation = new FindOperation(undefined, namespace, filter);

--- a/test/unit/operations/get_more.test.ts
+++ b/test/unit/operations/get_more.test.ts
@@ -26,7 +26,7 @@ describe('GetMoreOperation', function () {
   });
 
   describe('#constructor', function () {
-    const server = new Server(new Topology([], {} as any), new ServerDescription(''), {} as any);
+    const server = new Server(new Topology([], {} as any), new ServerDescription('a:1'), {} as any);
     const operation = new GetMoreOperation(namespace, cursorId, server, options);
 
     it('sets the namespace', function () {
@@ -47,7 +47,7 @@ describe('GetMoreOperation', function () {
       it('executes a getMore on the provided server', async function () {
         const server = new Server(
           new Topology([], {} as any),
-          new ServerDescription(''),
+          new ServerDescription('a:1'),
           {} as any
         );
         const opts = { ...options, documentsReturnedIn: 'nextBatch', returnFieldSelector: null };
@@ -74,12 +74,12 @@ describe('GetMoreOperation', function () {
       it('errors in the callback', function (done) {
         const server1 = new Server(
           new Topology([], {} as any),
-          new ServerDescription(''),
+          new ServerDescription('a:1'),
           {} as any
         );
         const server2 = new Server(
           new Topology([], {} as any),
-          new ServerDescription(''),
+          new ServerDescription('a:1'),
           {} as any
         );
         const session = sinon.createStubInstance(ClientSession);
@@ -97,7 +97,11 @@ describe('GetMoreOperation', function () {
     context('command construction', () => {
       const cursorId = Long.fromBigInt(0xffff_ffffn);
       const namespace = ns('db.collection');
-      const server = new Server(new Topology([], {} as any), new ServerDescription(''), {} as any);
+      const server = new Server(
+        new Topology([], {} as any),
+        new ServerDescription('a:1'),
+        {} as any
+      );
 
       it('should build basic getMore command with cursorId and collection', async () => {
         const getMoreOperation = new GetMoreOperation(namespace, cursorId, server, {});
@@ -178,7 +182,7 @@ describe('GetMoreOperation', function () {
           it(`${verb} set the comment on the command if the server wire version is ${state}`, async () => {
             const server = new Server(
               new Topology([], {} as any),
-              new ServerDescription(''),
+              new ServerDescription('a:1'),
               {} as any
             );
             server.hello = {
@@ -195,7 +199,7 @@ describe('GetMoreOperation', function () {
   });
 
   describe('#hasAspect', function () {
-    const server = new Server(new Topology([], {} as any), new ServerDescription(''), {} as any);
+    const server = new Server(new Topology([], {} as any), new ServerDescription('a:1'), {} as any);
     const operation = new GetMoreOperation(namespace, cursorId, server, options);
 
     context('when the aspect is must select same server', function () {

--- a/test/unit/operations/kill_cursors.test.ts
+++ b/test/unit/operations/kill_cursors.test.ts
@@ -18,7 +18,7 @@ describe('class KillCursorsOperation', () => {
   describe('constructor()', () => {
     const cursorId = Long.fromBigInt(0xffff_ffffn);
     const namespace = ns('db.collection');
-    const server = new Server(new Topology([], {} as any), new ServerDescription(''), {} as any);
+    const server = new Server(new Topology([], {} as any), new ServerDescription('a:1'), {} as any);
     const options = {};
     const killCursorsOperation = new KillCursorsOperation(cursorId, namespace, server, options);
 
@@ -38,10 +38,10 @@ describe('class KillCursorsOperation', () => {
   describe('execute()', () => {
     const cursorId = Long.fromBigInt(0xffff_ffffn);
     const namespace = ns('db.collection');
-    const server = new Server(new Topology([], {} as any), new ServerDescription(''), {} as any);
+    const server = new Server(new Topology([], {} as any), new ServerDescription('a:1'), {} as any);
     const differentServer = new Server(
       new Topology([], {} as any),
-      new ServerDescription(''),
+      new ServerDescription('a:1'),
       {} as any
     );
     const options = {};

--- a/test/unit/sdam/server_description.test.ts
+++ b/test/unit/sdam/server_description.test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 
-import { MongoInvalidArgumentError } from '../../../src';
+import { MongoRuntimeError } from '../../../src';
 import { Long, ObjectId } from '../../../src/bson';
 import {
   compareTopologyVersion,
@@ -12,13 +12,13 @@ describe('ServerDescription', function () {
   describe('constructor()', () => {
     it('should throw if given a null address', () => {
       // @ts-expect-error: Passing nullish value to prove error will be thrown
-      expect(() => new ServerDescription(null)).to.throw(MongoInvalidArgumentError);
+      expect(() => new ServerDescription(null)).to.throw(MongoRuntimeError);
       // @ts-expect-error: Passing nullish value to prove error will be thrown
-      expect(() => new ServerDescription()).to.throw(MongoInvalidArgumentError);
+      expect(() => new ServerDescription()).to.throw(MongoRuntimeError);
     });
 
     it('should throw if given an empty string for an address', () => {
-      expect(() => new ServerDescription('')).to.throw(MongoInvalidArgumentError);
+      expect(() => new ServerDescription('')).to.throw(MongoRuntimeError);
     });
   });
 

--- a/test/unit/sdam/server_description.test.ts
+++ b/test/unit/sdam/server_description.test.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 
+import { MongoInvalidArgumentError } from '../../../src';
 import { Long, ObjectId } from '../../../src/bson';
 import {
   compareTopologyVersion,
@@ -8,6 +9,19 @@ import {
 } from '../../../src/sdam/server_description';
 
 describe('ServerDescription', function () {
+  describe('constructor()', () => {
+    it('should throw if given a null address', () => {
+      // @ts-expect-error: Passing nullish value to prove error will be thrown
+      expect(() => new ServerDescription(null)).to.throw(MongoInvalidArgumentError);
+      // @ts-expect-error: Passing nullish value to prove error will be thrown
+      expect(() => new ServerDescription()).to.throw(MongoInvalidArgumentError);
+    });
+
+    it('should throw if given an empty string for an address', () => {
+      expect(() => new ServerDescription('')).to.throw(MongoInvalidArgumentError);
+    });
+  });
+
   describe('error equality', function () {
     const errorEqualityTests = [
       {

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -607,7 +607,7 @@ describe('driver utils', function () {
         expect(ha).to.not.have.property('port');
       });
 
-      it('should handle encoded unix socket path with an non-encoded space', () => {
+      it('should handle encoded unix socket path with an unencoded space', () => {
         const socketPathWithSpaces = '/tmp/some directory/mongodb-27017.sock';
         const ha = new HostAddress(socketPathWithSpaces);
         expect(ha).to.have.property('socketPath', socketPathWithSpaces);
@@ -621,16 +621,17 @@ describe('driver utils', function () {
         expect(ha).to.not.have.property('port');
       });
 
-      it('should determine unix socket usage based on .sock ending', () => {
+      it('should only set the socketPath property on HostAddress when hostString ends in .sock', () => {
         // We heuristically determine if we are using a domain socket solely based on .sock
         // if someone has .sock in their hostname we will fail to connect to that host
         const hostnameThatEndsWithSock = 'iLoveJavascript.sock';
         const ha = new HostAddress(hostnameThatEndsWithSock);
         expect(ha).to.have.property('socketPath', hostnameThatEndsWithSock);
         expect(ha).to.not.have.property('port');
+        expect(ha).to.not.have.property('host');
       });
 
-      it('should allow port number to work around hostname ending in .sock limitation', () => {
+      it('should set the host and port property on HostAddress even when hostname ends in .sock if there is a port number specified', () => {
         // "should determine unix socket usage based on .sock ending" can be worked around by putting
         // the port number at the end of the hostname (even if it is the default)
         const hostnameThatEndsWithSockHasPort = 'iLoveJavascript.sock:27017';

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -6,6 +6,7 @@ import { MongoRuntimeError } from '../../src/error';
 import {
   BufferPool,
   eachAsync,
+  HostAddress,
   isHello,
   makeInterruptibleAsyncInterval,
   MongoDBNamespace,
@@ -582,6 +583,61 @@ describe('driver utils', function () {
         expect(withCollectionNamespace).to.not.equal(dbNamespace);
         expect(withCollectionNamespace).to.have.property('db', 'test');
         expect(withCollectionNamespace).to.have.property('collection', 'pets');
+      });
+    });
+  });
+
+  describe('class HostAddress', () => {
+    describe('constructor()', () => {
+      it('should freeze itself', () => {
+        const ha = new HostAddress('iLoveJavascript:22');
+        expect(ha).to.be.frozen;
+      });
+
+      const socketPath = '/tmp/mongodb-27017.sock';
+      it('should handle decoded unix socket path', () => {
+        const ha = new HostAddress(socketPath);
+        expect(ha).to.have.property('socketPath', socketPath);
+        expect(ha).to.not.have.property('port');
+      });
+
+      it('should handle encoded unix socket path', () => {
+        const ha = new HostAddress(encodeURIComponent(socketPath));
+        expect(ha).to.have.property('socketPath', socketPath);
+        expect(ha).to.not.have.property('port');
+      });
+
+      it('should handle encoded unix socket path with an non-encoded space', () => {
+        const socketPathWithSpaces = '/tmp/some directory/mongodb-27017.sock';
+        const ha = new HostAddress(socketPathWithSpaces);
+        expect(ha).to.have.property('socketPath', socketPathWithSpaces);
+        expect(ha).to.not.have.property('port');
+      });
+
+      it('should handle unix socket path that does not begin with a slash', () => {
+        const socketPathWithoutSlash = 'my_local/directory/mustEndWith.sock';
+        const ha = new HostAddress(socketPathWithoutSlash);
+        expect(ha).to.have.property('socketPath', socketPathWithoutSlash);
+        expect(ha).to.not.have.property('port');
+      });
+
+      it('should determine unix socket usage based on .sock ending', () => {
+        // We heuristically determine if we are using a domain socket solely based on .sock
+        // if someone has .sock in their hostname we will fail to connect to that host
+        const hostnameThatEndsWithSock = 'iLoveJavascript.sock';
+        const ha = new HostAddress(hostnameThatEndsWithSock);
+        expect(ha).to.have.property('socketPath', hostnameThatEndsWithSock);
+        expect(ha).to.not.have.property('port');
+      });
+
+      it('should allow port number to work around hostname ending in .sock limitation', () => {
+        // "should determine unix socket usage based on .sock ending" can be worked around by putting
+        // the port number at the end of the hostname (even if it is the default)
+        const hostnameThatEndsWithSockHasPort = 'iLoveJavascript.sock:27017';
+        const ha = new HostAddress(hostnameThatEndsWithSockHasPort);
+        expect(ha).to.not.have.property('socketPath');
+        expect(ha).to.have.property('host', 'iLoveJavascript.sock'.toLowerCase());
+        expect(ha).to.have.property('port', 27017);
       });
     });
   });


### PR DESCRIPTION
### Description

#### What is changing?

- Remove servers
- Null out fields on server description instead of omitted keys
- Fixes unix socket issue: https://jira.mongodb.org/browse/NODE-4512

#### What is the motivation for this change?

Aligns with spec test, easier assertion against unit specs

### Double check the following

- [ ] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
