### PR TITLE
refactor(NODE-4631): change_stream, gridfs to use maybeCallback

### DIFF
--- a/src/bulk/common.ts
+++ b/src/bulk/common.ts
@@ -22,7 +22,6 @@ import { executeOperation } from '../operations/execute_operation';
 import { InsertOperation } from '../operations/insert';
 import { AbstractOperation, Hint } from '../operations/operation';
 import { makeUpdateStatement, UpdateOperation, UpdateStatement } from '../operations/update';
-import { PromiseProvider } from '../promise_provider';
 import type { Server } from '../sdam/server';
 import type { Topology } from '../sdam/topology';
 import type { ClientSession } from '../sessions';

--- a/src/bulk/common.ts
+++ b/src/bulk/common.ts
@@ -1276,38 +1276,41 @@ export abstract class BulkOperationBase {
         : typeof options === 'function'
         ? options
         : undefined;
+    options = options != null && typeof options !== 'function' ? options : {};
 
-    return maybeCallback(async () => {
-      options = options != null && typeof options !== 'function' ? options : {};
-
-      if (this.s.executed) {
+    if (this.s.executed) {
+      // eslint-disable-next-line @typescript-eslint/require-await
+      return maybeCallback(async () => {
         throw new MongoBatchReExecutionError();
-      }
+      }, callback);
+    }
 
-      const writeConcern = WriteConcern.fromOptions(options);
-      if (writeConcern) {
-        this.s.writeConcern = writeConcern;
-      }
+    const writeConcern = WriteConcern.fromOptions(options);
+    if (writeConcern) {
+      this.s.writeConcern = writeConcern;
+    }
 
-      // If we have current batch
-      if (this.isOrdered) {
-        if (this.s.currentBatch) this.s.batches.push(this.s.currentBatch);
-      } else {
-        if (this.s.currentInsertBatch) this.s.batches.push(this.s.currentInsertBatch);
-        if (this.s.currentUpdateBatch) this.s.batches.push(this.s.currentUpdateBatch);
-        if (this.s.currentRemoveBatch) this.s.batches.push(this.s.currentRemoveBatch);
-      }
-      // If we have no operations in the bulk raise an error
-      if (this.s.batches.length === 0) {
+    // If we have current batch
+    if (this.isOrdered) {
+      if (this.s.currentBatch) this.s.batches.push(this.s.currentBatch);
+    } else {
+      if (this.s.currentInsertBatch) this.s.batches.push(this.s.currentInsertBatch);
+      if (this.s.currentUpdateBatch) this.s.batches.push(this.s.currentUpdateBatch);
+      if (this.s.currentRemoveBatch) this.s.batches.push(this.s.currentRemoveBatch);
+    }
+    // If we have no operations in the bulk raise an error
+    if (this.s.batches.length === 0) {
+      // eslint-disable-next-line @typescript-eslint/require-await
+      return maybeCallback(async () => {
         throw new MongoInvalidArgumentError('Invalid BulkOperation, Batch cannot be empty');
-      }
+      }, callback);
+    }
 
-      this.s.executed = true;
-      const finalOptions = { ...this.s.options, ...options };
-      const operation = new BulkWriteShimOperation(this, finalOptions);
+    this.s.executed = true;
+    const finalOptions = { ...this.s.options, ...options };
+    const operation = new BulkWriteShimOperation(this, finalOptions);
 
-      return await executeOperation(this.s.collection.s.db.s.client, operation);
-    }, callback);
+    return executeOperation(this.s.collection.s.db.s.client, operation, callback);
   }
 
   /**

--- a/src/gridfs/index.ts
+++ b/src/gridfs/index.ts
@@ -146,9 +146,10 @@ export class GridFSBucket extends TypedEventEmitter<GridFSBucketEvents> {
   delete(id: ObjectId, callback?: Callback<void>): Promise<void> | void {
     return maybeCallback(async () => {
       const { deletedCount } = await this.s._filesCollection.deleteOne({ _id: id });
-      await this.s._chunksCollection.deleteMany({ files_id: id });
 
       // Delete orphaned chunks before returning FileNotFound
+      await this.s._chunksCollection.deleteMany({ files_id: id });
+
       if (deletedCount === 0) {
         // TODO(NODE-3483): Replace with more appropriate error
         // Consider creating new error MongoGridFSFileNotFoundError

--- a/src/gridfs/index.ts
+++ b/src/gridfs/index.ts
@@ -7,7 +7,7 @@ import type { Logger } from '../logger';
 import { Filter, TypedEventEmitter } from '../mongo_types';
 import type { ReadPreference } from '../read_preference';
 import type { Sort } from '../sort';
-import { Callback, maybePromise } from '../utils';
+import { Callback, maybeCallback } from '../utils';
 import { WriteConcern, WriteConcernOptions } from '../write_concern';
 import type { FindOptions } from './../operations/find';
 import {
@@ -144,28 +144,17 @@ export class GridFSBucket extends TypedEventEmitter<GridFSBucketEvents> {
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   delete(id: ObjectId, callback: Callback<void>): void;
   delete(id: ObjectId, callback?: Callback<void>): Promise<void> | void {
-    return maybePromise(callback, callback => {
-      return this.s._filesCollection.deleteOne({ _id: id }, (error, res) => {
-        if (error) {
-          return callback(error);
-        }
+    return maybeCallback(async () => {
+      const { deletedCount } = await this.s._filesCollection.deleteOne({ _id: id });
+      await this.s._chunksCollection.deleteMany({ files_id: id });
 
-        return this.s._chunksCollection.deleteMany({ files_id: id }, error => {
-          if (error) {
-            return callback(error);
-          }
-
-          // Delete orphaned chunks before returning FileNotFound
-          if (!res?.deletedCount) {
-            // TODO(NODE-3483): Replace with more appropriate error
-            // Consider creating new error MongoGridFSFileNotFoundError
-            return callback(new MongoRuntimeError(`File not found for id ${id}`));
-          }
-
-          return callback();
-        });
-      });
-    });
+      // Delete orphaned chunks before returning FileNotFound
+      if (deletedCount === 0) {
+        // TODO(NODE-3483): Replace with more appropriate error
+        // Consider creating new error MongoGridFSFileNotFoundError
+        throw new MongoRuntimeError(`File not found for id ${id}`);
+      }
+    }, callback);
   }
 
   /** Convenience wrapper around find on the files collection */
