### PR TITLE
test(NODE-4422): use shared lib in prose tests

### DIFF
--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -767,37 +767,6 @@ functions:
         script: |
           ${PREPARE_SHELL}
           cat <<EOT > prepare_client_encryption.sh
-          export CLIENT_ENCRYPTION=${CLIENT_ENCRYPTION}
-          export CSFLE_KMS_PROVIDERS='${CSFLE_KMS_PROVIDERS}'
-          export AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}"
-          export AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}"
-          export CSFLE_GIT_REF="${CSFLE_GIT_REF}"
-          export CDRIVER_GIT_REF="${CDRIVER_GIT_REF}"
-          EOT
-    - command: shell.exec
-      type: test
-      params:
-        working_dir: "src"
-        timeout_secs: 60
-        script: |
-          ${PREPARE_SHELL}
-
-          # Disable xtrace (just in case it was accidentally set).
-          set +x
-          . ./prepare_client_encryption.sh
-          rm -f ./prepare_client_encryption.sh
-
-          MONGODB_URI="${MONGODB_URI}" bash ${PROJECT_DIRECTORY}/.evergreen/run-custom-csfle-tests.sh
-
-  "run custom csfle shared lib tests":
-    - command: shell.exec
-      type: test
-      params:
-        silent: true
-        working_dir: "src"
-        script: |
-          ${PREPARE_SHELL}
-          cat <<EOT > prepare_client_encryption.sh
           export CLIENT_ENCRYPTION='${CLIENT_ENCRYPTION}'
           export CSFLE_KMS_PROVIDERS='${CSFLE_KMS_PROVIDERS}'
           export AWS_ACCESS_KEY_ID='${AWS_ACCESS_KEY_ID}'
@@ -824,9 +793,8 @@ functions:
 
           source ${PROJECT_DIRECTORY}/.evergreen/prepare-crypt-shared-lib.sh
           export MONGODB_URI="${MONGODB_URI}"
-          export CRYPT_SHARED_LIB_PATH
 
-          echo "setting CRYPT_SHARED_LIB_PATH: $CRYPT_SHARED_LIB_PATH"
+          echo "CRYPT_SHARED_LIB_PATH: $CRYPT_SHARED_LIB_PATH"
 
           bash ${PROJECT_DIRECTORY}/.evergreen/run-custom-csfle-tests.sh
 

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -154,6 +154,7 @@ functions:
       params:
         working_dir: "src"
         timeout_secs: 300
+        shell: bash
         script: |
           ${PREPARE_SHELL}
 
@@ -163,6 +164,13 @@ functions:
             . ./prepare_client_encryption.sh
             rm -f ./prepare_client_encryption.sh
           fi
+
+          export VERSION=${VERSION}
+          export DRIVERS_TOOLS=${DRIVERS_TOOLS}
+
+          source ${PROJECT_DIRECTORY}/.evergreen/prepare-crypt-shared-lib.sh
+
+          echo "CRYPT_SHARED_LIB_PATH: $CRYPT_SHARED_LIB_PATH"
 
           MONGODB_URI="${MONGODB_URI}" \
           AUTH=${AUTH} SSL=${SSL} TEST_CSFLE=true \

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -733,36 +733,6 @@ functions:
         script: |
           ${PREPARE_SHELL}
           cat <<EOT > prepare_client_encryption.sh
-          export CLIENT_ENCRYPTION=${CLIENT_ENCRYPTION}
-          export CSFLE_KMS_PROVIDERS='${CSFLE_KMS_PROVIDERS}'
-          export AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}"
-          export AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}"
-          export CSFLE_GIT_REF="${CSFLE_GIT_REF}"
-          export CDRIVER_GIT_REF="${CDRIVER_GIT_REF}"
-          EOT
-    - command: shell.exec
-      type: test
-      params:
-        working_dir: src
-        timeout_secs: 60
-        script: |
-          ${PREPARE_SHELL}
-
-          # Disable xtrace (just in case it was accidentally set).
-          set +x
-          . ./prepare_client_encryption.sh
-          rm -f ./prepare_client_encryption.sh
-
-          MONGODB_URI="${MONGODB_URI}" bash ${PROJECT_DIRECTORY}/.evergreen/run-custom-csfle-tests.sh
-  run custom csfle shared lib tests:
-    - command: shell.exec
-      type: test
-      params:
-        silent: true
-        working_dir: src
-        script: |
-          ${PREPARE_SHELL}
-          cat <<EOT > prepare_client_encryption.sh
           export CLIENT_ENCRYPTION='${CLIENT_ENCRYPTION}'
           export CSFLE_KMS_PROVIDERS='${CSFLE_KMS_PROVIDERS}'
           export AWS_ACCESS_KEY_ID='${AWS_ACCESS_KEY_ID}'
