### PR TITLE
fix(NODE-4583): revert nested union type support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -324,6 +324,7 @@ export type {
   KeysOfOtherType,
   MatchKeysAndValues,
   NestedPaths,
+  NestedPathsOfType,
   NonObjectIdLikeDocument,
   NotAcceptedFields,
   NumericType,

--- a/test/types/community/collection/filterQuery.test-d.ts
+++ b/test/types/community/collection/filterQuery.test-d.ts
@@ -12,7 +12,7 @@ import {
 } from 'bson';
 import { expectAssignable, expectError, expectNotType, expectType } from 'tsd';
 
-import { Collection, Filter, MongoClient, UpdateFilter, WithId } from '../../../../src';
+import { Collection, Filter, MongoClient, WithId } from '../../../../src';
 
 /**
  * test the Filter type using collection.find<T>() method
@@ -405,37 +405,4 @@ nonSpecifiedCollection.find({
   otherField: {
     hello: 'world'
   }
-});
-
-// NODE-4513: improves support for union types and array operators
-type MyArraySchema = {
-  nested: { array: { a: number; b: boolean }[] };
-  something: { a: number } | { b: boolean };
-};
-
-// "element" now refers to the name used in arrayFilters, it can be any string
-expectAssignable<UpdateFilter<MyArraySchema>>({
-  $set: { 'nested.array.$[element]': { a: 2, b: false } }
-});
-expectAssignable<Filter<MyArraySchema>>({
-  $set: { 'nested.array.$[element]': { a: 2, b: false } }
-});
-
-// Specifying an identifier in the brackets is optional
-expectAssignable<UpdateFilter<MyArraySchema>>({
-  $set: { 'nested.array.$[].a': 2 }
-});
-expectAssignable<Filter<MyArraySchema>>({
-  $set: { 'nested.array.$[].a': 2 }
-});
-
-// Union usage examples
-expectAssignable<Filter<MyArraySchema>>({
-  'something.a': 2
-});
-expectError<Filter<MyArraySchema>>({
-  'something.a': false
-});
-expectAssignable<Filter<MyArraySchema>>({
-  'something.b': false
 });

--- a/test/types/community/collection/filterQuery.test-d.ts
+++ b/test/types/community/collection/filterQuery.test-d.ts
@@ -12,7 +12,7 @@ import {
 } from 'bson';
 import { expectAssignable, expectError, expectNotType, expectType } from 'tsd';
 
-import { Collection, Filter, MongoClient, WithId } from '../../../../src';
+import { Collection, Filter, MongoClient, UpdateFilter, WithId } from '../../../../src';
 
 /**
  * test the Filter type using collection.find<T>() method
@@ -405,4 +405,37 @@ nonSpecifiedCollection.find({
   otherField: {
     hello: 'world'
   }
+});
+
+type MyArraySchema = {
+  nested: { array: { a: number; b: boolean }[] };
+  something: { a: number } | { b: boolean };
+};
+
+// "element" now refers to the name used in arrayFilters, it can be any string
+expectAssignable<UpdateFilter<MyArraySchema>>({
+  $set: { 'nested.array.$[element]': { a: 2, b: false } }
+});
+expectAssignable<Filter<MyArraySchema>>({
+  $set: { 'nested.array.$[element]': { a: 2, b: false } }
+});
+
+// Specifying an identifier in the brackets is optional
+expectAssignable<UpdateFilter<MyArraySchema>>({
+  $set: { 'nested.array.$[].a': 2 }
+});
+expectAssignable<Filter<MyArraySchema>>({
+  $set: { 'nested.array.$[].a': 2 }
+});
+
+// Union usage examples
+expectAssignable<Filter<MyArraySchema>>({
+  'something.a': 2
+});
+//  TODO: NODE-4513: Nested union types don't error in this case.
+// expectError<Filter<MyArraySchema>>({
+//   'something.a': false
+// });
+expectAssignable<Filter<MyArraySchema>>({
+  'something.b': false
 });


### PR DESCRIPTION
### Description

Reverts the strict nested union types support.

#### What is changing?

Reverts https://github.com/mongodb/node-mongodb-native/pull/3349 and comments out the added test with link to original ticket.

Reopens NODE-4513

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-4583 / NODE-4571

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
