### PR TITLE
test(NODE-4472): fix session spec prose test numbering

### DIFF
--- a/test/integration/sessions/sessions.spec.prose.test.ts
+++ b/test/integration/sessions/sessions.spec.prose.test.ts
@@ -25,7 +25,7 @@ describe('ServerSession', () => {
    * Note that it's possible, although rare, for greater than 1 server session to be used because the session is not released until after the connection is checked in.
    * Drivers MUST assert that the number of allocated sessions is strictly less than the number of concurrent operations in every retry of this test. In this instance it would be less than (but NOT equal to) 8.
    */
-  it('13. may reuse one server session for many operations', async () => {
+  it('14. may reuse one server session for many operations', async () => {
     const events: CommandStartedEvent[] = [];
     client.on('commandStarted', ev => events.push(ev));
 


### PR DESCRIPTION
### Description

#### What is changing?

Fix a test number for spec prose.

> NOTE original ticket asked to confirm this test only uses one mongos (as in edit the connection string to only specify one host). We already limit to one mongos unless useMultiMongoses is set.

#### What is the motivation for this change?

Staying in sync with specs.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