@@ -789,9 +759,8 @@ functions:
 
           source ${PROJECT_DIRECTORY}/.evergreen/prepare-crypt-shared-lib.sh
           export MONGODB_URI="${MONGODB_URI}"
-          export CRYPT_SHARED_LIB_PATH
 
-          echo "setting CRYPT_SHARED_LIB_PATH: $CRYPT_SHARED_LIB_PATH"
+          echo "CRYPT_SHARED_LIB_PATH: $CRYPT_SHARED_LIB_PATH"
 
           bash ${PROJECT_DIRECTORY}/.evergreen/run-custom-csfle-tests.sh
   run custom snappy tests:
@@ -1716,7 +1685,7 @@ tasks:
         vars:
           NODE_LTS_NAME: erbium
           TEST_NPM_SCRIPT: check:unit
-  - name: run-custom-csfle-tests-mongocryptd-pinned-commit
+  - name: run-custom-csfle-tests-5.0-pinned-commit
     tags:
       - run-custom-dependency-tests
     commands:
@@ -1725,13 +1694,13 @@ tasks:
           NODE_LTS_NAME: erbium
       - func: bootstrap mongo-orchestration
         vars:
-          VERSION: latest
+          VERSION: '5.0'
           TOPOLOGY: replica_set
       - func: bootstrap kms servers
       - func: run custom csfle tests
         vars:
           CSFLE_GIT_REF: 41afd44ca04d246998969c53de4e0f22802b0c8a
-  - name: run-custom-csfle-tests-mongocryptd-master
+  - name: run-custom-csfle-tests-5.0-master
     tags:
       - run-custom-dependency-tests
     commands:
@@ -1740,13 +1709,13 @@ tasks:
           NODE_LTS_NAME: erbium
       - func: bootstrap mongo-orchestration
         vars:
-          VERSION: latest
+          VERSION: '5.0'
           TOPOLOGY: replica_set
       - func: bootstrap kms servers
       - func: run custom csfle tests
         vars:
           CSFLE_GIT_REF: master
-  - name: run-custom-csfle-shared-lib-tests-pinned-commit
+  - name: run-custom-csfle-tests-rapid-pinned-commit
     tags:
       - run-custom-dependency-tests
     commands:
@@ -1755,14 +1724,28 @@ tasks:
           NODE_LTS_NAME: erbium
       - func: bootstrap mongo-orchestration
         vars:
-          VERSION: latest
+          VERSION: rapid
           TOPOLOGY: replica_set
       - func: bootstrap kms servers
-      - func: run custom csfle shared lib tests
+      - func: run custom csfle tests
         vars:
-          VERSION: latest
           CSFLE_GIT_REF: 41afd44ca04d246998969c53de4e0f22802b0c8a
-  - name: run-custom-csfle-shared-lib-tests-master
+  - name: run-custom-csfle-tests-rapid-master
+    tags:
+      - run-custom-dependency-tests
+    commands:
+      - func: install dependencies
+        vars:
+          NODE_LTS_NAME: erbium
+      - func: bootstrap mongo-orchestration
+        vars:
+          VERSION: rapid
+          TOPOLOGY: replica_set
+      - func: bootstrap kms servers
+      - func: run custom csfle tests
+        vars:
+          CSFLE_GIT_REF: master
+  - name: run-custom-csfle-tests-latest-pinned-commit
     tags:
       - run-custom-dependency-tests
     commands:
@@ -1774,9 +1757,23 @@ tasks:
           VERSION: latest
           TOPOLOGY: replica_set
       - func: bootstrap kms servers
-      - func: run custom csfle shared lib tests
+      - func: run custom csfle tests
+        vars:
+          CSFLE_GIT_REF: 41afd44ca04d246998969c53de4e0f22802b0c8a
+  - name: run-custom-csfle-tests-latest-master
+    tags:
+      - run-custom-dependency-tests
+    commands:
+      - func: install dependencies
+        vars:
+          NODE_LTS_NAME: erbium
+      - func: bootstrap mongo-orchestration
         vars:
           VERSION: latest
