### PR TITLE
fix(NODE-4591): only set loadBalanced on handshake when explicitly set

### DIFF
--- a/src/cmap/connect.ts
+++ b/src/cmap/connect.ts
@@ -214,7 +214,7 @@ export interface HandshakeDocument extends Document {
   client: ClientMetadata;
   compression: string[];
   saslSupportedMechs?: string;
-  loadBalanced: boolean;
+  loadBalanced?: boolean;
 }
 
 function prepareHandshakeDocument(authContext: AuthContext, callback: Callback<HandshakeDocument>) {
@@ -226,9 +226,12 @@ function prepareHandshakeDocument(authContext: AuthContext, callback: Callback<H
     [serverApi?.version ? 'hello' : LEGACY_HELLO_COMMAND]: true,
     helloOk: true,
     client: options.metadata || makeClientMetadata(options),
-    compression: compressors,
-    loadBalanced: options.loadBalanced
+    compression: compressors
   };
+
+  if (typeof options.loadBalanced === 'boolean' && Boolean(options.loadBalanced) === true) {
+    handshakeDoc.loadBalanced = true;
+  }
 
   const credentials = authContext.credentials;
   if (credentials) {

--- a/src/cmap/connect.ts
+++ b/src/cmap/connect.ts
@@ -217,7 +217,15 @@ export interface HandshakeDocument extends Document {
   loadBalanced?: boolean;
 }
 
-function prepareHandshakeDocument(authContext: AuthContext, callback: Callback<HandshakeDocument>) {
+/**
+ * @internal
+ *
+ * This function is only exposed for testing purposes.
+ */
+export function prepareHandshakeDocument(
+  authContext: AuthContext,
+  callback: Callback<HandshakeDocument>
+) {
   const options = authContext.options;
   const compressors = options.compressors ? options.compressors : [];
   const { serverApi } = authContext.connection;
@@ -229,7 +237,7 @@ function prepareHandshakeDocument(authContext: AuthContext, callback: Callback<H
     compression: compressors
   };
 
-  if (typeof options.loadBalanced === 'boolean' && Boolean(options.loadBalanced) === true) {
+  if (options.loadBalanced === true) {
     handshakeDoc.loadBalanced = true;
   }
 


### PR DESCRIPTION
### Description

#### What is changing?

We only set `loadBalanced` on the initial hello when it is explicitly provided and set to true.

##### Is there new documentation needed for these changes?

No.

#### What is the motivation for this change?

Spec compliance.

Note that the load balancer tests still fail.  https://jira.mongodb.org/browse/SERVER-69146 has been filed to potentially revert the server changes so that `apiStrict: true` can be used with load balanced mode.  If it turns out the server change is intended behavior, then there will probably be a drivers ticket to skip these tests on load balanced topologies.

### Double check the following

- [x] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
