### PR TITLE
test(NODE-3897): re-enable combined coverage

### DIFF
--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -872,7 +872,7 @@ functions:
           # Download all the task coverage files.
           # NOTE: All coverage files are too large for V3 to handle the resulting call to
           #       JSON.stringify from within nyc, so with stick to latest Node only.
-          aws s3 cp --recursive s3://mciuploads/mongo-node-driver/${revision}/${version_id}/ \
+          aws s3 cp --recursive s3://mciuploads/${UPLOAD_BUCKET}/${revision}/${version_id}/ \
             coverage/ \
             --exclude "*rhel80-large*" \
             --include "*hydrogen"
@@ -887,7 +887,7 @@ functions:
           npx nyc report -t merged-coverage/ --reporter=html --report-dir coverage-report
 
           aws s3 cp coverage-report/ \
-            s3://mciuploads/mongo-node-driver/${revision}/${version_id}/coverage/ \
+            s3://mciuploads/${UPLOAD_BUCKET}/${revision}/${version_id}/coverage/ \
             --recursive \
             --acl public-read \
             --region us-east-1
@@ -896,7 +896,7 @@ functions:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
         local_file:  src/coverage-report/index.html
-        remote_file: mongo-node-driver/${revision}/${version_id}/coverage/index.html
+        remote_file: ${UPLOAD_BUCKET}/${revision}/${version_id}/coverage/index.html
         bucket: mciuploads
         permissions: public-read
         content_type: text/html

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -881,10 +881,9 @@ functions:
           npm install @istanbuljs/nyc-config-typescript
           cd coverage
           sed -i'' -e 's/\/data\/mci\/.\{32\}\/src\///g' *
-          rm *-e
+          ls -la
           cd ..
           npx nyc merge coverage/ merged-coverage/coverage.json
-          more merged-coverage/coverage.json
           npx nyc report -t merged-coverage/ --reporter=html --report-dir coverage-report
 
           aws s3 cp coverage-report/ \

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -880,9 +880,11 @@ functions:
           # npx does not recognize the dependency so install it directly.
           npm install @istanbuljs/nyc-config-typescript
           cd coverage
-          sed -i'' -e 's/\/data\/mci\/.\{32\}\/src//g' *
+          sed -i'' -e 's/\/data\/mci\/.\{32\}\/src\///g' *
+          rm *-e
           cd ..
           npx nyc merge coverage/ merged-coverage/coverage.json
+          more merged-coverage/coverage.json
           npx nyc report -t merged-coverage/ --reporter=html --report-dir coverage-report
 
           aws s3 cp coverage-report/ \

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -852,7 +852,7 @@ functions:
         # Upload the coverage report for all tasks in a single build to the same directory.
         # TODO NODE-3897 - change upload directory to mongo-node-driver-next
         # This change will require changing the `download and merge coverage` func as well
-        remote_file: mongo-node-driver/${revision}/${version_id}/coverage.${build_variant}.${task_name}.json
+        remote_file: ${UPLOAD_BUCKET}/${revision}/${version_id}/coverage.${build_variant}.${task_name}.json
         bucket: mciuploads
         permissions: public-read
         content_type: application/json
@@ -870,9 +870,9 @@ functions:
           sudo dnf install --assumeyes awscli
 
           # Download all the task coverage files.
-          # NOTE: All coverage files are too large for V3 to handle the resulting call to
+          # NOTE: All coverage files are too large for V8 to handle the resulting call to
           #       JSON.stringify from within nyc, so with stick to latest Node only.
-          aws s3 cp --recursive s3://mciuploads/mongo-node-driver/${revision}/${version_id}/ \
+          aws s3 cp --recursive s3://mciuploads/${UPLOAD_BUCKET}/${revision}/${version_id}/ \
             coverage/ \
             --exclude "*rhel80-large*" \
             --include "*hydrogen"
@@ -883,7 +883,7 @@ functions:
           npx nyc report -t merged-coverage --reporter=html --report-dir coverage
 
           aws s3 cp coverage/ \
-            s3://mciuploads/mongo-node-driver/${revision}/${version_id}/coverage/ \
+            s3://mciuploads/${UPLOAD_BUCKET}/${revision}/${version_id}/coverage/ \
             --recursive \
             --acl public-read \
             --region us-east-1
@@ -892,7 +892,7 @@ functions:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
         local_file:  src/coverage/index.html