+          TOPOLOGY: replica_set
+      - func: bootstrap kms servers
+      - func: run custom csfle tests
+        vars:
           CSFLE_GIT_REF: master
   - name: test-latest-server-noauth
     tags:
@@ -2339,10 +2336,12 @@ buildvariants:
       - run-custom-snappy-tests
       - run-bson-ext-integration
       - run-bson-ext-unit
-      - run-custom-csfle-tests-mongocryptd-pinned-commit
-      - run-custom-csfle-tests-mongocryptd-master
-      - run-custom-csfle-shared-lib-tests-pinned-commit
-      - run-custom-csfle-shared-lib-tests-master
+      - run-custom-csfle-tests-5.0-pinned-commit
+      - run-custom-csfle-tests-5.0-master
+      - run-custom-csfle-tests-rapid-pinned-commit
+      - run-custom-csfle-tests-rapid-master
+      - run-custom-csfle-tests-latest-pinned-commit
+      - run-custom-csfle-tests-latest-master
   - name: ubuntu1804-test-serverless
     display_name: Serverless Test
     run_on: ubuntu1804-test

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -134,6 +134,7 @@ functions:
       params:
         working_dir: src
         timeout_secs: 300
+        shell: bash
         script: |
           ${PREPARE_SHELL}
 
@@ -143,6 +144,13 @@ functions:
             . ./prepare_client_encryption.sh
             rm -f ./prepare_client_encryption.sh
           fi
+
+          export VERSION=${VERSION}
+          export DRIVERS_TOOLS=${DRIVERS_TOOLS}
+
+          source ${PROJECT_DIRECTORY}/.evergreen/prepare-crypt-shared-lib.sh
+
+          echo "CRYPT_SHARED_LIB_PATH: $CRYPT_SHARED_LIB_PATH"
 
           MONGODB_URI="${MONGODB_URI}" \
           AUTH=${AUTH} SSL=${SSL} TEST_CSFLE=true \

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -549,114 +549,35 @@ const oneOffFuncAsTasks = oneOffFuncs.map(oneOffFunc => ({
   ]
 }));
 
