### PR TITLE
test(NODE-4605, NODE-4597, NODE-4618): sync latest change stream unified tests

### DIFF
--- a/test/spec/change-streams/unified/change-streams-clusterTime.json
+++ b/test/spec/change-streams/unified/change-streams-clusterTime.json
@@ -1,0 +1,81 @@
+{
+  "description": "change-streams-clusterTime",
+  "schemaVersion": "1.3",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": false
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "database0"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "collection0"
+      }
+    }
+  ],
+  "runOnRequirements": [
+    {
+      "minServerVersion": "4.0.0",
+      "topologies": [
+        "replicaset",
+        "sharded-replicaset",
+        "load-balanced",
+        "sharded"
+      ]
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "collection0",
+      "databaseName": "database0",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "clusterTime is present",
+      "operations": [
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": []
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "ns": {
+              "db": "database0",
+              "coll": "collection0"
+            },
+            "clusterTime": {
+              "$$exists": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/change-streams/unified/change-streams-clusterTime.yml
+++ b/test/spec/change-streams/unified/change-streams-clusterTime.yml
@@ -1,0 +1,40 @@
+description: "change-streams-clusterTime"
+schemaVersion: "1.3"
+createEntities:
+  - client:
+      id: &client0 client0
+      useMultipleMongoses: false
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: *database0
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: *collection0
+
+runOnRequirements:
+  - minServerVersion: "4.0.0"
+    topologies: [ replicaset, sharded-replicaset, load-balanced, sharded ]
+
+initialData:
+  - collectionName: *collection0
+    databaseName: *database0
+    documents: []
+
+tests:
+  - description: "clusterTime is present"
+    operations:
+      - name: createChangeStream
+        object: *collection0
+        arguments: { pipeline: [] }
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: { _id: 1 }
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          ns: { db: *database0, coll: *collection0 }
+          clusterTime: { $$exists: true }

--- a/test/spec/change-streams/unified/change-streams-disambiguatedPaths.json
+++ b/test/spec/change-streams/unified/change-streams-disambiguatedPaths.json
@@ -1,6 +1,6 @@
 {
   "description": "disambiguatedPaths",
-  "schemaVersion": "1.3",
+  "schemaVersion": "1.4",
   "createEntities": [
     {
       "client": {
@@ -31,7 +31,8 @@
         "sharded-replicaset",
         "load-balanced",
         "sharded"
-      ]
+      ],
+      "serverless": "forbid"
     }
   ],
   "initialData": [

--- a/test/spec/change-streams/unified/change-streams-disambiguatedPaths.yml
+++ b/test/spec/change-streams/unified/change-streams-disambiguatedPaths.yml
@@ -1,5 +1,5 @@
 description: "disambiguatedPaths"
-schemaVersion: "1.3"
+schemaVersion: "1.4"
 createEntities:
   - client:
       id: &client0 client0
@@ -16,6 +16,7 @@ createEntities:
 runOnRequirements:
   - minServerVersion: "6.1.0"
     topologies: [ replicaset, sharded-replicaset, load-balanced, sharded ]
+    serverless: forbid
 
 initialData:
   - collectionName: *collection0

--- a/test/spec/change-streams/unified/change-streams-showExpandedEvents.json
+++ b/test/spec/change-streams/unified/change-streams-showExpandedEvents.json
@@ -275,7 +275,15 @@
           "name": "createChangeStream",
           "object": "collection0",
           "arguments": {
-            "pipeline": [],
+            "pipeline": [
+              {
+                "$match": {
+                  "operationType": {
+                    "$ne": "create"
+                  }
+                }
+              }
+            ],
             "showExpandedEvents": true
           },
           "saveResultAsEntity": "changeStream0"

--- a/test/spec/change-streams/unified/change-streams-showExpandedEvents.yml
+++ b/test/spec/change-streams/unified/change-streams-showExpandedEvents.yml
@@ -160,7 +160,15 @@ tests:
       - name: createChangeStream
         object: *collection0
         arguments:
-          pipeline: []
+          pipeline:
+            # On sharded clusters, the create command run when loading initial
+            # data sometimes is still reported in the change stream. To avoid
+            # this, we exclude the create command when creating the change
+            # stream, but specifically don't exclude other events to still catch
+            # driver errors.
+            - $match:
+                operationType:
+                  $ne: create
           showExpandedEvents: true
         saveResultAsEntity: &changeStream0 changeStream0
       - name: createIndex


### PR DESCRIPTION
### Description

#### What is changing?

This PR syncs the unified change stream tests to the latest in the specs repo.

There are three drivers tickets covered here.  I broke it out into one commit per drivers ticket:

- 2f263547a04b985b89e2afc52ef3ee50228e8681 covers [NODE-4605](https://jira.mongodb.org/browse/NODE-4605)
- 908ea4781c7424d5a8c8a0174e2f06a7ff0e4e1d covers [NODE-4597](https://jira.mongodb.org/browse/NODE-4597)
- 8bd1eebfaed0258c0ce30e854f6ef831c7d0f85b covers [NODE-4618](https://jira.mongodb.org/browse/NODE-4618)