-        remote_file: mongo-node-driver/${revision}/${version_id}/coverage/index.html
+        remote_file: ${UPLOAD_BUCKET}/${revision}/${version_id}/coverage/index.html
         bucket: mciuploads
         permissions: public-read
         content_type: text/html

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -892,7 +892,7 @@ functions:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
         local_file:  src/coverage/index.html
-        remote_file: mciuploads/mongo-node-driver/${revision}/${version_id}/coverage/index.html
+        remote_file: mongo-node-driver/${revision}/${version_id}/coverage/index.html
         bucket: mciuploads
         permissions: public-read
         content_type: text/html

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -861,7 +861,6 @@ functions:
   "download and merge coverage":
     - command: shell.exec
       params:
-        silent: true
         working_dir: "src"
         script: |
           ${PREPARE_SHELL}

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -871,11 +871,12 @@ functions:
 
           # Download all the task coverage files.
           # NOTE: All coverage files are too large for V8 to handle the resulting call to
-          #       JSON.stringify from within nyc, so with stick to latest Node only.
+          #       JSON.stringify from within nyc, so with stick to Fermiun to include the
+          #       compression tests.
           aws s3 cp --recursive s3://mciuploads/mongo-node-driver/${revision}/${version_id}/ \
             coverage/ \
             --exclude "*rhel80-large*" \
-            --include "*hydrogen"
+            --include "*fermiun"
 
           # npx does not recognize the dependency so install it directly.
           npm install @istanbuljs/nyc-config-typescript

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -850,7 +850,9 @@ functions:
         local_file:  src/coverage/coverage-final.json
         optional: true
         # Upload the coverage report for all tasks in a single build to the same directory.
-        remote_file: ${UPLOAD_BUCKET}/${revision}/${version_id}/coverage.${build_variant}.${task_name}.json
+        # TODO NODE-4707 - change upload directory to ${UPLOAD_BUCKET} 
+        # This change will require changing the `download and merge coverage` func as well
+        remote_file: mongo-node-driver/${revision}/${version_id}/coverage.${build_variant}.${task_name}.json
         bucket: mciuploads
         permissions: public-read
         content_type: application/json
@@ -870,7 +872,7 @@ functions:
           # Download all the task coverage files.
           # NOTE: All coverage files are too large for V8 to handle the resulting call to
           #       JSON.stringify from within nyc, so with stick to latest Node only.
-          aws s3 cp --recursive s3://mciuploads/${UPLOAD_BUCKET}/${revision}/${version_id}/ \
+          aws s3 cp --recursive s3://mciuploads/mongo-node-driver/${revision}/${version_id}/ \
             coverage/ \
             --exclude "*rhel80-large*" \
             --include "*hydrogen"
@@ -885,7 +887,7 @@ functions:
           npx nyc report -t merged-coverage/ --reporter=html --report-dir coverage-report
 
           aws s3 cp coverage-report/ \
-            s3://mciuploads/${UPLOAD_BUCKET}/${revision}/${version_id}/coverage/ \
+            s3://mciuploads/mongo-node-driver/${revision}/${version_id}/coverage/ \
             --recursive \
             --acl public-read \
             --region us-east-1
@@ -894,7 +896,7 @@ functions:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
         local_file:  src/coverage-report/index.html
-        remote_file: ${UPLOAD_BUCKET}/${revision}/${version_id}/coverage/index.html
+        remote_file: mongo-node-driver/${revision}/${version_id}/coverage/index.html
         bucket: mciuploads
         permissions: public-read
         content_type: text/html

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -850,8 +850,6 @@ functions:
         local_file:  src/coverage/coverage-final.json
         optional: true
         # Upload the coverage report for all tasks in a single build to the same directory.
-        # TODO NODE-3897 - change upload directory to mongo-node-driver-next
-        # This change will require changing the `download and merge coverage` func as well
         remote_file: ${UPLOAD_BUCKET}/${revision}/${version_id}/coverage.${build_variant}.${task_name}.json
         bucket: mciuploads
         permissions: public-read

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -852,7 +852,7 @@ functions:
         # Upload the coverage report for all tasks in a single build to the same directory.
         # TODO NODE-3897 - change upload directory to mongo-node-driver-next
         # This change will require changing the `download and merge coverage` func as well
