### PR TITLE
chore: update bson dependency to 4.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.8.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "bson": "^4.6.5",
+        "bson": "^4.7.0",
         "denque": "^2.1.0",
         "mongodb-connection-string-url": "^2.5.3",
         "socks": "^2.7.0"
@@ -1823,9 +1823,9 @@
       }
     },
     "node_modules/bson": {
-      "version": "4.6.5",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-4.6.5.tgz",
-      "integrity": "sha512-uqrgcjyOaZsHfz7ea8zLRCLe1u+QGUSzMZmvXqO24CDW7DWoW1qiN9folSwa7hSneTSgM2ykDIzF5kcQQ8cwNw==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.7.0.tgz",
+      "integrity": "sha512-VrlEE4vuiO1WTpfof4VmaVolCVYkYTgB9iWgYNOrVlnifpME/06fhFRmONgBhClD5pFC1t9ZWqFUQEQAzY43bA==",
       "dependencies": {
         "buffer": "^5.6.0"
       },
@@ -9525,9 +9525,9 @@
       }
     },
     "bson": {
-      "version": "4.6.5",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-4.6.5.tgz",
-      "integrity": "sha512-uqrgcjyOaZsHfz7ea8zLRCLe1u+QGUSzMZmvXqO24CDW7DWoW1qiN9folSwa7hSneTSgM2ykDIzF5kcQQ8cwNw==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.7.0.tgz",
+      "integrity": "sha512-VrlEE4vuiO1WTpfof4VmaVolCVYkYTgB9iWgYNOrVlnifpME/06fhFRmONgBhClD5pFC1t9ZWqFUQEQAzY43bA==",
       "requires": {
         "buffer": "^5.6.0"
       }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "email": "dbx-node@mongodb.com"
   },
   "dependencies": {
-    "bson": "^4.6.5",
+    "bson": "^4.7.0",
     "denque": "^2.1.0",
     "mongodb-connection-string-url": "^2.5.3",
     "socks": "^2.7.0"


### PR DESCRIPTION
### Description

#### What is changing?

bson 4.7.0

#### What is the motivation for this change?

bson is nice to have

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
