### PR TITLE
test(NODE-3735): update to use serverless uri

### DIFF
--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -191,10 +191,12 @@ functions:
           export SERVERLESS_ATLAS_PASSWORD="${SERVERLESS_ATLAS_PASSWORD}"
           export SERVERLESS_URI="${SERVERLESS_URI}"
 
+          echo "setting SERVERLESS_URI: $SERVERLESS_URI"
+
           export MONGODB_URI="${SERVERLESS_URI}"
           export SINGLE_MONGOS_LB_URI="${SERVERLESS_URI}"
 
-          # Setting MULTI_MONGOS to the SINGLE_ATLAS is intentional
+          # Setting MULTI_MONGOS to the SERVERLESS_URI is intentional
           # LB tests pick one host out of the comma separated list
           # so just passing the one host is equivalent
           export MULTI_MONGOS_LB_URI="${SERVERLESS_URI}"

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -189,6 +189,7 @@ functions:
           export SERVERLESS="1"
           export SERVERLESS_ATLAS_USER="${SERVERLESS_ATLAS_USER}"
           export SERVERLESS_ATLAS_PASSWORD="${SERVERLESS_ATLAS_PASSWORD}"
+          export SERVERLESS_URI="${SERVERLESS_URI}"
 
           export MONGODB_URI="${SERVERLESS_URI}"
           export SINGLE_MONGOS_LB_URI="${SERVERLESS_URI}"

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -190,16 +190,13 @@ functions:
           export SERVERLESS_ATLAS_USER="${SERVERLESS_ATLAS_USER}"
           export SERVERLESS_ATLAS_PASSWORD="${SERVERLESS_ATLAS_PASSWORD}"
 
-          export SINGLE_ATLASPROXY_SERVERLESS_URI="${SINGLE_ATLASPROXY_SERVERLESS_URI}"
-          export MULTI_ATLASPROXY_SERVERLESS_URI="${MULTI_ATLASPROXY_SERVERLESS_URI}"
-
-          export MONGODB_URI="${SINGLE_ATLASPROXY_SERVERLESS_URI}"
-          export SINGLE_MONGOS_LB_URI="${SINGLE_ATLASPROXY_SERVERLESS_URI}"
+          export MONGODB_URI="${SERVERLESS_URI}"
+          export SINGLE_MONGOS_LB_URI="${SERVERLESS_URI}"
 
           # Setting MULTI_MONGOS to the SINGLE_ATLAS is intentional
           # LB tests pick one host out of the comma separated list
           # so just passing the one host is equivalent
-          export MULTI_MONGOS_LB_URI="${SINGLE_ATLASPROXY_SERVERLESS_URI}"
+          export MULTI_MONGOS_LB_URI="${SERVERLESS_URI}"
 
           bash ${PROJECT_DIRECTORY}/.evergreen/run-serverless-tests.sh
 

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -169,16 +169,13 @@ functions:
           export SERVERLESS_ATLAS_USER="${SERVERLESS_ATLAS_USER}"
           export SERVERLESS_ATLAS_PASSWORD="${SERVERLESS_ATLAS_PASSWORD}"
 
-          export SINGLE_ATLASPROXY_SERVERLESS_URI="${SINGLE_ATLASPROXY_SERVERLESS_URI}"
-          export MULTI_ATLASPROXY_SERVERLESS_URI="${MULTI_ATLASPROXY_SERVERLESS_URI}"
-
-          export MONGODB_URI="${SINGLE_ATLASPROXY_SERVERLESS_URI}"
-          export SINGLE_MONGOS_LB_URI="${SINGLE_ATLASPROXY_SERVERLESS_URI}"
+          export MONGODB_URI="${SERVERLESS_URI}"
+          export SINGLE_MONGOS_LB_URI="${SERVERLESS_URI}"
 
           # Setting MULTI_MONGOS to the SINGLE_ATLAS is intentional
           # LB tests pick one host out of the comma separated list
           # so just passing the one host is equivalent
-          export MULTI_MONGOS_LB_URI="${SINGLE_ATLASPROXY_SERVERLESS_URI}"
+          export MULTI_MONGOS_LB_URI="${SERVERLESS_URI}"
 
           bash ${PROJECT_DIRECTORY}/.evergreen/run-serverless-tests.sh
   start-load-balancer:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -170,10 +170,12 @@ functions:
           export SERVERLESS_ATLAS_PASSWORD="${SERVERLESS_ATLAS_PASSWORD}"
           export SERVERLESS_URI="${SERVERLESS_URI}"
 
+          echo "setting SERVERLESS_URI: $SERVERLESS_URI"
+
           export MONGODB_URI="${SERVERLESS_URI}"
           export SINGLE_MONGOS_LB_URI="${SERVERLESS_URI}"
 
-          # Setting MULTI_MONGOS to the SINGLE_ATLAS is intentional
+          # Setting MULTI_MONGOS to the SERVERLESS_URI is intentional
           # LB tests pick one host out of the comma separated list
           # so just passing the one host is equivalent
           export MULTI_MONGOS_LB_URI="${SERVERLESS_URI}"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -168,6 +168,7 @@ functions:
           export SERVERLESS="1"
           export SERVERLESS_ATLAS_USER="${SERVERLESS_ATLAS_USER}"
           export SERVERLESS_ATLAS_PASSWORD="${SERVERLESS_ATLAS_PASSWORD}"
