### PR TITLE
fix(NODE-3144): pool clear event ordering and retryability tests

### DIFF
--- a/src/cmap/connection_pool.ts
+++ b/src/cmap/connection_pool.ts
@@ -423,11 +423,10 @@ export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
     this[kPoolState] = PoolState.paused;
 
     this.clearMinPoolSizeTimer();
-    this.processWaitQueue();
-
     if (!alreadyPaused) {
       this.emit(ConnectionPool.CONNECTION_POOL_CLEARED, new ConnectionPoolClearedEvent(this));
     }
+    this.processWaitQueue();
   }
 
   /** Close the pool */

--- a/src/cmap/errors.ts
+++ b/src/cmap/errors.ts
@@ -24,7 +24,6 @@ export class PoolClosedError extends MongoDriverError {
  * @category Error
  */
 export class PoolClearedError extends MongoNetworkError {
-  // TODO(NODE-3144): needs to extend RetryableError or be marked retryable in some other way per spec
   /** The address of the connection pool */
   address: string;
 

--- a/test/integration/retryable-reads/retryable_reads.spec.prose.test.ts
+++ b/test/integration/retryable-reads/retryable_reads.spec.prose.test.ts
@@ -1,0 +1,146 @@
+import { expect } from 'chai';
+
+import { Collection, MongoClient } from '../../../src';
+
+describe('Retryable Reads Spec Prose', () => {
+  let client: MongoClient, failPointName;
+
+  afterEach(async () => {
+    try {
+      if (failPointName) {
+        await client.db('admin').command({ configureFailPoint: failPointName, mode: 'off' });
+      }
+    } finally {
+      failPointName = undefined;
+      await client?.close();
+    }
+  });
+
+  describe('PoolClearedError Retryability Test', () => {
+    // This test will be used to ensure drivers properly retry after encountering PoolClearedErrors.
+    // It MUST be implemented by any driver that implements the CMAP specification.
+    // This test requires MongoDB 4.2.9+ for blockConnection support in the failpoint.
+
+    let observedEvents: Array<{ name: string; event: Record<string, any> }>;
+    let testCollection: Collection;
+    beforeEach(async function () {
+      // 1. Create a client with maxPoolSize=1 and retryReads=true.
+      // If testing against a sharded deployment, be sure to connect to only a single mongos. <-- TODO: what does that look like?
+      client = this.configuration.newClient({
+        maxPoolSize: 1,
+        retryReads: true,
+        monitorCommands: true
+      });
+      await client.connect();
+
+      testCollection = client.db('retryable-reads-prose').collection('pool-clear-retry');
+      await testCollection.drop().catch(() => null);
+      await testCollection.insertMany([{ test: 1 }, { test: 2 }]);
+
+      // 2. Enable the following failpoint:
+      // NOTE: "9. Disable the failpoint" is done in afterEach
+      failPointName = 'failCommand';
+      const failPoint = await client.db('admin').command({
+        configureFailPoint: failPointName,
+        mode: { times: 1 },
+        data: {
+          failCommands: ['find'],
+          errorCode: 91,
+          blockConnection: true,
+          blockTimeMS: 1000
+        }
+      });
+
+      expect(failPoint).to.have.property('ok', 1);
+
+      observedEvents = [];
+      for (const observedEvent of [
+        'connectionCheckOutStarted',
+        'connectionCheckedOut',
+        'connectionCheckOutFailed',
+        'connectionPoolCleared',
+        'commandStarted'
+      ]) {
+        client.on(observedEvent, ev => {
+          observedEvents.push({ name: observedEvent, event: ev });
+        });
+      }
+    });
+
+    it('should emit events in the expected sequence', {
+      metadata: { requires: { mongodb: '>=4.2.9' } },
+      test: async function () {
+        // 3. Start two threads and attempt to perform a findOne simultaneously on both.
+        const results = await Promise.all([
+          testCollection.findOne({ test: 1 }),
+          testCollection.findOne({ test: 2 })
+        ]);
+
+        client.removeAllListeners();
+        // 4. Verify that both findOne attempts succeed.
+        expect(results[0]).to.have.property('test', 1);
+        expect(results[1]).to.have.property('test', 2);
+
+        // 5. Via CMAP monitoring, assert that the first check out succeeds.
+        const indexOfFirstCheckoutAttempt = observedEvents.findIndex(
+          ev => ev.name === 'connectionCheckOutStarted'
+        );
+        expect(indexOfFirstCheckoutAttempt).to.be.greaterThan(
+          -1,
+          'expected a checkout started event to exist'
+        );
+        const indexOfFirstCheckoutSuccess = observedEvents.findIndex(
+          ev => ev.name === 'connectionCheckedOut'
+        );
+        expect(indexOfFirstCheckoutSuccess).to.be.greaterThan(
+          -1,
+          'expected at least one checkout success'
+        );
+        const indexOfFirstCheckoutFailure = observedEvents.findIndex(
+          ev => ev.name === 'connectionCheckOutFailed'
+        );
+        expect(indexOfFirstCheckoutFailure).to.be.greaterThan(
+          -1,
+          'expected at least one checkout failure'
+        );
+
+        expect(indexOfFirstCheckoutSuccess).to.be.greaterThan(
+          indexOfFirstCheckoutAttempt,
+          'expected checkout started before checkout success'
+        );
+        expect(indexOfFirstCheckoutSuccess).to.be.lessThan(
+          indexOfFirstCheckoutFailure,
+          'expected first connection checkout to succeed but it failed'
+        );
+
+        // 6. Via CMAP monitoring, assert that a PoolClearedEvent is then emitted.
+        const indexOfPoolClear = observedEvents.findIndex(
+          ev => ev.name === 'connectionPoolCleared'
+        );
+        expect(indexOfPoolClear).to.be.greaterThan(
+          indexOfFirstCheckoutSuccess,
+          'expected a pool cleared event to follow checkout success'
+        );
+
+        // 7. Via CMAP monitoring, assert that the second check out then fails due to a connection error.
+        expect(indexOfFirstCheckoutFailure).to.be.greaterThan(
+          indexOfPoolClear,
+          'expected checkout failure after pool clear'
+        );
+        expect(observedEvents[indexOfFirstCheckoutFailure].event).to.have.property(
+          'reason',
+          'connectionError'
+        );
+
+        // 8. Via Command Monitoring, assert that exactly three find CommandStartedEvents were observed in total.
+        const observedInsertCommandStartedEvents = observedEvents.filter(({ name, event }) => {
+          return name === 'commandStarted' && event.commandName === 'find';
+        });
+        expect(observedInsertCommandStartedEvents).to.have.lengthOf(
+          3,
+          'expected 3 find command started events'
+        );
+      }
+    });
+  });
+});

--- a/test/integration/retryable-reads/retryable_reads.spec.prose.test.ts
+++ b/test/integration/retryable-reads/retryable_reads.spec.prose.test.ts
@@ -31,7 +31,6 @@ describe('Retryable Reads Spec Prose', () => {
         retryReads: true,
         monitorCommands: true
       });
-      await client.connect();
 
       testCollection = client.db('retryable-reads-prose').collection('pool-clear-retry');
       await testCollection.drop().catch(() => null);

--- a/test/integration/retryable-reads/retryable_reads.spec.prose.test.ts
+++ b/test/integration/retryable-reads/retryable_reads.spec.prose.test.ts
@@ -27,12 +27,14 @@ describe('Retryable Reads Spec Prose', () => {
     let testCollection: Collection;
     beforeEach(async function () {
       // 1. Create a client with maxPoolSize=1 and retryReads=true.
-      client = this.configuration.newClient({
-        maxPoolSize: 1,
-        retryReads: true,
-        monitorCommands: true,
-        useMultipleMongoses: false // If testing against a sharded deployment, be sure to connect to only a single mongos.
-      });
+      client = this.configuration.newClient(
+        this.configuration.url({
+          useMultipleMongoses: false // If testing against a sharded deployment, be sure to connect to only a single mongos.
+        }),
+        { maxPoolSize: 1, retryReads: true, monitorCommands: true }
+      );
+
+      console.log(client.options);
 
       testCollection = client.db('retryable-reads-prose').collection('pool-clear-retry');
       await testCollection.drop().catch(() => null);

--- a/test/integration/retryable-reads/retryable_reads.spec.prose.test.ts
+++ b/test/integration/retryable-reads/retryable_reads.spec.prose.test.ts
@@ -27,11 +27,11 @@ describe('Retryable Reads Spec Prose', () => {
     let testCollection: Collection;
     beforeEach(async function () {
       // 1. Create a client with maxPoolSize=1 and retryReads=true.
-      // If testing against a sharded deployment, be sure to connect to only a single mongos. <-- TODO: what does that look like?
       client = this.configuration.newClient({
         maxPoolSize: 1,
         retryReads: true,
-        monitorCommands: true
+        monitorCommands: true,
+        useMultipleMongoses: false // If testing against a sharded deployment, be sure to connect to only a single mongos.
       });
 
       testCollection = client.db('retryable-reads-prose').collection('pool-clear-retry');

--- a/test/integration/retryable-reads/retryable_reads.spec.prose.test.ts
+++ b/test/integration/retryable-reads/retryable_reads.spec.prose.test.ts
@@ -68,7 +68,7 @@ describe('Retryable Reads Spec Prose', () => {
     });
 
     it('should emit events in the expected sequence', {
-      metadata: { requires: { mongodb: '>=4.2.9' } },
+      metadata: { requires: { mongodb: '>=4.2.9', topology: '!load-balanced' } },
       test: async function () {
         // 3. Start two threads and attempt to perform a findOne simultaneously on both.
         const results = await Promise.all([

--- a/test/integration/retryable-reads/retryable_reads.spec.prose.test.ts
+++ b/test/integration/retryable-reads/retryable_reads.spec.prose.test.ts
@@ -103,7 +103,7 @@ describe('Retryable Reads Spec Prose', () => {
         );
         expect(cmapEvents.shift()).to.have.property(
           'name',
-          'connectionCheckOutStarted',
+          'connectionCheckedOut',
           'expected 3) first checkout to succeed'
         );
 

--- a/test/integration/retryable-reads/retryable_reads.spec.prose.test.ts
+++ b/test/integration/retryable-reads/retryable_reads.spec.prose.test.ts
@@ -54,6 +54,7 @@ describe('Retryable Reads Spec Prose', () => {
       expect(failPoint).to.have.property('ok', 1);
 
       cmapEvents = [];
+      commandStartedEvents = [];
       for (const observedEvent of [
         'connectionCheckOutStarted',
         'connectionCheckedOut',

--- a/test/integration/retryable-reads/retryable_reads.spec.prose.test.ts
+++ b/test/integration/retryable-reads/retryable_reads.spec.prose.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { expect } from 'chai';
 
 import { Collection, MongoClient } from '../../../src';
@@ -121,7 +122,7 @@ describe('Retryable Reads Spec Prose', () => {
           'connectionCheckOutFailed',
           'expected 5) checkout 2 to fail'
         );
-        expect(nextEvent).to.have.deep.property('event.reason', 'connectionError');
+        expect(nextEvent!.event).to.have.property('reason', 'connectionError');
 
         // 8. Via Command Monitoring, assert that exactly three find CommandStartedEvents were observed in total.
         const observedFindCommandStartedEvents = commandStartedEvents.filter(

--- a/test/integration/retryable-reads/retryable_reads.spec.prose.test.ts
+++ b/test/integration/retryable-reads/retryable_reads.spec.prose.test.ts
@@ -21,7 +21,8 @@ describe('Retryable Reads Spec Prose', () => {
     // It MUST be implemented by any driver that implements the CMAP specification.
     // This test requires MongoDB 4.2.9+ for blockConnection support in the failpoint.
 
-    let observedEvents: Array<{ name: string; event: Record<string, any> }>;
+    let cmapEvents: Array<{ name: string; event: Record<string, any> }>;
+    let commandStartedEvents: Array<Record<string, any>>;
     let testCollection: Collection;
     beforeEach(async function () {
       // 1. Create a client with maxPoolSize=1 and retryReads=true.
@@ -52,18 +53,21 @@ describe('Retryable Reads Spec Prose', () => {
 
       expect(failPoint).to.have.property('ok', 1);
 
-      observedEvents = [];
+      cmapEvents = [];
       for (const observedEvent of [
         'connectionCheckOutStarted',
         'connectionCheckedOut',
         'connectionCheckOutFailed',
-        'connectionPoolCleared',
-        'commandStarted'
+        'connectionPoolCleared'
       ]) {
         client.on(observedEvent, ev => {
-          observedEvents.push({ name: observedEvent, event: ev });
+          cmapEvents.push({ name: observedEvent, event: ev });
         });
       }
+
+      client.on('commandStarted', ev => {
+        commandStartedEvents.push(ev);
+      });
     });
 
     it('should emit events in the expected sequence', {
@@ -80,62 +84,49 @@ describe('Retryable Reads Spec Prose', () => {
         expect(results[0]).to.have.property('test', 1);
         expect(results[1]).to.have.property('test', 2);
 
-        // 5. Via CMAP monitoring, assert that the first check out succeeds.
-        const indexOfFirstCheckoutAttempt = observedEvents.findIndex(
-          ev => ev.name === 'connectionCheckOutStarted'
-        );
-        expect(indexOfFirstCheckoutAttempt).to.be.greaterThan(
-          -1,
-          'expected a checkout started event to exist'
-        );
-        const indexOfFirstCheckoutSuccess = observedEvents.findIndex(
-          ev => ev.name === 'connectionCheckedOut'
-        );
-        expect(indexOfFirstCheckoutSuccess).to.be.greaterThan(
-          -1,
-          'expected at least one checkout success'
-        );
-        const indexOfFirstCheckoutFailure = observedEvents.findIndex(
-          ev => ev.name === 'connectionCheckOutFailed'
-        );
-        expect(indexOfFirstCheckoutFailure).to.be.greaterThan(
-          -1,
-          'expected at least one checkout failure'
-        );
+        // NOTE: For the subsequent checks, we rely on the exact sequence of ALL events
+        // for ease of readability; however, only the relative order matters for
+        // the purposes of this test, so if this ever becomes an issue, the test
+        // can be refactored to assert on relative index values instead
 
-        expect(indexOfFirstCheckoutSuccess).to.be.greaterThan(
-          indexOfFirstCheckoutAttempt,
-          'expected checkout started before checkout success'
+        // 5. Via CMAP monitoring, assert that the first check out succeeds.
+        expect(cmapEvents.shift()).to.have.property(
+          'name',
+          'connectionCheckOutStarted',
+          'expected 1) checkout 1 to start'
         );
-        expect(indexOfFirstCheckoutSuccess).to.be.lessThan(
-          indexOfFirstCheckoutFailure,
-          'expected first connection checkout to succeed but it failed'
+        expect(cmapEvents.shift()).to.have.property(
+          'name',
+          'connectionCheckOutStarted',
+          'expected 2) checkout 2 to start'
+        );
+        expect(cmapEvents.shift()).to.have.property(
+          'name',
+          'connectionCheckOutStarted',
+          'expected 3) first checkout to succeed'
         );
 
         // 6. Via CMAP monitoring, assert that a PoolClearedEvent is then emitted.
-        const indexOfPoolClear = observedEvents.findIndex(
-          ev => ev.name === 'connectionPoolCleared'
-        );
-        expect(indexOfPoolClear).to.be.greaterThan(
-          indexOfFirstCheckoutSuccess,
-          'expected a pool cleared event to follow checkout success'
+        expect(cmapEvents.shift()).to.have.property(
+          'name',
+          'connectionPoolCleared',
+          'expected 4) pool to clear'
         );
 
         // 7. Via CMAP monitoring, assert that the second check out then fails due to a connection error.
-        expect(indexOfFirstCheckoutFailure).to.be.greaterThan(
-          indexOfPoolClear,
-          'expected checkout failure after pool clear'
+        const nextEvent = cmapEvents.shift();
+        expect(nextEvent).to.have.property(
+          'name',
+          'connectionCheckOutFailed',
+          'expected 5) checkout 2 to fail'
         );
-        expect(observedEvents[indexOfFirstCheckoutFailure].event).to.have.property(
-          'reason',
-          'connectionError'
-        );
+        expect(nextEvent).to.have.deep.property('event.reason', 'connectionError');
 
         // 8. Via Command Monitoring, assert that exactly three find CommandStartedEvents were observed in total.
-        const observedInsertCommandStartedEvents = observedEvents.filter(({ name, event }) => {
-          return name === 'commandStarted' && event.commandName === 'find';
-        });
-        expect(observedInsertCommandStartedEvents).to.have.lengthOf(
+        const observedFindCommandStartedEvents = commandStartedEvents.filter(
+          ({ commandName }) => commandName === 'find'
+        );
+        expect(observedFindCommandStartedEvents).to.have.lengthOf(
           3,
           'expected 3 find command started events'
         );

--- a/test/integration/retryable-writes/retryable_writes.spec.prose.test.ts
+++ b/test/integration/retryable-writes/retryable_writes.spec.prose.test.ts
@@ -85,7 +85,6 @@ describe('Retryable Writes Spec Prose', () => {
         retryWrites: true,
         monitorCommands: true
       });
-      console.log(client.options.retryReads, client.options.retryWrites);
       await client.connect();
 
       testCollection = client.db('retryable-writes-prose').collection('pool-clear-retry');
@@ -123,7 +122,7 @@ describe('Retryable Writes Spec Prose', () => {
     });
 
     it('should emit events in the expected sequence', {
-      metadata: { requires: { mongodb: '>=4.2.9' } },
+      metadata: { requires: { mongodb: '>=4.2.9', topology: ['replicaset', 'sharded'] } },
       test: async function () {
         // iii. Start two threads and attempt to perform an insertOne simultaneously on both.
         await Promise.all([

--- a/test/integration/retryable-writes/retryable_writes.spec.prose.test.ts
+++ b/test/integration/retryable-writes/retryable_writes.spec.prose.test.ts
@@ -83,7 +83,6 @@ describe('Retryable Writes Spec Prose', () => {
         retryWrites: true,
         monitorCommands: true
       });
-      await client.connect();
 
       testCollection = client.db('retryable-writes-prose').collection('pool-clear-retry');
       await testCollection.drop().catch(() => null);

--- a/test/integration/retryable-writes/retryable_writes.spec.prose.test.ts
+++ b/test/integration/retryable-writes/retryable_writes.spec.prose.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { expect } from 'chai';
 
 import { Collection, MongoClient, MongoError, MongoServerError } from '../../../src';
@@ -174,7 +175,7 @@ describe('Retryable Writes Spec Prose', () => {
           'connectionCheckOutFailed',
           'expected 5) checkout 2 to fail'
         );
-        expect(nextEvent).to.have.deep.property('event.reason', 'connectionError');
+        expect(nextEvent!.event).to.have.property('reason', 'connectionError');
 
         // viii. Via Command Monitoring, assert that exactly three insert CommandStartedEvents were observed in total.
         const observedInsertCommandStartedEvents = commandStartedEvents.filter(

--- a/test/integration/retryable-writes/retryable_writes.spec.prose.test.ts
+++ b/test/integration/retryable-writes/retryable_writes.spec.prose.test.ts
@@ -1,64 +1,203 @@
 import { expect } from 'chai';
 
-import { MongoError, MongoServerError, TopologyType } from '../../../src';
+import { Collection, MongoClient, MongoError, MongoServerError, TopologyType } from '../../../src';
 
 describe('Retryable Writes Spec Prose', () => {
-  /**
-   * 1 Test that retryable writes raise an exception when using the MMAPv1 storage engine.
-   * For this test, execute a write operation, such as insertOne, which should generate an exception and the error code is 20.
-   * Assert that the error message is the replacement error message:
-   *
-   * ```
-   * This MongoDB deployment does not support retryable writes. Please add
-   * retryWrites=false to your connection string.
-   * ```
-   * Note: Drivers that rely on serverStatus to determine the storage engine in use MAY skip this test for sharded clusters, since mongos does not report this information in its serverStatus response.
-   */
-  let client;
-
-  beforeEach(async function () {
-    if (
-      this.configuration.buildInfo.versionArray[0] < 4 ||
-      this.configuration.topologyType !== TopologyType.ReplicaSetWithPrimary
-    ) {
-      this.currentTest.skipReason =
-        'configureFailPoint only works on server versions greater than 4';
-      this.skip();
-    }
-    client = this.configuration.newClient();
-    await client.connect();
-  });
+  let client: MongoClient, failPointName;
 
   afterEach(async () => {
-    await client?.close();
+    try {
+      if (failPointName) {
+        await client.db('admin').command({ configureFailPoint: failPointName, mode: 'off' });
+      }
+    } finally {
+      failPointName = undefined;
+      await client?.close();
+    }
   });
 
-  it('retryable writes raise an exception when using the MMAPv1 storage engine', async () => {
-    const failPoint = await client.db('admin').command({
-      configureFailPoint: 'failCommand',
-      mode: { times: 1 },
-      data: {
-        failCommands: ['insert'],
-        errorCode: 20, // MMAP Error code,
-        closeConnection: false
+  describe('1. Test that retryable writes raise an exception when using the MMAPv1 storage engine.', () => {
+    /**
+     * For this test, execute a write operation, such as insertOne, which should generate an exception and the error code is 20.
+     * Assert that the error message is the replacement error message:
+     *
+     * ```
+     * This MongoDB deployment does not support retryable writes. Please add
+     * retryWrites=false to your connection string.
+     * ```
+     * Note: Drivers that rely on serverStatus to determine the storage engine in use MAY skip this test for sharded clusters, since mongos does not report this information in its serverStatus response.
+     */
+    beforeEach(async function () {
+      if (
+        this.configuration.buildInfo.versionArray[0] < 4 ||
+        this.configuration.topologyType !== TopologyType.ReplicaSetWithPrimary
+      ) {
+        this.currentTest.skipReason =
+          'configureFailPoint only works on server versions greater than 4';
+        this.skip();
+      }
+      client = this.configuration.newClient();
+      await client.connect();
+
+      failPointName = 'failCommand';
+      const failPoint = await client.db('admin').command({
+        configureFailPoint: failPointName,
+        mode: { times: 1 },
+        data: {
+          failCommands: ['insert'],
+          errorCode: 20, // MMAP Error code,
+          closeConnection: false
+        }
+      });
+
+      expect(failPoint).to.have.property('ok', 1);
+    });
+
+    it('should error with the correct error message', async () => {
+      const error = await client
+        .db('test')
+        .collection('test')
+        .insertOne({ a: 1 })
+        .catch(error => error);
+
+      expect(error).to.exist;
+      expect(error).that.is.instanceOf(MongoServerError);
+      expect(error).to.have.property('originalError').that.instanceOf(MongoError);
+      expect(error.originalError).to.have.property('code', 20);
+      expect(error).to.have.property(
+        'message',
+        'This MongoDB deployment does not support retryable writes. Please add retryWrites=false to your connection string.'
+      );
+    });
+  });
+
+  describe('2. Test that drivers properly retry after encountering PoolClearedErrors.', () => {
+    // This test MUST be implemented by any driver that implements the CMAP specification.
+    // This test requires MongoDB 4.2.9+ for blockConnection support in the failpoint.
+
+    let observedEvents: Array<{ name: string; event: Record<string, any> }>;
+    let testCollection: Collection;
+    beforeEach(async function () {
+      // i. Create a client with maxPoolSize=1 and retryWrites=true.
+      // If testing against a sharded deployment, be sure to connect to only a single mongos. <-- TODO: what does that look like?
+      client = this.configuration.newClient({
+        maxPoolSize: 1,
+        retryWrites: true,
+        monitorCommands: true
+      });
+      console.log(client.options.retryReads, client.options.retryWrites);
+      await client.connect();
+
+      testCollection = client.db('retryable-writes-prose').collection('pool-clear-retry');
+      await testCollection.drop().catch(() => null);
+
+      // ii. Enable the following failpoint:
+      // NOTE: "ix. Disable the failpoint" is done in afterEach
+      failPointName = 'failCommand';
+      const failPoint = await client.db('admin').command({
+        configureFailPoint: failPointName,
+        mode: { times: 1 },
+        data: {
+          failCommands: ['insert'],
+          errorCode: 91,
+          blockConnection: true,
+          blockTimeMS: 1000,
+          errorLabels: ['RetryableWriteError']
+        }
+      });
+
+      expect(failPoint).to.have.property('ok', 1);
+
+      observedEvents = [];
+      for (const observedEvent of [
+        'connectionCheckOutStarted',
+        'connectionCheckedOut',
+        'connectionCheckOutFailed',
+        'connectionPoolCleared',
+        'commandStarted'
+      ]) {
+        client.on(observedEvent, ev => {
+          observedEvents.push({ name: observedEvent, event: ev });
+        });
       }
     });
 
-    expect(failPoint).to.have.property('ok', 1);
+    it('should emit events in the expected sequence', {
+      metadata: { requires: { mongodb: '>=4.2.9' } },
+      test: async function () {
+        // iii. Start two threads and attempt to perform an insertOne simultaneously on both.
+        await Promise.all([
+          testCollection.insertOne({ test: 1 }),
+          testCollection.insertOne({ test: 2 })
+        ]);
 
-    const error = await client
-      .db('test')
-      .collection('test')
-      .insertOne({ a: 1 })
-      .catch(error => error);
+        client.removeAllListeners();
+        // iv. Verify that both insertOne attempts succeed.
+        const result = await testCollection.find().toArray();
+        expect(result).to.have.lengthOf(2);
+        const mappedAndSortedResult = result.map(item => item.test).sort();
+        expect(mappedAndSortedResult).to.deep.equal([1, 2]);
 
-    expect(error).to.exist;
-    expect(error).that.is.instanceOf(MongoServerError);
-    expect(error).to.have.property('originalError').that.instanceOf(MongoError);
-    expect(error.originalError).to.have.property('code', 20);
-    expect(error).to.have.property(
-      'message',
-      'This MongoDB deployment does not support retryable writes. Please add retryWrites=false to your connection string.'
-    );
+        // v. Via CMAP monitoring, assert that the first check out succeeds.
+        const indexOfFirstCheckoutAttempt = observedEvents.findIndex(
+          ev => ev.name === 'connectionCheckOutStarted'
+        );
+        expect(indexOfFirstCheckoutAttempt).to.be.greaterThan(
+          -1,
+          'expected a checkout started event to exist'
+        );
+        const indexOfFirstCheckoutSuccess = observedEvents.findIndex(
+          ev => ev.name === 'connectionCheckedOut'
+        );
+        expect(indexOfFirstCheckoutSuccess).to.be.greaterThan(
+          -1,
+          'expected at least one checkout success'
+        );
+        const indexOfFirstCheckoutFailure = observedEvents.findIndex(
+          ev => ev.name === 'connectionCheckOutFailed'
+        );
+        expect(indexOfFirstCheckoutFailure).to.be.greaterThan(
+          -1,
+          'expected at least one checkout failure'
+        );
+
+        expect(indexOfFirstCheckoutSuccess).to.be.greaterThan(
+          indexOfFirstCheckoutAttempt,
+          'expected checkout started before checkout success'
+        );
+        expect(indexOfFirstCheckoutSuccess).to.be.lessThan(
+          indexOfFirstCheckoutFailure,
+          'expected first connection checkout to succeed but it failed'
+        );
+
+        // vi. Via CMAP monitoring, assert that a PoolClearedEvent is then emitted.
+        const indexOfPoolClear = observedEvents.findIndex(
+          ev => ev.name === 'connectionPoolCleared'
+        );
+        expect(indexOfPoolClear).to.be.greaterThan(
+          indexOfFirstCheckoutSuccess,
+          'expected a pool cleared event to follow checkout success'
+        );
+
+        // vii. Via CMAP monitoring, assert that the second check out then fails due to a connection error.
+        expect(indexOfFirstCheckoutFailure).to.be.greaterThan(
+          indexOfPoolClear,
+          'expected checkout failure after pool clear'
+        );
+        expect(observedEvents[indexOfFirstCheckoutFailure].event).to.have.property(
+          'reason',
+          'connectionError'
+        );
+
+        // viii. Via Command Monitoring, assert that exactly three insert CommandStartedEvents were observed in total.
+        const observedInsertCommandStartedEvents = observedEvents.filter(({ name, event }) => {
+          return name === 'commandStarted' && event.commandName === 'insert';
+        });
+        expect(observedInsertCommandStartedEvents).to.have.lengthOf(
+          3,
+          'expected 3 insert command started events'
+        );
+      }
+    });
   });
 });

--- a/test/integration/retryable-writes/retryable_writes.spec.prose.test.ts
+++ b/test/integration/retryable-writes/retryable_writes.spec.prose.test.ts
@@ -79,11 +79,11 @@ describe('Retryable Writes Spec Prose', () => {
     let testCollection: Collection;
     beforeEach(async function () {
       // i. Create a client with maxPoolSize=1 and retryWrites=true.
-      // If testing against a sharded deployment, be sure to connect to only a single mongos. <-- TODO: what does that look like?
       client = this.configuration.newClient({
         maxPoolSize: 1,
         retryWrites: true,
-        monitorCommands: true
+        monitorCommands: true,
+        useMultipleMongoses: false // If testing against a sharded deployment, be sure to connect to only a single mongos.
       });
 
       testCollection = client.db('retryable-writes-prose').collection('pool-clear-retry');

--- a/test/integration/retryable-writes/retryable_writes.spec.prose.test.ts
+++ b/test/integration/retryable-writes/retryable_writes.spec.prose.test.ts
@@ -106,6 +106,7 @@ describe('Retryable Writes Spec Prose', () => {
       expect(failPoint).to.have.property('ok', 1);
 
       cmapEvents = [];
+      commandStartedEvents = [];
       for (const observedEvent of [
         'connectionCheckOutStarted',
         'connectionCheckedOut',

--- a/test/integration/retryable-writes/retryable_writes.spec.prose.test.ts
+++ b/test/integration/retryable-writes/retryable_writes.spec.prose.test.ts
@@ -156,7 +156,7 @@ describe('Retryable Writes Spec Prose', () => {
         );
         expect(cmapEvents.shift()).to.have.property(
           'name',
-          'connectionCheckOutStarted',
+          'connectionCheckedOut',
           'expected 3) first checkout to succeed'
         );
 

--- a/test/integration/retryable-writes/retryable_writes.spec.prose.test.ts
+++ b/test/integration/retryable-writes/retryable_writes.spec.prose.test.ts
@@ -79,12 +79,12 @@ describe('Retryable Writes Spec Prose', () => {
     let testCollection: Collection;
     beforeEach(async function () {
       // i. Create a client with maxPoolSize=1 and retryWrites=true.
-      client = this.configuration.newClient({
-        maxPoolSize: 1,
-        retryWrites: true,
-        monitorCommands: true,
-        useMultipleMongoses: false // If testing against a sharded deployment, be sure to connect to only a single mongos.
-      });
+      client = this.configuration.newClient(
+        this.configuration.url({
+          useMultipleMongoses: false // If testing against a sharded deployment, be sure to connect to only a single mongos.
+        }),
+        { maxPoolSize: 1, retryWrites: true, monitorCommands: true }
+      );
 
       testCollection = client.db('retryable-writes-prose').collection('pool-clear-retry');
       await testCollection.drop().catch(() => null);


### PR DESCRIPTION
### Description
NODE-3144

#### What is changing?
- Fixed the ordering of PoolCleared event to happen before the corresponding CheckOutFailed events from waitqueue eviction
- Implemented retryable reads and writes prose tests
  - As part of this, I reorganized the existing retryable write prose test so that it would uniformly reset the failPoint with the new added test, but otherwise left it alone

##### Is there new documentation needed for these changes?
No

#### What is the motivation for this change?
Spec compliance

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
