### PR TITLE
test(NODE-4585): ensure empty aws env variables

### DIFF
--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -619,6 +619,9 @@ functions:
         working_dir: "src"
         script: |
           ${PREPARE_SHELL}
+          # Write an empty prepare_mongodb_aws so no auth environment variables
+          # are set.
+          echo "" > "${PROJECT_DIRECTORY}/prepare_mongodb_aws.sh"
           cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
           . ./activate_venv.sh
           ${MONGODB_BINARIES}/mongo aws_e2e_ec2.js

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -584,6 +584,9 @@ functions:
         working_dir: src
         script: |
           ${PREPARE_SHELL}
+          # Write an empty prepare_mongodb_aws so no auth environment variables
+          # are set.
+          echo "" > "${PROJECT_DIRECTORY}/prepare_mongodb_aws.sh"
           cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
           . ./activate_venv.sh
           ${MONGODB_BINARIES}/mongo aws_e2e_ec2.js


### PR DESCRIPTION
### Description

Ensures that when testing AWS auth against EC2 does not accidentally pull the secret key or access key from the written prepare_mongodb_aws.sh script.

#### What is changing?

Writes an empty file to prepare_mongodb_aws.sh before the EC2 auth task runs.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-4585

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