@@ -215,21 +204,14 @@ export class GridFSBucket extends TypedEventEmitter<GridFSBucketEvents> {
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   rename(id: ObjectId, filename: string, callback: Callback<void>): void;
   rename(id: ObjectId, filename: string, callback?: Callback<void>): Promise<void> | void {
-    return maybePromise(callback, callback => {
+    return maybeCallback(async () => {
       const filter = { _id: id };
       const update = { $set: { filename } };
-      return this.s._filesCollection.updateOne(filter, update, (error?, res?) => {
-        if (error) {
-          return callback(error);
-        }
-
-        if (!res?.matchedCount) {
-          return callback(new MongoRuntimeError(`File with id ${id} not found`));
-        }
-
-        return callback();
-      });
-    });
+      const { matchedCount } = await this.s._filesCollection.updateOne(filter, update);
+      if (matchedCount === 0) {
+        throw new MongoRuntimeError(`File with id ${id} not found`);
+      }
+    }, callback);
   }
 
   /** Removes this bucket's files collection, followed by its chunks collection. */
@@ -237,20 +219,10 @@ export class GridFSBucket extends TypedEventEmitter<GridFSBucketEvents> {
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   drop(callback: Callback<void>): void;
   drop(callback?: Callback<void>): Promise<void> | void {
-    return maybePromise(callback, callback => {
-      return this.s._filesCollection.drop(error => {
-        if (error) {
-          return callback(error);
-        }
-        return this.s._chunksCollection.drop(error => {
-          if (error) {
-            return callback(error);
-          }
-
-          return callback();
-        });
-      });
-    });
+    return maybeCallback(async () => {
+      await this.s._filesCollection.drop();
+      await this.s._chunksCollection.drop();
+    }, callback);
   }
 
   /** Get the Db scoped logger. */

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -29,6 +29,7 @@ import {
   Callback,
   ClientMetadata,
   HostAddress,
+  maybeCallback,
   maybePromise,
   MongoDBNamespace,
   ns,
@@ -580,26 +581,18 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> {
     options?: MongoClientOptions | Callback<MongoClient>,
     callback?: Callback<MongoClient>
   ): Promise<MongoClient> | void {
-    if (typeof options === 'function') (callback = options), (options = {});
-    options = options ?? {};
+    callback =
+      typeof callback === 'function'
+        ? callback
+        : typeof options === 'function'
+        ? options
+        : undefined;
 
-    try {
-      // Create client
-      const mongoClient = new MongoClient(url, options);
-      // Execute the connect method
-      if (callback) {
-        return mongoClient.connect(callback);
-      } else {
-        return mongoClient.connect();
-      }
-    } catch (error) {
-      if (callback) {
-        return callback(error);
-      } else {
-        const PromiseConstructor = PromiseProvider.get() ?? Promise;
-        return PromiseConstructor.reject(error);
-      }
-    }
+    return maybeCallback(async () => {
+      options = typeof options !== 'function' ? options : undefined;
+      const client = new this(url, options);
+      return await client.connect();
+    }, callback);
   }
 
   /** Starts a new session on the server */

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -17,7 +17,6 @@ import { MongoInvalidArgumentError } from './error';
 import type { Logger, LoggerLevel } from './logger';
 import { TypedEventEmitter } from './mongo_types';
 import { connect } from './operations/connect';
-import { PromiseProvider } from './promise_provider';
 import type { ReadConcern, ReadConcernLevel, ReadConcernLike } from './read_concern';
 import { ReadPreference, ReadPreferenceMode } from './read_preference';
 import type { TagSet } from './sdam/server_description';

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -646,7 +646,11 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> {
       try {
         await withSessionCallback(session);
       } finally {
-        session.endSession().catch(() => null);
+        try {
+          await session.endSession();
+        } catch {
+          // We are not concerned with errors from endSession()
+        }
       }
     }, null);
   }

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -642,16 +642,14 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> {
     }
 
     const session = this.startSession(options);
-    const PromiseConstructor = PromiseProvider.get() ?? Promise;
 
-    return PromiseConstructor.resolve()
-      .then(() => withSessionCallback(session))
-      .then(() => {
-        // Do not return the result of callback
-      })
-      .finally(() => {
+    return maybeCallback(async () => {
+      try {
+        await withSessionCallback(session);
+      } finally {
         session.endSession().catch(() => null);
-      });
+      }
+    }, null);
   }
 
   /**

--- a/src/promise_provider.ts
+++ b/src/promise_provider.ts
@@ -38,6 +38,7 @@ export class PromiseProvider {
       store[kPromise] = null;
       return;
     }
+
     if (!PromiseProvider.validate(lib)) {
       // validate
       return;

--- a/src/promise_provider.ts
+++ b/src/promise_provider.ts
@@ -38,7 +38,6 @@ export class PromiseProvider {
       store[kPromise] = null;
       return;
     }
-
     if (!PromiseProvider.validate(lib)) {
       // validate
       return;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -438,9 +438,14 @@ export function* makeCounter(seed = 0): Generator<number> {
 /**
  * Helper for handling legacy callback support.
  */
