### PR TITLE
feat(NODE-4547): mark all callback APIs as deprecated

### DIFF
--- a/src/admin.ts
+++ b/src/admin.ts
@@ -29,26 +29,15 @@ export interface AdminPrivate {
  * @public
  *
  * @example
- * ```js
- * const MongoClient = require('mongodb').MongoClient;
- * const test = require('assert');
- * // Connection url
- * const url = 'mongodb://localhost:27017';
- * // Database Name
- * const dbName = 'test';
+ * ```ts
+ * import { MongoClient } from 'mongodb';
  *
- * // Connect using MongoClient
- * MongoClient.connect(url, function(err, client) {
- *   // Use the admin database for the operation
- *   const adminDb = client.db(dbName).admin();
- *
- *   // List all the available databases
- *   adminDb.listDatabases(function(err, dbs) {
- *     expect(err).to.not.exist;
- *     test.ok(dbs.databases.length > 0);
- *     client.close();
- *   });
- * });
+ * const client = new MongoClient('mongodb://localhost:27017');
+ * const admin = client.db().admin();
+ * const dbInfo = await admin.listDatabases();
+ * for (const db of dbInfo.databases) {
+ *   console.dir(db.name);
+ * }
  * ```
  */
 export class Admin {

--- a/src/admin.ts
+++ b/src/admin.ts
@@ -224,8 +224,10 @@ export class Admin {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   removeUser(username: string): Promise<boolean>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   removeUser(username: string, callback: Callback<boolean>): void;
   removeUser(username: string, options: RemoveUserOptions): Promise<boolean>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   removeUser(username: string, options: RemoveUserOptions, callback: Callback<boolean>): void;
   removeUser(
     username: string,

--- a/src/admin.ts
+++ b/src/admin.ts
@@ -36,7 +36,7 @@ export interface AdminPrivate {
  * const admin = client.db().admin();
  * const dbInfo = await admin.listDatabases();
  * for (const db of dbInfo.databases) {
- *   console.dir(db.name);
+ *   console.log(db.name);
  * }
  * ```
  */

--- a/src/admin.ts
+++ b/src/admin.ts
@@ -71,8 +71,10 @@ export class Admin {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   command(command: Document): Promise<Document>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   command(command: Document, callback: Callback<Document>): void;
   command(command: Document, options: RunCommandOptions): Promise<Document>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   command(command: Document, options: RunCommandOptions, callback: Callback<Document>): void;
   command(
     command: Document,
@@ -96,8 +98,10 @@ export class Admin {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   buildInfo(): Promise<Document>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   buildInfo(callback: Callback<Document>): void;
   buildInfo(options: CommandOperationOptions): Promise<Document>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   buildInfo(options: CommandOperationOptions, callback: Callback<Document>): void;
   buildInfo(
     options?: CommandOperationOptions | Callback<Document>,
@@ -115,8 +119,10 @@ export class Admin {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   serverInfo(): Promise<Document>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   serverInfo(callback: Callback<Document>): void;
   serverInfo(options: CommandOperationOptions): Promise<Document>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   serverInfo(options: CommandOperationOptions, callback: Callback<Document>): void;
   serverInfo(
     options?: CommandOperationOptions | Callback<Document>,
@@ -134,8 +140,10 @@ export class Admin {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   serverStatus(): Promise<Document>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   serverStatus(callback: Callback<Document>): void;
   serverStatus(options: CommandOperationOptions): Promise<Document>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   serverStatus(options: CommandOperationOptions, callback: Callback<Document>): void;
   serverStatus(
     options?: CommandOperationOptions | Callback<Document>,
@@ -153,8 +161,10 @@ export class Admin {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   ping(): Promise<Document>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   ping(callback: Callback<Document>): void;
   ping(options: CommandOperationOptions): Promise<Document>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   ping(options: CommandOperationOptions, callback: Callback<Document>): void;
   ping(
     options?: CommandOperationOptions | Callback<Document>,
@@ -174,12 +184,16 @@ export class Admin {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   addUser(username: string): Promise<Document>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   addUser(username: string, callback: Callback<Document>): void;
   addUser(username: string, password: string): Promise<Document>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   addUser(username: string, password: string, callback: Callback<Document>): void;
   addUser(username: string, options: AddUserOptions): Promise<Document>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   addUser(username: string, options: AddUserOptions, callback: Callback<Document>): void;
   addUser(username: string, password: string, options: AddUserOptions): Promise<Document>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   addUser(
     username: string,
     password: string,
@@ -247,8 +261,10 @@ export class Admin {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   validateCollection(collectionName: string): Promise<Document>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   validateCollection(collectionName: string, callback: Callback<Document>): void;
   validateCollection(collectionName: string, options: ValidateCollectionOptions): Promise<Document>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   validateCollection(
     collectionName: string,
     options: ValidateCollectionOptions,
@@ -276,8 +292,10 @@ export class Admin {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   listDatabases(): Promise<ListDatabasesResult>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   listDatabases(callback: Callback<ListDatabasesResult>): void;
   listDatabases(options: ListDatabasesOptions): Promise<ListDatabasesResult>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   listDatabases(options: ListDatabasesOptions, callback: Callback<ListDatabasesResult>): void;
   listDatabases(
     options?: ListDatabasesOptions | Callback<ListDatabasesResult>,
@@ -300,8 +318,10 @@ export class Admin {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   replSetGetStatus(): Promise<Document>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   replSetGetStatus(callback: Callback<Document>): void;
   replSetGetStatus(options: CommandOperationOptions): Promise<Document>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   replSetGetStatus(options: CommandOperationOptions, callback: Callback<Document>): void;
   replSetGetStatus(
     options?: CommandOperationOptions | Callback<Document>,

--- a/src/admin.ts
+++ b/src/admin.ts
@@ -60,10 +60,10 @@ export class Admin {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   command(command: Document): Promise<Document>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   command(command: Document, callback: Callback<Document>): void;
   command(command: Document, options: RunCommandOptions): Promise<Document>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   command(command: Document, options: RunCommandOptions, callback: Callback<Document>): void;
   command(
     command: Document,
@@ -87,10 +87,10 @@ export class Admin {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   buildInfo(): Promise<Document>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   buildInfo(callback: Callback<Document>): void;
   buildInfo(options: CommandOperationOptions): Promise<Document>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   buildInfo(options: CommandOperationOptions, callback: Callback<Document>): void;
   buildInfo(
     options?: CommandOperationOptions | Callback<Document>,
@@ -108,10 +108,10 @@ export class Admin {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   serverInfo(): Promise<Document>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   serverInfo(callback: Callback<Document>): void;
   serverInfo(options: CommandOperationOptions): Promise<Document>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   serverInfo(options: CommandOperationOptions, callback: Callback<Document>): void;
   serverInfo(
     options?: CommandOperationOptions | Callback<Document>,
@@ -129,10 +129,10 @@ export class Admin {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   serverStatus(): Promise<Document>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   serverStatus(callback: Callback<Document>): void;
   serverStatus(options: CommandOperationOptions): Promise<Document>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   serverStatus(options: CommandOperationOptions, callback: Callback<Document>): void;
   serverStatus(
     options?: CommandOperationOptions | Callback<Document>,
@@ -150,10 +150,10 @@ export class Admin {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   ping(): Promise<Document>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   ping(callback: Callback<Document>): void;
   ping(options: CommandOperationOptions): Promise<Document>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   ping(options: CommandOperationOptions, callback: Callback<Document>): void;
   ping(
     options?: CommandOperationOptions | Callback<Document>,
@@ -173,16 +173,16 @@ export class Admin {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   addUser(username: string): Promise<Document>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   addUser(username: string, callback: Callback<Document>): void;
   addUser(username: string, password: string): Promise<Document>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   addUser(username: string, password: string, callback: Callback<Document>): void;
   addUser(username: string, options: AddUserOptions): Promise<Document>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   addUser(username: string, options: AddUserOptions, callback: Callback<Document>): void;
   addUser(username: string, password: string, options: AddUserOptions): Promise<Document>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   addUser(
     username: string,
     password: string,
@@ -224,10 +224,10 @@ export class Admin {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   removeUser(username: string): Promise<boolean>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   removeUser(username: string, callback: Callback<boolean>): void;
   removeUser(username: string, options: RemoveUserOptions): Promise<boolean>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   removeUser(username: string, options: RemoveUserOptions, callback: Callback<boolean>): void;
   removeUser(
     username: string,
@@ -252,10 +252,10 @@ export class Admin {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   validateCollection(collectionName: string): Promise<Document>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   validateCollection(collectionName: string, callback: Callback<Document>): void;
   validateCollection(collectionName: string, options: ValidateCollectionOptions): Promise<Document>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   validateCollection(
     collectionName: string,
     options: ValidateCollectionOptions,
@@ -283,10 +283,10 @@ export class Admin {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   listDatabases(): Promise<ListDatabasesResult>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   listDatabases(callback: Callback<ListDatabasesResult>): void;
   listDatabases(options: ListDatabasesOptions): Promise<ListDatabasesResult>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   listDatabases(options: ListDatabasesOptions, callback: Callback<ListDatabasesResult>): void;
   listDatabases(
     options?: ListDatabasesOptions | Callback<ListDatabasesResult>,
@@ -309,10 +309,10 @@ export class Admin {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   replSetGetStatus(): Promise<Document>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   replSetGetStatus(callback: Callback<Document>): void;
   replSetGetStatus(options: CommandOperationOptions): Promise<Document>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   replSetGetStatus(options: CommandOperationOptions, callback: Callback<Document>): void;
   replSetGetStatus(
     options?: CommandOperationOptions | Callback<Document>,

--- a/src/bulk/common.ts
+++ b/src/bulk/common.ts
@@ -1247,11 +1247,11 @@ export abstract class BulkOperationBase {
   }
 
   execute(options?: BulkWriteOptions): Promise<BulkWriteResult>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   execute(callback: Callback<BulkWriteResult>): void;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   execute(options: BulkWriteOptions | undefined, callback: Callback<BulkWriteResult>): void;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   execute(
     options?: BulkWriteOptions | Callback<BulkWriteResult>,
     callback?: Callback<BulkWriteResult>

--- a/src/bulk/common.ts
+++ b/src/bulk/common.ts
@@ -1251,6 +1251,7 @@ export abstract class BulkOperationBase {
   execute(callback: Callback<BulkWriteResult>): void;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   execute(options: BulkWriteOptions | undefined, callback: Callback<BulkWriteResult>): void;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   execute(
     options?: BulkWriteOptions | Callback<BulkWriteResult>,
     callback?: Callback<BulkWriteResult>

--- a/src/bulk/common.ts
+++ b/src/bulk/common.ts
@@ -1247,7 +1247,9 @@ export abstract class BulkOperationBase {
   }
 
   execute(options?: BulkWriteOptions): Promise<BulkWriteResult>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   execute(callback: Callback<BulkWriteResult>): void;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   execute(options: BulkWriteOptions | undefined, callback: Callback<BulkWriteResult>): void;
   execute(
     options?: BulkWriteOptions | Callback<BulkWriteResult>,

--- a/src/bulk/common.ts
+++ b/src/bulk/common.ts
@@ -1065,7 +1065,7 @@ export abstract class BulkOperationBase {
    * Add a single insert document to the bulk operation
    *
    * @example
-   * ```js
+   * ```ts
    * const bulkOp = collection.initializeOrderedBulkOp();
    *
    * // Adds three inserts to the bulkOp.
@@ -1089,7 +1089,7 @@ export abstract class BulkOperationBase {
    * Returns a builder object used to complete the definition of the operation.
    *
    * @example
-   * ```js
+   * ```ts
    * const bulkOp = collection.initializeOrderedBulkOp();
    *
    * // Add an updateOne to the bulkOp

--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -645,7 +645,7 @@ export class ChangeStream<
 
   /** Check if there is any document still available in the Change Stream */
   hasNext(): Promise<boolean>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   hasNext(callback: Callback<boolean>): void;
   hasNext(callback?: Callback): Promise<boolean> | void {
     this._setIsIterator();
@@ -676,7 +676,7 @@ export class ChangeStream<
 
   /** Get the next available document from the Change Stream. */
   next(): Promise<TChange>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   next(callback: Callback<TChange>): void;
   next(callback?: Callback<TChange>): Promise<TChange> | void {
     this._setIsIterator();
@@ -711,7 +711,7 @@ export class ChangeStream<
    * Try to get the next available document from the Change Stream's cursor or `null` if an empty batch is returned
    */
   tryNext(): Promise<Document | null>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   tryNext(callback: Callback<Document | null>): void;
   tryNext(callback?: Callback<Document | null>): Promise<Document | null> | void {
     this._setIsIterator();
@@ -747,7 +747,7 @@ export class ChangeStream<
 
   /** Close the Change Stream */
   close(): Promise<void>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   close(callback: Callback): void;
   close(callback?: Callback): Promise<void> | void {
     this[kClosed] = true;

--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -645,6 +645,7 @@ export class ChangeStream<
 
   /** Check if there is any document still available in the Change Stream */
   hasNext(): Promise<boolean>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   hasNext(callback: Callback<boolean>): void;
   hasNext(callback?: Callback): Promise<boolean> | void {
     this._setIsIterator();
@@ -675,6 +676,7 @@ export class ChangeStream<
 
   /** Get the next available document from the Change Stream. */
   next(): Promise<TChange>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   next(callback: Callback<TChange>): void;
   next(callback?: Callback<TChange>): Promise<TChange> | void {
     this._setIsIterator();
@@ -709,6 +711,7 @@ export class ChangeStream<
    * Try to get the next available document from the Change Stream's cursor or `null` if an empty batch is returned
    */
   tryNext(): Promise<Document | null>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   tryNext(callback: Callback<Document | null>): void;
   tryNext(callback?: Callback<Document | null>): Promise<Document | null> | void {
     this._setIsIterator();

--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -747,6 +747,7 @@ export class ChangeStream<
 
   /** Close the Change Stream */
   close(): Promise<void>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   close(callback: Callback): void;
   close(callback?: Callback): Promise<void> | void {
     this[kClosed] = true;

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -155,7 +155,7 @@ export interface CollectionPrivate {
  *
  * const petCursor = pets.find();
  *
- * for (const pet of petCursor) {
+ * for await (const pet of petCursor) {
  *   console.log(`${pet.name} is a ${pet.kind}!`);
  * }
  * ```

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -265,6 +265,7 @@ export class Collection<TSchema extends Document = Document> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   insertOne(doc: OptionalUnlessRequiredId<TSchema>): Promise<InsertOneResult<TSchema>>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   insertOne(
     doc: OptionalUnlessRequiredId<TSchema>,
     callback: Callback<InsertOneResult<TSchema>>
@@ -273,6 +274,7 @@ export class Collection<TSchema extends Document = Document> {
     doc: OptionalUnlessRequiredId<TSchema>,
     options: InsertOneOptions
   ): Promise<InsertOneResult<TSchema>>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   insertOne(
     doc: OptionalUnlessRequiredId<TSchema>,
     options: InsertOneOptions,
@@ -315,6 +317,7 @@ export class Collection<TSchema extends Document = Document> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   insertMany(docs: OptionalUnlessRequiredId<TSchema>[]): Promise<InsertManyResult<TSchema>>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   insertMany(
     docs: OptionalUnlessRequiredId<TSchema>[],
     callback: Callback<InsertManyResult<TSchema>>
@@ -323,6 +326,7 @@ export class Collection<TSchema extends Document = Document> {
     docs: OptionalUnlessRequiredId<TSchema>[],
     options: BulkWriteOptions
   ): Promise<InsertManyResult<TSchema>>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   insertMany(
     docs: OptionalUnlessRequiredId<TSchema>[],
     options: BulkWriteOptions,
@@ -379,6 +383,7 @@ export class Collection<TSchema extends Document = Document> {
    * @throws MongoDriverError if operations is not an array
    */
   bulkWrite(operations: AnyBulkWriteOperation<TSchema>[]): Promise<BulkWriteResult>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   bulkWrite(
     operations: AnyBulkWriteOperation<TSchema>[],
     callback: Callback<BulkWriteResult>
@@ -387,6 +392,7 @@ export class Collection<TSchema extends Document = Document> {
     operations: AnyBulkWriteOperation<TSchema>[],
     options: BulkWriteOptions
   ): Promise<BulkWriteResult>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   bulkWrite(
     operations: AnyBulkWriteOperation<TSchema>[],
     options: BulkWriteOptions,
@@ -427,6 +433,7 @@ export class Collection<TSchema extends Document = Document> {
     filter: Filter<TSchema>,
     update: UpdateFilter<TSchema> | Partial<TSchema>
   ): Promise<UpdateResult>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   updateOne(
     filter: Filter<TSchema>,
     update: UpdateFilter<TSchema> | Partial<TSchema>,
@@ -437,6 +444,7 @@ export class Collection<TSchema extends Document = Document> {
     update: UpdateFilter<TSchema> | Partial<TSchema>,
     options: UpdateOptions
   ): Promise<UpdateResult>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   updateOne(
     filter: Filter<TSchema>,
     update: UpdateFilter<TSchema> | Partial<TSchema>,
@@ -475,6 +483,7 @@ export class Collection<TSchema extends Document = Document> {
     filter: Filter<TSchema>,
     replacement: WithoutId<TSchema>
   ): Promise<UpdateResult | Document>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   replaceOne(
     filter: Filter<TSchema>,
     replacement: WithoutId<TSchema>,
@@ -485,6 +494,7 @@ export class Collection<TSchema extends Document = Document> {
     replacement: WithoutId<TSchema>,
     options: ReplaceOptions
   ): Promise<UpdateResult | Document>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   replaceOne(
     filter: Filter<TSchema>,
     replacement: WithoutId<TSchema>,
@@ -523,6 +533,7 @@ export class Collection<TSchema extends Document = Document> {
     filter: Filter<TSchema>,
     update: UpdateFilter<TSchema>
   ): Promise<UpdateResult | Document>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   updateMany(
     filter: Filter<TSchema>,
     update: UpdateFilter<TSchema>,
@@ -533,6 +544,7 @@ export class Collection<TSchema extends Document = Document> {
     update: UpdateFilter<TSchema>,
     options: UpdateOptions
   ): Promise<UpdateResult | Document>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   updateMany(
     filter: Filter<TSchema>,
     update: UpdateFilter<TSchema>,
@@ -567,8 +579,10 @@ export class Collection<TSchema extends Document = Document> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   deleteOne(filter: Filter<TSchema>): Promise<DeleteResult>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   deleteOne(filter: Filter<TSchema>, callback: Callback<DeleteResult>): void;
   deleteOne(filter: Filter<TSchema>, options: DeleteOptions): Promise<DeleteResult>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   deleteOne(
     filter: Filter<TSchema>,
     options: DeleteOptions,
@@ -596,8 +610,10 @@ export class Collection<TSchema extends Document = Document> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   deleteMany(filter: Filter<TSchema>): Promise<DeleteResult>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   deleteMany(filter: Filter<TSchema>, callback: Callback<DeleteResult>): void;
   deleteMany(filter: Filter<TSchema>, options: DeleteOptions): Promise<DeleteResult>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   deleteMany(
     filter: Filter<TSchema>,
     options: DeleteOptions,
@@ -639,8 +655,10 @@ export class Collection<TSchema extends Document = Document> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   rename(newName: string): Promise<Collection>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   rename(newName: string, callback: Callback<Collection>): void;
   rename(newName: string, options: RenameOptions): Promise<Collection>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   rename(newName: string, options: RenameOptions, callback: Callback<Collection>): void;
   rename(
     newName: string,
@@ -667,8 +685,10 @@ export class Collection<TSchema extends Document = Document> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   drop(): Promise<boolean>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   drop(callback: Callback<boolean>): void;
   drop(options: DropCollectionOptions): Promise<boolean>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   drop(options: DropCollectionOptions, callback: Callback<boolean>): void;
   drop(
     options?: DropCollectionOptions | Callback<boolean>,
@@ -692,10 +712,13 @@ export class Collection<TSchema extends Document = Document> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   findOne(): Promise<WithId<TSchema> | null>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   findOne(callback: Callback<WithId<TSchema> | null>): void;
   findOne(filter: Filter<TSchema>): Promise<WithId<TSchema> | null>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   findOne(filter: Filter<TSchema>, callback: Callback<WithId<TSchema> | null>): void;
   findOne(filter: Filter<TSchema>, options: FindOptions): Promise<WithId<TSchema> | null>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   findOne(
     filter: Filter<TSchema>,
     options: FindOptions,
@@ -704,9 +727,11 @@ export class Collection<TSchema extends Document = Document> {
 
   // allow an override of the schema.
   findOne<T = TSchema>(): Promise<T | null>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   findOne<T = TSchema>(callback: Callback<T | null>): void;
   findOne<T = TSchema>(filter: Filter<TSchema>): Promise<T | null>;
   findOne<T = TSchema>(filter: Filter<TSchema>, options?: FindOptions): Promise<T | null>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   findOne<T = TSchema>(
     filter: Filter<TSchema>,
     options?: FindOptions,
@@ -772,8 +797,10 @@ export class Collection<TSchema extends Document = Document> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   options(): Promise<Document>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   options(callback: Callback<Document>): void;
   options(options: OperationOptions): Promise<Document>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   options(options: OperationOptions, callback: Callback<Document>): void;
   options(
     options?: OperationOptions | Callback<Document>,
@@ -795,8 +822,10 @@ export class Collection<TSchema extends Document = Document> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   isCapped(): Promise<boolean>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   isCapped(callback: Callback<boolean>): void;
   isCapped(options: OperationOptions): Promise<boolean>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   isCapped(options: OperationOptions, callback: Callback<boolean>): void;
   isCapped(
     options?: OperationOptions | Callback<boolean>,
@@ -841,8 +870,10 @@ export class Collection<TSchema extends Document = Document> {
    * ```
    */
   createIndex(indexSpec: IndexSpecification): Promise<string>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   createIndex(indexSpec: IndexSpecification, callback: Callback<string>): void;
   createIndex(indexSpec: IndexSpecification, options: CreateIndexesOptions): Promise<string>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   createIndex(
     indexSpec: IndexSpecification,
     options: CreateIndexesOptions,
@@ -900,8 +931,10 @@ export class Collection<TSchema extends Document = Document> {
    * ```
    */
   createIndexes(indexSpecs: IndexDescription[]): Promise<string[]>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   createIndexes(indexSpecs: IndexDescription[], callback: Callback<string[]>): void;
   createIndexes(indexSpecs: IndexDescription[], options: CreateIndexesOptions): Promise<string[]>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   createIndexes(
     indexSpecs: IndexDescription[],
     options: CreateIndexesOptions,
@@ -936,8 +969,10 @@ export class Collection<TSchema extends Document = Document> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   dropIndex(indexName: string): Promise<Document>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   dropIndex(indexName: string, callback: Callback<Document>): void;
   dropIndex(indexName: string, options: DropIndexesOptions): Promise<Document>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   dropIndex(indexName: string, options: DropIndexesOptions, callback: Callback<Document>): void;
   dropIndex(
     indexName: string,
@@ -964,8 +999,10 @@ export class Collection<TSchema extends Document = Document> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   dropIndexes(): Promise<Document>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   dropIndexes(callback: Callback<Document>): void;
   dropIndexes(options: DropIndexesOptions): Promise<Document>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   dropIndexes(options: DropIndexesOptions, callback: Callback<Document>): void;
   dropIndexes(
     options?: DropIndexesOptions | Callback<Document>,
@@ -997,8 +1034,10 @@ export class Collection<TSchema extends Document = Document> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   indexExists(indexes: string | string[]): Promise<boolean>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   indexExists(indexes: string | string[], callback: Callback<boolean>): void;
   indexExists(indexes: string | string[], options: IndexInformationOptions): Promise<boolean>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   indexExists(
     indexes: string | string[],
     options: IndexInformationOptions,
@@ -1025,8 +1064,10 @@ export class Collection<TSchema extends Document = Document> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   indexInformation(): Promise<Document>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   indexInformation(callback: Callback<Document>): void;
   indexInformation(options: IndexInformationOptions): Promise<Document>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   indexInformation(options: IndexInformationOptions, callback: Callback<Document>): void;
   indexInformation(
     options?: IndexInformationOptions | Callback<Document>,
@@ -1056,8 +1097,10 @@ export class Collection<TSchema extends Document = Document> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   estimatedDocumentCount(): Promise<number>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   estimatedDocumentCount(callback: Callback<number>): void;
   estimatedDocumentCount(options: EstimatedDocumentCountOptions): Promise<number>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   estimatedDocumentCount(options: EstimatedDocumentCountOptions, callback: Callback<number>): void;
   estimatedDocumentCount(
     options?: EstimatedDocumentCountOptions | Callback<number>,
@@ -1098,15 +1141,19 @@ export class Collection<TSchema extends Document = Document> {
    * @see https://docs.mongodb.com/manual/reference/operator/query/centerSphere/#op._S_centerSphere
    */
   countDocuments(): Promise<number>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   countDocuments(callback: Callback<number>): void;
   countDocuments(filter: Filter<TSchema>): Promise<number>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   countDocuments(callback: Callback<number>): void;
   countDocuments(filter: Filter<TSchema>, options: CountDocumentsOptions): Promise<number>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   countDocuments(
     filter: Filter<TSchema>,
     options: CountDocumentsOptions,
     callback: Callback<number>
   ): void;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   countDocuments(filter: Filter<TSchema>, callback: Callback<number>): void;
   countDocuments(
     filter?: Document | CountDocumentsOptions | Callback<number>,
@@ -1146,6 +1193,7 @@ export class Collection<TSchema extends Document = Document> {
   distinct<Key extends keyof WithId<TSchema>>(
     key: Key
   ): Promise<Array<Flatten<WithId<TSchema>[Key]>>>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   distinct<Key extends keyof WithId<TSchema>>(
     key: Key,
     callback: Callback<Array<Flatten<WithId<TSchema>[Key]>>>
@@ -1154,6 +1202,7 @@ export class Collection<TSchema extends Document = Document> {
     key: Key,
     filter: Filter<TSchema>
   ): Promise<Array<Flatten<WithId<TSchema>[Key]>>>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   distinct<Key extends keyof WithId<TSchema>>(
     key: Key,
     filter: Filter<TSchema>,
@@ -1164,6 +1213,7 @@ export class Collection<TSchema extends Document = Document> {
     filter: Filter<TSchema>,
     options: DistinctOptions
   ): Promise<Array<Flatten<WithId<TSchema>[Key]>>>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   distinct<Key extends keyof WithId<TSchema>>(
     key: Key,
     filter: Filter<TSchema>,
@@ -1173,10 +1223,13 @@ export class Collection<TSchema extends Document = Document> {
 
   // Embedded documents overload
   distinct(key: string): Promise<any[]>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   distinct(key: string, callback: Callback<any[]>): void;
   distinct(key: string, filter: Filter<TSchema>): Promise<any[]>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   distinct(key: string, filter: Filter<TSchema>, callback: Callback<any[]>): void;
   distinct(key: string, filter: Filter<TSchema>, options: DistinctOptions): Promise<any[]>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   distinct(
     key: string,
     filter: Filter<TSchema>,
@@ -1218,8 +1271,10 @@ export class Collection<TSchema extends Document = Document> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   indexes(): Promise<Document[]>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   indexes(callback: Callback<Document[]>): void;
   indexes(options: IndexInformationOptions): Promise<Document[]>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   indexes(options: IndexInformationOptions, callback: Callback<Document[]>): void;
   indexes(
     options?: IndexInformationOptions | Callback<Document[]>,
@@ -1241,8 +1296,10 @@ export class Collection<TSchema extends Document = Document> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   stats(): Promise<CollStats>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   stats(callback: Callback<CollStats>): void;
   stats(options: CollStatsOptions): Promise<CollStats>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   stats(options: CollStatsOptions, callback: Callback<CollStats>): void;
   stats(
     options?: CollStatsOptions | Callback<CollStats>,
@@ -1270,7 +1327,9 @@ export class Collection<TSchema extends Document = Document> {
     filter: Filter<TSchema>,
     options: FindOneAndDeleteOptions
   ): Promise<ModifyResult<TSchema>>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   findOneAndDelete(filter: Filter<TSchema>, callback: Callback<ModifyResult<TSchema>>): void;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   findOneAndDelete(
     filter: Filter<TSchema>,
     options: FindOneAndDeleteOptions,
@@ -1306,6 +1365,7 @@ export class Collection<TSchema extends Document = Document> {
     filter: Filter<TSchema>,
     replacement: WithoutId<TSchema>
   ): Promise<ModifyResult<TSchema>>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   findOneAndReplace(
     filter: Filter<TSchema>,
     replacement: WithoutId<TSchema>,
@@ -1316,6 +1376,7 @@ export class Collection<TSchema extends Document = Document> {
     replacement: WithoutId<TSchema>,
     options: FindOneAndReplaceOptions
   ): Promise<ModifyResult<TSchema>>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   findOneAndReplace(
     filter: Filter<TSchema>,
     replacement: WithoutId<TSchema>,
@@ -1354,6 +1415,7 @@ export class Collection<TSchema extends Document = Document> {
     filter: Filter<TSchema>,
     update: UpdateFilter<TSchema>
   ): Promise<ModifyResult<TSchema>>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   findOneAndUpdate(
     filter: Filter<TSchema>,
     update: UpdateFilter<TSchema>,
@@ -1364,6 +1426,7 @@ export class Collection<TSchema extends Document = Document> {
     update: UpdateFilter<TSchema>,
     options: FindOneAndUpdateOptions
   ): Promise<ModifyResult<TSchema>>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   findOneAndUpdate(
     filter: Filter<TSchema>,
     update: UpdateFilter<TSchema>,
@@ -1486,6 +1549,7 @@ export class Collection<TSchema extends Document = Document> {
     map: string | MapFunction<TSchema>,
     reduce: string | ReduceFunction<TKey, TValue>
   ): Promise<Document | Document[]>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   mapReduce<TKey = any, TValue = any>(
     map: string | MapFunction<TSchema>,
     reduce: string | ReduceFunction<TKey, TValue>,
@@ -1496,6 +1560,7 @@ export class Collection<TSchema extends Document = Document> {
     reduce: string | ReduceFunction<TKey, TValue>,
     options: MapReduceOptions<TKey, TValue>
   ): Promise<Document | Document[]>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   mapReduce<TKey = any, TValue = any>(
     map: string | MapFunction<TSchema>,
     reduce: string | ReduceFunction<TKey, TValue>,
@@ -1582,7 +1647,7 @@ export class Collection<TSchema extends Document = Document> {
    * one will be added to each of the documents missing it by the driver, mutating the document. This behavior
    * can be overridden by setting the **forceServerObjectId** flag.
    *
-   * @deprecated Use insertOne, insertMany or bulkWrite instead.
+   * @deprecated Use insertOne, insertMany or bulkWrite instead. Callbacks are deprecated and will be removed in the next major version
    * @param docs - The documents to insert
    * @param options - Optional settings for the command
    * @param callback - An optional callback, a Promise will be returned if none is provided
@@ -1609,7 +1674,7 @@ export class Collection<TSchema extends Document = Document> {
   /**
    * Updates documents.
    *
-   * @deprecated use updateOne, updateMany or bulkWrite
+   * @deprecated use updateOne, updateMany or bulkWrite. Callbacks are deprecated and will be removed in the next major version
    * @param filter - The filter for the update operation.
    * @param update - The update operations to be applied to the documents
    * @param options - Optional settings for the command
@@ -1633,7 +1698,7 @@ export class Collection<TSchema extends Document = Document> {
   /**
    * Remove documents.
    *
-   * @deprecated use deleteOne, deleteMany or bulkWrite
+   * @deprecated use deleteOne, deleteMany or bulkWrite. Callbacks are deprecated and will be removed in the next major version
    * @param filter - The filter for the remove operation.
    * @param options - Optional settings for the command
    * @param callback - An optional callback, a Promise will be returned if none is provided
@@ -1666,10 +1731,13 @@ export class Collection<TSchema extends Document = Document> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   count(): Promise<number>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   count(callback: Callback<number>): void;
   count(filter: Filter<TSchema>): Promise<number>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   count(filter: Filter<TSchema>, callback: Callback<number>): void;
   count(filter: Filter<TSchema>, options: CountOptions): Promise<number>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   count(
     filter: Filter<TSchema>,
     options: CountOptions,

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -136,30 +136,28 @@ export interface CollectionPrivate {
 
 /**
  * The **Collection** class is an internal class that embodies a MongoDB collection
- * allowing for insert/update/remove/find and other command operation on that MongoDB collection.
+ * allowing for insert/find/update/delete and other command operation on that MongoDB collection.
  *
  * **COLLECTION Cannot directly be instantiated**
  * @public
  *
  * @example
- * ```js
- * const MongoClient = require('mongodb').MongoClient;
- * const test = require('assert');
- * // Connection url
- * const url = 'mongodb://localhost:27017';
- * // Database Name
- * const dbName = 'test';
- * // Connect using MongoClient
- * MongoClient.connect(url, function(err, client) {
- *   // Create a collection we want to drop later
- *   const col = client.db(dbName).collection('createIndexExample1');
- *   // Show that duplicate records got dropped
- *   col.find({}).toArray(function(err, items) {
- *     expect(err).to.not.exist;
- *     test.equal(4, items.length);
- *     client.close();
- *   });
- * });
+ * ```ts
+ * import { MongoClient } from 'mongodb';
+ *
+ * interface Pet {
+ *   name: string;
+ *   kind: 'dog' | 'cat' | 'fish';
+ * }
+ *
+ * const client = new MongoClient('mongodb://localhost:27017');
+ * const pets = client.db().collection<Pet>('pets');
+ *
+ * const petCursor = pets.find();
+ *
+ * for (const pet of petCursor) {
+ *   console.log(`${pet.name} is a ${pet.kind}!`);
+ * }
  * ```
  */
 export class Collection<TSchema extends Document = Document> {
@@ -356,20 +354,22 @@ export class Collection<TSchema extends Document = Document> {
    *
    * Legal operation types are
    *
-   * ```js
-   *  { insertOne: { document: { a: 1 } } }
+   * ```ts
+   * [
+   *   { insertOne: { document: { a: 1 } } },
    *
-   *  { updateOne: { filter: {a:2}, update: {$set: {a:2}}, upsert:true } }
+   *   { updateOne: { filter: { a: 2 }, update: { $set: { a: 2 } }, upsert: true } },
    *
-   *  { updateMany: { filter: {a:2}, update: {$set: {a:2}}, upsert:true } }
+   *   { updateMany: { filter: { a: 2 }, update: { $set: { a: 2 } }, upsert: true } },
    *
-   *  { updateMany: { filter: {}, update: {$set: {"a.$[i].x": 5}}, arrayFilters: [{ "i.x": 5 }]} }
+   *   { updateMany: { filter: {}, update: { $set: { 'a.$[i].x': 5 } }, arrayFilters: [{ 'i.x': 5 }] } },
    *
-   *  { deleteOne: { filter: {c:1} } }
+   *   { deleteOne: { filter: { c: 1 } } },
    *
-   *  { deleteMany: { filter: {c:1} } }
+   *   { deleteMany: { filter: { c: 1 } } },
    *
-   *  { replaceOne: { filter: {c:3}, replacement: {c:4}, upsert:true} }
+   *   { replaceOne: { filter: { c: 3 }, replacement: { c: 4 }, upsert: true } },
+   * ]
    *```
    * Please note that raw operations are no longer accepted as of driver version 4.0.
    *
@@ -848,7 +848,7 @@ export class Collection<TSchema extends Document = Document> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    *
    * @example
-   * ```js
+   * ```ts
    * const collection = client.db('foo').collection('bar');
    *
    * await collection.createIndex({ a: 1, b: -1 });
@@ -911,7 +911,7 @@ export class Collection<TSchema extends Document = Document> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    *
    * @example
-   * ```js
+   * ```ts
    * const collection = client.db('foo').collection('bar');
    * await collection.createIndexes([
    *   // Simple index on field fizz

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -263,7 +263,7 @@ export class Collection<TSchema extends Document = Document> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   insertOne(doc: OptionalUnlessRequiredId<TSchema>): Promise<InsertOneResult<TSchema>>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   insertOne(
     doc: OptionalUnlessRequiredId<TSchema>,
     callback: Callback<InsertOneResult<TSchema>>
@@ -272,7 +272,7 @@ export class Collection<TSchema extends Document = Document> {
     doc: OptionalUnlessRequiredId<TSchema>,
     options: InsertOneOptions
   ): Promise<InsertOneResult<TSchema>>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   insertOne(
     doc: OptionalUnlessRequiredId<TSchema>,
     options: InsertOneOptions,
@@ -315,7 +315,7 @@ export class Collection<TSchema extends Document = Document> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   insertMany(docs: OptionalUnlessRequiredId<TSchema>[]): Promise<InsertManyResult<TSchema>>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   insertMany(
     docs: OptionalUnlessRequiredId<TSchema>[],
     callback: Callback<InsertManyResult<TSchema>>
@@ -324,7 +324,7 @@ export class Collection<TSchema extends Document = Document> {
     docs: OptionalUnlessRequiredId<TSchema>[],
     options: BulkWriteOptions
   ): Promise<InsertManyResult<TSchema>>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   insertMany(
     docs: OptionalUnlessRequiredId<TSchema>[],
     options: BulkWriteOptions,
@@ -372,7 +372,7 @@ export class Collection<TSchema extends Document = Document> {
    * @throws MongoDriverError if operations is not an array
    */
   bulkWrite(operations: AnyBulkWriteOperation<TSchema>[]): Promise<BulkWriteResult>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   bulkWrite(
     operations: AnyBulkWriteOperation<TSchema>[],
     callback: Callback<BulkWriteResult>
@@ -381,7 +381,7 @@ export class Collection<TSchema extends Document = Document> {
     operations: AnyBulkWriteOperation<TSchema>[],
     options: BulkWriteOptions
   ): Promise<BulkWriteResult>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   bulkWrite(
     operations: AnyBulkWriteOperation<TSchema>[],
     options: BulkWriteOptions,
@@ -422,7 +422,7 @@ export class Collection<TSchema extends Document = Document> {
     filter: Filter<TSchema>,
     update: UpdateFilter<TSchema> | Partial<TSchema>
   ): Promise<UpdateResult>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   updateOne(
     filter: Filter<TSchema>,
     update: UpdateFilter<TSchema> | Partial<TSchema>,
@@ -433,7 +433,7 @@ export class Collection<TSchema extends Document = Document> {
     update: UpdateFilter<TSchema> | Partial<TSchema>,
     options: UpdateOptions
   ): Promise<UpdateResult>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   updateOne(
     filter: Filter<TSchema>,
     update: UpdateFilter<TSchema> | Partial<TSchema>,
@@ -472,7 +472,7 @@ export class Collection<TSchema extends Document = Document> {
     filter: Filter<TSchema>,
     replacement: WithoutId<TSchema>
   ): Promise<UpdateResult | Document>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   replaceOne(
     filter: Filter<TSchema>,
     replacement: WithoutId<TSchema>,
@@ -483,7 +483,7 @@ export class Collection<TSchema extends Document = Document> {
     replacement: WithoutId<TSchema>,
     options: ReplaceOptions
   ): Promise<UpdateResult | Document>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   replaceOne(
     filter: Filter<TSchema>,
     replacement: WithoutId<TSchema>,
@@ -522,7 +522,7 @@ export class Collection<TSchema extends Document = Document> {
     filter: Filter<TSchema>,
     update: UpdateFilter<TSchema>
   ): Promise<UpdateResult | Document>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   updateMany(
     filter: Filter<TSchema>,
     update: UpdateFilter<TSchema>,
@@ -533,7 +533,7 @@ export class Collection<TSchema extends Document = Document> {
     update: UpdateFilter<TSchema>,
     options: UpdateOptions
   ): Promise<UpdateResult | Document>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   updateMany(
     filter: Filter<TSchema>,
     update: UpdateFilter<TSchema>,
@@ -568,10 +568,10 @@ export class Collection<TSchema extends Document = Document> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   deleteOne(filter: Filter<TSchema>): Promise<DeleteResult>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   deleteOne(filter: Filter<TSchema>, callback: Callback<DeleteResult>): void;
   deleteOne(filter: Filter<TSchema>, options: DeleteOptions): Promise<DeleteResult>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   deleteOne(
     filter: Filter<TSchema>,
     options: DeleteOptions,
@@ -599,10 +599,10 @@ export class Collection<TSchema extends Document = Document> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   deleteMany(filter: Filter<TSchema>): Promise<DeleteResult>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   deleteMany(filter: Filter<TSchema>, callback: Callback<DeleteResult>): void;
   deleteMany(filter: Filter<TSchema>, options: DeleteOptions): Promise<DeleteResult>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   deleteMany(
     filter: Filter<TSchema>,
     options: DeleteOptions,
@@ -644,10 +644,10 @@ export class Collection<TSchema extends Document = Document> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   rename(newName: string): Promise<Collection>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   rename(newName: string, callback: Callback<Collection>): void;
   rename(newName: string, options: RenameOptions): Promise<Collection>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   rename(newName: string, options: RenameOptions, callback: Callback<Collection>): void;
   rename(
     newName: string,
@@ -674,10 +674,10 @@ export class Collection<TSchema extends Document = Document> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   drop(): Promise<boolean>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   drop(callback: Callback<boolean>): void;
   drop(options: DropCollectionOptions): Promise<boolean>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   drop(options: DropCollectionOptions, callback: Callback<boolean>): void;
   drop(
     options?: DropCollectionOptions | Callback<boolean>,
@@ -701,13 +701,13 @@ export class Collection<TSchema extends Document = Document> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   findOne(): Promise<WithId<TSchema> | null>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   findOne(callback: Callback<WithId<TSchema> | null>): void;
   findOne(filter: Filter<TSchema>): Promise<WithId<TSchema> | null>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   findOne(filter: Filter<TSchema>, callback: Callback<WithId<TSchema> | null>): void;
   findOne(filter: Filter<TSchema>, options: FindOptions): Promise<WithId<TSchema> | null>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   findOne(
     filter: Filter<TSchema>,
     options: FindOptions,
@@ -716,11 +716,11 @@ export class Collection<TSchema extends Document = Document> {
 
   // allow an override of the schema.
   findOne<T = TSchema>(): Promise<T | null>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   findOne<T = TSchema>(callback: Callback<T | null>): void;
   findOne<T = TSchema>(filter: Filter<TSchema>): Promise<T | null>;
   findOne<T = TSchema>(filter: Filter<TSchema>, options?: FindOptions): Promise<T | null>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   findOne<T = TSchema>(
     filter: Filter<TSchema>,
     options?: FindOptions,
@@ -786,10 +786,10 @@ export class Collection<TSchema extends Document = Document> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   options(): Promise<Document>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   options(callback: Callback<Document>): void;
   options(options: OperationOptions): Promise<Document>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   options(options: OperationOptions, callback: Callback<Document>): void;
   options(
     options?: OperationOptions | Callback<Document>,
@@ -811,10 +811,10 @@ export class Collection<TSchema extends Document = Document> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   isCapped(): Promise<boolean>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   isCapped(callback: Callback<boolean>): void;
   isCapped(options: OperationOptions): Promise<boolean>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   isCapped(options: OperationOptions, callback: Callback<boolean>): void;
   isCapped(
     options?: OperationOptions | Callback<boolean>,
@@ -859,10 +859,10 @@ export class Collection<TSchema extends Document = Document> {
    * ```
    */
   createIndex(indexSpec: IndexSpecification): Promise<string>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   createIndex(indexSpec: IndexSpecification, callback: Callback<string>): void;
   createIndex(indexSpec: IndexSpecification, options: CreateIndexesOptions): Promise<string>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   createIndex(
     indexSpec: IndexSpecification,
     options: CreateIndexesOptions,
@@ -920,10 +920,10 @@ export class Collection<TSchema extends Document = Document> {
    * ```
    */
   createIndexes(indexSpecs: IndexDescription[]): Promise<string[]>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   createIndexes(indexSpecs: IndexDescription[], callback: Callback<string[]>): void;
   createIndexes(indexSpecs: IndexDescription[], options: CreateIndexesOptions): Promise<string[]>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   createIndexes(
     indexSpecs: IndexDescription[],
     options: CreateIndexesOptions,
@@ -958,10 +958,10 @@ export class Collection<TSchema extends Document = Document> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   dropIndex(indexName: string): Promise<Document>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   dropIndex(indexName: string, callback: Callback<Document>): void;
   dropIndex(indexName: string, options: DropIndexesOptions): Promise<Document>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   dropIndex(indexName: string, options: DropIndexesOptions, callback: Callback<Document>): void;
   dropIndex(
     indexName: string,
@@ -988,10 +988,10 @@ export class Collection<TSchema extends Document = Document> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   dropIndexes(): Promise<Document>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   dropIndexes(callback: Callback<Document>): void;
   dropIndexes(options: DropIndexesOptions): Promise<Document>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   dropIndexes(options: DropIndexesOptions, callback: Callback<Document>): void;
   dropIndexes(
     options?: DropIndexesOptions | Callback<Document>,
@@ -1023,10 +1023,10 @@ export class Collection<TSchema extends Document = Document> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   indexExists(indexes: string | string[]): Promise<boolean>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   indexExists(indexes: string | string[], callback: Callback<boolean>): void;
   indexExists(indexes: string | string[], options: IndexInformationOptions): Promise<boolean>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   indexExists(
     indexes: string | string[],
     options: IndexInformationOptions,
@@ -1053,10 +1053,10 @@ export class Collection<TSchema extends Document = Document> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   indexInformation(): Promise<Document>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   indexInformation(callback: Callback<Document>): void;
   indexInformation(options: IndexInformationOptions): Promise<Document>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   indexInformation(options: IndexInformationOptions, callback: Callback<Document>): void;
   indexInformation(
     options?: IndexInformationOptions | Callback<Document>,
@@ -1086,10 +1086,10 @@ export class Collection<TSchema extends Document = Document> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   estimatedDocumentCount(): Promise<number>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   estimatedDocumentCount(callback: Callback<number>): void;
   estimatedDocumentCount(options: EstimatedDocumentCountOptions): Promise<number>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   estimatedDocumentCount(options: EstimatedDocumentCountOptions, callback: Callback<number>): void;
   estimatedDocumentCount(
     options?: EstimatedDocumentCountOptions | Callback<number>,
@@ -1130,19 +1130,19 @@ export class Collection<TSchema extends Document = Document> {
    * @see https://docs.mongodb.com/manual/reference/operator/query/centerSphere/#op._S_centerSphere
    */
   countDocuments(): Promise<number>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   countDocuments(callback: Callback<number>): void;
   countDocuments(filter: Filter<TSchema>): Promise<number>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   countDocuments(callback: Callback<number>): void;
   countDocuments(filter: Filter<TSchema>, options: CountDocumentsOptions): Promise<number>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   countDocuments(
     filter: Filter<TSchema>,
     options: CountDocumentsOptions,
     callback: Callback<number>
   ): void;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   countDocuments(filter: Filter<TSchema>, callback: Callback<number>): void;
   countDocuments(
     filter?: Document | CountDocumentsOptions | Callback<number>,
@@ -1182,7 +1182,7 @@ export class Collection<TSchema extends Document = Document> {
   distinct<Key extends keyof WithId<TSchema>>(
     key: Key
   ): Promise<Array<Flatten<WithId<TSchema>[Key]>>>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   distinct<Key extends keyof WithId<TSchema>>(
     key: Key,
     callback: Callback<Array<Flatten<WithId<TSchema>[Key]>>>
@@ -1191,7 +1191,7 @@ export class Collection<TSchema extends Document = Document> {
     key: Key,
     filter: Filter<TSchema>
   ): Promise<Array<Flatten<WithId<TSchema>[Key]>>>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   distinct<Key extends keyof WithId<TSchema>>(
     key: Key,
     filter: Filter<TSchema>,
@@ -1202,7 +1202,7 @@ export class Collection<TSchema extends Document = Document> {
     filter: Filter<TSchema>,
     options: DistinctOptions
   ): Promise<Array<Flatten<WithId<TSchema>[Key]>>>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   distinct<Key extends keyof WithId<TSchema>>(
     key: Key,
     filter: Filter<TSchema>,
@@ -1212,13 +1212,13 @@ export class Collection<TSchema extends Document = Document> {
 
   // Embedded documents overload
   distinct(key: string): Promise<any[]>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   distinct(key: string, callback: Callback<any[]>): void;
   distinct(key: string, filter: Filter<TSchema>): Promise<any[]>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   distinct(key: string, filter: Filter<TSchema>, callback: Callback<any[]>): void;
   distinct(key: string, filter: Filter<TSchema>, options: DistinctOptions): Promise<any[]>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   distinct(
     key: string,
     filter: Filter<TSchema>,
@@ -1260,10 +1260,10 @@ export class Collection<TSchema extends Document = Document> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   indexes(): Promise<Document[]>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   indexes(callback: Callback<Document[]>): void;
   indexes(options: IndexInformationOptions): Promise<Document[]>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   indexes(options: IndexInformationOptions, callback: Callback<Document[]>): void;
   indexes(
     options?: IndexInformationOptions | Callback<Document[]>,
@@ -1285,10 +1285,10 @@ export class Collection<TSchema extends Document = Document> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   stats(): Promise<CollStats>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   stats(callback: Callback<CollStats>): void;
   stats(options: CollStatsOptions): Promise<CollStats>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   stats(options: CollStatsOptions, callback: Callback<CollStats>): void;
   stats(
     options?: CollStatsOptions | Callback<CollStats>,
@@ -1316,9 +1316,9 @@ export class Collection<TSchema extends Document = Document> {
     filter: Filter<TSchema>,
     options: FindOneAndDeleteOptions
   ): Promise<ModifyResult<TSchema>>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   findOneAndDelete(filter: Filter<TSchema>, callback: Callback<ModifyResult<TSchema>>): void;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   findOneAndDelete(
     filter: Filter<TSchema>,
     options: FindOneAndDeleteOptions,
@@ -1354,7 +1354,7 @@ export class Collection<TSchema extends Document = Document> {
     filter: Filter<TSchema>,
     replacement: WithoutId<TSchema>
   ): Promise<ModifyResult<TSchema>>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   findOneAndReplace(
     filter: Filter<TSchema>,
     replacement: WithoutId<TSchema>,
@@ -1365,7 +1365,7 @@ export class Collection<TSchema extends Document = Document> {
     replacement: WithoutId<TSchema>,
     options: FindOneAndReplaceOptions
   ): Promise<ModifyResult<TSchema>>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   findOneAndReplace(
     filter: Filter<TSchema>,
     replacement: WithoutId<TSchema>,
@@ -1404,7 +1404,7 @@ export class Collection<TSchema extends Document = Document> {
     filter: Filter<TSchema>,
     update: UpdateFilter<TSchema>
   ): Promise<ModifyResult<TSchema>>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   findOneAndUpdate(
     filter: Filter<TSchema>,
     update: UpdateFilter<TSchema>,
@@ -1415,7 +1415,7 @@ export class Collection<TSchema extends Document = Document> {
     update: UpdateFilter<TSchema>,
     options: FindOneAndUpdateOptions
   ): Promise<ModifyResult<TSchema>>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   findOneAndUpdate(
     filter: Filter<TSchema>,
     update: UpdateFilter<TSchema>,
@@ -1538,7 +1538,7 @@ export class Collection<TSchema extends Document = Document> {
     map: string | MapFunction<TSchema>,
     reduce: string | ReduceFunction<TKey, TValue>
   ): Promise<Document | Document[]>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   mapReduce<TKey = any, TValue = any>(
     map: string | MapFunction<TSchema>,
     reduce: string | ReduceFunction<TKey, TValue>,
@@ -1549,7 +1549,7 @@ export class Collection<TSchema extends Document = Document> {
     reduce: string | ReduceFunction<TKey, TValue>,
     options: MapReduceOptions<TKey, TValue>
   ): Promise<Document | Document[]>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   mapReduce<TKey = any, TValue = any>(
     map: string | MapFunction<TSchema>,
     reduce: string | ReduceFunction<TKey, TValue>,
@@ -1636,7 +1636,7 @@ export class Collection<TSchema extends Document = Document> {
    * one will be added to each of the documents missing it by the driver, mutating the document. This behavior
    * can be overridden by setting the **forceServerObjectId** flag.
    *
-   * @deprecated Use insertOne, insertMany or bulkWrite instead. Callbacks are deprecated and will be removed in the next major version
+   * @deprecated Use insertOne, insertMany or bulkWrite instead. Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance
    * @param docs - The documents to insert
    * @param options - Optional settings for the command
    * @param callback - An optional callback, a Promise will be returned if none is provided
@@ -1663,7 +1663,7 @@ export class Collection<TSchema extends Document = Document> {
   /**
    * Updates documents.
    *
-   * @deprecated use updateOne, updateMany or bulkWrite. Callbacks are deprecated and will be removed in the next major version
+   * @deprecated use updateOne, updateMany or bulkWrite. Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance
    * @param filter - The filter for the update operation.
    * @param update - The update operations to be applied to the documents
    * @param options - Optional settings for the command
@@ -1687,7 +1687,7 @@ export class Collection<TSchema extends Document = Document> {
   /**
    * Remove documents.
    *
-   * @deprecated use deleteOne, deleteMany or bulkWrite. Callbacks are deprecated and will be removed in the next major version
+   * @deprecated use deleteOne, deleteMany or bulkWrite. Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance
    * @param filter - The filter for the remove operation.
    * @param options - Optional settings for the command
    * @param callback - An optional callback, a Promise will be returned if none is provided
@@ -1720,13 +1720,13 @@ export class Collection<TSchema extends Document = Document> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   count(): Promise<number>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   count(callback: Callback<number>): void;
   count(filter: Filter<TSchema>): Promise<number>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   count(filter: Filter<TSchema>, callback: Callback<number>): void;
   count(filter: Filter<TSchema>, options: CountOptions): Promise<number>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   count(
     filter: Filter<TSchema>,
     options: CountOptions,

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -353,24 +353,13 @@ export class Collection<TSchema extends Document = Document> {
    * Perform a bulkWrite operation without a fluent API
    *
    * Legal operation types are
+   * - `insertOne`
+   * - `replaceOne`
+   * - `updateOne`
+   * - `updateMany`
+   * - `deleteOne`
+   * - `deleteMany`
    *
-   * ```ts
-   * [
-   *   { insertOne: { document: { a: 1 } } },
-   *
-   *   { updateOne: { filter: { a: 2 }, update: { $set: { a: 2 } }, upsert: true } },
-   *
-   *   { updateMany: { filter: { a: 2 }, update: { $set: { a: 2 } }, upsert: true } },
-   *
-   *   { updateMany: { filter: {}, update: { $set: { 'a.$[i].x': 5 } }, arrayFilters: [{ 'i.x': 5 }] } },
-   *
-   *   { deleteOne: { filter: { c: 1 } } },
-   *
-   *   { deleteMany: { filter: { c: 1 } } },
-   *
-   *   { replaceOne: { filter: { c: 3 }, replacement: { c: 4 }, upsert: true } },
-   * ]
-   *```
    * Please note that raw operations are no longer accepted as of driver version 4.0.
    *
    * If documents passed in do not contain the **_id** field,

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -317,6 +317,7 @@ export abstract class AbstractCursor<
   }
 
   hasNext(): Promise<boolean>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   hasNext(callback: Callback<boolean>): void;
   hasNext(callback?: Callback<boolean>): Promise<boolean> | void {
     return maybePromise(callback, done => {
@@ -344,7 +345,9 @@ export abstract class AbstractCursor<
 
   /** Get the next available document from the cursor, returns null if no more documents are available. */
   next(): Promise<TSchema | null>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   next(callback: Callback<TSchema | null>): void;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   next(callback?: Callback<TSchema | null>): Promise<TSchema | null> | void;
   next(callback?: Callback<TSchema | null>): Promise<TSchema | null> | void {
     return maybePromise(callback, done => {
@@ -360,6 +363,7 @@ export abstract class AbstractCursor<
    * Try to get the next available document from the cursor or `null` if an empty batch is returned
    */
   tryNext(): Promise<TSchema | null>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   tryNext(callback: Callback<TSchema | null>): void;
   tryNext(callback?: Callback<TSchema | null>): Promise<TSchema | null> | void {
     return maybePromise(callback, done => {
@@ -378,6 +382,7 @@ export abstract class AbstractCursor<
    * @param callback - The end callback.
    */
   forEach(iterator: (doc: TSchema) => boolean | void): Promise<void>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   forEach(iterator: (doc: TSchema) => boolean | void, callback: Callback<void>): void;
   forEach(
     iterator: (doc: TSchema) => boolean | void,
@@ -423,13 +428,14 @@ export abstract class AbstractCursor<
   }
 
   close(): Promise<void>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   close(callback: Callback): void;
   /**
    * @deprecated options argument is deprecated
    */
   close(options: CursorCloseOptions): Promise<void>;
   /**
-   * @deprecated options argument is deprecated
+   * @deprecated options argument is deprecated. Callbacks are deprecated and will be removed in the next major version
    */
   close(options: CursorCloseOptions, callback: Callback): void;
   close(options?: CursorCloseOptions | Callback, callback?: Callback): Promise<void> | void {
@@ -451,6 +457,7 @@ export abstract class AbstractCursor<
    * @param callback - The result callback.
    */
   toArray(): Promise<TSchema[]>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   toArray(callback: Callback<TSchema[]>): void;
   toArray(callback?: Callback<TSchema[]>): Promise<TSchema[]> | void {
     return maybePromise(callback, done => {

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -317,7 +317,7 @@ export abstract class AbstractCursor<
   }
 
   hasNext(): Promise<boolean>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   hasNext(callback: Callback<boolean>): void;
   hasNext(callback?: Callback<boolean>): Promise<boolean> | void {
     return maybePromise(callback, done => {
@@ -345,9 +345,9 @@ export abstract class AbstractCursor<
 
   /** Get the next available document from the cursor, returns null if no more documents are available. */
   next(): Promise<TSchema | null>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   next(callback: Callback<TSchema | null>): void;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   next(callback?: Callback<TSchema | null>): Promise<TSchema | null> | void;
   next(callback?: Callback<TSchema | null>): Promise<TSchema | null> | void {
     return maybePromise(callback, done => {
@@ -363,7 +363,7 @@ export abstract class AbstractCursor<
    * Try to get the next available document from the cursor or `null` if an empty batch is returned
    */
   tryNext(): Promise<TSchema | null>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   tryNext(callback: Callback<TSchema | null>): void;
   tryNext(callback?: Callback<TSchema | null>): Promise<TSchema | null> | void {
     return maybePromise(callback, done => {
@@ -382,7 +382,7 @@ export abstract class AbstractCursor<
    * @param callback - The end callback.
    */
   forEach(iterator: (doc: TSchema) => boolean | void): Promise<void>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   forEach(iterator: (doc: TSchema) => boolean | void, callback: Callback<void>): void;
   forEach(
     iterator: (doc: TSchema) => boolean | void,
@@ -428,14 +428,14 @@ export abstract class AbstractCursor<
   }
 
   close(): Promise<void>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   close(callback: Callback): void;
   /**
    * @deprecated options argument is deprecated
    */
   close(options: CursorCloseOptions): Promise<void>;
   /**
-   * @deprecated options argument is deprecated. Callbacks are deprecated and will be removed in the next major version
+   * @deprecated options argument is deprecated. Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance
    */
   close(options: CursorCloseOptions, callback: Callback): void;
   close(options?: CursorCloseOptions | Callback, callback?: Callback): Promise<void> | void {
@@ -457,7 +457,7 @@ export abstract class AbstractCursor<
    * @param callback - The result callback.
    */
   toArray(): Promise<TSchema[]>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   toArray(callback: Callback<TSchema[]>): void;
   toArray(callback?: Callback<TSchema[]>): Promise<TSchema[]> | void {
     return maybePromise(callback, done => {

--- a/src/cursor/aggregation_cursor.ts
+++ b/src/cursor/aggregation_cursor.ts
@@ -78,6 +78,7 @@ export class AggregationCursor<TSchema = any> extends AbstractCursor<TSchema> {
 
   /** Execute the explain for the cursor */
   explain(): Promise<Document>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   explain(callback: Callback): void;
   explain(verbosity: ExplainVerbosityLike): Promise<Document>;
   explain(

--- a/src/cursor/aggregation_cursor.ts
+++ b/src/cursor/aggregation_cursor.ts
@@ -78,7 +78,7 @@ export class AggregationCursor<TSchema = any> extends AbstractCursor<TSchema> {
 
   /** Execute the explain for the cursor */
   explain(): Promise<Document>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   explain(callback: Callback): void;
   explain(verbosity: ExplainVerbosityLike): Promise<Document>;
   explain(

--- a/src/cursor/find_cursor.ts
+++ b/src/cursor/find_cursor.ts
@@ -122,11 +122,11 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
    * @deprecated Use `collection.estimatedDocumentCount` or `collection.countDocuments` instead
    */
   count(): Promise<number>;
-  /** @deprecated Use `collection.estimatedDocumentCount` or `collection.countDocuments` instead */
+  /** @deprecated Use `collection.estimatedDocumentCount` or `collection.countDocuments` instead. Callbacks are deprecated and will be removed in the next major version */
   count(callback: Callback<number>): void;
-  /** @deprecated Use `collection.estimatedDocumentCount` or `collection.countDocuments` instead */
+  /** @deprecated Use `collection.estimatedDocumentCount` or `collection.countDocuments` instead. */
   count(options: CountOptions): Promise<number>;
-  /** @deprecated Use `collection.estimatedDocumentCount` or `collection.countDocuments` instead */
+  /** @deprecated Use `collection.estimatedDocumentCount` or `collection.countDocuments` instead. Callbacks are deprecated and will be removed in the next major version */
   count(options: CountOptions, callback: Callback<number>): void;
   count(
     options?: CountOptions | Callback<number>,
@@ -155,6 +155,7 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
 
   /** Execute the explain for the cursor */
   explain(): Promise<Document>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   explain(callback: Callback): void;
   explain(verbosity?: ExplainVerbosityLike): Promise<Document>;
   explain(

--- a/src/cursor/find_cursor.ts
+++ b/src/cursor/find_cursor.ts
@@ -122,11 +122,11 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
    * @deprecated Use `collection.estimatedDocumentCount` or `collection.countDocuments` instead
    */
   count(): Promise<number>;
-  /** @deprecated Use `collection.estimatedDocumentCount` or `collection.countDocuments` instead. Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Use `collection.estimatedDocumentCount` or `collection.countDocuments` instead. Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   count(callback: Callback<number>): void;
   /** @deprecated Use `collection.estimatedDocumentCount` or `collection.countDocuments` instead. */
   count(options: CountOptions): Promise<number>;
-  /** @deprecated Use `collection.estimatedDocumentCount` or `collection.countDocuments` instead. Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Use `collection.estimatedDocumentCount` or `collection.countDocuments` instead. Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   count(options: CountOptions, callback: Callback<number>): void;
   count(
     options?: CountOptions | Callback<number>,
@@ -155,7 +155,7 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
 
   /** Execute the explain for the cursor */
   explain(): Promise<Document>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   explain(callback: Callback): void;
   explain(verbosity?: ExplainVerbosityLike): Promise<Document>;
   explain(

--- a/src/db.ts
+++ b/src/db.ts
@@ -241,12 +241,12 @@ export class Db {
     name: string,
     options?: CreateCollectionOptions
   ): Promise<Collection<TSchema>>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   createCollection<TSchema extends Document = Document>(
     name: string,
     callback: Callback<Collection<TSchema>>
   ): void;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   createCollection<TSchema extends Document = Document>(
     name: string,
     options: CreateCollectionOptions | undefined,
@@ -277,10 +277,10 @@ export class Db {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   command(command: Document): Promise<Document>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   command(command: Document, callback: Callback<Document>): void;
   command(command: Document, options: RunCommandOptions): Promise<Document>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   command(command: Document, options: RunCommandOptions, callback: Callback<Document>): void;
   command(
     command: Document,
@@ -354,10 +354,10 @@ export class Db {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   stats(): Promise<Document>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   stats(callback: Callback<Document>): void;
   stats(options: DbStatsOptions): Promise<Document>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   stats(options: DbStatsOptions, callback: Callback<Document>): void;
   stats(
     options?: DbStatsOptions | Callback<Document>,
@@ -413,7 +413,7 @@ export class Db {
     fromCollection: string,
     toCollection: string
   ): Promise<Collection<TSchema>>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   renameCollection<TSchema extends Document = Document>(
     fromCollection: string,
     toCollection: string,
@@ -424,7 +424,7 @@ export class Db {
     toCollection: string,
     options: RenameOptions
   ): Promise<Collection<TSchema>>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   renameCollection<TSchema extends Document = Document>(
     fromCollection: string,
     toCollection: string,
@@ -464,10 +464,10 @@ export class Db {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   dropCollection(name: string): Promise<boolean>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   dropCollection(name: string, callback: Callback<boolean>): void;
   dropCollection(name: string, options: DropCollectionOptions): Promise<boolean>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   dropCollection(name: string, options: DropCollectionOptions, callback: Callback<boolean>): void;
   dropCollection(
     name: string,
@@ -490,10 +490,10 @@ export class Db {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   dropDatabase(): Promise<boolean>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   dropDatabase(callback: Callback<boolean>): void;
   dropDatabase(options: DropDatabaseOptions): Promise<boolean>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   dropDatabase(options: DropDatabaseOptions, callback: Callback<boolean>): void;
   dropDatabase(
     options?: DropDatabaseOptions | Callback<boolean>,
@@ -515,10 +515,10 @@ export class Db {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   collections(): Promise<Collection[]>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   collections(callback: Callback<Collection[]>): void;
   collections(options: ListCollectionsOptions): Promise<Collection[]>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   collections(options: ListCollectionsOptions, callback: Callback<Collection[]>): void;
   collections(
     options?: ListCollectionsOptions | Callback<Collection[]>,
@@ -542,14 +542,14 @@ export class Db {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   createIndex(name: string, indexSpec: IndexSpecification): Promise<string>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   createIndex(name: string, indexSpec: IndexSpecification, callback: Callback<string>): void;
   createIndex(
     name: string,
     indexSpec: IndexSpecification,
     options: CreateIndexesOptions
   ): Promise<string>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   createIndex(
     name: string,
     indexSpec: IndexSpecification,
@@ -580,16 +580,16 @@ export class Db {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   addUser(username: string): Promise<Document>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   addUser(username: string, callback: Callback<Document>): void;
   addUser(username: string, password: string): Promise<Document>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   addUser(username: string, password: string, callback: Callback<Document>): void;
   addUser(username: string, options: AddUserOptions): Promise<Document>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   addUser(username: string, options: AddUserOptions, callback: Callback<Document>): void;
   addUser(username: string, password: string, options: AddUserOptions): Promise<Document>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   addUser(
     username: string,
     password: string,
@@ -629,10 +629,10 @@ export class Db {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   removeUser(username: string): Promise<boolean>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   removeUser(username: string, callback: Callback<boolean>): void;
   removeUser(username: string, options: RemoveUserOptions): Promise<boolean>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   removeUser(username: string, options: RemoveUserOptions, callback: Callback<boolean>): void;
   removeUser(
     username: string,
@@ -656,13 +656,13 @@ export class Db {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   setProfilingLevel(level: ProfilingLevel): Promise<ProfilingLevel>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   setProfilingLevel(level: ProfilingLevel, callback: Callback<ProfilingLevel>): void;
   setProfilingLevel(
     level: ProfilingLevel,
     options: SetProfilingLevelOptions
   ): Promise<ProfilingLevel>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   setProfilingLevel(
     level: ProfilingLevel,
     options: SetProfilingLevelOptions,
@@ -689,10 +689,10 @@ export class Db {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   profilingLevel(): Promise<string>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   profilingLevel(callback: Callback<string>): void;
   profilingLevel(options: ProfilingLevelOptions): Promise<string>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   profilingLevel(options: ProfilingLevelOptions, callback: Callback<string>): void;
   profilingLevel(
     options?: ProfilingLevelOptions | Callback<string>,
@@ -715,10 +715,10 @@ export class Db {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   indexInformation(name: string): Promise<Document>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   indexInformation(name: string, callback: Callback<Document>): void;
   indexInformation(name: string, options: IndexInformationOptions): Promise<Document>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   indexInformation(
     name: string,
     options: IndexInformationOptions,

--- a/src/db.ts
+++ b/src/db.ts
@@ -110,18 +110,21 @@ export interface DbOptions extends BSONSerializeOptions, WriteConcernOptions, Lo
  * @public
  *
  * @example
- * ```js
- * const { MongoClient } = require('mongodb');
- * // Connection url
- * const url = 'mongodb://localhost:27017';
- * // Database Name
- * const dbName = 'test';
- * // Connect using MongoClient
- * MongoClient.connect(url, function(err, client) {
- *   // Select the database by name
- *   const testDb = client.db(dbName);
- *   client.close();
- * });
+ * ```ts
+ * import { MongoClient } from 'mongodb';
+ *
+ * interface Pet {
+ *   name: string;
+ *   kind: 'dog' | 'cat' | 'fish';
+ * }
+ *
+ * const client = new MongoClient('mongodb://localhost:27017');
+ * const db = client.db();
+ *
+ * // Create a collection that validates our union
+ * await db.createCollection<Pet>('pets', {
+ *   validator: { $expr: { $in: ['$kind', ['dog', 'cat', 'fish']] } }
+ * })
  * ```
  */
 export class Db {

--- a/src/db.ts
+++ b/src/db.ts
@@ -238,10 +238,12 @@ export class Db {
     name: string,
     options?: CreateCollectionOptions
   ): Promise<Collection<TSchema>>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   createCollection<TSchema extends Document = Document>(
     name: string,
     callback: Callback<Collection<TSchema>>
   ): void;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   createCollection<TSchema extends Document = Document>(
     name: string,
     options: CreateCollectionOptions | undefined,
@@ -272,8 +274,10 @@ export class Db {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   command(command: Document): Promise<Document>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   command(command: Document, callback: Callback<Document>): void;
   command(command: Document, options: RunCommandOptions): Promise<Document>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   command(command: Document, options: RunCommandOptions, callback: Callback<Document>): void;
   command(
     command: Document,
@@ -347,8 +351,10 @@ export class Db {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   stats(): Promise<Document>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   stats(callback: Callback<Document>): void;
   stats(options: DbStatsOptions): Promise<Document>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   stats(options: DbStatsOptions, callback: Callback<Document>): void;
   stats(
     options?: DbStatsOptions | Callback<Document>,
@@ -404,6 +410,7 @@ export class Db {
     fromCollection: string,
     toCollection: string
   ): Promise<Collection<TSchema>>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   renameCollection<TSchema extends Document = Document>(
     fromCollection: string,
     toCollection: string,
@@ -414,6 +421,7 @@ export class Db {
     toCollection: string,
     options: RenameOptions
   ): Promise<Collection<TSchema>>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   renameCollection<TSchema extends Document = Document>(
     fromCollection: string,
     toCollection: string,
@@ -453,8 +461,10 @@ export class Db {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   dropCollection(name: string): Promise<boolean>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   dropCollection(name: string, callback: Callback<boolean>): void;
   dropCollection(name: string, options: DropCollectionOptions): Promise<boolean>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   dropCollection(name: string, options: DropCollectionOptions, callback: Callback<boolean>): void;
   dropCollection(
     name: string,
@@ -477,8 +487,10 @@ export class Db {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   dropDatabase(): Promise<boolean>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   dropDatabase(callback: Callback<boolean>): void;
   dropDatabase(options: DropDatabaseOptions): Promise<boolean>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   dropDatabase(options: DropDatabaseOptions, callback: Callback<boolean>): void;
   dropDatabase(
     options?: DropDatabaseOptions | Callback<boolean>,
@@ -500,8 +512,10 @@ export class Db {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   collections(): Promise<Collection[]>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   collections(callback: Callback<Collection[]>): void;
   collections(options: ListCollectionsOptions): Promise<Collection[]>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   collections(options: ListCollectionsOptions, callback: Callback<Collection[]>): void;
   collections(
     options?: ListCollectionsOptions | Callback<Collection[]>,
@@ -525,12 +539,14 @@ export class Db {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   createIndex(name: string, indexSpec: IndexSpecification): Promise<string>;
-  createIndex(name: string, indexSpec: IndexSpecification, callback?: Callback<string>): void;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  createIndex(name: string, indexSpec: IndexSpecification, callback: Callback<string>): void;
   createIndex(
     name: string,
     indexSpec: IndexSpecification,
     options: CreateIndexesOptions
   ): Promise<string>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   createIndex(
     name: string,
     indexSpec: IndexSpecification,
@@ -561,12 +577,16 @@ export class Db {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   addUser(username: string): Promise<Document>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   addUser(username: string, callback: Callback<Document>): void;
   addUser(username: string, password: string): Promise<Document>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   addUser(username: string, password: string, callback: Callback<Document>): void;
   addUser(username: string, options: AddUserOptions): Promise<Document>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   addUser(username: string, options: AddUserOptions, callback: Callback<Document>): void;
   addUser(username: string, password: string, options: AddUserOptions): Promise<Document>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   addUser(
     username: string,
     password: string,
@@ -606,8 +626,10 @@ export class Db {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   removeUser(username: string): Promise<boolean>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   removeUser(username: string, callback: Callback<boolean>): void;
   removeUser(username: string, options: RemoveUserOptions): Promise<boolean>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   removeUser(username: string, options: RemoveUserOptions, callback: Callback<boolean>): void;
   removeUser(
     username: string,
@@ -631,11 +653,13 @@ export class Db {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   setProfilingLevel(level: ProfilingLevel): Promise<ProfilingLevel>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   setProfilingLevel(level: ProfilingLevel, callback: Callback<ProfilingLevel>): void;
   setProfilingLevel(
     level: ProfilingLevel,
     options: SetProfilingLevelOptions
   ): Promise<ProfilingLevel>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   setProfilingLevel(
     level: ProfilingLevel,
     options: SetProfilingLevelOptions,
@@ -662,8 +686,10 @@ export class Db {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   profilingLevel(): Promise<string>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   profilingLevel(callback: Callback<string>): void;
   profilingLevel(options: ProfilingLevelOptions): Promise<string>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   profilingLevel(options: ProfilingLevelOptions, callback: Callback<string>): void;
   profilingLevel(
     options?: ProfilingLevelOptions | Callback<string>,
@@ -686,8 +712,10 @@ export class Db {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   indexInformation(name: string): Promise<Document>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   indexInformation(name: string, callback: Callback<Document>): void;
   indexInformation(name: string, options: IndexInformationOptions): Promise<Document>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   indexInformation(
     name: string,
     options: IndexInformationOptions,

--- a/src/gridfs/index.ts
+++ b/src/gridfs/index.ts
@@ -141,6 +141,7 @@ export class GridFSBucket extends TypedEventEmitter<GridFSBucketEvents> {
    * @param id - The id of the file doc
    */
   delete(id: ObjectId): Promise<void>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   delete(id: ObjectId, callback: Callback<void>): void;
   delete(id: ObjectId, callback?: Callback<void>): Promise<void> | void {
     return maybePromise(callback, callback => {
@@ -211,6 +212,7 @@ export class GridFSBucket extends TypedEventEmitter<GridFSBucketEvents> {
    * @param filename - new name for the file
    */
   rename(id: ObjectId, filename: string): Promise<void>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   rename(id: ObjectId, filename: string, callback: Callback<void>): void;
   rename(id: ObjectId, filename: string, callback?: Callback<void>): Promise<void> | void {
     return maybePromise(callback, callback => {
@@ -232,6 +234,7 @@ export class GridFSBucket extends TypedEventEmitter<GridFSBucketEvents> {
 
   /** Removes this bucket's files collection, followed by its chunks collection. */
   drop(): Promise<void>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   drop(callback: Callback<void>): void;
   drop(callback?: Callback<void>): Promise<void> | void {
     return maybePromise(callback, callback => {

--- a/src/gridfs/index.ts
+++ b/src/gridfs/index.ts
@@ -141,7 +141,7 @@ export class GridFSBucket extends TypedEventEmitter<GridFSBucketEvents> {
    * @param id - The id of the file doc
    */
   delete(id: ObjectId): Promise<void>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   delete(id: ObjectId, callback: Callback<void>): void;
   delete(id: ObjectId, callback?: Callback<void>): Promise<void> | void {
     return maybePromise(callback, callback => {
@@ -212,7 +212,7 @@ export class GridFSBucket extends TypedEventEmitter<GridFSBucketEvents> {
    * @param filename - new name for the file
    */
   rename(id: ObjectId, filename: string): Promise<void>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   rename(id: ObjectId, filename: string, callback: Callback<void>): void;
   rename(id: ObjectId, filename: string, callback?: Callback<void>): Promise<void> | void {
     return maybePromise(callback, callback => {
@@ -234,7 +234,7 @@ export class GridFSBucket extends TypedEventEmitter<GridFSBucketEvents> {
 
   /** Removes this bucket's files collection, followed by its chunks collection. */
   drop(): Promise<void>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   drop(callback: Callback<void>): void;
   drop(callback?: Callback<void>): Promise<void> | void {
     return maybePromise(callback, callback => {

--- a/src/gridfs/upload.ts
+++ b/src/gridfs/upload.ts
@@ -145,6 +145,7 @@ export class GridFSBucketWriteStream extends Writable implements NodeJS.Writable
    * @param callback - called when chunks are successfully removed or error occurred
    */
   abort(): Promise<void>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   abort(callback: Callback<void>): void;
   abort(callback?: Callback<void>): Promise<void> | void {
     return maybePromise(callback, callback => {

--- a/src/gridfs/upload.ts
+++ b/src/gridfs/upload.ts
@@ -145,7 +145,7 @@ export class GridFSBucketWriteStream extends Writable implements NodeJS.Writable
    * @param callback - called when chunks are successfully removed or error occurred
    */
   abort(): Promise<void>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   abort(callback: Callback<void>): void;
   abort(callback?: Callback<void>): Promise<void> | void {
     return maybePromise(callback, callback => {

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -427,7 +427,7 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> {
    * @see docs.mongodb.org/manual/reference/connection-string/
    */
   connect(): Promise<this>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   connect(callback: Callback<this>): void;
   connect(callback?: Callback<this>): Promise<this> | void {
     if (callback && typeof callback !== 'function') {
@@ -449,10 +449,10 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   close(): Promise<void>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   close(callback: Callback<void>): void;
   close(force: boolean): Promise<void>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   close(force: boolean, callback: Callback<void>): void;
   close(
     forceOrCallback?: boolean | Callback<void>,
@@ -567,10 +567,10 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> {
    * @see https://docs.mongodb.org/manual/reference/connection-string/
    */
   static connect(url: string): Promise<MongoClient>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   static connect(url: string, callback: Callback<MongoClient>): void;
   static connect(url: string, options: MongoClientOptions): Promise<MongoClient>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   static connect(url: string, options: MongoClientOptions, callback: Callback<MongoClient>): void;
   static connect(
     url: string,

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -318,36 +318,15 @@ const kOptions = Symbol('options');
  * The programmatically provided options take precedence over the URI options.
  *
  * @example
- * ```js
- * // Connect using a MongoClient instance
- * const MongoClient = require('mongodb').MongoClient;
- * const test = require('assert');
- * // Connection url
- * const url = 'mongodb://localhost:27017';
- * // Database Name
- * const dbName = 'test';
- * // Connect using MongoClient
- * const mongoClient = new MongoClient(url);
- * mongoClient.connect(function(err, client) {
- *   const db = client.db(dbName);
- *   client.close();
- * });
- * ```
+ * ```ts
+ * import { MongoClient } from 'mongodb';
  *
- * @example
- * ```js
- * // Connect using the MongoClient.connect static method
- * const MongoClient = require('mongodb').MongoClient;
- * const test = require('assert');
- * // Connection url
- * const url = 'mongodb://localhost:27017';
- * // Database Name
- * const dbName = 'test';
- * // Connect using MongoClient
- * MongoClient.connect(url, function(err, client) {
- *   const db = client.db(dbName);
- *   client.close();
- * });
+ * // Enable command monitoring for debugging
+ * const client = new MongoClient('mongodb://localhost:27017', { monitorCommands: true });
+ *
+ * client.on('commandStarted', started => console.log(started));
+ * client.db().collection('pets');
+ * await client.insertOne({ name: 'spot', kind: 'dog' });
  * ```
  */
 export class MongoClient extends TypedEventEmitter<MongoClientEvents> {

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -448,6 +448,7 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> {
    * @see docs.mongodb.org/manual/reference/connection-string/
    */
   connect(): Promise<this>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   connect(callback: Callback<this>): void;
   connect(callback?: Callback<this>): Promise<this> | void {
     if (callback && typeof callback !== 'function') {
@@ -469,8 +470,10 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   close(): Promise<void>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   close(callback: Callback<void>): void;
   close(force: boolean): Promise<void>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   close(force: boolean, callback: Callback<void>): void;
   close(
     forceOrCallback?: boolean | Callback<void>,
@@ -585,8 +588,10 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> {
    * @see https://docs.mongodb.org/manual/reference/connection-string/
    */
   static connect(url: string): Promise<MongoClient>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   static connect(url: string, callback: Callback<MongoClient>): void;
   static connect(url: string, options: MongoClientOptions): Promise<MongoClient>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   static connect(url: string, options: MongoClientOptions, callback: Callback<MongoClient>): void;
   static connect(
     url: string,

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -245,10 +245,10 @@ export class ClientSession extends TypedEventEmitter<ClientSessionEvents> {
    * @param callback - Optional callback for completion of this operation
    */
   endSession(): Promise<void>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   endSession(callback: Callback<void>): void;
   endSession(options: EndSessionOptions): Promise<void>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   endSession(options: EndSessionOptions, callback: Callback<void>): void;
   endSession(
     options?: EndSessionOptions | Callback<void>,
@@ -435,7 +435,7 @@ export class ClientSession extends TypedEventEmitter<ClientSessionEvents> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   commitTransaction(): Promise<Document>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   commitTransaction(callback: Callback<Document>): void;
   commitTransaction(callback?: Callback<Document>): Promise<Document> | void {
     return maybePromise(callback, cb => endTransaction(this, 'commitTransaction', cb));
@@ -447,7 +447,7 @@ export class ClientSession extends TypedEventEmitter<ClientSessionEvents> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   abortTransaction(): Promise<Document>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   abortTransaction(callback: Callback<Document>): void;
   abortTransaction(callback?: Callback<Document>): Promise<Document> | void {
     return maybePromise(callback, cb => endTransaction(this, 'abortTransaction', cb));

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -245,8 +245,10 @@ export class ClientSession extends TypedEventEmitter<ClientSessionEvents> {
    * @param callback - Optional callback for completion of this operation
    */
   endSession(): Promise<void>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   endSession(callback: Callback<void>): void;
   endSession(options: EndSessionOptions): Promise<void>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   endSession(options: EndSessionOptions, callback: Callback<void>): void;
   endSession(
     options?: EndSessionOptions | Callback<void>,
@@ -433,6 +435,7 @@ export class ClientSession extends TypedEventEmitter<ClientSessionEvents> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   commitTransaction(): Promise<Document>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   commitTransaction(callback: Callback<Document>): void;
   commitTransaction(callback?: Callback<Document>): Promise<Document> | void {
     return maybePromise(callback, cb => endTransaction(this, 'commitTransaction', cb));
@@ -444,6 +447,7 @@ export class ClientSession extends TypedEventEmitter<ClientSessionEvents> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   abortTransaction(): Promise<Document>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version */
   abortTransaction(callback: Callback<Document>): void;
   abortTransaction(callback?: Callback<Document>): Promise<Document> | void {
     return maybePromise(callback, cb => endTransaction(this, 'abortTransaction', cb));

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1233,7 +1233,7 @@ export const DEFAULT_PK_FACTORY = {
  * @public
  *
  * @example
- * ```js
+ * ```ts
  * process.on('warning', (warning) => {
  *  if (warning.code === MONGODB_WARNING_CODE) console.error('Ah an important warning! :)')
  * })


### PR DESCRIPTION
### Description

#### What is changing?

* tsdoc indicated deprecations for callbacks

#### What is the motivation for this change?

* deprecation will strike through code in editors supporting type info

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- N/A Changes are covered by tests
- N/A New TODOs have a related JIRA ticket