-        remote_file: mongo-node-driver/${revision}/${version_id}/coverage.${build_variant}.${task_name}.json
+        remote_file: ${UPLOAD_BUCKET}/${revision}/${version_id}/coverage.${build_variant}.${task_name}.json
         bucket: mciuploads
         permissions: public-read
         content_type: application/json
@@ -870,7 +870,7 @@ functions:
           sudo dnf install --assumeyes awscli
 
           # Download all the task coverage files.
-          # NOTE: All coverage files are too large for V3 to handle the resulting call to
+          # NOTE: All coverage files are too large for V8 to handle the resulting call to
           #       JSON.stringify from within nyc, so with stick to latest Node only.
           aws s3 cp --recursive s3://mciuploads/${UPLOAD_BUCKET}/${revision}/${version_id}/ \
             coverage/ \

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -867,8 +867,6 @@ functions:
           export AWS_ACCESS_KEY_ID=${aws_key}
           export AWS_SECRET_ACCESS_KEY=${aws_secret}
 
-          sudo dnf install --assumeyes awscli
-
           # Download all the task coverage files.
           # NOTE: All coverage files are too large for V8 to handle the resulting call to
           #       JSON.stringify from within nyc, so with stick to Fermiun to include the

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -852,7 +852,7 @@ functions:
         # Upload the coverage report for all tasks in a single build to the same directory.
         # TODO NODE-3897 - change upload directory to mongo-node-driver-next
         # This change will require changing the `download and merge coverage` func as well
-        remote_file: ${UPLOAD_BUCKET}/${revision}/${version_id}/coverage.${build_variant}.${task_name}.json
+        remote_file: mongo-node-driver/${revision}/${version_id}/coverage.${build_variant}.${task_name}.json
         bucket: mciuploads
         permissions: public-read
         content_type: application/json
@@ -870,9 +870,9 @@ functions:
           sudo dnf install --assumeyes awscli
 
           # Download all the task coverage files.
-          # NOTE: All coverage files are too large for V8 to handle the resulting call to
+          # NOTE: All coverage files are too large for V3 to handle the resulting call to
           #       JSON.stringify from within nyc, so with stick to latest Node only.
-          aws s3 cp --recursive s3://mciuploads/${UPLOAD_BUCKET}/${revision}/${version_id}/ \
+          aws s3 cp --recursive s3://mciuploads/mongo-node-driver/${revision}/${version_id}/ \
             coverage/ \
             --exclude "*rhel80-large*" \
             --include "*hydrogen"
@@ -883,7 +883,7 @@ functions:
           npx nyc report -t merged-coverage --reporter=html --report-dir coverage
 
           aws s3 cp coverage/ \
-            s3://mciuploads/${UPLOAD_BUCKET}/${revision}/${version_id}/coverage/ \
+            s3://mciuploads/mongo-node-driver/${revision}/${version_id}/coverage/ \
             --recursive \
             --acl public-read \
             --region us-east-1
@@ -892,7 +892,7 @@ functions:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
         local_file:  src/coverage/index.html
-        remote_file: ${UPLOAD_BUCKET}/${revision}/${version_id}/coverage/index.html
+        remote_file: mongo-node-driver/${revision}/${version_id}/coverage/index.html
         bucket: mciuploads
         permissions: public-read
         content_type: text/html

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -870,10 +870,14 @@ functions:
           sudo dnf install --assumeyes awscli
 
           # Download all the task coverage files.
-          # TODO NODE-3897 - finish this function.  the code below this point is untested because
-          #   aws s3 cp fails due to permissions errors
-          aws s3 cp --recursive s3://mciuploads/mongo-node-driver/${revision}/${version_id}/ coverage/
+          # NOTE: All coverage files are too large for V3 to handle the resulting call to
+          #       JSON.stringify from within nyc, so with stick to latest Node only.
+          aws s3 cp --recursive s3://mciuploads/mongo-node-driver/${revision}/${version_id}/ \
+            coverage/ \
+            --exclude "*rhel80-large*" \
+            --include "*hydrogen"
 
+          # npx does not recognize the dependency so install it directly.
           npm install @istanbuljs/nyc-config-typescript
           npx nyc merge coverage/ merged-coverage/coverage.json
           npx nyc report -t merged-coverage --reporter=html --report-dir output

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -894,7 +894,7 @@ functions:
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file:  src/coverage/index.html
+        local_file:  src/coverage-report/index.html
         remote_file: mongo-node-driver/${revision}/${version_id}/coverage/index.html
         bucket: mciuploads
         permissions: public-read

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -879,10 +879,13 @@ functions:
 
           # npx does not recognize the dependency so install it directly.
           npm install @istanbuljs/nyc-config-typescript
