### PR TITLE
fix(NODE-4429): select server sync for endSessions during close

### DIFF
--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -522,7 +522,7 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> {
         })
         .then(() => {
           if (this.topology == null) {
-            return callback();
+            return;
           }
           // clear out references to old topology
           const topology = this.topology;

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -21,6 +21,7 @@ import { PromiseProvider } from './promise_provider';
 import type { ReadConcern, ReadConcernLevel, ReadConcernLike } from './read_concern';
 import { ReadPreference, ReadPreferenceMode } from './read_preference';
 import type { TagSet } from './sdam/server_description';
+import { readPreferenceServerSelector } from './sdam/server_selection';
 import type { SrvPoller } from './sdam/srv_polling';
 import type { Topology, TopologyEvents } from './sdam/topology';
 import { ClientSession, ClientSessionOptions, ServerSessionPool } from './sessions';
@@ -500,6 +501,16 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> {
 
       Promise.all(activeSessionEnds)
         .then(() => {
+          // If we would attempt to select a server and get nothing back we short circuit
+          // to avoid the server selection timeout.
+          const selector = readPreferenceServerSelector(ReadPreference.primaryPreferred);
+          const topologyDescription = this.topology.description;
+          const serverDescriptions = Array.from(topologyDescription.servers.values());
+          const servers = selector(topologyDescription, serverDescriptions);
+          if (servers.length === 0) {
+            return callback();
+          }
+
           const endSessions = Array.from(this.s.sessionPool.sessions, ({ id }) => id);
           if (endSessions.length === 0) return;
           return this.db('admin')

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -501,6 +501,9 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> {
 
       Promise.all(activeSessionEnds)
         .then(() => {
+          if (this.topology == null) {
+            return;
+          }
           // If we would attempt to select a server and get nothing back we short circuit
           // to avoid the server selection timeout.
           const selector = readPreferenceServerSelector(ReadPreference.primaryPreferred);

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -508,7 +508,7 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> {
           const serverDescriptions = Array.from(topologyDescription.servers.values());
           const servers = selector(topologyDescription, serverDescriptions);
           if (servers.length === 0) {
-            return callback();
+            return;
           }
 
           const endSessions = Array.from(this.s.sessionPool.sessions, ({ id }) => id);

--- a/test/integration/node-specific/mongo_client.test.ts
+++ b/test/integration/node-specific/mongo_client.test.ts
@@ -13,6 +13,7 @@ import {
 } from '../../../src';
 import { Connection } from '../../../src/cmap/connection';
 import { Db } from '../../../src/db';
+import { ServerDescription } from '../../../src/sdam/server_description';
 import { Topology } from '../../../src/sdam/topology';
 import { getTopology, isHello } from '../../../src/utils';
 import { runLater } from '../../tools/utils';
@@ -648,6 +649,26 @@ describe('class MongoClient', function () {
       expect(startedEvents[0]).to.have.property('commandName', 'endSessions');
       expect(endEvents).to.have.lengthOf(1);
       expect(endEvents[0]).to.have.property('reply', undefined); // noReponse: true
+    });
+
+    context('when server selection would return no servers', () => {
+      const serverDescription = new ServerDescription('a:1');
+
+      it('short circuits and does not end sessions', async () => {
+        const session = client.startSession(); // make a session to be ended
+        await client.db('test').command({ ping: 1 }, { session });
+        await session.endSession();
+
+        const startedEvents: CommandStartedEvent[] = [];
+        client.on('commandStarted', event => startedEvents.push(event));
+
+        const servers = new Map<string, ServerDescription>();
+        servers.set(serverDescription.address, serverDescription);
+        client.topology.description.servers = servers;
+        await client.close();
+
+        expect(startedEvents).to.be.empty;
+      });
     });
   });
 });

--- a/test/integration/node-specific/mongo_client.test.ts
+++ b/test/integration/node-specific/mongo_client.test.ts
@@ -668,6 +668,7 @@ describe('class MongoClient', function () {
         await client.close();
 
         expect(startedEvents).to.be.empty;
+        expect(client.s.sessionPool.sessions).to.have.lengthOf(1);
       });
     });
   });


### PR DESCRIPTION
### Description

This prevents the `endSessions` command from going through server selection when no server would be selected after calling `client.close()`. This could happen in situations where the server has gone down but server selection keeps forcing monitor checks for up to `serverSelectionTimeoutMS` when an immediate return is desired.

#### What is changing?

- `MongoClient`'s `close()` method now does a quick server selection to get the list of servers that would be returned with a primary preferred read preference. If nothing is returned then calling `endSessions` is skipped.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-4429

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
