### PR TITLE
test(NODE-4479): adjust number of iterations of flakey test

### DIFF
--- a/test/integration/server-selection/server_selection.prose.operation_count.test.ts
+++ b/test/integration/server-selection/server_selection.prose.operation_count.test.ts
@@ -150,7 +150,9 @@ describe('operationCount-based Selection Within Latency Window - Prose Test', fu
     const numberTaskGroups = 10;
     const numberOfTasks = 1000;
     const totalNumberOfTasks = numberTaskGroups * numberOfTasks;
-
+    
+    // This test has proved flakey, not just for Node.  The number of iterations for the test has been increased,
+    // to prevent the test from failing.
     // Step 8: Start 10 concurrent threads / tasks that each run 100 findOne operations with empty filters using that client.
     await Promise.all(
       Array.from({ length: numberTaskGroups }, () => runTaskGroup(collection, numberOfTasks))

--- a/test/integration/server-selection/server_selection.prose.operation_count.test.ts
+++ b/test/integration/server-selection/server_selection.prose.operation_count.test.ts
@@ -150,7 +150,7 @@ describe('operationCount-based Selection Within Latency Window - Prose Test', fu
     const numberTaskGroups = 10;
     const numberOfTasks = 1000;
     const totalNumberOfTasks = numberTaskGroups * numberOfTasks;
-    
+
     // This test has proved flakey, not just for Node.  The number of iterations for the test has been increased,
     // to prevent the test from failing.
     // Step 8: Start 10 concurrent threads / tasks that each run 100 findOne operations with empty filters using that client.

--- a/test/integration/server-selection/server_selection.prose.operation_count.test.ts
+++ b/test/integration/server-selection/server_selection.prose.operation_count.test.ts
@@ -19,7 +19,7 @@ const failPoint = {
 
 const POOL_SIZE = 100;
 
-async function runTaskGroup(collection: Collection, count: 10 | 100 | 500) {
+async function runTaskGroup(collection: Collection, count: 10 | 100 | 1000) {
   for (let i = 0; i < count; ++i) {
     await collection.findOne({});
   }
@@ -148,7 +148,7 @@ describe('operationCount-based Selection Within Latency Window - Prose Test', fu
     const collection = client.db('test-db').collection('collection0');
 
     const numberTaskGroups = 10;
-    const numberOfTasks = 500;
+    const numberOfTasks = 1000;
     const totalNumberOfTasks = numberTaskGroups * numberOfTasks;
 
     // Step 8: Start 10 concurrent threads / tasks that each run 100 findOne operations with empty filters using that client.

--- a/test/integration/server-selection/server_selection.prose.operation_count.test.ts
+++ b/test/integration/server-selection/server_selection.prose.operation_count.test.ts
@@ -19,7 +19,7 @@ const failPoint = {
 
 const POOL_SIZE = 100;
 
-async function runTaskGroup(collection: Collection, count: 10 | 100) {
+async function runTaskGroup(collection: Collection, count: 10 | 100 | 500) {
   for (let i = 0; i < count; ++i) {
     await collection.findOne({});
   }
@@ -147,13 +147,19 @@ describe('operationCount-based Selection Within Latency Window - Prose Test', fu
   it('equally distributes operations with both hosts are fine', TEST_METADATA, async function () {
     const collection = client.db('test-db').collection('collection0');
 
+    const numberTaskGroups = 10;
+    const numberOfTasks = 500;
+    const totalNumberOfTasks = numberTaskGroups * numberOfTasks;
+
     // Step 8: Start 10 concurrent threads / tasks that each run 100 findOne operations with empty filters using that client.
-    await Promise.all(Array.from({ length: 10 }, () => runTaskGroup(collection, 100)));
+    await Promise.all(
+      Array.from({ length: numberTaskGroups }, () => runTaskGroup(collection, numberOfTasks))
+    );
 
     // Step 9: Using command monitoring events, assert that each mongos was selected roughly 50% of the time (within +/- 10%).
     const [host1, host2] = seeds.map(seed => seed.split(':')[1]);
-    const percentageToHost1 = (counts[host1] / 1000) * 100;
-    const percentageToHost2 = (counts[host2] / 1000) * 100;
+    const percentageToHost1 = (counts[host1] / totalNumberOfTasks) * 100;
+    const percentageToHost2 = (counts[host2] / totalNumberOfTasks) * 100;
     expect(percentageToHost1).to.be.greaterThan(40).and.lessThan(60);
     expect(percentageToHost2).to.be.greaterThan(40).and.lessThan(60);
   });


### PR DESCRIPTION
### Description

#### What is changing?

The server selection operation count latency window test often fails because the observed percentage of requests sent to each mongos is outside the threshold.  Experimenting locally does demonstrate that the percentage approaches 50% to each mongos as the total number of operations increases (which makes sense - as the total time the test runs increases, any ephemeral variations will be averaged away). 

This PR bumps the total number of iterations to a number that when run locally leaves the latency window.  This is purely empirical, and it is possible that the number of iterations is not high enough to reliably run in CI but I believe this should resolve the flakiness of the tests.  I discussed these changes with Patrick and other drivers still see these tests flaking as well.  I propose merging this PR and watching for the flakey test, and if a period of time goes by and we don't see any flakiness, we can propose modifying the spec.

##### Is there new documentation needed for these changes?

No.

#### What is the motivation for this change?

Cleaning up our flakey CI.

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