+          cd coverage
+          sed -i'' -e 's/\/data\/mci\/.\{32\}\/src//g' *
+          cd ..
           npx nyc merge coverage/ merged-coverage/coverage.json
-          npx nyc report -t merged-coverage --reporter=html --report-dir coverage
+          npx nyc report -t merged-coverage/ --reporter=html --report-dir coverage-report
 
-          aws s3 cp coverage/ \
+          aws s3 cp coverage-report/ \
             s3://mciuploads/mongo-node-driver/${revision}/${version_id}/coverage/ \
             --recursive \
             --acl public-read \

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -866,6 +866,9 @@ functions:
           ${PREPARE_SHELL}
           export AWS_ACCESS_KEY_ID=${aws_key}
           export AWS_SECRET_ACCESS_KEY=${aws_secret}
+
+          sudo dnf install --assumeyes awscli
+
           # Download all the task coverage files.
           # TODO NODE-3897 - finish this function.  the code below this point is untested because
           #   aws s3 cp fails due to permissions errors

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -880,9 +880,23 @@ functions:
           # npx does not recognize the dependency so install it directly.
           npm install @istanbuljs/nyc-config-typescript
           npx nyc merge coverage/ merged-coverage/coverage.json
-          npx nyc report -t merged-coverage --reporter=html --report-dir output
+          npx nyc report -t merged-coverage --reporter=html --report-dir coverage
 
-          aws s3 cp output/ s3://mciuploads/mongo-node-driver/${revision}/${version_id}/lcov-report/
+          aws s3 cp coverage/ \
+            s3://mciuploads/mongo-node-driver/${revision}/${version_id}/coverage/ \
+            --recursive \
+            --acl public-read \
+            --region us-east-1
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file:  src/coverage/index.html
+        remote_file: mciuploads/mongo-node-driver/${revision}/${version_id}/coverage/index.html
+        bucket: mciuploads
+        permissions: public-read
+        content_type: text/html
+        display_name: "Coverage Report HTML"
 
   "run spec driver benchmarks":
     - command: subprocess.exec

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -874,6 +874,7 @@ functions:
           #   aws s3 cp fails due to permissions errors
           aws s3 cp --recursive s3://mciuploads/mongo-node-driver/${revision}/${version_id}/ coverage/
 
+          npm install @istanbuljs/nyc-config-typescript
           npx nyc merge coverage/ merged-coverage/coverage.json
           npx nyc report -t merged-coverage --reporter=html --report-dir output
 

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -882,7 +882,7 @@ functions:
           npx nyc merge coverage/ merged-coverage/coverage.json
           npx nyc report -t merged-coverage --reporter=html --report-dir output
 
-          aws s3 cp output/lcov-report s3://mciuploads/mongo-node-driver/${revision}/${version_id}//lcov-report/
+          aws s3 cp output/ s3://mciuploads/mongo-node-driver/${revision}/${version_id}/lcov-report/
 
   "run spec driver benchmarks":
     - command: subprocess.exec

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -842,7 +842,7 @@ functions:
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/coverage/index.html
+        local_file: src/coverage-report/index.html
         remote_file: mongo-node-driver/${revision}/${version_id}/coverage/index.html
         bucket: mciuploads
         permissions: public-read

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -814,6 +814,9 @@ functions:
           ${PREPARE_SHELL}
           export AWS_ACCESS_KEY_ID=${aws_key}
           export AWS_SECRET_ACCESS_KEY=${aws_secret}
+
+          sudo dnf install --assumeyes awscli
+
           # Download all the task coverage files.
           # TODO NODE-3897 - finish this function.  the code below this point is untested because
           #   aws s3 cp fails due to permissions errors

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -801,7 +801,7 @@ functions:
         aws_secret: ${aws_secret}
         local_file: src/coverage/coverage-final.json
         optional: true
-        remote_file: ${UPLOAD_BUCKET}/${revision}/${version_id}/coverage.${build_variant}.${task_name}.json
+        remote_file: mongo-node-driver/${revision}/${version_id}/coverage.${build_variant}.${task_name}.json
         bucket: mciuploads
         permissions: public-read
         content_type: application/json
@@ -818,9 +818,9 @@ functions:
           sudo dnf install --assumeyes awscli
 
           # Download all the task coverage files.
