### PR TITLE
test(NODE-4562): reduce macos coverage

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -880,6 +880,45 @@ tasks:
           AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
+  - name: test-rapid-server
+    tags:
+      - rapid
+      - server
+    commands:
+      - func: install dependencies
+      - func: bootstrap mongo-orchestration
+        vars:
+          VERSION: rapid
+          TOPOLOGY: server
+          AUTH: auth
+      - func: bootstrap kms servers
+      - func: run tests
+  - name: test-rapid-replica_set
+    tags:
+      - rapid
+      - replica_set
+    commands:
+      - func: install dependencies
+      - func: bootstrap mongo-orchestration
+        vars:
+          VERSION: rapid
+          TOPOLOGY: replica_set
+          AUTH: auth
+      - func: bootstrap kms servers
+      - func: run tests
+  - name: test-rapid-sharded_cluster
+    tags:
+      - rapid
+      - sharded_cluster
+    commands:
+      - func: install dependencies
+      - func: bootstrap mongo-orchestration
+        vars:
+          VERSION: rapid
+          TOPOLOGY: sharded_cluster
+          AUTH: auth
+      - func: bootstrap kms servers
+      - func: run tests
   - name: test-6.0-server
     tags:
       - '6.0'
@@ -1825,6 +1864,48 @@ tasks:
           AUTH: noauth
       - func: bootstrap kms servers
       - func: run tests
+  - name: test-rapid-server-noauth
+    tags:
+      - rapid
+      - server
+      - noauth
+    commands:
+      - func: install dependencies
+      - func: bootstrap mongo-orchestration
+        vars:
+          VERSION: rapid
+          TOPOLOGY: server
+          AUTH: noauth
+      - func: bootstrap kms servers
+      - func: run tests
+  - name: test-rapid-replica_set-noauth
+    tags:
+      - rapid
+      - replica_set
+      - noauth
+    commands:
+      - func: install dependencies
+      - func: bootstrap mongo-orchestration
+        vars:
+          VERSION: rapid
+          TOPOLOGY: replica_set
+          AUTH: noauth
+      - func: bootstrap kms servers
+      - func: run tests
+  - name: test-rapid-sharded_cluster-noauth
+    tags:
+      - rapid
+      - sharded_cluster
+      - noauth
+    commands:
+      - func: install dependencies
+      - func: bootstrap mongo-orchestration
+        vars:
+          VERSION: rapid
+          TOPOLOGY: sharded_cluster
+          AUTH: noauth
+      - func: bootstrap kms servers
+      - func: run tests
   - name: test-6.0-server-noauth
     tags:
       - '6.0'
@@ -2125,102 +2206,13 @@ post:
 ignore:
   - '*.md'
 buildvariants:
-  - name: macos-1014-erbium
-    display_name: macOS 10.14 Node Erbium
-    run_on: macos-1014
-    expansions:
-      NODE_LTS_NAME: erbium
-      CLIENT_ENCRYPTION: true
-    tasks: &ref_0
-      - test-latest-server
-      - test-latest-replica_set
-      - test-latest-sharded_cluster
-      - test-6.0-server
-      - test-6.0-replica_set
-      - test-6.0-sharded_cluster
-      - test-5.0-server
-      - test-5.0-replica_set
-      - test-5.0-sharded_cluster
-      - test-4.4-server
-      - test-4.4-replica_set
-      - test-4.4-sharded_cluster
-      - test-4.2-server
-      - test-4.2-replica_set
-      - test-4.2-sharded_cluster
-      - test-4.0-server
-      - test-4.0-replica_set
-      - test-4.0-sharded_cluster
-      - test-3.6-server
-      - test-3.6-replica_set
-      - test-3.6-sharded_cluster
-      - test-latest-server-v1-api
-      - test-atlas-connectivity
-      - test-atlas-data-lake
-      - test-auth-kerberos
-      - test-auth-ldap
-      - test-socks5
-      - test-socks5-tls
-      - test-zstd-compression
-      - test-snappy-compression
-      - test-tls-support-latest
-      - test-tls-support-6.0
-      - test-tls-support-5.0
-      - test-tls-support-4.4
-      - test-tls-support-4.2
-  - name: macos-1014-fermium
-    display_name: macOS 10.14 Node Fermium
-    run_on: macos-1014
-    expansions:
-      NODE_LTS_NAME: fermium
-      CLIENT_ENCRYPTION: true
-    tasks: *ref_0
-  - name: macos-1014-gallium
-    display_name: macOS 10.14 Node Gallium
-    run_on: macos-1014
-    expansions:
-      NODE_LTS_NAME: gallium
-      CLIENT_ENCRYPTION: true
-    tasks:
-      - test-latest-server
-      - test-latest-replica_set
-      - test-latest-sharded_cluster
-      - test-6.0-server
-      - test-6.0-replica_set
-      - test-6.0-sharded_cluster
-      - test-5.0-server
-      - test-5.0-replica_set
-      - test-5.0-sharded_cluster
-      - test-4.4-server
-      - test-4.4-replica_set
-      - test-4.4-sharded_cluster
-      - test-4.2-server
-      - test-4.2-replica_set
-      - test-4.2-sharded_cluster
-      - test-4.0-server
-      - test-4.0-replica_set
-      - test-4.0-sharded_cluster
-      - test-3.6-server
-      - test-3.6-replica_set
-      - test-3.6-sharded_cluster
-      - test-latest-server-v1-api
-      - test-atlas-connectivity
-      - test-atlas-data-lake
-      - test-auth-kerberos
-      - test-auth-ldap
-      - test-socks5
-      - test-socks5-tls
-      - test-tls-support-latest
-      - test-tls-support-6.0
-      - test-tls-support-5.0
-      - test-tls-support-4.4
-      - test-tls-support-4.2
   - name: ubuntu-18.04-erbium
     display_name: Ubuntu 18.04 Node Erbium
     run_on: ubuntu1804-large
     expansions:
       NODE_LTS_NAME: erbium
       CLIENT_ENCRYPTION: true