-oneOffFuncAsTasks.push({
-  name: 'run-custom-csfle-tests-mongocryptd-pinned-commit',
-  tags: ['run-custom-dependency-tests'],
-  commands: [
-    {
-      func: 'install dependencies',
-      vars: {
-        NODE_LTS_NAME: LOWEST_LTS
-      }
-    },
-    {
-      func: 'bootstrap mongo-orchestration',
-      vars: {
-        VERSION: 'latest',
-        TOPOLOGY: 'replica_set'
-      }
-    },
-    { func: 'bootstrap kms servers' },
-    {
-      func: 'run custom csfle tests',
-      vars: {
-        CSFLE_GIT_REF: '41afd44ca04d246998969c53de4e0f22802b0c8a'
-      }
-    }
-  ]
-});
-
-oneOffFuncAsTasks.push({
-  name: 'run-custom-csfle-tests-mongocryptd-master',
-  tags: ['run-custom-dependency-tests'],
-  commands: [
-    {
-      func: 'install dependencies',
-      vars: {
-        NODE_LTS_NAME: LOWEST_LTS
-      }
-    },
-    {
-      func: 'bootstrap mongo-orchestration',
-      vars: {
-        VERSION: 'latest',
-        TOPOLOGY: 'replica_set'
-      }
-    },
-    { func: 'bootstrap kms servers' },
-    {
-      func: 'run custom csfle tests',
-      vars: {
-        CSFLE_GIT_REF: 'master'
-      }
-    }
-  ]
-});
-
-oneOffFuncAsTasks.push({
-  name: 'run-custom-csfle-shared-lib-tests-pinned-commit',
-  tags: ['run-custom-dependency-tests'],
-  commands: [
-    {
-      func: 'install dependencies',
-      vars: {
-        NODE_LTS_NAME: LOWEST_LTS
-      }
-    },
-    {
-      func: 'bootstrap mongo-orchestration',
-      vars: {
-        VERSION: 'latest',
-        TOPOLOGY: 'replica_set'
-      }
-    },
-    { func: 'bootstrap kms servers' },
-    {
-      func: 'run custom csfle shared lib tests',
-      vars: {
-        VERSION: 'latest',
-        CSFLE_GIT_REF: '41afd44ca04d246998969c53de4e0f22802b0c8a'
-      }
-    }
-  ]
-});
-
-oneOffFuncAsTasks.push({
-  name: 'run-custom-csfle-shared-lib-tests-master',
-  tags: ['run-custom-dependency-tests'],
-  commands: [
-    {
-      func: 'install dependencies',
-      vars: {
-        NODE_LTS_NAME: LOWEST_LTS
-      }
-    },
-    {
-      func: 'bootstrap mongo-orchestration',
-      vars: {
-        VERSION: 'latest',
-        TOPOLOGY: 'replica_set'
-      }
-    },
-    { func: 'bootstrap kms servers' },
-    {
-      func: 'run custom csfle shared lib tests',
-      vars: {
-        VERSION: 'latest',
-        CSFLE_GIT_REF: 'master'
-      }
-    }
-  ]
+[ '5.0', 'rapid', 'latest' ].forEach(version => {
+  [ '41afd44ca04d246998969c53de4e0f22802b0c8a', 'master' ].forEach(ref => {
+    oneOffFuncAsTasks.push({
+      name: `run-custom-csfle-tests-${version}-${ref == 'master' ? ref : 'pinned-commit'}`,
+      tags: ['run-custom-dependency-tests'],
+      commands: [
+        {
+          func: 'install dependencies',
+          vars: {
+            NODE_LTS_NAME: LOWEST_LTS
+          }
+        },
+        {
+          func: 'bootstrap mongo-orchestration',
+          vars: {
+            VERSION: version,
+            TOPOLOGY: 'replica_set'
+          }
+        },
+        { func: 'bootstrap kms servers' },
+        {
+          func: 'run custom csfle tests',
+          vars: {
+            CSFLE_GIT_REF: ref
+          }
+        }
+      ]
+    });
+  });
 });
 
 // TODO NODE-3897 - generate combined coverage report

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -552,7 +552,7 @@ const oneOffFuncAsTasks = oneOffFuncs.map(oneOffFunc => ({
 [ '5.0', 'rapid', 'latest' ].forEach(version => {
   [ '41afd44ca04d246998969c53de4e0f22802b0c8a', 'master' ].forEach(ref => {
     oneOffFuncAsTasks.push({
-      name: `run-custom-csfle-tests-${version}-${ref == 'master' ? ref : 'pinned-commit'}`,
+      name: `run-custom-csfle-tests-${version}-${ref === 'master' ? ref : 'pinned-commit'}`,
       tags: ['run-custom-dependency-tests'],
       commands: [
         {

--- a/.evergreen/prepare-crypt-shared-lib.sh
+++ b/.evergreen/prepare-crypt-shared-lib.sh
@@ -12,7 +12,6 @@ get_mongodb_download_url_for "$DISTRO" "$MONGODB_VERSION"
 # get_mongodb_download_url_for defines $MONGO_CRYPT_SHARED_DOWNLOAD_URL and $EXTRACT.
 if [ -z "$MONGO_CRYPT_SHARED_DOWNLOAD_URL" ]; then
   echo "There is no crypt_shared library for distro='$DISTRO' and version='$MONGODB_VERSION'".
-  exit 1
 else
   echo "Downloading crypt_shared package from $MONGO_CRYPT_SHARED_DOWNLOAD_URL"
   download_and_extract_crypt_shared "$MONGO_CRYPT_SHARED_DOWNLOAD_URL" "$EXTRACT"

--- a/test/integration/client-side-encryption/client_side_encryption.prose.corpus.test.js
+++ b/test/integration/client-side-encryption/client_side_encryption.prose.corpus.test.js
@@ -7,6 +7,7 @@ const path = require('path');
 const BSON = require('bson');
 const { EJSON } = require('bson');
 const { expect } = require('chai');
+const { getEncryptExtraOptions } = require('../../tools/utils');
 
 describe('Client Side Encryption Prose Corpus Test', function () {
   const metadata = {
@@ -214,10 +215,12 @@ describe('Client Side Encryption Prose Corpus Test', function () {
               tlsCertificateKeyFile: process.env.KMIP_TLS_CERT_FILE
             }
           };
+          const extraOptions = getEncryptExtraOptions();
           const autoEncryption = {
             keyVaultNamespace,
             kmsProviders,
-            tlsOptions
+            tlsOptions,
+            extraOptions
           };
           if (useClientSideSchema) {
             autoEncryption.schemaMap = {
@@ -231,7 +234,8 @@ describe('Client Side Encryption Prose Corpus Test', function () {
               bson: BSON,
               keyVaultNamespace,
               kmsProviders,
-              tlsOptions
+              tlsOptions,
+              extraOptions
             });
           });
         });

--- a/test/integration/client-side-encryption/client_side_encryption.prose.deadlock.js
+++ b/test/integration/client-side-encryption/client_side_encryption.prose.deadlock.js
@@ -6,6 +6,7 @@ const { dropCollection } = require('../shared');
 const util = require('util');
 const fs = require('fs');
 const path = require('path');
+const { getEncryptExtraOptions } = require('../../tools/utils');
 
 /* REFERENCE: (note commit hash) */
 /* https://github.com/mongodb/specifications/blob/b3beada72ae1c992294ae6a8eea572003a274c35/source/client-side-encryption/tests/README.rst#deadlock-tests */
@@ -56,7 +57,8 @@ function deadlockTest(options, assertions) {
         keyVaultNamespace: 'keyvault.datakeys',
         kmsProviders: { local: { key: LOCAL_KEY } },
         bypassAutoEncryption: options.bypassAutoEncryption,
-        keyVaultClient: options.useKeyVaultClient ? this.clientKeyVault : undefined
+        keyVaultClient: options.useKeyVaultClient ? this.clientKeyVault : undefined,
+        extraOptions: getEncryptExtraOptions()
       },
       maxPoolSize: options.maxPoolSize
     };
@@ -122,7 +124,8 @@ function deadlockTests(_metadata) {
             this.clientEncryption = new mongodbClientEncryption.ClientEncryption(this.clientTest, {
               kmsProviders: { local: { key: LOCAL_KEY } },
               keyVaultNamespace: 'keyvault.datakeys',
-              keyVaultClient: this.keyVaultClient
+              keyVaultClient: this.keyVaultClient,
+              extraOptions: getEncryptExtraOptions()
             });
             this.clientEncryption.encryptPromisified = util.promisify(
               this.clientEncryption.encrypt.bind(this.clientEncryption)

--- a/test/integration/client-side-encryption/client_side_encryption.prose.test.js
+++ b/test/integration/client-side-encryption/client_side_encryption.prose.test.js
@@ -10,6 +10,7 @@ const { dropCollection, APMEventCollector } = require('../shared');
 const { EJSON, Binary } = BSON;
 const { LEGACY_HELLO_COMMAND } = require('../../../src/constants');
 const { MongoNetworkError, MongoServerError } = require('../../../src/error');
+const { getEncryptExtraOptions } = require('../../tools/utils');
 
 const getKmsProviders = (localKey, kmipEndpoint, azureEndpoint, gcpEndpoint) => {
   const result = BSON.EJSON.parse(process.env.CSFLE_KMS_PROVIDERS || '{}');
@@ -133,7 +134,8 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
           .then(() => {
             this.clientEncryption = new mongodbClientEncryption.ClientEncryption(this.client, {
               kmsProviders: getKmsProviders(),
-              keyVaultNamespace
+              keyVaultNamespace,
+              extraOptions: getEncryptExtraOptions()
             });
           })
           .then(() => {
@@ -143,6 +145,7 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
                 autoEncryption: {
                   keyVaultNamespace,
                   kmsProviders: getKmsProviders(),
+                  extraOptions: getEncryptExtraOptions(),
                   schemaMap
                 }
               }
@@ -422,7 +425,8 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
                 const options = {
                   bson: BSON,
                   keyVaultNamespace,
-                  kmsProviders: getKmsProviders(LOCAL_KEY)
+                  kmsProviders: getKmsProviders(LOCAL_KEY),
+                  extraOptions: getEncryptExtraOptions()
                 };
 
                 if (withExternalKeyVault) {
@@ -599,7 +603,8 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
           monitorCommands: true,
           autoEncryption: {
             keyVaultNamespace,
-            kmsProviders: getKmsProviders(LOCAL_KEY)
+            kmsProviders: getKmsProviders(LOCAL_KEY),
+            extraOptions: getEncryptExtraOptions()
           }
         }
       );
@@ -782,7 +787,8 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
         {
           autoEncryption: {
             keyVaultNamespace,
-            kmsProviders: getKmsProviders(LOCAL_KEY)
+            kmsProviders: getKmsProviders(LOCAL_KEY),
+            extraOptions: getEncryptExtraOptions()
           }
         }
       );
@@ -855,7 +861,8 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
               tlsCAFile: process.env.KMIP_TLS_CA_FILE,
               tlsCertificateKeyFile: process.env.KMIP_TLS_CERT_FILE
             }
-          }
+          },
+          extraOptions: getEncryptExtraOptions()
         });
 
         this.clientEncryptionInvalid = new mongodbClientEncryption.ClientEncryption(this.client, {
@@ -866,7 +873,8 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
               tlsCAFile: process.env.KMIP_TLS_CA_FILE,
               tlsCertificateKeyFile: process.env.KMIP_TLS_CERT_FILE
             }
-          }
+          },
+          extraOptions: getEncryptExtraOptions()
         });
       });
     });
@@ -1139,7 +1147,8 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
       const clientNoTlsOptions = {
         keyVaultNamespace,
         kmsProviders: getKmsProviders(null, null, '127.0.0.1:8002', '127.0.0.1:8002'),
-        tlsOptions: tlsCaOptions
+        tlsOptions: tlsCaOptions,
+        extraOptions: getEncryptExtraOptions()
       };
       const clientWithTlsOptions = {
         keyVaultNamespace,
@@ -1161,17 +1170,20 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
             tlsCAFile: process.env.KMIP_TLS_CA_FILE,
             tlsCertificateKeyFile: process.env.KMIP_TLS_CERT_FILE
           }
-        }
+        },
+        extraOptions: getEncryptExtraOptions()
       };
       const clientWithTlsExpiredOptions = {
         keyVaultNamespace,
         kmsProviders: getKmsProviders(null, '127.0.0.1:8000', '127.0.0.1:8000', '127.0.0.1:8000'),
-        tlsOptions: tlsCaOptions
+        tlsOptions: tlsCaOptions,
+        extraOptions: getEncryptExtraOptions()
       };
       const clientWithInvalidHostnameOptions = {
         keyVaultNamespace,
         kmsProviders: getKmsProviders(null, '127.0.0.1:8001', '127.0.0.1:8001', '127.0.0.1:8001'),
-        tlsOptions: tlsCaOptions
+        tlsOptions: tlsCaOptions,
+        extraOptions: getEncryptExtraOptions()
       };
       const mongodbClientEncryption = this.configuration.mongodbClientEncryption;
 