-          # NOTE: All coverage files are too large for V8 to handle the resulting call to
+          # NOTE: All coverage files are too large for V3 to handle the resulting call to
           #       JSON.stringify from within nyc, so with stick to latest Node only.
-          aws s3 cp --recursive s3://mciuploads/${UPLOAD_BUCKET}/${revision}/${version_id}/ \
+          aws s3 cp --recursive s3://mciuploads/mongo-node-driver/${revision}/${version_id}/ \
             coverage/ \
             --exclude "*rhel80-large*" \
             --include "*hydrogen"
@@ -831,7 +831,7 @@ functions:
           npx nyc report -t merged-coverage --reporter=html --report-dir coverage
 
           aws s3 cp coverage/ \
-            s3://mciuploads/${UPLOAD_BUCKET}/${revision}/${version_id}/coverage/ \
+            s3://mciuploads/mongo-node-driver/${revision}/${version_id}/coverage/ \
             --recursive \
             --acl public-read \
             --region us-east-1
@@ -840,7 +840,7 @@ functions:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
         local_file: src/coverage/index.html
-        remote_file: ${UPLOAD_BUCKET}/${revision}/${version_id}/coverage/index.html
+        remote_file: mongo-node-driver/${revision}/${version_id}/coverage/index.html
         bucket: mciuploads
         permissions: public-read
         content_type: text/html

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -819,11 +819,12 @@ functions:
 
           # Download all the task coverage files.
           # NOTE: All coverage files are too large for V8 to handle the resulting call to
-          #       JSON.stringify from within nyc, so with stick to latest Node only.
+          #       JSON.stringify from within nyc, so with stick to Fermiun to include the
+          #       compression tests.
           aws s3 cp --recursive s3://mciuploads/mongo-node-driver/${revision}/${version_id}/ \
             coverage/ \
             --exclude "*rhel80-large*" \
-            --include "*hydrogen"
+            --include "*fermiun"
 
           # npx does not recognize the dependency so install it directly.
           npm install @istanbuljs/nyc-config-typescript

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -809,7 +809,6 @@ functions:
   download and merge coverage:
     - command: shell.exec
       params:
-        silent: true
         working_dir: src
         script: |
           ${PREPARE_SHELL}
@@ -2061,6 +2060,15 @@ tasks:
         vars:
           NODE_LTS_NAME: gallium
       - func: run mongosh integration tests
+  - name: download-and-merge-coverage
+    tags: []
+    commands:
+      - func: download and merge coverage
+    depends_on:
+      - name: '*'
+        variant: '*'
+        status: '*'
+        patch_optional: true
   - name: run-custom-snappy-tests
     tags:
       - run-custom-dependency-tests
@@ -2974,6 +2982,11 @@ buildvariants:
       - run-typescript-current
       - run-typescript-oldest
       - run-typescript-next
+  - name: generate-combined-coverage
+    display_name: Generate Combined Coverage
+    run_on: ubuntu1804-large
+    tasks:
+      - download-and-merge-coverage
   - name: mongosh_integration_tests
     display_name: mongosh integration tests
     run_on: ubuntu1804-large

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -827,10 +827,13 @@ functions:
 
           # npx does not recognize the dependency so install it directly.
           npm install @istanbuljs/nyc-config-typescript
+          cd coverage
+          sed -i'' -e 's/\/data\/mci\/.\{32\}\/src//g' *
+          cd ..
           npx nyc merge coverage/ merged-coverage/coverage.json
-          npx nyc report -t merged-coverage --reporter=html --report-dir coverage
+          npx nyc report -t merged-coverage/ --reporter=html --report-dir coverage-report
 
-          aws s3 cp coverage/ \
+          aws s3 cp coverage-report/ \
             s3://mciuploads/mongo-node-driver/${revision}/${version_id}/coverage/ \
             --recursive \
             --acl public-read \

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -818,10 +818,14 @@ functions:
           sudo dnf install --assumeyes awscli
 
           # Download all the task coverage files.
-          # TODO NODE-3897 - finish this function.  the code below this point is untested because
-          #   aws s3 cp fails due to permissions errors
-          aws s3 cp --recursive s3://mciuploads/mongo-node-driver/${revision}/${version_id}/ coverage/
+          # NOTE: All coverage files are too large for V3 to handle the resulting call to
+          #       JSON.stringify from within nyc, so with stick to latest Node only.
+          aws s3 cp --recursive s3://mciuploads/mongo-node-driver/${revision}/${version_id}/ \
+            coverage/ \
+            --exclude "*rhel80-large*" \
+            --include "*hydrogen"
 
