### PR TITLE
refactor(NODE-4617): use promise apis in benchmarks

### DIFF
--- a/test/benchmarks/mongoBench/benchmark.js
+++ b/test/benchmarks/mongoBench/benchmark.js
@@ -14,6 +14,7 @@ class Benchmark {
     // Meta information
     this._taskSize = null;
     this._description = null;
+    this._taskType = 'async';
   }
 
   /**
@@ -97,6 +98,23 @@ class Benchmark {
   }
 
   /**
+   * Sets the task type - either a synchronous or asynchronous task.  The default is async.
+   *
+   * @param {'async' | 'sync'} type - the type of task
+   */
+  taskType(type) {
+    if (['async', 'sync'].includes(type)) {
+      this._taskType = type;
+    } else {
+      throw new Error(
+        `Invalid value for benchmark field _taskType: expected either 'async' or 'sync', but received ${type}`
+      );
+    }
+
+    return this;
+  }
+
+  /**
    * Set the Description
    *
    * @param {string} description The description of the benchmark
@@ -122,11 +140,11 @@ class Benchmark {
    * @throws Error
    */
   validate() {
-    ['_task', '_taskSize'].forEach(key => {
+    for (const key of ['_task', '_taskSize', '_taskType']) {
       if (!this[key]) {
         throw new Error(`Benchmark is missing required field ${key}`);
       }
-    });
+    }
   }
 
   toObj() {

--- a/test/benchmarks/mongoBench/runner.js
+++ b/test/benchmarks/mongoBench/runner.js
@@ -9,33 +9,10 @@ function percentileIndex(percentile, total) {
   return Math.max(Math.floor((total * percentile) / 100 - 1), 0);
 }
 
-function timeDoneTask(task, ctx) {
-  return new Promise((resolve, reject) => {
-    let called = false;
-    const start = performance.now();
-    task.call(ctx, err => {
-      const end = performance.now(start);
-      if (called) return;
-      if (err) return reject(err);
-      return resolve((end - start) / 1000);
-    });
-  });
-}
-
 async function timeTask(task, ctx) {
-  // Some tasks are async, so they take callbacks.
-  if (task.length) {
-    return timeDoneTask(task, ctx);
-  }
-
   const start = performance.now();
-  const ret = task.call(ctx);
-  let end = performance.now();
-
-  if (ret && ret.then) {
-    await ret;
-    end = performance.now();
-  }
+  await task.call(ctx);
+  const end = performance.now();
 
   return (end - start) / 1000;
 }

--- a/test/benchmarks/mongoBench/runner.js
+++ b/test/benchmarks/mongoBench/runner.js
@@ -165,22 +165,14 @@ class Runner {
     let time = performance.now() - start;
     let count = 1;
 
-    if (benchmark._taskType === 'sync') {
+    const taskTimer = benchmark._taskType === 'sync' ? timeSyncTask : timeAsyncTask;
+
       while (time < maxExecutionTime && (time < minExecutionTime || count < minExecutionCount)) {
         await benchmark.beforeTask.call(ctx);
-        const executionTime = timeSyncTask(benchmark.task, ctx);
+      const executionTime = await taskTimer(benchmark.task, ctx);
         rawData.push(executionTime);
         count++;
         time = performance.now();
-      }
-    } else {
-      while (time < maxExecutionTime && (time < minExecutionTime || count < minExecutionCount)) {
-        await benchmark.beforeTask.call(ctx);
-        const executionTime = await timeAsyncTask(benchmark.task, ctx);
-        rawData.push(executionTime);
-        count++;
-        time = performance.now();
-      }
     }
 
     return {

--- a/test/benchmarks/mongoBench/runner.js
+++ b/test/benchmarks/mongoBench/runner.js
@@ -167,12 +167,12 @@ class Runner {
 
     const taskTimer = benchmark._taskType === 'sync' ? timeSyncTask : timeAsyncTask;
 
-      while (time < maxExecutionTime && (time < minExecutionTime || count < minExecutionCount)) {
-        await benchmark.beforeTask.call(ctx);
+    while (time < maxExecutionTime && (time < minExecutionTime || count < minExecutionCount)) {
+      await benchmark.beforeTask.call(ctx);
       const executionTime = await taskTimer(benchmark.task, ctx);
-        rawData.push(executionTime);
-        count++;
-        time = performance.now();
+      rawData.push(executionTime);
+      count++;
+      time = performance.now();
     }
 
     return {

--- a/test/benchmarks/mongoBench/suites/bsonBench.js
+++ b/test/benchmarks/mongoBench/suites/bsonBench.js
@@ -27,22 +27,22 @@ function makeBsonBench({ suite, BSON }) {
   }
   return suite
     .benchmark('flatBsonEncoding', benchmark =>
-      benchmark.taskSize(75.31).setup(makeBSONLoader('flat_bson')).task(encodeBSON)
+      benchmark.taskSize(75.31).taskType('sync').setup(makeBSONLoader('flat_bson')).task(encodeBSON)
     )
     .benchmark('flatBsonDecoding', benchmark =>
-      benchmark.taskSize(75.31).setup(makeBSONLoader('flat_bson')).task(decodeBSON)
+      benchmark.taskSize(75.31).taskType('sync').setup(makeBSONLoader('flat_bson')).task(decodeBSON)
     )
     .benchmark('deepBsonEncoding', benchmark =>
-      benchmark.taskSize(19.64).setup(makeBSONLoader('deep_bson')).task(encodeBSON)
+      benchmark.taskSize(19.64).taskType('sync').setup(makeBSONLoader('deep_bson')).task(encodeBSON)
     )
     .benchmark('deepBsonDecoding', benchmark =>
-      benchmark.taskSize(19.64).setup(makeBSONLoader('deep_bson')).task(decodeBSON)
+      benchmark.taskSize(19.64).taskType('sync').setup(makeBSONLoader('deep_bson')).task(decodeBSON)
     )
     .benchmark('fullBsonEncoding', benchmark =>
-      benchmark.taskSize(57.34).setup(makeBSONLoader('full_bson')).task(encodeBSON)
+      benchmark.taskSize(57.34).taskType('sync').setup(makeBSONLoader('full_bson')).task(encodeBSON)
     )
     .benchmark('fullBsonDecoding', benchmark =>
-      benchmark.taskSize(57.34).setup(makeBSONLoader('full_bson')).task(decodeBSON)
+      benchmark.taskSize(57.34).taskType('sync').setup(makeBSONLoader('full_bson')).task(decodeBSON)
     );
 }
 

--- a/test/benchmarks/mongoBench/suites/singleBench.js
+++ b/test/benchmarks/mongoBench/suites/singleBench.js
@@ -84,7 +84,7 @@ function makeSingleBench(suite) {
         .beforeTask(createCollection)
         .beforeTask(initCollection)
         .beforeTask(function () {
-          this.docs = Array.from(10, () => Object.assign({}, this.doc));
+          this.docs = Array.from({ length: 10 }, () => Object.assign({}, this.doc));
         })
         .task(async function () {
           for (const doc of this.docs) {

--- a/test/benchmarks/mongoBench/suites/singleBench.js
+++ b/test/benchmarks/mongoBench/suites/singleBench.js
@@ -59,7 +59,7 @@ function makeSingleBench(suite) {
         .beforeTask(createCollection)
         .beforeTask(initCollection)
         .beforeTask(function () {
-          this.docs = Array.from(10000, () => Object.assign({}, this.doc));
+          this.docs = Array.from({ length: 10000 }, () => Object.assign({}, this.doc));
         })
         .task(async function () {
           for (const doc of this.docs) {

--- a/test/benchmarks/mongoBench/suites/singleBench.js
+++ b/test/benchmarks/mongoBench/suites/singleBench.js
@@ -58,9 +58,11 @@ function makeSingleBench(suite) {
         .beforeTask(dropCollection)
         .beforeTask(createCollection)
         .beforeTask(initCollection)
+        .beforeTask(function () {
+          this.docs = Array.from(10000, () => Object.assign({}, this.doc));
+        })
         .task(async function () {
-          for (let i = 0; i < 10000; ++i) {
-            const doc = Object.assign({}, this.doc);
+          for (const doc of this.docs) {
             await this.collection.insertOne(doc);
           }
         })
@@ -81,9 +83,11 @@ function makeSingleBench(suite) {
         .beforeTask(dropCollection)
         .beforeTask(createCollection)
         .beforeTask(initCollection)
+        .beforeTask(function () {
+          this.docs = Array.from(10, () => Object.assign({}, this.doc));
+        })
         .task(async function () {
-          for (let i = 0; i < 10; ++i) {
-            const doc = Object.assign({}, this.doc);
+          for (const doc of this.docs) {
             await this.collection.insertOne(doc);
           }
         })

--- a/test/benchmarks/mongoBench/suites/singleBench.js
+++ b/test/benchmarks/mongoBench/suites/singleBench.js
@@ -11,45 +11,6 @@ const {
   makeLoadTweets
 } = require('../../driverBench/common');
 
-function makeTestInsertOne(numberOfOps) {
-  return function (done) {
-    const loop = _id => {
-      if (_id > numberOfOps) {
-        return done();
-      }
-
-      const doc = Object.assign({}, this.doc);
-
-      this.collection.insertOne(doc, err => (err ? done(err) : loop(_id + 1)));
-    };
-
-    loop(1);
-  };
-}
-
-function findOneById(done) {
-  const loop = _id => {
-    if (_id > 10000) {
-      return done();
-    }
-
-    return this.collection.findOne({ _id }, err => (err ? done(err) : loop(_id + 1)));
-  };
-
-  return loop(1);
-}
-
-function runCommand(done) {
-  const loop = _id => {
-    if (_id > 10000) {
-      return done();
-    }
-    return this.db.command({ hello: true }, err => (err ? done(err) : loop(_id + 1)));
-  };
-
-  return loop(1);
-}
-
 function makeSingleBench(suite) {
   suite
     .benchmark('runCommand', benchmark =>
@@ -58,7 +19,11 @@ function makeSingleBench(suite) {
         .setup(makeClient)
         .setup(connectClient)
         .setup(initDb)
-        .task(runCommand)
+        .task(async function () {
+          for (let i = 0; i < 10000; ++i) {
+            await this.db.command({ hello: true });
+          }
+        })
         .teardown(disconnectClient)
     )
     .benchmark('findOne', benchmark =>
@@ -71,7 +36,11 @@ function makeSingleBench(suite) {
         .setup(dropDb)
         .setup(initCollection)
         .setup(makeLoadTweets(true))
-        .task(findOneById)
+        .task(async function () {
+          for (let _id = 0; _id < 10000; ++_id) {
+            await this.collection.findOne({ _id });
+          }
+        })
         .teardown(dropDb)
         .teardown(disconnectClient)
     )
@@ -89,7 +58,12 @@ function makeSingleBench(suite) {
         .beforeTask(dropCollection)
         .beforeTask(createCollection)
         .beforeTask(initCollection)
-        .task(makeTestInsertOne(10000))
+        .task(async function () {
+          for (let i = 0; i < 10000; ++i) {
+            const doc = Object.assign({}, this.doc);
+            await this.collection.insertOne(doc);
+          }
+        })
         .teardown(dropDb)
         .teardown(disconnectClient)
     )
@@ -107,7 +81,12 @@ function makeSingleBench(suite) {
         .beforeTask(dropCollection)
         .beforeTask(createCollection)
         .beforeTask(initCollection)
-        .task(makeTestInsertOne(10))
+        .task(async function () {
+          for (let i = 0; i < 10; ++i) {
+            const doc = Object.assign({}, this.doc);
+            await this.collection.insertOne(doc);
+          }
+        })
         .teardown(dropDb)
         .teardown(disconnectClient)
     );


### PR DESCRIPTION
### Description

#### What is changing?

Our benchmarks now test the promise-based API instead of the callback based api.

##### Is there new documentation needed for these changes?

No.

#### What is the motivation for this change?

We should benchmark the API we plan to support.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
