### PR TITLE
feat(NODE-4540): add deprecation notice of callback support

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -459,10 +459,10 @@ export function maybePromise<T>(
     });
   } else {
     const cbMsg = `\nCallback support is deprecated and will be removed in the next major version.
-If this impacts your usage of the driver there are few migration paths to consider:
-  - You can start to using async/await syntax, which works with our driver today.
+If this impacts your usage of the driver there are a few migration paths to consider:
+  - You can start using async/await syntax, which works with our driver today.
   - You can use .then/.catch at the end of any of our promise returning APIs and call you callback from within those.
-  - You can install and import 'mongodb-legacy' a package that wraps all the async driver APIs and continues to provide the optional callback support.
+  - You can install and import 'mongodb-legacy': a package that wraps all the currently existing async driver APIs and continues to provide the optional callback support.
 You can read more about this here: LINK\n`;
     emitWarningOnce(cbMsg);
   }


### PR DESCRIPTION
### Description

#### What is changing?

Callback usage will now emit a deprecation warning once and instructions about how to migrate. 

Preview:
```txt
(node:55630) [MONGODB DRIVER] Warning: 
Callback support is deprecated and will be removed in the next major version.
If this impacts your usage of the driver there are few migration paths to consider:
  - You can start to using async/await syntax, which works with our driver today.
  - You can use .then/.catch at the end of any of our promise returning APIs and call you callback from within those.
  - You can install and import 'mongodb-legacy' a package that wraps all the async driver APIs and continues to provide the optional callback support.
You can read more about this here: LINK

(Use `node --trace-warnings ...` to show where the warning was created)
```

#### What is the motivation for this change?

Maintainable API, Sensible Error handling, consistent return values, less overloads, better type info.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