+          # npx does not recognize the dependency so install it directly.
           npm install @istanbuljs/nyc-config-typescript
           npx nyc merge coverage/ merged-coverage/coverage.json
           npx nyc report -t merged-coverage --reporter=html --report-dir output

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2984,7 +2984,7 @@ buildvariants:
       - run-typescript-next
   - name: generate-combined-coverage
     display_name: Generate Combined Coverage
-    run_on: ubuntu1804-large
+    run_on: rhel80-large
     tasks:
       - download-and-merge-coverage
   - name: mongosh_integration_tests

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -801,7 +801,7 @@ functions:
         aws_secret: ${aws_secret}
         local_file: src/coverage/coverage-final.json
         optional: true
-        remote_file: mongo-node-driver/${revision}/${version_id}/coverage.${build_variant}.${task_name}.json
+        remote_file: ${UPLOAD_BUCKET}/${revision}/${version_id}/coverage.${build_variant}.${task_name}.json
         bucket: mciuploads
         permissions: public-read
         content_type: application/json
@@ -818,7 +818,7 @@ functions:
           sudo dnf install --assumeyes awscli
 
           # Download all the task coverage files.
-          # NOTE: All coverage files are too large for V3 to handle the resulting call to
+          # NOTE: All coverage files are too large for V8 to handle the resulting call to
           #       JSON.stringify from within nyc, so with stick to latest Node only.
           aws s3 cp --recursive s3://mciuploads/${UPLOAD_BUCKET}/${revision}/${version_id}/ \
             coverage/ \

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -830,7 +830,7 @@ functions:
           npx nyc merge coverage/ merged-coverage/coverage.json
           npx nyc report -t merged-coverage --reporter=html --report-dir output
 
-          aws s3 cp output/lcov-report s3://mciuploads/mongo-node-driver/${revision}/${version_id}//lcov-report/
+          aws s3 cp output/ s3://mciuploads/mongo-node-driver/${revision}/${version_id}/lcov-report/
   run spec driver benchmarks:
     - command: subprocess.exec
       type: test

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -829,10 +829,9 @@ functions:
           npm install @istanbuljs/nyc-config-typescript
           cd coverage
           sed -i'' -e 's/\/data\/mci\/.\{32\}\/src\///g' *
-          rm *-e
+          ls -la
           cd ..
           npx nyc merge coverage/ merged-coverage/coverage.json
-          more merged-coverage/coverage.json
           npx nyc report -t merged-coverage/ --reporter=html --report-dir coverage-report
 
           aws s3 cp coverage-report/ \

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -820,7 +820,7 @@ functions:
           # Download all the task coverage files.
           # NOTE: All coverage files are too large for V3 to handle the resulting call to
           #       JSON.stringify from within nyc, so with stick to latest Node only.
-          aws s3 cp --recursive s3://mciuploads/mongo-node-driver/${revision}/${version_id}/ \
+          aws s3 cp --recursive s3://mciuploads/${UPLOAD_BUCKET}/${revision}/${version_id}/ \
             coverage/ \
             --exclude "*rhel80-large*" \
             --include "*hydrogen"
@@ -835,7 +835,7 @@ functions:
           npx nyc report -t merged-coverage/ --reporter=html --report-dir coverage-report
 
           aws s3 cp coverage-report/ \
-            s3://mciuploads/mongo-node-driver/${revision}/${version_id}/coverage/ \
+            s3://mciuploads/${UPLOAD_BUCKET}/${revision}/${version_id}/coverage/ \
             --recursive \
             --acl public-read \
             --region us-east-1
@@ -844,7 +844,7 @@ functions:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
         local_file: src/coverage-report/index.html
-        remote_file: mongo-node-driver/${revision}/${version_id}/coverage/index.html
+        remote_file: ${UPLOAD_BUCKET}/${revision}/${version_id}/coverage/index.html
         bucket: mciuploads
         permissions: public-read
         content_type: text/html

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -822,6 +822,7 @@ functions:
           #   aws s3 cp fails due to permissions errors
           aws s3 cp --recursive s3://mciuploads/mongo-node-driver/${revision}/${version_id}/ coverage/
 