@@ -1480,7 +1492,8 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
       clientEncryption = new mongodbClientEncryption.ClientEncryption(keyVaultClient, {
         keyVaultNamespace: 'keyvault.datakeys',
         kmsProviders: getKmsProviders(LOCAL_KEY),
-        bson: BSON
+        bson: BSON,
+        extraOptions: getEncryptExtraOptions()
       });
       // Create a MongoClient named ``encryptedClient`` with these ``AutoEncryptionOpts``:
       //   AutoEncryptionOpts {
@@ -1494,7 +1507,8 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
           autoEncryption: {
             bypassQueryAnalysis: true,
             keyVaultNamespace: 'keyvault.datakeys',
-            kmsProviders: getKmsProviders(LOCAL_KEY)
+            kmsProviders: getKmsProviders(LOCAL_KEY),
+            extraOptions: getEncryptExtraOptions()
           }
         }
       );
@@ -1752,7 +1766,8 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
       // Create a ClientEncryption object (referred to as client_encryption) with client set as the keyVaultClient.
       clientEncryption = new this.configuration.mongodbClientEncryption.ClientEncryption(client, {
         keyVaultNamespace: 'keyvault.datakeys',
-        kmsProviders: getKmsProviders()
+        kmsProviders: getKmsProviders(),
+        extraOptions: getEncryptExtraOptions()
       });
 
       // Using client_encryption, create a data key with a local KMS provider and the keyAltName "def".
