### PR TITLE
test(NODE-4525): bump mongodb-client-encryption to 2.2.0 in CI

### DIFF
--- a/.evergreen/run-bson-ext-test.sh
+++ b/.evergreen/run-bson-ext-test.sh
@@ -23,7 +23,7 @@ fi
 # run tests
 echo "Running $AUTH tests over $SSL, connecting to $MONGODB_URI"
 
-npm install mongodb-client-encryption@">=2.2.0-alpha.6"
+npm install mongodb-client-encryption@">=2.2.0"
 npm install bson-ext
 
 export MONGODB_API_VERSION=${MONGODB_API_VERSION}

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -56,7 +56,7 @@ else
   source "$DRIVERS_TOOLS"/.evergreen/csfle/set-temp-creds.sh
 fi
 
-npm install mongodb-client-encryption@">=2.2.0-alpha.6"
+npm install mongodb-client-encryption@">=2.2.0"
 npm install @mongodb-js/zstd
 npm install snappy
 


### PR DESCRIPTION
### Description

#### What is changing?

This PR bumps our pinned version of mongodb-client-encryption to 2.2.0 in CI.
