### PR TITLE
fix(NODE-4555): export BSON internally

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1707,7 +1707,7 @@ tasks:
       - func: bootstrap kms servers
       - func: run custom csfle tests
         vars:
-          CSFLE_GIT_REF: 41afd44ca04d246998969c53de4e0f22802b0c8a
+          CSFLE_GIT_REF: 4e4613a0e725a8ba10f2c6ce8bff666e2f184549
   - name: run-custom-csfle-tests-5.0-master
     tags:
       - run-custom-dependency-tests
@@ -1737,7 +1737,7 @@ tasks:
       - func: bootstrap kms servers
       - func: run custom csfle tests
         vars:
-          CSFLE_GIT_REF: 41afd44ca04d246998969c53de4e0f22802b0c8a
+          CSFLE_GIT_REF: 4e4613a0e725a8ba10f2c6ce8bff666e2f184549
   - name: run-custom-csfle-tests-rapid-master
     tags:
       - run-custom-dependency-tests
@@ -1767,7 +1767,7 @@ tasks:
       - func: bootstrap kms servers
       - func: run custom csfle tests
         vars:
-          CSFLE_GIT_REF: 41afd44ca04d246998969c53de4e0f22802b0c8a
+          CSFLE_GIT_REF: 4e4613a0e725a8ba10f2c6ce8bff666e2f184549
   - name: run-custom-csfle-tests-latest-master
     tags:
       - run-custom-dependency-tests

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -550,7 +550,7 @@ const oneOffFuncAsTasks = oneOffFuncs.map(oneOffFunc => ({
 }));
 
 [ '5.0', 'rapid', 'latest' ].forEach(version => {
-  [ '41afd44ca04d246998969c53de4e0f22802b0c8a', 'master' ].forEach(ref => {
+  [ '4e4613a0e725a8ba10f2c6ce8bff666e2f184549', 'master' ].forEach(ref => {
     oneOffFuncAsTasks.push({
       name: `run-custom-csfle-tests-${version}-${ref === 'master' ? ref : 'pinned-commit'}`,
       tags: ['run-custom-dependency-tests'],

--- a/src/bson.ts
+++ b/src/bson.ts
@@ -6,6 +6,7 @@ import type {
   SerializeOptions
 } from 'bson';
 
+/** @internal */
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 let BSON = require('bson');
 
@@ -38,6 +39,9 @@ export {
   ObjectId,
   Timestamp
 } from 'bson';
+
+/** @internal */
+export { BSON };
 
 /**
  * BSON Serialization options.

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,8 @@ import { MongoClient } from './mongo_client';
 import { CancellationToken } from './mongo_types';
 import { PromiseProvider } from './promise_provider';
 
+/** @internal */
+export { BSON } from './bson';
 export {
   Binary,
   BSONRegExp,

--- a/src/sdam/topology.ts
+++ b/src/sdam/topology.ts
@@ -3,7 +3,6 @@ import { clearTimeout, setTimeout } from 'timers';
 import { promisify } from 'util';
 
 import type { BSONSerializeOptions, Document } from '../bson';
-import { deserialize, serialize } from '../bson';
 import type { MongoCredentials } from '../cmap/auth/mongo_credentials';
 import type { ConnectionEvents, DestroyOptions } from '../cmap/connection';
 import type { CloseOptions, ConnectionPoolEvents } from '../cmap/connection_pool';
@@ -222,25 +221,10 @@ export class Topology extends TypedEventEmitter<TopologyEvents> {
   static readonly TIMEOUT = TIMEOUT;
 
   /**
-   * @internal
-   *
-   * @privateRemarks
-   * mongodb-client-encryption's class ClientEncryption falls back to finding the bson lib
-   * defined on client.topology.bson, in order to maintain compatibility with any version
-   * of mongodb-client-encryption we keep a reference to serialize and deserialize here.
-   */
-  bson: { serialize: typeof serialize; deserialize: typeof deserialize };
-
-  /**
    * @param seedlist - a list of HostAddress instances to connect to
    */
   constructor(seeds: string | string[] | HostAddress | HostAddress[], options: TopologyOptions) {
     super();
-
-    // Legacy CSFLE support
-    this.bson = Object.create(null);
-    this.bson.serialize = serialize;
-    this.bson.deserialize = deserialize;
 
     // Options should only be undefined in tests, MongoClient will always have defined options
     options = options ?? {


### PR DESCRIPTION
### Description

Exports `BSON` from the library so that it can be used in other modules that depend on `mongodb`, such as `mongodb-client-encryption`.

See https://github.com/mongodb/libmongocrypt/pull/443 for the libmongocrypt changes.

Patch build against this branch from libmongocrypt: https://spruce.mongodb.com/version/62fd246f3627e0758c2439c8/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

#### What is changing?

- Exports `BSON` from the library.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-4516/NODE-4555

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