@@ -1854,7 +1869,8 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
       clientEncryption = new mongodbClientEncryption.ClientEncryption(setupClient, {
         keyVaultNamespace: 'keyvault.datakeys',
         kmsProviders: getKmsProviders(LOCAL_KEY),
-        bson: BSON
+        bson: BSON,
+        extraOptions: getEncryptExtraOptions()
       });
       // Create a data key with the "local" KMS provider.
       // Storing the result in a variable named ``keyID``.
@@ -1887,7 +1903,8 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
           monitorCommands: true,
           autoEncryption: {
             keyVaultNamespace: 'keyvault.datakeys',
-            kmsProviders: getKmsProviders(LOCAL_KEY)
+            kmsProviders: getKmsProviders(LOCAL_KEY),
+            extraOptions: getEncryptExtraOptions()
           }
         }
       );
@@ -2114,6 +2131,7 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
                   tlsCertificateKeyFile: process.env.KMIP_TLS_CERT_FILE
                 }
               },
+              extraOptions: getEncryptExtraOptions(),
               bson: BSON
             }
           );
@@ -2141,6 +2159,7 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
                   tlsCertificateKeyFile: process.env.KMIP_TLS_CERT_FILE
                 }
               },
+              extraOptions: getEncryptExtraOptions(),
               bson: BSON
             }
           );

