### PR TITLE
fix(NODE-4608): prevent parallel monitor checks

### DIFF
--- a/src/sdam/monitor.ts
+++ b/src/sdam/monitor.ts
@@ -329,7 +329,7 @@ function checkServer(monitor: Monitor, callback: Callback<Document | null>) {
 function monitorServer(monitor: Monitor) {
   return (callback: Callback) => {
     if (monitor.s.state === STATE_MONITORING) {
-      callback();
+      process.nextTick(callback);
       return;
     }
     stateTransition(monitor, STATE_MONITORING);

--- a/src/sdam/monitor.ts
+++ b/src/sdam/monitor.ts
@@ -328,6 +328,10 @@ function checkServer(monitor: Monitor, callback: Callback<Document | null>) {
 
 function monitorServer(monitor: Monitor) {
   return (callback: Callback) => {
+    if (monitor.s.state === STATE_MONITORING) {
+      callback();
+      return;
+    }
     stateTransition(monitor, STATE_MONITORING);
     function done() {
       if (!isInCloseState(monitor)) {

--- a/test/integration/server-discovery-and-monitoring/server_discovery_and_monitoring.spec.test.ts
+++ b/test/integration/server-discovery-and-monitoring/server_discovery_and_monitoring.spec.test.ts
@@ -25,8 +25,8 @@ describe('SDAM Unified Tests', function () {
     // TODO(NODE-4573): fix socket leaks
     const LEAKY_TESTS = [
       'Command error on Monitor handshake',
-      'Network error on Monitor check',
-      'Network timeout on Monitor check',
+      // 'Network error on Monitor check',
+      // 'Network timeout on Monitor check',
       'Network error on Monitor handshake',
       'Network timeout on Monitor handshake'
     ];

--- a/test/integration/server-discovery-and-monitoring/server_discovery_and_monitoring.spec.test.ts
+++ b/test/integration/server-discovery-and-monitoring/server_discovery_and_monitoring.spec.test.ts
@@ -1,37 +1,8 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
-import { Socket } from 'net';
 import * as path from 'path';
 
 import { loadSpecTests } from '../../spec';
 import { runUnifiedSuite } from '../../tools/unified-spec-runner/runner';
-import { sleep } from '../../tools/utils';
 
 describe('SDAM Unified Tests', function () {
-  afterEach(async function () {
-    if (this.currentTest!.pending) {
-      return;
-    }
-    // TODO(NODE-4573): fix socket leaks
-    const LEAKY_TESTS = [
-      'Command error on Monitor handshake',
-      'Network error on Monitor handshake',
-      'Network timeout on Monitor handshake'
-    ];
-
-    await sleep(250);
-    const sockArray = (process as any)._getActiveHandles().filter(handle => {
-      // Stdio are instanceof Socket so look for fd to be null
-      return handle.fd == null && handle instanceof Socket && handle.destroyed !== true;
-    });
-    if (!sockArray.length) {
-      return;
-    }
-    for (const sock of sockArray) {
-      sock.destroy();
-    }
-    if (!LEAKY_TESTS.some(test => test === this.currentTest!.title)) {
-      this.test!.error(new Error(`Test failed to clean up ${sockArray.length} socket(s)`));
-    }
-  });
   runUnifiedSuite(loadSpecTests(path.join('server-discovery-and-monitoring', 'unified')));
 });

--- a/test/integration/server-discovery-and-monitoring/server_discovery_and_monitoring.spec.test.ts
+++ b/test/integration/server-discovery-and-monitoring/server_discovery_and_monitoring.spec.test.ts
@@ -14,8 +14,6 @@ describe('SDAM Unified Tests', function () {
     // TODO(NODE-4573): fix socket leaks
     const LEAKY_TESTS = [
       'Command error on Monitor handshake',
-      // 'Network error on Monitor check',
-      // 'Network timeout on Monitor check',
       'Network error on Monitor handshake',
       'Network timeout on Monitor handshake'
     ];

--- a/test/integration/server-discovery-and-monitoring/server_discovery_and_monitoring.spec.test.ts
+++ b/test/integration/server-discovery-and-monitoring/server_discovery_and_monitoring.spec.test.ts
@@ -4,18 +4,7 @@ import * as path from 'path';
 
 import { loadSpecTests } from '../../spec';
 import { runUnifiedSuite } from '../../tools/unified-spec-runner/runner';
-import { TestFilter } from '../../tools/unified-spec-runner/schema';
 import { sleep } from '../../tools/utils';
-
-const filter: TestFilter = ({ description }) => {
-  switch (description) {
-    case 'Network error on Monitor check':
-    case 'Network timeout on Monitor check':
-      return 'TODO(NODE-4608): Disallow parallel monitor checks';
-    default:
-      return false;
-  }
-};
 
 describe('SDAM Unified Tests', function () {
   afterEach(async function () {
@@ -46,5 +35,5 @@ describe('SDAM Unified Tests', function () {
       this.test!.error(new Error(`Test failed to clean up ${sockArray.length} socket(s)`));
     }
   });
-  runUnifiedSuite(loadSpecTests(path.join('server-discovery-and-monitoring', 'unified')), filter);
+  runUnifiedSuite(loadSpecTests(path.join('server-discovery-and-monitoring', 'unified')));
 });

--- a/test/unit/sdam/monitor.test.ts
+++ b/test/unit/sdam/monitor.test.ts
@@ -400,71 +400,41 @@ describe('monitoring', function () {
         });
       });
 
-      context(
-        'when it has been < minHeartbeatFrequencyMS and >= 0 since fn() last completed',
-        function () {
-          beforeEach(function () {
-            executor = new MonitorInterval(fnSpy, {
-              minHeartbeatFrequencyMS: 10,
-              heartbeatFrequencyMS: 30
-            });
-
-            // call fn() once
-            clock.tick(30);
-            expect(fnSpy.calledOnce).to.be.true;
-
-            fnSpy.callCount = 0;
-
-            // advance less than minHeartbeatFrequency
-            clock.tick(5);
-
-            executor.wake();
-          });
-
-          it('reschedules fn() to minHeartbeatFrequencyMS after the last call', function () {
-            expect(fnSpy.callCount).to.equal(0);
-            clock.tick(5);
-            expect(fnSpy.calledOnce).to.be.true;
-          });
-
-          context('when wake() is called more than once', function () {
-            it('schedules fn() minHeartbeatFrequencyMS after the last call to fn()', function () {
-              executor.wake();
-              executor.wake();
-              executor.wake();
-
-              expect(fnSpy.callCount).to.equal(0);
-              clock.tick(5);
-              expect(fnSpy.calledOnce).to.be.true;
-            });
-          });
-        }
-      );
-
-      context('when it has been <0 since fn() has last executed', function () {
+      context('when it has been < minHeartbeatFrequencyMS since fn() last completed', function () {
         beforeEach(function () {
           executor = new MonitorInterval(fnSpy, {
             minHeartbeatFrequencyMS: 10,
             heartbeatFrequencyMS: 30
           });
 
-          // negative ticks aren't supported, so manually set execution time
-          executor.lastExecutionEnded = Infinity;
+          // call fn() once
+          clock.tick(30);
+          expect(fnSpy.calledOnce).to.be.true;
+
+          fnSpy.callCount = 0;
+
+          // advance less than minHeartbeatFrequency
+          clock.tick(5);
+
           executor.wake();
         });
 
-        it('executes fn() immediately', function () {
+        it('reschedules fn() to minHeartbeatFrequencyMS after the last call', function () {
+          expect(fnSpy.callCount).to.equal(0);
+          clock.tick(5);
           expect(fnSpy.calledOnce).to.be.true;
         });
 
-        it('reschedules fn() to minHeartbeatFrequency away', function () {
-          fnSpy.callCount = 0;
+        context('when wake() is called more than once', function () {
+          it('schedules fn() minHeartbeatFrequencyMS after the last call to fn()', function () {
+            executor.wake();
+            executor.wake();
+            executor.wake();
 
-          clock.tick(29);
-          expect(fnSpy.callCount).to.equal(0);
-
-          clock.tick(1);
-          expect(fnSpy.calledOnce).to.be.true;
+            expect(fnSpy.callCount).to.equal(0);
+            clock.tick(5);
+            expect(fnSpy.calledOnce).to.be.true;
+          });
         });
       });
     });


### PR DESCRIPTION
### Description

#### What is changing?

Prevents the Monitor.wake() method from proceeding if the monitor is already in a monitoring state.  This PR also unskips the two remaining SDAM tests, as well as removes the socket leak checks in the sdam unified runner.

##### Is there new documentation needed for these changes?

No.

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
