### PR TITLE
feat(NODE-4519): deprecate promiseLibrary and check for emitted warning

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -97,10 +97,11 @@ export {
   Logger,
   MongoClient,
   OrderedBulkOperation,
-  // Utils
-  PromiseProvider as Promise,
   UnorderedBulkOperation
 };
+
+/** @deprecated Setting a custom promise library is deprecated the next major version will use the global Promise constructor only. */
+export const Promise = PromiseProvider;
 
 // enums
 export { BatchType } from './bulk/common';

--- a/src/index.ts
+++ b/src/index.ts
@@ -100,8 +100,8 @@ export {
   UnorderedBulkOperation
 };
 
-/** @deprecated Setting a custom promise library is deprecated the next major version will use the global Promise constructor only. */
-export const Promise = PromiseProvider;
+// Deprecated, remove in next major
+export { PromiseProvider as Promise };
 
 // enums
 export { BatchType } from './bulk/common';

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -230,7 +230,10 @@ export interface MongoClientOptions extends BSONSerializeOptions, SupportedNodeC
   raw?: boolean;
   /** A primary key factory function for generation of custom `_id` keys */
   pkFactory?: PkFactory;
-  /** A Promise library class the application wishes to use such as Bluebird, must be ES6 compatible */
+  /**
+   * A Promise library class the application wishes to use such as Bluebird, must be ES6 compatible
+   * @deprecated Setting a custom promise library is deprecated the next major version will use the global Promise constructor only.
+   */
   promiseLibrary?: any;
   /** The logging level */
   loggerLevel?: LoggerLevel;

--- a/src/promise_provider.ts
+++ b/src/promise_provider.ts
@@ -17,14 +17,20 @@ const store: PromiseStore = {
  * @public
  */
 export class PromiseProvider {
-  /** Validates the passed in promise library */
+  /**
+   * Validates the passed in promise library
+   * @deprecated Setting a custom promise library is deprecated the next major version will use the global Promise constructor only.
+   */
   static validate(lib: unknown): lib is PromiseConstructor {
     if (typeof lib !== 'function')
       throw new MongoInvalidArgumentError(`Promise must be a function, got ${lib}`);
     return !!lib;
   }
 
-  /** Sets the promise library */
+  /**
+   * Sets the promise library
+   * @deprecated Setting a custom promise library is deprecated the next major version will use the global Promise constructor only.
+   */
   static set(lib: PromiseConstructor): void {
     if (!PromiseProvider.validate(lib)) {
       // validate
@@ -33,7 +39,10 @@ export class PromiseProvider {
     store[kPromise] = lib;
   }
 
-  /** Get the stored promise library, or resolves passed in */
+  /**
+   * Get the stored promise library, or resolves passed in
+   * @deprecated Setting a custom promise library is deprecated the next major version will use the global Promise constructor only.
+   */
   static get(): PromiseConstructor {
     return store[kPromise] as PromiseConstructor;
   }

--- a/src/promise_provider.ts
+++ b/src/promise_provider.ts
@@ -13,6 +13,7 @@ const store: PromiseStore = {
 
 /**
  * Global promise store allowing user-provided promises
+ * @deprecated Setting a custom promise library is deprecated the next major version will use the global Promise constructor only.
  * @public
  */
 export class PromiseProvider {

--- a/test/integration/node-specific/custom_promise_library.test.js
+++ b/test/integration/node-specific/custom_promise_library.test.js
@@ -1,7 +1,9 @@
 'use strict';
 
+const { once } = require('events');
 const { expect } = require('chai');
 const { PromiseProvider } = require('../../../src/promise_provider');
+const { MongoClient } = require('../../../src/mongo_client');
 
 class CustomPromise extends Promise {}
 CustomPromise.prototype.isCustomMongo = true;
@@ -9,6 +11,13 @@ CustomPromise.prototype.isCustomMongo = true;
 describe('Optional PromiseLibrary', function () {
   afterEach(() => {
     PromiseProvider.set(Promise);
+  });
+
+  it('should emit a deprecation warning when a promiseLibrary is set', async () => {
+    const willEmitWarning = once(process, 'warning');
+    new MongoClient('mongodb://iLoveJavascript', { promiseLibrary: () => {} });
+    const [warning] = await willEmitWarning;
+    expect(warning).to.have.property('message', 'promiseLibrary is a deprecated option');
   });
 
   it('should correctly implement custom dependency-less promise', function (done) {

--- a/test/types/mongodb.test-d.ts
+++ b/test/types/mongodb.test-d.ts
@@ -21,8 +21,10 @@ expectDeprecated(FindCursor.prototype.count);
 expectDeprecated(Topology.prototype.unref);
 expectDeprecated(Db.prototype.unref);
 expectDeprecated(MongoDBDriver.ObjectID);
-expectDeprecated(MongoDBDriver.Promise);
 expectNotDeprecated(MongoDBDriver.ObjectId);
+
+// Unfortunately we cannot deprecate the export will also satisfying our tooling that requires every public symbol be exported
+expectNotDeprecated(MongoDBDriver.Promise);
 
 declare const options: MongoDBDriver.MongoClientOptions;
 expectDeprecated(options.w);

--- a/test/types/mongodb.test-d.ts
+++ b/test/types/mongodb.test-d.ts
@@ -23,8 +23,14 @@ expectDeprecated(Db.prototype.unref);
 expectDeprecated(MongoDBDriver.ObjectID);
 expectNotDeprecated(MongoDBDriver.ObjectId);
 
-// Unfortunately we cannot deprecate the export will also satisfying our tooling that requires every public symbol be exported
+// We cannot attach a deprecation tag to an export
+// We tried export const Promise = PromiseProvider;
+// but then api-extractor claims PromiseProvider is not exported
+// Instead we've deprecated all the methods on the class
 expectNotDeprecated(MongoDBDriver.Promise);
+expectDeprecated(MongoDBDriver.Promise.validate);
+expectDeprecated(MongoDBDriver.Promise.get);
+expectDeprecated(MongoDBDriver.Promise.set);
 
 declare const options: MongoDBDriver.MongoClientOptions;
 expectDeprecated(options.w);

--- a/test/types/mongodb.test-d.ts
+++ b/test/types/mongodb.test-d.ts
@@ -21,6 +21,7 @@ expectDeprecated(FindCursor.prototype.count);
 expectDeprecated(Topology.prototype.unref);
 expectDeprecated(Db.prototype.unref);
 expectDeprecated(MongoDBDriver.ObjectID);
+expectDeprecated(MongoDBDriver.Promise);
 expectNotDeprecated(MongoDBDriver.ObjectId);
 
 declare const options: MongoDBDriver.MongoClientOptions;

--- a/test/types/mongodb.test-d.ts
+++ b/test/types/mongodb.test-d.ts
@@ -27,6 +27,7 @@ declare const options: MongoDBDriver.MongoClientOptions;
 expectDeprecated(options.w);
 expectDeprecated(options.journal);
 expectDeprecated(options.wtimeoutMS);
+expectDeprecated(options.promiseLibrary);
 expectNotDeprecated(options.writeConcern);
 expectType<WriteConcernSettings | WriteConcern | undefined>(options.writeConcern);
 


### PR DESCRIPTION
### Description

#### What is changing?

Added the deprecation tag to the API docs for promiseLibrary

#### What is the motivation for this change?

async/await in the future

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