--- a/test/integration/client-side-encryption/driver.test.ts
+++ b/test/integration/client-side-encryption/driver.test.ts
@@ -5,6 +5,7 @@ import * as crypto from 'crypto';
 import { Collection, CommandStartedEvent, MongoClient } from '../../../src';
 import * as BSON from '../../../src/bson';
 import { ClientEncryption } from '../../tools/unified-spec-runner/schema';
+import { getEncryptExtraOptions } from '../../tools/utils';
 
 const metadata = {
   requires: {
@@ -71,6 +72,7 @@ describe('Client Side Encryption Functional', function () {
                     key: 'A'.repeat(128)
                   }
                 },
+                extraOptions: getEncryptExtraOptions(),
                 encryptedFieldsMap: {
                   'test.coll': {
                     fields: [
@@ -130,7 +132,8 @@ describe('Client Side Encryption Functional', function () {
       const encryption: ClientEncryption = new mongodbClientEncryption.ClientEncryption(client, {
         bson: BSON,
         keyVaultNamespace,
-        kmsProviders
+        kmsProviders,
+        extraOptions: getEncryptExtraOptions()
       });
 
       const dataDb = client.db(dataDbName);
@@ -157,7 +160,13 @@ describe('Client Side Encryption Functional', function () {
 
       encryptedClient = this.configuration.newClient(
         {},
-        { autoEncryption: { keyVaultNamespace, kmsProviders } }
+        {
+          autoEncryption: {
+            keyVaultNamespace,
+            kmsProviders,
+            extraOptions: getEncryptExtraOptions()
+          }
+        }
       );
 
       await encryptedClient.connect();
@@ -221,7 +230,8 @@ describe('Client Side Encryption Functional', function () {
         monitorCommands: true,
         autoEncryption: {
           keyVaultNamespace,
-          kmsProviders: { local: { key: 'A'.repeat(128) } }
+          kmsProviders: { local: { key: 'A'.repeat(128) } },
+          extraOptions: getEncryptExtraOptions()
         }
       };
       client = this.configuration.newClient({}, encryptionOptions);

--- a/test/tools/utils.ts
+++ b/test/tools/utils.ts
@@ -143,6 +143,13 @@ export class EventCollector {
   }
 }
 
+export function getEncryptExtraOptions() {
+  if (process.env.CRYPT_SHARED_LIB_PATH) {
+    return { cryptSharedLibPath: process.env.CRYPT_SHARED_LIB_PATH };
+  }
+  return {};
+}
+
 export function getSymbolFrom(target: any, symbolName: any, assertExists = true) {
   const symbol = Object.getOwnPropertySymbols(target).filter(
     s => s.toString() === `Symbol(${symbolName})`


### PR DESCRIPTION
### Description

Uses the shared lib in the csfle prose tests when the environment supports it.

#### What is changing?

Modifies all csfle prose, corpus, and driver tests to set `extraOptions.sharedCryptLibPath` when CRYPT_SHARED_LIB_PATH is in the environment. Updates the evg config to test csfle against 5.0, rapid, and latest, where CRYPT_SHARED_LIB_PATH will get set currently only with latest and 5.0 and rapid will run against mongocryptd.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
