### PR TITLE
fix(NODE-4513): type for nested objects in query & update

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -321,7 +321,6 @@ export type {
   KeysOfOtherType,
   MatchKeysAndValues,
   NestedPaths,
-  NestedPathsOfType,
   NonObjectIdLikeDocument,
   NotAcceptedFields,
   NumericType,

--- a/src/mongo_types.ts
+++ b/src/mongo_types.ts
@@ -470,7 +470,9 @@ export type PropertyType<
   AllowToSkipArrayIndex extends boolean
 > = Type extends unknown
   ? string extends Property
-    ? never
+    ? Type extends Map<string, infer MapType>
+      ? MapType
+      : never
     :
         | (AllowToSkipArrayIndex extends false
             ? never
@@ -489,9 +491,7 @@ export type PropertyType<
                 ? PropertyType<ArrayType, Rest, AllowToSkipArrayIndex>
                 : never
               : Key extends keyof Type
-              ? Type[Key] extends Map<string, infer MapType>
-                ? MapType
-                : PropertyType<Type[Key], Rest, AllowToSkipArrayIndex>
+              ? PropertyType<Type[Key], Rest, AllowToSkipArrayIndex>
               : never
             : never)
   : never;

--- a/test/types/community/collection/filterQuery.test-d.ts
+++ b/test/types/community/collection/filterQuery.test-d.ts
@@ -12,7 +12,7 @@ import {
 } from 'bson';
 import { expectAssignable, expectError, expectNotType, expectType } from 'tsd';
 
-import { Collection, Filter, MongoClient, WithId } from '../../../../src';
+import { Collection, Filter, MongoClient, UpdateFilter, WithId } from '../../../../src';
 
 /**
  * test the Filter type using collection.find<T>() method
@@ -405,4 +405,37 @@ nonSpecifiedCollection.find({
   otherField: {
     hello: 'world'
   }
+});
+
+// NODE-4513: improves support for union types and array operators
+type MyArraySchema = {
+  nested: { array: { a: number; b: boolean }[] };
+  something: { a: number } | { b: boolean };
+};
+
+// "element" now refers to the name used in arrayFilters, it can be any string
+expectAssignable<UpdateFilter<MyArraySchema>>({
+  $set: { 'nested.array.$[element]': { a: 2, b: false } }
+});
+expectAssignable<Filter<MyArraySchema>>({
+  $set: { 'nested.array.$[element]': { a: 2, b: false } }
+});
+
+// Specifying an identifier in the brackets is optional
+expectAssignable<UpdateFilter<MyArraySchema>>({
+  $set: { 'nested.array.$[].a': 2 }
+});
+expectAssignable<Filter<MyArraySchema>>({
+  $set: { 'nested.array.$[].a': 2 }
+});
+
+// Union usage examples
+expectAssignable<Filter<MyArraySchema>>({
+  'something.a': 2
+});
+expectError<Filter<MyArraySchema>>({
+  'something.a': false
+});
+expectAssignable<Filter<MyArraySchema>>({
+  'something.b': false
 });


### PR DESCRIPTION
### Description

Fix type for nested objects in query & update added in https://github.com/mongodb/node-mongodb-native/pull/3328

#### What is changing?

- Support union types (... extends unknown ? ... : never)
- Fail if path is wrong (never vs unknown)
- Support array operators in the middle of a path (number replaced by number | `$${'' | `[${string}]`}` and NestedPathsOfType removed)

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->
```ts
const _: MatchKeysAndValues<{ aaa: readonly { bbb: 'ccc' }[] }> = { 'aaa.$.bbb': 'ccc' }; // Error
const _: MatchKeysAndValues<{ aaa: { bbb: { ccc: 'ddd'[] }[] }> = { 'aaa.$.bbb.$[arrayFilter]': 'ddd' }; // Error
```

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