+          export SERVERLESS_URI="${SERVERLESS_URI}"
 
           export MONGODB_URI="${SERVERLESS_URI}"
           export SINGLE_MONGOS_LB_URI="${SERVERLESS_URI}"

--- a/.evergreen/run-serverless-tests.sh
+++ b/.evergreen/run-serverless-tests.sh
@@ -3,8 +3,7 @@
 source "${PROJECT_DIRECTORY}/.evergreen/install-dependencies.sh"
 
 if [ -z ${SERVERLESS+omitted} ]; then echo "SERVERLESS is unset" && exit 1; fi
-if [ -z ${MULTI_ATLASPROXY_SERVERLESS_URI+omitted} ]; then echo "MULTI_ATLASPROXY_SERVERLESS_URI is unset" && exit 1; fi
-if [ -z ${SINGLE_ATLASPROXY_SERVERLESS_URI+omitted} ]; then echo "SINGLE_ATLASPROXY_SERVERLESS_URI is unset" && exit 1; fi
+if [ -z ${SERVERLESS_URI+omitted} ]; then echo "MULTI_ATLASPROXY_SERVERLESS_URI is unset" && exit 1; fi
 if [ -z ${SINGLE_MONGOS_LB_URI+omitted} ]; then echo "SINGLE_MONGOS_LB_URI is unset" && exit 1; fi
 if [ -z ${MULTI_MONGOS_LB_URI+omitted} ]; then echo "MULTI_MONGOS_LB_URI is unset" && exit 1; fi
 if [ -z ${MONGODB_URI+omitted} ]; then echo "MONGODB_URI is unset" && exit 1; fi

--- a/.evergreen/run-serverless-tests.sh
+++ b/.evergreen/run-serverless-tests.sh
@@ -3,7 +3,7 @@
 source "${PROJECT_DIRECTORY}/.evergreen/install-dependencies.sh"
 
 if [ -z ${SERVERLESS+omitted} ]; then echo "SERVERLESS is unset" && exit 1; fi
-if [ -z ${SERVERLESS_URI+omitted} ]; then echo "MULTI_ATLASPROXY_SERVERLESS_URI is unset" && exit 1; fi
+if [ -z ${SERVERLESS_URI+omitted} ]; then echo "SERVERLESS_URI is unset" && exit 1; fi
 if [ -z ${SINGLE_MONGOS_LB_URI+omitted} ]; then echo "SINGLE_MONGOS_LB_URI is unset" && exit 1; fi
 if [ -z ${MULTI_MONGOS_LB_URI+omitted} ]; then echo "MULTI_MONGOS_LB_URI is unset" && exit 1; fi
 if [ -z ${MONGODB_URI+omitted} ]; then echo "MONGODB_URI is unset" && exit 1; fi
@@ -15,10 +15,10 @@ npx mocha \
   test/integration/crud/crud.spec.test.js \
   test/integration/crud/crud.prose.test.js \
   test/integration/retryable-reads/retryable_reads.spec.test.js \
-  test/integration/retryable-writes/retryable_writes.spec.test.js \
-  test/integration/sessions/sessions.spec.test.js \
-  test/integration/sessions/sessions.test.js \
+  test/integration/retryable-writes/retryable_writes.spec.test.ts \
+  test/integration/sessions/sessions.spec.test.ts \
+  test/integration/sessions/sessions.test.ts \
   test/integration/transactions/transactions.spec.test.js \
-  test/integration/transactions/transactions.test.js \
+  test/integration/transactions/transactions.test.ts \
   test/integration/versioned-api/versioned_api.spec.test.js \
   test/integration/load-balancers/load_balancers.spec.test.js

--- a/test/readme.md
+++ b/test/readme.md
@@ -231,8 +231,7 @@ The following steps will walk you through how to create and test a MongoDB Serve
    AUTH: xxx
    TOPOLOGY: xxx
    SERVERLESS: xxx
-   MULTI_ATLASPROXY_SERVERLESS_URI: xxx
-   SINGLE_ATLASPROXY_SERVERLESS_URI: xxx
+   SERVERLESS_URI: xxx
    ```
 
 1. Generate a sourceable environment file from `serverless-expansion.yml` by running the following command:
@@ -245,9 +244,9 @@ The following steps will walk you through how to create and test a MongoDB Serve
 
 1. Update the following variables in `serverless.env`, so that they are equivalent to what our Evergreen builds do:
 
-   - Change `MONGODB_URI` to have the same value as `SINGLE_ATLASPROXY_SERVERLESS_URI`.
-   - Add `SINGLE_MONGOS_LB_URI` and set it to the value of `SINGLE_ATLASPROXY_SERVERLESS_URI`.
-   - Add `MULTI_MONGOS_LB_URI` and set it to the value of `SINGLE_ATLASPROXY_SERVERLESS_URI`.
+   - Change `MONGODB_URI` to have the same value as `SERVERLESS_URI`.
+   - Add `SINGLE_MONGOS_LB_URI` and set it to the value of `SERVERLESS_URI`.
+   - Add `MULTI_MONGOS_LB_URI` and set it to the value of `SERVERLESS_URI`.
 
 1. Source the environment variables using a command like `source serverless.env`.
 


### PR DESCRIPTION
### Description

Updates the serverless tests to use the new `SERVERLESS_URI` set from the drivers tools scripts.

#### What is changing?

- Sets all relevant testing uris to `SERVERLESS_URI`
- Updates the evergreen project config to use the new Atlas group.
- Fixes the test runner to be able to handle the srv `SERVERLESS_URI` now set (was not srv before)

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-3735

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
