### PR TITLE
fix(NODE-3986): unskip MONGODB-AWS test

### DIFF
--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -8,7 +8,12 @@ import { MongoCredentials } from './cmap/auth/mongo_credentials';
 import { AUTH_MECHS_AUTH_SRC_EXTERNAL, AuthMechanism } from './cmap/auth/providers';
 import { Compressor, CompressorName } from './cmap/wire_protocol/compression';
 import { Encrypter } from './encrypter';
-import { MongoAPIError, MongoInvalidArgumentError, MongoParseError } from './error';
+import {
+  MongoAPIError,
+  MongoInvalidArgumentError,
+  MongoMissingCredentialsError,
+  MongoParseError
+} from './error';
 import { Logger, LoggerLevel } from './logger';
 import {
   DriverInfo,
@@ -408,7 +413,7 @@ export function parseOptions(
     }
 
     if (isAws && mongoOptions.credentials.username && !mongoOptions.credentials.password) {
-      throw new MongoParseError(
+      throw new MongoMissingCredentialsError(
         `When using ${mongoOptions.credentials.mechanism} password must be set when a username is specified`
       );
     }

--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -409,7 +409,7 @@ export function parseOptions(
 
     if (isAws && mongoOptions.credentials.username && !mongoOptions.credentials.password) {
       throw new MongoParseError(
-        `${mongoOptions.credentials} must receive a password when a username is specified`
+        `${mongoOptions.credentials.mechanism} must receive a password when a username is specified`
       );
     }
 

--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -409,7 +409,7 @@ export function parseOptions(
 
     if (isAws && mongoOptions.credentials.username && !mongoOptions.credentials.password) {
       throw new MongoParseError(
-        `${mongoOptions.credentials.mechanism} must receive a password when a username is specified`
+        `When using ${mongoOptions.credentials.mechanism} password must be set when a username is specified`
       );
     }
 

--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -407,6 +407,12 @@ export function parseOptions(
       });
     }
 
+    if (isAws && mongoOptions.credentials.username && !mongoOptions.credentials.password) {
+      throw new MongoParseError(
+        `${mongoOptions.credentials} must receive a password when a username is specified`
+      );
+    }
+
     mongoOptions.credentials.validate();
 
     // Check if the only auth related option provided was authSource, if so we can remove credentials

--- a/test/unit/assorted/auth.spec.test.ts
+++ b/test/unit/assorted/auth.spec.test.ts
@@ -1,8 +1,6 @@
 import { loadSpecTests } from '../../spec';
 import { executeUriValidationTest } from '../../tools/uri_spec_runner';
 
-const SKIP = ['should throw an exception if username and no password (MONGODB-AWS)'];
-
 describe('Auth option spec tests', function () {
   const suites = loadSpecTests('auth');
 
@@ -10,10 +8,6 @@ describe('Auth option spec tests', function () {
     describe(suite.name, function () {
       for (const test of suite.tests) {
         it(`${test.description}`, function () {
-          if (SKIP.includes(test.description)) {
-            this.test.skipReason = 'NODE-3986: Fix MONGODB-AWS Spec Test';
-            this.skip();
-          }
           executeUriValidationTest(test);
         });
       }


### PR DESCRIPTION
### Description

Update driver to throw exception when the following conditions are met:

- Using `MONGODB-AWS` auth mechanism
- A `username` is provided
- A `password` is not provided 

#### What is changing?

Adding check to see if preceding conditions are met when constructing `mongoOptions` object.

Unskip [test](https://github.com/mongodb/specifications/blob/master/source/auth/tests/connection-string.json#L453-L456) that checks this behavior.

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

[NODE-3986](https://jira.mongodb.org/browse/NODE-3986)

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
