### PR TITLE
test(NODE-4566): fix csfle pinned commit

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1707,7 +1707,7 @@ tasks:
       - func: bootstrap kms servers
       - func: run custom csfle tests
         vars:
-          CSFLE_GIT_REF: 4e4613a0e725a8ba10f2c6ce8bff666e2f184549
+          CSFLE_GIT_REF: c071d5a8d59ddcad40f22887a12bdb374c2f86af
   - name: run-custom-csfle-tests-5.0-master
     tags:
       - run-custom-dependency-tests
@@ -1737,7 +1737,7 @@ tasks:
       - func: bootstrap kms servers
       - func: run custom csfle tests
         vars:
-          CSFLE_GIT_REF: 4e4613a0e725a8ba10f2c6ce8bff666e2f184549
+          CSFLE_GIT_REF: c071d5a8d59ddcad40f22887a12bdb374c2f86af
   - name: run-custom-csfle-tests-rapid-master
     tags:
       - run-custom-dependency-tests
@@ -1767,7 +1767,7 @@ tasks:
       - func: bootstrap kms servers
       - func: run custom csfle tests
         vars:
-          CSFLE_GIT_REF: 4e4613a0e725a8ba10f2c6ce8bff666e2f184549
+          CSFLE_GIT_REF: c071d5a8d59ddcad40f22887a12bdb374c2f86af
   - name: run-custom-csfle-tests-latest-master
     tags:
       - run-custom-dependency-tests

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -550,7 +550,7 @@ const oneOffFuncAsTasks = oneOffFuncs.map(oneOffFunc => ({
 }));
 
 [ '5.0', 'rapid', 'latest' ].forEach(version => {
-  [ '4e4613a0e725a8ba10f2c6ce8bff666e2f184549', 'master' ].forEach(ref => {
+  [ 'c071d5a8d59ddcad40f22887a12bdb374c2f86af', 'master' ].forEach(ref => {
     oneOffFuncAsTasks.push({
       name: `run-custom-csfle-tests-${version}-${ref === 'master' ? ref : 'pinned-commit'}`,
       tags: ['run-custom-dependency-tests'],


### PR DESCRIPTION
### Description

Fixes the CSFLE pinned commit tests.

#### What is changing?

Updates the pinned commit to latest: c071d5a8d59ddcad40f22887a12bdb374c2f86af

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-4566

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
