### PR TITLE
fix(NODE-4557): randomize servers when there are only 2 eligible servers 

### DIFF
--- a/src/sdam/topology.ts
+++ b/src/sdam/topology.ts
@@ -903,6 +903,20 @@ function processWaitQueue(topology: Topology) {
       continue;
     } else if (selectedDescriptions.length === 1) {
       selectedServer = topology.s.servers.get(selectedDescriptions[0].address);
+    } else if (selectedDescriptions.length === 2) {
+      // If there are only two servers, we avoid shuffling the array of
+      // server descriptions
+      const server1 = topology.s.servers.get(selectedDescriptions[0].address);
+      const server2 = topology.s.servers.get(selectedDescriptions[1].address);
+
+      if (server1?.s.operationCount === server2?.s.operationCount) {
+        selectedServer = Math.floor(Math.random() * 2) === 0 ? server1 : server2;
+      } else {
+        selectedServer =
+          server1 && server2 && server1.s.operationCount < server2.s.operationCount
+            ? server1
+            : server2;
+      }
     } else {
       const descriptions = shuffle(selectedDescriptions, 2);
       const server1 = topology.s.servers.get(descriptions[0].address);

--- a/src/sdam/topology.ts
+++ b/src/sdam/topology.ts
@@ -903,19 +903,6 @@ function processWaitQueue(topology: Topology) {
       continue;
     } else if (selectedDescriptions.length === 1) {
       selectedServer = topology.s.servers.get(selectedDescriptions[0].address);
-    } else if (selectedDescriptions.length === 2) {
-      const server1 = topology.s.servers.get(selectedDescriptions[0].address);
-      const server2 = topology.s.servers.get(selectedDescriptions[1].address);
-
-      if (server1 && server2) {
-        if (server1.s.operationCount === server2.s.operationCount) {
-          // If there are only two servers, we avoid shuffling the array of
-          // server descriptions
-          selectedServer = Math.floor(Math.random() * 2) === 0 ? server1 : server2;
-        } else {
-          selectedServer = server1.s.operationCount < server2.s.operationCount ? server1 : server2;
-        }
-      }
     } else {
       const descriptions = shuffle(selectedDescriptions, 2);
       const server1 = topology.s.servers.get(descriptions[0].address);

--- a/src/sdam/topology.ts
+++ b/src/sdam/topology.ts
@@ -904,9 +904,7 @@ function processWaitQueue(topology: Topology) {
     } else if (selectedDescriptions.length === 1) {
       selectedServer = topology.s.servers.get(selectedDescriptions[0].address);
     } else {
-      // don't shuffle the array if there are only two elements
-      const descriptions =
-        selectedDescriptions.length === 2 ? selectedDescriptions : shuffle(selectedDescriptions, 2);
+      const descriptions = shuffle(selectedDescriptions, 2);
       const server1 = topology.s.servers.get(descriptions[0].address);
       const server2 = topology.s.servers.get(descriptions[1].address);
 

--- a/src/sdam/topology.ts
+++ b/src/sdam/topology.ts
@@ -904,13 +904,13 @@ function processWaitQueue(topology: Topology) {
     } else if (selectedDescriptions.length === 1) {
       selectedServer = topology.s.servers.get(selectedDescriptions[0].address);
     } else if (selectedDescriptions.length === 2) {
-      // If there are only two servers, we avoid shuffling the array of
-      // server descriptions
       const server1 = topology.s.servers.get(selectedDescriptions[0].address);
       const server2 = topology.s.servers.get(selectedDescriptions[1].address);
 
       if (server1 && server2) {
         if (server1.s.operationCount === server2.s.operationCount) {
+          // If there are only two servers, we avoid shuffling the array of
+          // server descriptions
           selectedServer = Math.floor(Math.random() * 2) === 0 ? server1 : server2;
         } else {
           selectedServer = server1.s.operationCount < server2.s.operationCount ? server1 : server2;

--- a/src/sdam/topology.ts
+++ b/src/sdam/topology.ts
@@ -909,13 +909,12 @@ function processWaitQueue(topology: Topology) {
       const server1 = topology.s.servers.get(selectedDescriptions[0].address);
       const server2 = topology.s.servers.get(selectedDescriptions[1].address);
 
-      if (server1?.s.operationCount === server2?.s.operationCount) {
-        selectedServer = Math.floor(Math.random() * 2) === 0 ? server1 : server2;
-      } else {
-        selectedServer =
-          server1 && server2 && server1.s.operationCount < server2.s.operationCount
-            ? server1
-            : server2;
+      if (server1 && server2) {
+        if (server1.s.operationCount === server2.s.operationCount) {
+          selectedServer = Math.floor(Math.random() * 2) === 0 ? server1 : server2;
+        } else {
+          selectedServer = server1.s.operationCount < server2.s.operationCount ? server1 : server2;
+        }
       }
     } else {
       const descriptions = shuffle(selectedDescriptions, 2);

--- a/test/integration/server-selection/server_selection.prose.operation_count.test.ts
+++ b/test/integration/server-selection/server_selection.prose.operation_count.test.ts
@@ -165,4 +165,27 @@ describe('operationCount-based Selection Within Latency Window - Prose Test', fu
     expect(percentageToHost1).to.be.greaterThan(40).and.lessThan(60);
     expect(percentageToHost2).to.be.greaterThan(40).and.lessThan(60);
   });
+
+  it(
+    'equally distributes operations with both hosts when requests are in parallel',
+    TEST_METADATA,
+    async function () {
+      const collection = client.db('test-db').collection('collection0');
+
+      const { insertedId } = await collection.insertOne({ name: 'bumpy' });
+
+      const n = 1000;
+
+      for (let i = 0; i < n; ++i) {
+        await collection.findOne({ _id: insertedId });
+      }
+
+      // Step 9: Using command monitoring events, assert that each mongos was selected roughly 50% of the time (within +/- 10%).
+      const [host1, host2] = seeds.map(seed => seed.split(':')[1]);
+      const percentageToHost1 = (counts[host1] / n) * 100;
+      const percentageToHost2 = (counts[host2] / n) * 100;
+      expect(percentageToHost1).to.be.greaterThan(40).and.lessThan(60);
+      expect(percentageToHost2).to.be.greaterThan(40).and.lessThan(60);
+    }
+  );
 });

--- a/test/integration/server-selection/server_selection.prose.operation_count.test.ts
+++ b/test/integration/server-selection/server_selection.prose.operation_count.test.ts
@@ -167,8 +167,12 @@ describe('operationCount-based Selection Within Latency Window - Prose Test', fu
   });
 
   it(
-    'equally distributes operations with both hosts when requests are in parallel',
+    'equally distributes operations with both hosts when requests are in sequence',
     TEST_METADATA,
+    /**
+     * note that this test is NOT a prose test, but it lives in this file because it uses the
+     * same setup as the operation count prose tests
+     */
     async function () {
       const collection = client.db('test-db').collection('collection0');
 
@@ -180,7 +184,6 @@ describe('operationCount-based Selection Within Latency Window - Prose Test', fu
         await collection.findOne({ _id: insertedId });
       }
 
-      // Step 9: Using command monitoring events, assert that each mongos was selected roughly 50% of the time (within +/- 10%).
       const [host1, host2] = seeds.map(seed => seed.split(':')[1]);
       const percentageToHost1 = (counts[host1] / n) * 100;
       const percentageToHost2 = (counts[host2] / n) * 100;


### PR DESCRIPTION
### Description

#### What is changing?

When we encounter exactly 2 eligible servers in the server selection process, we now shuffle the array of two servers.   This prevents a scenario where, when we receive a sequence of operations and each operation completes before the next (or approximately this scenario), we would select the same server for each request.

##### Is there new documentation needed for these changes?

No.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
