### PR TITLE
fix(NODE-4516): dont require a connected client

### DIFF
--- a/src/deps.ts
+++ b/src/deps.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-import type { deserialize, Document, serialize } from './bson';
+import type { Document } from './bson';
 import type { ProxyOptions } from './cmap/connection';
 import { MongoMissingDependencyError } from './error';
 import type { MongoClient } from './mongo_client';
@@ -213,8 +213,6 @@ export interface AutoEncryptionTlsOptions {
 
 /** @public */
 export interface AutoEncryptionOptions {
-  /** @internal */
-  bson?: { serialize: typeof serialize; deserialize: typeof deserialize };
   /** @internal client for metadata lookups */
   metadataClient?: MongoClient;
   /** A `MongoClient` used to fetch keys from a key vault */

--- a/src/encrypter.ts
+++ b/src/encrypter.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-import { deserialize, serialize } from './bson';
 import { MONGO_CLIENT_EVENTS } from './constants';
 import type { AutoEncrypter, AutoEncryptionOptions } from './deps';
 import { MongoInvalidArgumentError, MongoMissingDependencyError } from './error';
@@ -56,12 +55,6 @@ export class Encrypter {
         proxyPassword: options.proxyPassword
       };
     }
-
-    options.autoEncryption.bson = Object.create(null);
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    options.autoEncryption.bson!.serialize = serialize;
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    options.autoEncryption.bson!.deserialize = deserialize;
 
     this.autoEncrypter = new AutoEncrypterClass(client, options.autoEncryption);
   }

--- a/src/sdam/topology.ts
+++ b/src/sdam/topology.ts
@@ -3,7 +3,6 @@ import { clearTimeout, setTimeout } from 'timers';
 import { promisify } from 'util';
 
 import type { BSONSerializeOptions, Document } from '../bson';
-import { deserialize, serialize } from '../bson';
 import type { MongoCredentials } from '../cmap/auth/mongo_credentials';
 import type { ConnectionEvents, DestroyOptions } from '../cmap/connection';
 import type { CloseOptions, ConnectionPoolEvents } from '../cmap/connection_pool';
@@ -222,25 +221,10 @@ export class Topology extends TypedEventEmitter<TopologyEvents> {
   static readonly TIMEOUT = TIMEOUT;
 
   /**
-   * @internal
-   *
-   * @privateRemarks
-   * mongodb-client-encryption's class ClientEncryption falls back to finding the bson lib
-   * defined on client.topology.bson, in order to maintain compatibility with any version
-   * of mongodb-client-encryption we keep a reference to serialize and deserialize here.
-   */
-  bson: { serialize: typeof serialize; deserialize: typeof deserialize };
-
-  /**
    * @param seedlist - a list of HostAddress instances to connect to
    */
   constructor(seeds: string | string[] | HostAddress | HostAddress[], options: TopologyOptions) {
     super();
-
-    // Legacy CSFLE support
-    this.bson = Object.create(null);
-    this.bson.serialize = serialize;
-    this.bson.deserialize = deserialize;
 
     // Options should only be undefined in tests, MongoClient will always have defined options
     options = options ?? {

--- a/test/integration/node-specific/mongo_client.test.ts
+++ b/test/integration/node-specific/mongo_client.test.ts
@@ -13,6 +13,7 @@ import {
 } from '../../../src';
 import { Connection } from '../../../src/cmap/connection';
 import { Db } from '../../../src/db';
+import { ServerDescription } from '../../../src/sdam/server_description';
 import { Topology } from '../../../src/sdam/topology';
 import { getTopology, isHello } from '../../../src/utils';
 import { runLater } from '../../tools/utils';
@@ -648,6 +649,26 @@ describe('class MongoClient', function () {
       expect(startedEvents[0]).to.have.property('commandName', 'endSessions');
       expect(endEvents).to.have.lengthOf(1);
       expect(endEvents[0]).to.have.property('reply', undefined); // noReponse: true
+    });
+
+    context('when server selection would return no servers', () => {
+      const serverDescription = new ServerDescription('a:1');
+
+      it('short circuits and does not end sessions', async () => {
+        const session = client.startSession(); // make a session to be ended
+        await client.db('test').command({ ping: 1 }, { session });
+        await session.endSession();
+
+        const startedEvents: CommandStartedEvent[] = [];
+        client.on('commandStarted', event => startedEvents.push(event));
+
+        const servers = new Map<string, ServerDescription>();
+        servers.set(serverDescription.address, serverDescription);
+        client.topology.description.servers = servers;
+        await client.close();
+
+        expect(startedEvents).to.be.empty;
+      });
     });
   });
 });


### PR DESCRIPTION
### Description

Allows mongodb-client-encryption to be run without a connected `MongoClient`

#### What is changing?

- Removes the internal `bson` auto encryption option and no longer passes it to the auto encrypter when instantiating it.
- Removes the internal `bson` options from the topology.

https://github.com/mongodb/libmongocrypt/pull/442

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-4516

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
