### PR TITLE
docs(NODE-4230): update clustered collection reference link

### DIFF
--- a/src/operations/create_collection.ts
+++ b/src/operations/create_collection.ts
@@ -44,8 +44,7 @@ export interface TimeSeriesCollectionOptions extends Document {
 
 /** @public
  * Configuration options for clustered collections
- * TODO: NODE-4230 replace with normal manual link once it is on there.
- * @see https://www.mongodb.com/docs/v5.3/core/clustered-collections/
+ * @see https://www.mongodb.com/docs/manual/core/clustered-collections/
  */
 export interface ClusteredCollectionOptions extends Document {
   name?: string;


### PR DESCRIPTION
### Description
NODE-4230
#### What is changing?
- Updating docs reference link for clustered collections

##### Is there new documentation needed for these changes?
This is a docs change

#### What is the motivation for this change?

Consistent permanent link style

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [N/A] Changes are covered by tests
- [N/A] New TODOs have a related JIRA ticket
