### PR TITLE
fix(NODE-4639): allow PromiseProvider to be null

### DIFF
--- a/src/bulk/common.ts
+++ b/src/bulk/common.ts
@@ -1346,13 +1346,13 @@ function handleEarlyError(
   err?: AnyError,
   callback?: Callback<BulkWriteResult>
 ): Promise<BulkWriteResult> | void {
-  const Promise = PromiseProvider.get();
   if (typeof callback === 'function') {
     callback(err);
     return;
   }
 
-  return Promise.reject(err);
+  const PromiseConstructor = PromiseProvider.get() ?? Promise;
+  return PromiseConstructor.reject(err);
 }
 
 function shouldForceServerObjectId(bulkOperation: BulkOperationBase): boolean {

--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -438,7 +438,9 @@ export function parseOptions(
 
   checkTLSOptions(mongoOptions);
 
-  if (options.promiseLibrary) PromiseProvider.set(options.promiseLibrary);
+  if (options.promiseLibrary) {
+    PromiseProvider.set(options.promiseLibrary);
+  }
 
   const lbError = validateLoadBalancedOptions(hosts, mongoOptions, isSRV);
   if (lbError) {

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -593,8 +593,12 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> {
         return mongoClient.connect();
       }
     } catch (error) {
-      if (callback) return callback(error);
-      else return PromiseProvider.get().reject(error);
+      if (callback) {
+        return callback(error);
+      } else {
+        const PromiseConstructor = PromiseProvider.get() ?? Promise;
+        return PromiseConstructor.reject(error);
+      }
     }
   }
 
@@ -645,9 +649,9 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> {
     }
 
     const session = this.startSession(options);
-    const Promise = PromiseProvider.get();
+    const PromiseConstructor = PromiseProvider.get() ?? Promise;
 
-    return Promise.resolve()
+    return PromiseConstructor.resolve()
       .then(() => withSessionCallback(session))
       .then(() => {
         // Do not return the result of callback

--- a/src/promise_provider.ts
+++ b/src/promise_provider.ts
@@ -4,11 +4,11 @@ import { MongoInvalidArgumentError } from './error';
 const kPromise = Symbol('promise');
 
 interface PromiseStore {
-  [kPromise]?: PromiseConstructor;
+  [kPromise]: PromiseConstructor | null;
 }
 
 const store: PromiseStore = {
-  [kPromise]: undefined
+  [kPromise]: null
 };
 
 /**
@@ -31,7 +31,14 @@ export class PromiseProvider {
    * Sets the promise library
    * @deprecated Setting a custom promise library is deprecated the next major version will use the global Promise constructor only.
    */
-  static set(lib: PromiseConstructor): void {
+  static set(lib: PromiseConstructor | null): void {
+    // eslint-disable-next-line no-restricted-syntax
+    if (lib === null) {
+      // Check explicitly against null since `.set()` (no args) should fall through to validate
+      store[kPromise] = null;
+      return;
+    }
+
     if (!PromiseProvider.validate(lib)) {
       // validate
       return;
@@ -43,9 +50,7 @@ export class PromiseProvider {
    * Get the stored promise library, or resolves passed in
    * @deprecated Setting a custom promise library is deprecated the next major version will use the global Promise constructor only.
    */
-  static get(): PromiseConstructor {
-    return store[kPromise] as PromiseConstructor;
+  static get(): PromiseConstructor | null {
+    return store[kPromise];
   }
 }
-
-PromiseProvider.set(global.Promise);

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -609,14 +609,14 @@ function attemptTransaction<TSchema>(
   fn: WithTransactionCallback<TSchema>,
   options?: TransactionOptions
 ): Promise<any> {
-  const Promise = PromiseProvider.get();
   session.startTransaction(options);
 
   let promise;
   try {
     promise = fn(session);
   } catch (err) {
-    promise = Promise.reject(err);
+    const PromiseConstructor = PromiseProvider.get() ?? Promise;
+    promise = PromiseConstructor.reject(err);
   }
 
   if (!isPromiseLike(promise)) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -448,10 +448,10 @@ export function maybePromise<T>(
   callback: Callback<T> | undefined,
   wrapper: (fn: Callback<T>) => void
 ): Promise<T> | void {
-  const Promise = PromiseProvider.get();
+  const PromiseConstructor = PromiseProvider.get() ?? Promise;
   let result: Promise<T> | void;
   if (typeof callback !== 'function') {
-    result = new Promise<any>((resolve, reject) => {
+    result = new PromiseConstructor<any>((resolve, reject) => {
       callback = (err, res) => {
         if (err) return reject(err);
         resolve(res);

--- a/test/integration/node-specific/cursor_async_iterator.test.js
+++ b/test/integration/node-specific/cursor_async_iterator.test.js
@@ -109,7 +109,7 @@ describe('Cursor Async Iterator Tests', function () {
 
     afterEach(() => {
       promiseSpy.restore();
-      PromiseProvider.set(Promise);
+      PromiseProvider.set(null);
       return client.close();
     });
 

--- a/test/integration/node-specific/custom_promise_library.test.js
+++ b/test/integration/node-specific/custom_promise_library.test.js
@@ -9,8 +9,23 @@ class CustomPromise extends Promise {}
 CustomPromise.prototype.isCustomMongo = true;
 
 describe('Optional PromiseLibrary', function () {
+  beforeEach(() => {
+    PromiseProvider.set(null);
+  });
+
   afterEach(() => {
+    PromiseProvider.set(null);
+  });
+
+  it('should initially be set to null', () => {
+    expect(PromiseProvider.get()).to.be.null;
+  });
+
+  it('should allow passing null to .set() to clear the set promise', () => {
     PromiseProvider.set(Promise);
+    expect(PromiseProvider.get()).to.equal(Promise);
+    expect(() => PromiseProvider.set(null)).to.not.throw();
+    expect(PromiseProvider.get()).to.be.null;
   });
 
   it('should emit a deprecation warning when a promiseLibrary is set', async () => {

--- a/test/types/community/client.test-d.ts
+++ b/test/types/community/client.test-d.ts
@@ -35,7 +35,6 @@ const options: MongoClientOptions = {
   promoteBuffers: false,
   authMechanism: 'SCRAM-SHA-1',
   forceServerObjectId: false,
-  promiseLibrary: Promise,
   directConnection: false
 };
 

--- a/test/unit/mongo_client.test.js
+++ b/test/unit/mongo_client.test.js
@@ -110,7 +110,6 @@ describe('MongoOptions', function () {
         return 'very unique';
       }
     },
-    promiseLibrary: global.Promise,
     promoteBuffers: true,
     promoteLongs: false,
     promoteValues: false,


### PR DESCRIPTION
### Description

PromiseProvider fix from #3406

#### What is changing?

#### What is the motivation for this change?

The promise provider could have always returned a nullish value, the types were casting away the potential issue. This corrects the issue and allows the PromiseProvider to be unset with `null`

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
