### PR TITLE
test: fix incorrect uuid construction

### DIFF
--- a/test/integration/crud/insert.test.js
+++ b/test/integration/crud/insert.test.js
@@ -665,9 +665,12 @@ describe('crud - insert', function () {
 
                   // Generate a binary id
                   var binaryUUID = new Binary(
-                    '00000078123456781234567812345678',
+                    Buffer.from('00000078123456781234567812345678', 'hex'),
                     Binary.SUBTYPE_UUID
                   );
+
+                  // UUID must be 16 bytes
+                  expect(binaryUUID.buffer).to.have.property('byteLength', 16);
 
                   collection.insert(
                     { _id: binaryUUID, field: '2' },


### PR DESCRIPTION
### Description

#### What is changing?

We were not correctly manually constructing a UUID in our tests, the Binary constructor does not accept hex strings.

#### What is the motivation for this change?

Green trees: 🌲 

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