-    tasks: &ref_1
+    tasks: &ref_0
       - test-latest-server
       - test-latest-replica_set
       - test-latest-sharded_cluster
@@ -2265,7 +2257,7 @@ buildvariants:
     expansions:
       NODE_LTS_NAME: fermium
       CLIENT_ENCRYPTION: true
-    tasks: *ref_1
+    tasks: *ref_0
   - name: ubuntu-18.04-gallium
     display_name: Ubuntu 18.04 Node Gallium
     run_on: ubuntu1804-large
@@ -2315,7 +2307,7 @@ buildvariants:
     expansions:
       NODE_LTS_NAME: erbium
       MSVS_VERSION: 2019
-    tasks: &ref_2
+    tasks: &ref_1
       - test-latest-server
       - test-latest-replica_set
       - test-latest-sharded_cluster
@@ -2354,7 +2346,7 @@ buildvariants:
     expansions:
       NODE_LTS_NAME: fermium
       MSVS_VERSION: 2019
-    tasks: *ref_2
+    tasks: *ref_1
   - name: windows-64-vs2019-gallium
     display_name: Windows (VS2019) Node Gallium
     run_on: windows-64-vs2019-large
@@ -2392,6 +2384,14 @@ buildvariants:
       - test-tls-support-5.0
       - test-tls-support-4.4
       - test-tls-support-4.2
+  - name: macos-1100
+    display_name: MacOS 11 Node Gallium
+    run_on: macos-1100
+    expansions:
+      NODE_LTS_NAME: gallium
+      CLIENT_ENCRYPTION: true
+    tasks:
+      - test-rapid-server
   - name: lint
     display_name: lint
     run_on: ubuntu1804-large
@@ -2465,6 +2465,9 @@ buildvariants:
       - test-latest-server-noauth
       - test-latest-replica_set-noauth
       - test-latest-sharded_cluster-noauth
+      - test-rapid-server-noauth
+      - test-rapid-replica_set-noauth
+      - test-rapid-sharded_cluster-noauth
       - test-6.0-server-noauth
       - test-6.0-replica_set-noauth
       - test-6.0-sharded_cluster-noauth

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2391,7 +2391,7 @@ buildvariants:
       NODE_LTS_NAME: gallium
       CLIENT_ENCRYPTION: true
     tasks:
-      - test-rapid-server
+      - test-rapid-replica_set
   - name: lint
     display_name: lint
     run_on: ubuntu1804-large

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2391,7 +2391,7 @@ buildvariants:
       NODE_LTS_NAME: gallium
       CLIENT_ENCRYPTION: true
     tasks:
-      - test-rapid-replica_set
+      - test-rapid-server
   - name: lint
     display_name: lint
     run_on: ubuntu1804-large

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -379,7 +379,7 @@ BUILD_VARIANTS.push({
     NODE_LTS_NAME: LATEST_LTS,
     CLIENT_ENCRYPTION: true
   },
-  tasks: ['test-rapid-replica_set']
+  tasks: ['test-rapid-server']
 });
 
 // singleton build variant for linting

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -3,10 +3,11 @@ const fs = require('fs');
 const yaml = require('js-yaml');
 
 const LATEST_EFFECTIVE_VERSION = '6.0';