+          npm install @istanbuljs/nyc-config-typescript
           npx nyc merge coverage/ merged-coverage/coverage.json
           npx nyc report -t merged-coverage --reporter=html --report-dir output
 

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -828,9 +828,11 @@ functions:
           # npx does not recognize the dependency so install it directly.
           npm install @istanbuljs/nyc-config-typescript
           cd coverage
-          sed -i'' -e 's/\/data\/mci\/.\{32\}\/src//g' *
+          sed -i'' -e 's/\/data\/mci\/.\{32\}\/src\///g' *
+          rm *-e
           cd ..
           npx nyc merge coverage/ merged-coverage/coverage.json
+          more merged-coverage/coverage.json
           npx nyc report -t merged-coverage/ --reporter=html --report-dir coverage-report
 
           aws s3 cp coverage-report/ \

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -815,8 +815,6 @@ functions:
           export AWS_ACCESS_KEY_ID=${aws_key}
           export AWS_SECRET_ACCESS_KEY=${aws_secret}
 
-          sudo dnf install --assumeyes awscli
-
           # Download all the task coverage files.
           # NOTE: All coverage files are too large for V8 to handle the resulting call to
           #       JSON.stringify from within nyc, so with stick to Fermiun to include the

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -801,7 +801,7 @@ functions:
         aws_secret: ${aws_secret}
         local_file: src/coverage/coverage-final.json
         optional: true
-        remote_file: mongo-node-driver/${revision}/${version_id}/coverage.${build_variant}.${task_name}.json
+        remote_file: ${UPLOAD_BUCKET}/${revision}/${version_id}/coverage.${build_variant}.${task_name}.json
         bucket: mciuploads
         permissions: public-read
         content_type: application/json
@@ -818,9 +818,9 @@ functions:
           sudo dnf install --assumeyes awscli
 
           # Download all the task coverage files.
-          # NOTE: All coverage files are too large for V3 to handle the resulting call to
+          # NOTE: All coverage files are too large for V8 to handle the resulting call to
           #       JSON.stringify from within nyc, so with stick to latest Node only.
-          aws s3 cp --recursive s3://mciuploads/mongo-node-driver/${revision}/${version_id}/ \
+          aws s3 cp --recursive s3://mciuploads/${UPLOAD_BUCKET}/${revision}/${version_id}/ \
             coverage/ \
             --exclude "*rhel80-large*" \
             --include "*hydrogen"
@@ -831,7 +831,7 @@ functions:
           npx nyc report -t merged-coverage --reporter=html --report-dir coverage
 
           aws s3 cp coverage/ \
-            s3://mciuploads/mongo-node-driver/${revision}/${version_id}/coverage/ \
+            s3://mciuploads/${UPLOAD_BUCKET}/${revision}/${version_id}/coverage/ \
             --recursive \
             --acl public-read \
             --region us-east-1
@@ -840,7 +840,7 @@ functions:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
         local_file: src/coverage/index.html
-        remote_file: mongo-node-driver/${revision}/${version_id}/coverage/index.html
+        remote_file: ${UPLOAD_BUCKET}/${revision}/${version_id}/coverage/index.html
         bucket: mciuploads
         permissions: public-read
         content_type: text/html

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -801,7 +801,7 @@ functions:
         aws_secret: ${aws_secret}
         local_file: src/coverage/coverage-final.json
         optional: true
-        remote_file: ${UPLOAD_BUCKET}/${revision}/${version_id}/coverage.${build_variant}.${task_name}.json
+        remote_file: mongo-node-driver/${revision}/${version_id}/coverage.${build_variant}.${task_name}.json
         bucket: mciuploads
         permissions: public-read
         content_type: application/json
@@ -820,7 +820,7 @@ functions:
           # Download all the task coverage files.
           # NOTE: All coverage files are too large for V8 to handle the resulting call to
           #       JSON.stringify from within nyc, so with stick to latest Node only.
-          aws s3 cp --recursive s3://mciuploads/${UPLOAD_BUCKET}/${revision}/${version_id}/ \
+          aws s3 cp --recursive s3://mciuploads/mongo-node-driver/${revision}/${version_id}/ \
             coverage/ \
             --exclude "*rhel80-large*" \
             --include "*hydrogen"
@@ -835,7 +835,7 @@ functions:
           npx nyc report -t merged-coverage/ --reporter=html --report-dir coverage-report
 
           aws s3 cp coverage-report/ \