+export function maybeCallback<T>(promiseFn: () => Promise<T>, callback: null): Promise<T>;
 export function maybeCallback<T>(
   promiseFn: () => Promise<T>,
   callback?: Callback<T>
+): Promise<T> | void;
+export function maybeCallback<T>(
+  promiseFn: () => Promise<T>,
+  callback?: Callback<T> | null
 ): Promise<T> | void {
   const PromiseConstructor = PromiseProvider.get();
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -445,21 +445,19 @@ export function maybeCallback<T>(
   const PromiseConstructor = PromiseProvider.get();
 
   const promise = promiseFn();
-  if (callback == null && PromiseConstructor == null) {
-    return promise;
-  }
-
-  if (PromiseConstructor != null) {
-    return new PromiseConstructor((resolve, reject) => {
-      promise.then(resolve, reject);
-    });
+  if (callback == null) {
+    if (PromiseConstructor == null) {
+      return promise;
+    } else {
+      return new PromiseConstructor((resolve, reject) => {
+        promise.then(resolve, reject);
+      });
+    }
   }
 
   promise.then(
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    result => callback!(undefined, result),
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    error => callback!(error)
+    result => callback(undefined, result),
+    error => callback(error)
   );
   return;
 }

--- a/test/integration/sessions/sessions.spec.prose.test.ts
+++ b/test/integration/sessions/sessions.spec.prose.test.ts
@@ -46,6 +46,6 @@ describe('ServerSession', () => {
     expect(events).to.have.lengthOf(operations.length);
 
     // This is a guarantee in node, unless you are performing a transaction (which is not being done in this test)
-    expect(new Set(events.map(ev => ev.command.lsid.id.toString('hex'))).size).to.equal(1);
+    expect(new Set(events.map(ev => ev.command.lsid.id.toString('hex')))).to.have.lengthOf(1);
   });
 });

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -355,7 +355,7 @@ describe('driver utils', function () {
   });
 
   describe('maybeCallback()', () => {
-    it('should accept to two arguments', () => {
+    it('should accept two arguments', () => {
       expect(maybeCallback).to.have.lengthOf(2);
     });
 
@@ -445,7 +445,6 @@ describe('driver utils', function () {
 
     describe('when a custom promise constructor is set', () => {
       beforeEach(() => {
-        // @ts-expect-error: Bluebird does not have type info
         PromiseProvider.set(BluebirdPromise);
       });
 

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -2,11 +2,13 @@ import { expect } from 'chai';
 
 import { LEGACY_HELLO_COMMAND } from '../../src/constants';
 import { MongoRuntimeError } from '../../src/error';
+import { Promise as PromiseProvider } from '../../src/index';
 import {
   BufferPool,
   eachAsync,
   HostAddress,
   isHello,
+  maybeCallback,
   MongoDBNamespace,
   shuffle
 } from '../../src/utils';
@@ -347,6 +349,119 @@ describe('driver utils', function () {
         expect(ha).to.have.property('socketPath', undefined);
         expect(ha).to.have.property('host', 'iLoveJavascript.sock'.toLowerCase());
         expect(ha).to.have.property('port', 27017);
+      });
+    });
+  });
+
+  describe('maybeCallback()', () => {
+    it('should accept to two arguments', () => {
+      expect(maybeCallback).to.have.lengthOf(2);
+    });
+
+    describe('when handling an error case', () => {
+      it('should pass the error to the callback provided', done => {
+        const superPromiseRejection = Promise.reject(new Error('fail'));
+        const result = maybeCallback(
+          () => superPromiseRejection,
+          (error, result) => {
+            try {
+              expect(result).to.not.exist;
+              expect(error).to.be.instanceOf(Error);
+              return done();
+            } catch (assertionError) {
+              return done(assertionError);
+            }
+          }
+        );
+        expect(result).to.be.undefined;
+      });
+
+      it('should return the rejected promise to the caller when no callback is provided', async () => {
+        const superPromiseRejection = Promise.reject(new Error('fail'));
+        const returnedPromise = maybeCallback(() => superPromiseRejection, undefined);
+        expect(returnedPromise).to.equal(superPromiseRejection);
+        // @ts-expect-error: There is no overload to change the return type not be nullish,
+        // and we do not want to add one in fear of making it too easy to neglect adding the callback argument
+        const thrownError = await returnedPromise.catch(error => error);
+        expect(thrownError).to.be.instanceOf(Error);
+      });
+
+      it('should not modify a rejection error promise', async () => {
+        class MyError extends Error {}
+        const driverError = Object.freeze(new MyError());
+        const rejection = Promise.reject(driverError);
+        // @ts-expect-error: There is no overload to change the return type not be nullish,
+        // and we do not want to add one in fear of making it too easy to neglect adding the callback argument
+        const thrownError = await maybeCallback(() => rejection, undefined).catch(error => error);
+        expect(thrownError).to.be.equal(driverError);
+      });
+
+      it('should not modify a rejection error when passed to callback', done => {
+        class MyError extends Error {}
+        const driverError = Object.freeze(new MyError());
+        const rejection = Promise.reject(driverError);
+        maybeCallback(
+          () => rejection,
+          error => {
+            try {
+              expect(error).to.exist;
+              expect(error).to.equal(driverError);
+              done();
+            } catch (assertionError) {
+              done(assertionError);
+            }
+          }
+        );
+      });
+    });
+
+    describe('when handling a success case', () => {
+      it('should pass the result and undefined error to the callback provided', done => {
+        const superPromiseSuccess = Promise.resolve(2);
+
+        const result = maybeCallback(
+          () => superPromiseSuccess,
+          (error, result) => {
+            try {
+              expect(error).to.be.undefined;
+              expect(result).to.equal(2);
+              done();
+            } catch (assertionError) {
+              done(assertionError);
+            }
+          }
+        );
+        expect(result).to.be.undefined;
+      });
+
+      it('should return the resolved promise to the caller when no callback is provided', async () => {
+        const superPromiseSuccess = Promise.resolve(2);
+        const result = maybeCallback(() => superPromiseSuccess);
+        expect(result).to.equal(superPromiseSuccess);
+        expect(await result).to.equal(2);
+      });
+    });
+
+    describe('when a custom promise constructor is set', () => {
+      class CustomPromise {
+        then() {
+          // do nothing
+        }
+      }
+
+      beforeEach(() => {
+        PromiseProvider.set(CustomPromise as unknown as PromiseConstructor);
+      });
+
+      afterEach(() => {
+        PromiseProvider.set(null);
+      });
+
+      it('should return the custom promise if no callback is provided', async () => {
+        const superPromiseSuccess = Promise.resolve(2);
+        const result = maybeCallback(() => superPromiseSuccess);
+        expect(result).to.not.equal(superPromiseSuccess);
+        expect(result).to.be.instanceOf(CustomPromise);
       });
     });
   });

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -470,7 +470,7 @@ describe('driver utils', function () {
         expect(await result.catch(e => e)).to.have.property('message', 'ah!');
       });
 
-      it('should return void event if a custom promise is set and a callback is provided', async () => {
+      it('should return void even if a custom promise is set and a callback is provided', async () => {
         const superPromiseSuccess = Promise.resolve(2);
         const result = maybeCallback(
           () => superPromiseSuccess,

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -463,6 +463,17 @@ describe('driver utils', function () {
         expect(result).to.not.equal(superPromiseSuccess);
         expect(result).to.be.instanceOf(CustomPromise);
       });
+
+      it('should return void event if a custom promise is set and a callback is provided', async () => {
+        const superPromiseSuccess = Promise.resolve(2);
+        const result = maybeCallback(
+          () => superPromiseSuccess,
+          () => {
+            // ignore
+          }
+        );
+        expect(result).to.be.undefined;
+      });
     });
   });
 });


### PR DESCRIPTION
### Description

#### What is changing?

- Adds maybeCallback helper with tests
- Changes PromiseProvider to communicate an unset state
- Refactors:
  - ChangeStream
  - ClientSession
  - GridFS

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