-const MONGODB_VERSIONS = ['latest', '6.0', '5.0', '4.4', '4.2', '4.0', '3.6'];
+const MONGODB_VERSIONS = ['latest', 'rapid', '6.0', '5.0', '4.4', '4.2', '4.0', '3.6'];
 const NODE_VERSIONS = ['erbium', 'fermium', 'gallium'];
 NODE_VERSIONS.sort();
 const LOWEST_LTS = NODE_VERSIONS[0];
+const LATEST_LTS = NODE_VERSIONS[NODE_VERSIONS.length - 1];
 
 const TOPOLOGIES = ['server', 'replica_set', 'sharded_cluster'];
 const AWS_AUTH_VERSIONS = ['latest', '6.0', '5.0', '4.4'];
@@ -15,11 +16,6 @@ const TLS_VERSIONS = ['latest', '6.0', '5.0', '4.4', '4.2'];
 const DEFAULT_OS = 'ubuntu1804-large';
 
 const OPERATING_SYSTEMS = [
-  {
-    name: 'macos-1014',
-    display_name: 'macOS 10.14',
-    run_on: 'macos-1014'
-  },
   {
     name: 'ubuntu-18.04',
     display_name: 'Ubuntu 18.04',
@@ -361,7 +357,7 @@ OPERATING_SYSTEMS.forEach(
     const tasks = getTaskList(mongoVersion, osName.split('-')[0]);
 
     testedNodeVersions.forEach(NODE_LTS_NAME => {
-      const nodeLtsDisplayName = `Node ${NODE_LTS_NAME[0].toUpperCase()}${NODE_LTS_NAME.substr(1)}`;
+      const nodeLtsDisplayName = `Node ${NODE_LTS_NAME[0].toUpperCase()}${NODE_LTS_NAME.slice(1)}`;
       const name = `${osName}-${NODE_LTS_NAME}`;
       const display_name = `${osDisplayName} ${nodeLtsDisplayName}`;
       const expansions = { NODE_LTS_NAME };
@@ -377,6 +373,17 @@ OPERATING_SYSTEMS.forEach(
     });
   }
 );
+
+BUILD_VARIANTS.push({
+  name: 'macos-1100',
+  display_name: `MacOS 11 Node ${LATEST_LTS[0].toUpperCase()}${LATEST_LTS.slice(1)}`,
+  run_on: 'macos-1100',
+  expansions: {
+    NODE_LTS_NAME: LATEST_LTS,
+    CLIENT_ENCRYPTION: true
+  },
+  tasks: ['test-rapid-server']
+});
 
 // singleton build variant for linting
 SINGLETON_TASKS.push(

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -38,7 +38,6 @@ const OPERATING_SYSTEMS = [
 
 // TODO: NODE-3060: enable skipped tests on windows
 const WINDOWS_SKIP_TAGS = new Set(['atlas-connect', 'auth', 'load_balancer']);
-const MACOS_SKIP_TAGS = new Set(['load_balancer']);
 
 const TASKS = [];
 const SINGLETON_TASKS = [];
@@ -315,11 +314,9 @@ const getTaskList = (() => {
       .filter(task => {
         if (task.name.match(/^aws/)) return false;
 
-        // skip unsupported tasks on windows or macos
         if (
           task.tags &&
-          ((os.match(/^windows/) && task.tags.filter(tag => WINDOWS_SKIP_TAGS.has(tag)).length) ||
-            (os.match(/^macos/) && task.tags.filter(tag => MACOS_SKIP_TAGS.has(tag)).length))
+          (os.match(/^windows/) && task.tags.filter(tag => WINDOWS_SKIP_TAGS.has(tag)).length)
         ) {
           return false;
         }
@@ -382,7 +379,7 @@ BUILD_VARIANTS.push({
     NODE_LTS_NAME: LATEST_LTS,
     CLIENT_ENCRYPTION: true
   },
-  tasks: ['test-rapid-server']
+  tasks: ['test-rapid-replica_set']
 });
 
 // singleton build variant for linting


### PR DESCRIPTION
### Description

#### What is changing?

This PR updates our CI matrix to only test the rapid release on a standalone server on macos.

##### Is there new documentation needed for these changes?

No.

#### What is the motivation for this change?

Green CI.

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