-            s3://mciuploads/${UPLOAD_BUCKET}/${revision}/${version_id}/coverage/ \
+            s3://mciuploads/mongo-node-driver/${revision}/${version_id}/coverage/ \
             --recursive \
             --acl public-read \
             --region us-east-1
@@ -844,7 +844,7 @@ functions:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
         local_file: src/coverage-report/index.html
-        remote_file: ${UPLOAD_BUCKET}/${revision}/${version_id}/coverage/index.html
+        remote_file: mongo-node-driver/${revision}/${version_id}/coverage/index.html
         bucket: mciuploads
         permissions: public-read
         content_type: text/html

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -840,7 +840,7 @@ functions:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
         local_file: src/coverage/index.html
-        remote_file: mciuploads/mongo-node-driver/${revision}/${version_id}/coverage/index.html
+        remote_file: mongo-node-driver/${revision}/${version_id}/coverage/index.html
         bucket: mciuploads
         permissions: public-read
         content_type: text/html

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -828,9 +828,23 @@ functions:
           # npx does not recognize the dependency so install it directly.
           npm install @istanbuljs/nyc-config-typescript
           npx nyc merge coverage/ merged-coverage/coverage.json
-          npx nyc report -t merged-coverage --reporter=html --report-dir output
+          npx nyc report -t merged-coverage --reporter=html --report-dir coverage
 
-          aws s3 cp output/ s3://mciuploads/mongo-node-driver/${revision}/${version_id}/lcov-report/
+          aws s3 cp coverage/ \
+            s3://mciuploads/mongo-node-driver/${revision}/${version_id}/coverage/ \
+            --recursive \
+            --acl public-read \
+            --region us-east-1
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/coverage/index.html
+        remote_file: mciuploads/mongo-node-driver/${revision}/${version_id}/coverage/index.html
+        bucket: mciuploads
+        permissions: public-read
+        content_type: text/html
+        display_name: Coverage Report HTML
   run spec driver benchmarks:
     - command: subprocess.exec
       type: test

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -501,13 +501,12 @@ BUILD_VARIANTS.push({
   ]
 });
 
-// TODO NODE-3897 - generate combined coverage report
-// BUILD_VARIANTS.push({
-//   name: 'generate-combined-coverage',
-//   display_name: 'Generate Combined Coverage',
-//   run_on: DEFAULT_OS,
-//   tasks: ['download-and-merge-coverage']
-// });
+BUILD_VARIANTS.push({
+  name: 'generate-combined-coverage',
+  display_name: 'Generate Combined Coverage',
+  run_on: DEFAULT_OS,
+  tasks: ['download-and-merge-coverage']
+});
 
 // singleton build variant for mongosh integration tests
 SINGLETON_TASKS.push({
@@ -619,7 +618,6 @@ for (const version of ['5.0', 'rapid', 'latest']) {
   }
 }
 
-// TODO NODE-3897 - generate combined coverage report
 const coverageTask = {
   name: 'download and merge coverage'.split(' ').join('-'),
   tags: [],
@@ -631,6 +629,7 @@ const coverageTask = {
   depends_on: [{ name: '*', variant: '*', status: '*', patch_optional: true }]
 };
 
+SINGLETON_TASKS.push(coverageTask);
 SINGLETON_TASKS.push(...oneOffFuncAsTasks);
 
 BUILD_VARIANTS.push({

--- a/.evergreen/prepare-shell.sh
+++ b/.evergreen/prepare-shell.sh
@@ -11,7 +11,7 @@ PROJECT_DIRECTORY="$(pwd)"
 DRIVERS_TOOLS=$(cd .. && echo "$(pwd)/drivers-tools")
 MONGO_ORCHESTRATION_HOME="$DRIVERS_TOOLS/.evergreen/orchestration"
 MONGODB_BINARIES="$DRIVERS_TOOLS/mongodb/bin"
-UPLOAD_BUCKET="$PROJECT"
+UPLOAD_BUCKET="${project}"
 
 if [ "Windows_NT" = "${OS:-notWindows}" ]; then
   # fix paths on windows


### PR DESCRIPTION
### Description

Re-enables the combined coverage tasks.

#### What is changing?

Re-enables the tasks and switches to RHEL 8. 

https://mciuploads.s3.amazonaws.com/mongo-node-driver/6fb87e41e6300129503722d6232fcaaf6a556019/6351390d57e85a401615adba/coverage/index.html

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-3897

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
