### PR TITLE
feat(NODE-4634): add support for bulk FindOperators.hint()

### DIFF
--- a/src/bulk/common.ts
+++ b/src/bulk/common.ts
@@ -869,7 +869,7 @@ export class FindOperators {
     return this;
   }
 
-  /** Specifies hint for UpdateOne or UpdateMany bulk operations. */
+  /** Specifies hint for the bulk operation. */
   hint(hint: Hint): this {
     if (!this.bulkOperation.s.currentOp) {
       this.bulkOperation.s.currentOp = {};

--- a/src/bulk/common.ts
+++ b/src/bulk/common.ts
@@ -784,7 +784,7 @@ export class FindOperators {
   }
 
   /** Add a multiple update operation to the bulk operation */
-  update(updateDocument: Document): BulkOperationBase {
+  update(updateDocument: Document | Document[]): BulkOperationBase {
     const currentOp = buildCurrentOp(this.bulkOperation);
     return this.bulkOperation.addToOperationsList(
       BatchType.UPDATE,
@@ -796,7 +796,7 @@ export class FindOperators {
   }
 
   /** Add a single update operation to the bulk operation */
-  updateOne(updateDocument: Document): BulkOperationBase {
+  updateOne(updateDocument: Document | Document[]): BulkOperationBase {
     if (!hasAtomicOperators(updateDocument)) {
       throw new MongoInvalidArgumentError('Update document requires atomic operators');
     }
@@ -866,6 +866,16 @@ export class FindOperators {
     }
 
     this.bulkOperation.s.currentOp.arrayFilters = arrayFilters;
+    return this;
+  }
+
+  /** Specifies hint for UpdateOne or UpdateMany bulk operations. */
+  hint(hint: Hint): this {
+    if (!this.bulkOperation.s.currentOp) {
+      this.bulkOperation.s.currentOp = {};
+    }
+
+    this.bulkOperation.s.currentOp.hint = hint;
     return this;
   }
 }

--- a/src/operations/update.ts
+++ b/src/operations/update.ts
@@ -22,7 +22,7 @@ export interface UpdateOptions extends CommandOperationOptions {
   /** Specifies a collation */
   collation?: CollationOptions;
   /** Specify that the update query should only consider plans using the hinted index */
-  hint?: string | Document;
+  hint?: Hint;
   /** When true, creates a new document if no document matches the query */
   upsert?: boolean;
   /** Map of parameter names and values that can be accessed using $$var (requires MongoDB 5.0). */
@@ -280,7 +280,7 @@ export class ReplaceOneOperation extends UpdateOperation {
 
 export function makeUpdateStatement(
   filter: Document,
-  update: Document,
+  update: Document | Document[],
   options: UpdateOptions & { multi?: boolean }
 ): UpdateStatement {
   if (filter == null || typeof filter !== 'object') {

--- a/test/integration/crud/bulk.test.ts
+++ b/test/integration/crud/bulk.test.ts
@@ -1717,23 +1717,19 @@ describe('Bulk', function () {
 
       await bulk.execute();
 
-      try {
-        expect(events).to.be.an('array').with.length.at.least(1);
-        expect(events[0]).property('commandName').to.equal('update');
-        const updateCommand = events[0].command;
-        expect(updateCommand).property('updates').to.be.an('array').with.length(3);
-        updateCommand.updates.forEach(statement => {
-          expect(statement).property('hint').to.eql({ b: 1 });
-        });
-        expect(events[1]).property('commandName').to.equal('delete');
-        const deleteCommand = events[1].command;
-        expect(deleteCommand).property('deletes').to.be.an('array').with.length(2);
-        deleteCommand.deletes.forEach(statement => {
-          expect(statement).property('hint').to.eql({ b: 1 });
-        });
-      } finally {
-        await client.close();
-      }
+      expect(events).to.be.an('array').with.length.at.least(1);
+      expect(events[0]).property('commandName').to.equal('update');
+      const updateCommand = events[0].command;
+      expect(updateCommand).property('updates').to.be.an('array').with.length(3);
+      updateCommand.updates.forEach(statement => {
+        expect(statement).property('hint').to.eql({ b: 1 });
+      });
+      expect(events[1]).property('commandName').to.equal('delete');
+      const deleteCommand = events[1].command;
+      expect(deleteCommand).property('deletes').to.be.an('array').with.length(2);
+      deleteCommand.deletes.forEach(statement => {
+        expect(statement).property('hint').to.eql({ b: 1 });
+      });
     }
   });
 
@@ -1799,12 +1795,8 @@ describe('Bulk', function () {
 
       await bulk.execute();
 
-      try {
-        const contents = await coll.find().project({ _id: 0 }).toArray();
-        expect(contents).to.deep.equal([{ a: 11 }, { a: 102 }]);
-      } finally {
-        await client.close();
-      }
+      const contents = await coll.find().project({ _id: 0 }).toArray();
+      expect(contents).to.deep.equal([{ a: 11 }, { a: 102 }]);
     }
   });
 

--- a/test/integration/crud/bulk.test.ts
+++ b/test/integration/crud/bulk.test.ts
@@ -1689,7 +1689,7 @@ describe('Bulk', function () {
   });
 
   it('should apply hint via FindOperators', {
-    metadata: { requires: { mongodb: '>= 4.2' } },
+    metadata: { requires: { mongodb: '>= 4.4' } },
     async test() {
       const bulk = client.db().collection('coll').initializeOrderedBulkOp();
 

--- a/test/integration/crud/bulk.test.ts
+++ b/test/integration/crud/bulk.test.ts
@@ -1688,6 +1688,55 @@ describe('Bulk', function () {
     }
   });
 
+  it('should apply hint via FindOperators', {
+    metadata: { requires: { mongodb: '>= 4.2' } },
+    async test() {
+      const bulk = client.db().collection('coll').initializeOrderedBulkOp();
+
+      const events = [];
+      client.on('commandStarted', event => {
+        if (['update', 'delete'].includes(event.commandName)) {
+          events.push(event);
+        }
+      });
+
+      // updates
+      bulk
+        .find({ b: 1 })
+        .hint({ b: 1 })
+        .updateOne({ $set: { b: 2 } });
+      bulk
+        .find({ b: 2 })
+        .hint({ b: 1 })
+        .update({ $set: { b: 3 } });
+      bulk.find({ b: 3 }).hint({ b: 1 }).replaceOne({ b: 2 });
+
+      // deletes
+      bulk.find({ b: 2 }).hint({ b: 1 }).deleteOne();
+      bulk.find({ b: 1 }).hint({ b: 1 }).delete();
+
+      await bulk.execute();
+
+      try {
+        expect(events).to.be.an('array').with.length.at.least(1);
+        expect(events[0]).property('commandName').to.equal('update');
+        const updateCommand = events[0].command;
+        expect(updateCommand).property('updates').to.be.an('array').with.length(3);
+        updateCommand.updates.forEach(statement => {
+          expect(statement).property('hint').to.eql({ b: 1 });
+        });
+        expect(events[1]).property('commandName').to.equal('delete');
+        const deleteCommand = events[1].command;
+        expect(deleteCommand).property('deletes').to.be.an('array').with.length(2);
+        deleteCommand.deletes.forEach(statement => {
+          expect(statement).property('hint').to.eql({ b: 1 });
+        });
+      } finally {
+        await client.close();
+      }
+    }
+  });
+
   it('should apply arrayFilters to bulk updates via FindOperators', {
     metadata: { requires: { mongodb: '>= 3.6' } },
     test: function (done) {
@@ -1734,6 +1783,28 @@ describe('Bulk', function () {
           });
         });
       });
+    }
+  });
+
+  it('should accept pipeline-style updates', {
+    metadata: { requires: { mongodb: '>= 4.2' } },
+    async test() {
+      const coll = client.db().collection('coll');
+      const bulk = coll.initializeOrderedBulkOp();
+
+      coll.insertMany([{ a: 1 }, { a: 2 }]);
+
+      bulk.find({ a: 1 }).updateOne([{ $project: { a: { $add: ['$a', 10] } } }]);
+      bulk.find({ a: 2 }).update([{ $project: { a: { $add: ['$a', 100] } } }]);
+
+      await bulk.execute();
+
+      try {
+        const contents = await coll.find().project({ _id: 0 }).toArray();
+        expect(contents).to.deep.equal([{ a: 11 }, { a: 102 }]);
+      } finally {
+        await client.close();
+      }
     }
   });
 


### PR DESCRIPTION
### Description

#### What is changing?

- `FindOperators.update()` and `.updateOne()` use updated TS definitions to allow pipeline-style updates (which are supported by the server and by the actual implementation itself)
- `FindOperators.hint()` is added as an analogue to the `.collation()`, `.arrayHints()` and `.upsert()` methods
- Tests for both of the above are added, modeled on existing tests

##### Is there new documentation needed for these changes?

I would assume so.

#### What is the motivation for this change?

mongosh cannot implement `.hint()` in its own bulk write builder API without one of:

- Modifying driver internals, or
- Implementing the entire bulk builder API itself on top of `collection.bulkWrite()`, or
- This change

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
