### PR TITLE
refactor(NODE-4638): prevent parallel calls to `fn` in the async interval

### DIFF
--- a/src/sdam/monitor.ts
+++ b/src/sdam/monitor.ts
@@ -489,7 +489,7 @@ export class MonitorInterval {
 
   constructor(fn: (callback: Callback) => void, options: Partial<MonitorIntervalOptions> = {}) {
     this.fn = fn;
-    this.lastExecutionEnded = 0;
+    this.lastExecutionEnded = -Infinity;
 
     this.heartbeatFrequencyMS = options.heartbeatFrequencyMS ?? 1000;
     this.minHeartbeatFrequencyMS = options.minHeartbeatFrequencyMS ?? 500;
@@ -497,7 +497,6 @@ export class MonitorInterval {
     if (options.immediate) {
       this._executeAndReschedule();
     } else {
-      this.lastExecutionEnded = now();
       this._reschedule(undefined);
     }
   }
@@ -506,9 +505,8 @@ export class MonitorInterval {
     const currentTime = now();
     const timeSinceLastCall = currentTime - this.lastExecutionEnded;
 
-    if (!this.hasExecutedOnce) {
-      this._executeAndReschedule();
-      return;
+    if (timeSinceLastCall < 0) {
+      return this._executeAndReschedule();
     }
 
     if (this.isExecutionInProgress) {
@@ -538,7 +536,7 @@ export class MonitorInterval {
       this.timerId = undefined;
     }
 
-    this.lastExecutionEnded = 0;
+    this.lastExecutionEnded = -Infinity;
     this.isExpeditedCallToFnScheduled = false;
   }
 
@@ -576,7 +574,6 @@ export class MonitorInterval {
       clearTimeout(this.timerId);
     }
 
-    this.hasExecutedOnce = true;
     this.isExpeditedCallToFnScheduled = false;
     this.isExecutionInProgress = true;
 

--- a/src/sdam/monitor.ts
+++ b/src/sdam/monitor.ts
@@ -505,6 +505,7 @@ export class MonitorInterval {
     const currentTime = now();
     const timeSinceLastCall = currentTime - this.lastExecutionEnded;
 
+    // TODO(NODE-4674): Add error handling and logging to the monitor
     if (timeSinceLastCall < 0) {
       return this._executeAndReschedule();
     }

--- a/test/integration/change-streams/change_stream.test.ts
+++ b/test/integration/change-streams/change_stream.test.ts
@@ -5,7 +5,7 @@ import { gte, lt } from 'semver';
 import * as sinon from 'sinon';
 import { PassThrough } from 'stream';
 import { setTimeout } from 'timers';
-import { inspect, promisify } from 'util';
+import { promisify } from 'util';
 
 import {
   AbstractCursor,
@@ -1041,12 +1041,6 @@ describe('Change Streams', function () {
       let client: MongoClient;
       let changeStream: ChangeStream;
 
-      async function initCursor(cursor: AbstractCursor) {
-        const init = getSymbolFrom(AbstractCursor.prototype, 'kInit');
-        const initFunction = promisify(cursor[init]).bind(cursor);
-        return initFunction();
-      }
-
       beforeEach(async function () {
         client = this.configuration.newClient();
         await client.connect();
@@ -1075,7 +1069,7 @@ describe('Change Streams', function () {
 
         changeStream = collection.watch([], { batchSize: 1 });
 
-        await initCursor(changeStream.cursor);
+        await initIteratorMode(changeStream);
 
         await collection.insertOne({ name: 'bumpy' });
         await collection.insertOne({ name: 'bumpy' });

--- a/test/integration/change-streams/change_streams.spec.test.ts
+++ b/test/integration/change-streams/change_streams.spec.test.ts
@@ -4,5 +4,9 @@ import { loadSpecTests } from '../../spec';
 import { runUnifiedSuite } from '../../tools/unified-spec-runner/runner';
 
 describe('Change Streams Spec - Unified', function () {
-  runUnifiedSuite(loadSpecTests(path.join('change-streams', 'unified')));
+  runUnifiedSuite(loadSpecTests(path.join('change-streams', 'unified')), test =>
+    test.description === 'Test consecutive resume'
+      ? 'TODO(NODE-4670): fix consecutive resume change stream test'
+      : false
+  );
 });

--- a/test/integration/unified-test-format/unified_test_format.spec.test.ts
+++ b/test/integration/unified-test-format/unified_test_format.spec.test.ts
@@ -23,6 +23,10 @@ const filter: TestFilter = ({ description }) => {
     return 'TODO(NODE-3308): failures due unnecessary getMore and killCursors calls in 5.0';
   }
 
+  if (description === 'Test consecutive resume') {
+    return 'TODO(NODE-4670): fix consecutive resume change stream test';
+  }
+
   if (
     process.env.AUTH === 'auth' &&
     [

--- a/test/unit/sdam/monitor.test.ts
+++ b/test/unit/sdam/monitor.test.ts
@@ -283,275 +283,231 @@ describe('monitoring', function () {
       timerSandbox.restore();
     });
 
-    context('when the immediate option is provided', function () {
-      it('executes the function immediately and schedules the next execution on the interval', function () {
-        executor = new MonitorInterval(fnSpy, {
-          immediate: true,
-          minHeartbeatFrequencyMS: 10,
-          heartbeatFrequencyMS: 30
+    context('#constructor()', function () {
+      context('when the immediate option is provided', function () {
+        it('executes the function immediately and schedules the next execution on the interval', function () {
+          executor = new MonitorInterval(fnSpy, {
+            immediate: true,
+            minHeartbeatFrequencyMS: 10,
+            heartbeatFrequencyMS: 30
+          });
+          // expect immediate invocation
+          expect(fnSpy.calledOnce).to.be.true;
+          // advance clock by less than the scheduled interval to ensure we don't execute early
+          clock.tick(29);
+          expect(fnSpy.calledOnce).to.be.true;
+          // advance clock to the interval
+          clock.tick(1);
+          expect(fnSpy.calledTwice).to.be.true;
         });
-        // expect immediate invocation
-        expect(fnSpy.calledOnce).to.be.true;
-        // advance clock by less than the scheduled interval to ensure we don't execute early
-        clock.tick(29);
-        expect(fnSpy.calledOnce).to.be.true;
-        // advance clock to the interval
-        clock.tick(1);
-        expect(fnSpy.calledTwice).to.be.true;
+      });
+
+      context('when the immediate option is not provided', function () {
+        it('executes the function on the provided interval', function () {
+          executor = new MonitorInterval(fnSpy, {
+            minHeartbeatFrequencyMS: 10,
+            heartbeatFrequencyMS: 30
+          });
+          // advance clock by less than the scheduled interval to ensure we don't execute early
+          clock.tick(29);
+          expect(fnSpy.callCount).to.equal(0);
+          // advance clock to the interval
+          clock.tick(1);
+          expect(fnSpy.calledOnce).to.be.true;
+          // advance clock by the interval
+          clock.tick(30);
+          expect(fnSpy.calledTwice).to.be.true;
+        });
       });
     });
 
-    context('when the immediate option is not provided', function () {
-      it('executes the function on the provided interval', function () {
+    describe('#wake()', function () {
+      context('when fn()  has not executed yet', function () {
+        beforeEach(function () {
+          executor = new MonitorInterval(fnSpy, {
+            minHeartbeatFrequencyMS: 10,
+            heartbeatFrequencyMS: 30
+          });
+
+          // tick less than heartbeatFrequencyMS
+          clock.tick(5);
+
+          executor.wake();
+        });
+        it('executes immediately', function () {
+          expect(fnSpy.calledOnce).to.be.true;
+        });
+        it('schedules fn() for heartbeatFrequencyMS away', function () {
+          // advance the clock almost heartbeatFrequencyMS away
+          clock.tick(29);
+          expect(fnSpy.calledOnce).to.be.true;
+
+          // advance it to heartbeatFrequencyMS
+          clock.tick(1);
+          expect(fnSpy.calledTwice).to.be.true;
+        });
+      });
+
+      context('when fn() is in progress', function () {
+        beforeEach(function () {
+          // create an asynchronous spy
+          fnSpy = sinon.spy(cb => setTimeout(cb, 5));
+
+          executor = new MonitorInterval(fnSpy, {
+            minHeartbeatFrequencyMS: 10,
+            heartbeatFrequencyMS: 30
+          });
+
+          // advance to point of execution
+          clock.tick(30);
+        });
+        it('does not trigger another call to fn()', function () {
+          executor.wake();
+          executor.wake();
+          executor.wake();
+          executor.wake();
+
+          expect(fnSpy.calledOnce).to.be.true;
+        });
+      });
+
+      context('when it has been >=minHeartbeatFrequencyMS since fn() last completed', function () {
+        beforeEach(function () {
+          executor = new MonitorInterval(fnSpy, {
+            minHeartbeatFrequencyMS: 10,
+            heartbeatFrequencyMS: 30
+          });
+
+          // call fn() once
+          clock.tick(30);
+          expect(fnSpy.calledOnce).to.be.true;
+
+          fnSpy.callCount = 0;
+
+          // advance further than minHeartbeatFrequency
+          clock.tick(20);
+
+          executor.wake();
+        });
+        it('executes fn() immediately', function () {
+          expect(fnSpy.calledOnce).to.be.true;
+        });
+        it('schedules fn() for heartbeatFrequencyMS away', function () {
+          clock.tick(29);
+          expect(fnSpy.calledOnce).to.be.true;
+          clock.tick(1);
+          expect(fnSpy.calledTwice).to.be.true;
+        });
+      });
+
+      context('when it has been < minHeartbeatFrequencyMS since fn() last completed', function () {
+        beforeEach(function () {
+          executor = new MonitorInterval(fnSpy, {
+            minHeartbeatFrequencyMS: 10,
+            heartbeatFrequencyMS: 30
+          });
+
+          // call fn() once
+          clock.tick(30);
+          expect(fnSpy.calledOnce).to.be.true;
+
+          fnSpy.callCount = 0;
+
+          // advance less than minHeartbeatFrequency
+          clock.tick(5);
+
+          executor.wake();
+        });
+
+        it('reschedules fn() to minHeartbeatFrequencyMS after the last call', function () {
+          expect(fnSpy.callCount).to.equal(0);
+          clock.tick(5);
+          expect(fnSpy.calledOnce).to.be.true;
+        });
+
+        context('when wake() is called more than once', function () {
+          it('schedules fn() minHeartbeatFrequencyMS after the last call to fn()', function () {
+            executor.wake();
+            executor.wake();
+            executor.wake();
+
+            expect(fnSpy.callCount).to.equal(0);
+            clock.tick(5);
+            expect(fnSpy.calledOnce).to.be.true;
+          });
+        });
+      });
+    });
+
+    describe('#stop()', function () {
+      context('when fn() is executing', function () {
+        beforeEach(function () {
+          // create an asynchronous spy
+          fnSpy = sinon.spy(cb => setTimeout(cb, 5));
+
+          executor = new MonitorInterval(fnSpy, {
+            minHeartbeatFrequencyMS: 10,
+            heartbeatFrequencyMS: 30
+          });
+
+          // advance to point of execution
+          clock.tick(30);
+
+          executor.stop();
+        });
+        it('does not reschedule fn() after fn() finishes executing', function () {
+          // exhaust the spy fn
+          clock.tick(5);
+
+          expect(fnSpy.calledOnce).to.be.true;
+
+          // advance heartbeatFrequencyMS
+          clock.tick(30);
+          expect(fnSpy.calledOnce).to.be.true;
+        });
+      });
+      context('when fn() is not executing', function () {
+        beforeEach(function () {
+          executor = new MonitorInterval(fnSpy, {
+            minHeartbeatFrequencyMS: 10,
+            heartbeatFrequencyMS: 30
+          });
+
+          executor.stop();
+
+          // advance heartbeatFrequencyMS
+          clock.tick(30);
+        });
+        it('clears any scheduled executions of fn()', function () {
+          expect(fnSpy.callCount).to.equal(0);
+        });
+      });
+    });
+
+    context('when fn() returns an error', function () {
+      let uncaughtErrors = [];
+      beforeEach(function () {
+        uncaughtErrors = [];
+        process.on('uncaughtException', e => uncaughtErrors.push(e));
+
+        fnSpy = sinon.spy(cb => cb(new Error('ahh')));
+
         executor = new MonitorInterval(fnSpy, {
           minHeartbeatFrequencyMS: 10,
           heartbeatFrequencyMS: 30
         });
-        // advance clock by less than the scheduled interval to ensure we don't execute early
-        clock.tick(29);
-        expect(fnSpy.callCount).to.equal(0);
-        // advance clock to the interval
-        clock.tick(1);
-        expect(fnSpy.calledOnce).to.be.true;
-        // advance clock by the interval
+
+        clock.tick(30);
+      });
+
+      afterEach(() => process.removeAllListeners());
+
+      it('no error is thrown by the MonitorInterval', function () {
+        expect(uncaughtErrors).to.have.lengthOf(0);
+      });
+      it('reschedules another call to fn() for heartbeatFrequencyMS in the future', function () {
         clock.tick(30);
         expect(fnSpy.calledTwice).to.be.true;
-      });
-    });
-
-    describe('#wake', function () {
-      context('when the time until next call is negative', () => {
-        // somehow we missed the execution, due to an unreliable clock
-
-        it('should execute immediately and schedule the next execution on the interval if this is the first wake', () => {
-          let fakeClockHasTicked = false;
-          executor = new MonitorInterval(fnSpy, {
-            minHeartbeatFrequencyMS: 10,
-            heartbeatFrequencyMS: 30,
-            clock: () => {
-              if (fakeClockHasTicked) {
-                return 81;
-              }
-              fakeClockHasTicked = true;
-              return 50;
-            }
-          });
-
-          // tick the environment clock by a smaller amount than the interval
-          clock.tick(2);
-          // sanity check to make sure we haven't called execute yet
-          expect(fnSpy.callCount).to.equal(0);
-          executor.wake();
-          // expect immediate execution since expected next call time was 50 + 30 = 80, but the clock shows 81
-          expect(fnSpy.calledOnce).to.be.true;
-          // move forward by more than minInterval but less than full interval to ensure we're scheduling correctly
-          clock.tick(29);
-          expect(fnSpy.calledOnce).to.be.true;
-          // move forward by the full interval to make sure the scheduled call executes
-          clock.tick(1);
-          expect(fnSpy.calledTwice).to.be.true;
-        });
-
-        it('should execute immediately and schedule the next execution on the interval if this is a repeated wake and the current execution is not rescheduled', () => {
-          let fakeClockTickCount = 0;
-          executor = new MonitorInterval(fnSpy, {
-            minHeartbeatFrequencyMS: 10,
-            heartbeatFrequencyMS: 30,
-            clock: () => {
-              if (fakeClockTickCount === 0) {
-                // on init, return arbitrary starting time
-                fakeClockTickCount++;
-                return 50;
-              }
-              if (fakeClockTickCount === 1) {
-                // expected execution time is 80
-                // on first wake return a time so less than minInterval is left and no need to reschedule
-                fakeClockTickCount++;
-                return 71;
-              }
-              return 81;
-            }
-          });
-
-          // tick the clock by a small amount before and after the wake to make sure no unexpected async things are happening
-          clock.tick(11);
-          executor.wake();
-          clock.tick(5);
-          expect(fnSpy.callCount).to.equal(0);
-          // call our second wake that gets the overdue timer, so expect immediate execution
-          executor.wake();
-          expect(fnSpy.calledOnce).to.be.true;
-          // move forward by more than minInterval but less than full interval to ensure we're scheduling correctly
-          clock.tick(29);
-          expect(fnSpy.calledOnce).to.be.true;
-          // move forward by the full interval to make sure the scheduled call executes
-          clock.tick(1);
-          expect(fnSpy.calledTwice).to.be.true;
-        });
-
-        it('should execute immediately and schedule the next execution on the interval if this is a repeated wake even if the current execution is rescheduled', () => {
-          let fakeClockTickCount = 0;
-          executor = new MonitorInterval(fnSpy, {
-            minHeartbeatFrequencyMS: 10,
-            heartbeatFrequencyMS: 30,
-            clock: () => {
-              if (fakeClockTickCount === 0) {
-                // on init, return arbitrary starting time
-                fakeClockTickCount++;
-                return 50;
-              }
-              if (fakeClockTickCount === 1) {
-                // expected execution time is 80
-                // on first wake return a time so that more than minInterval is left
-                fakeClockTickCount++;
-                return 61;
-              }
-              return 81;
-            }
-          });
-
-          // tick the clock by a small amount before and after the wake to make sure no unexpected async things are happening
-          clock.tick(2);
-          executor.wake();
-          clock.tick(9);
-          expect(fnSpy.callCount).to.equal(0);
-          // call our second wake that gets the overdue timer, so expect immediate execution
-          executor.wake();
-          expect(fnSpy.calledOnce).to.be.true;
-          // move forward by more than minInterval but less than full interval to ensure we're scheduling correctly
-          clock.tick(29);
-          expect(fnSpy.calledOnce).to.be.true;
-          // move forward by the full interval to make sure the scheduled call executes
-          clock.tick(1);
-          expect(fnSpy.calledTwice).to.be.true;
-        });
-      });
-
-      context('when the time until next call is less than the minInterval', () => {
-        // we can't make it go any faster, so we should let the scheduled execution run
-
-        it('should execute on the interval if this is the first wake', () => {
-          executor = new MonitorInterval(fnSpy, {
-            minHeartbeatFrequencyMS: 10,
-            heartbeatFrequencyMS: 30
-          });
-          // tick the environment clock so that less than minInterval is left
-          clock.tick(21);
-          executor.wake();
-          // move forward to just before exepected execution time
-          clock.tick(8);
-          expect(fnSpy.callCount).to.equal(0);
-          // move forward to the full interval to make sure the scheduled call executes
-          clock.tick(1);
-          expect(fnSpy.calledOnce).to.be.true;
-          // check to make sure the next execution runs as expected
-          clock.tick(29);
-          expect(fnSpy.calledOnce).to.be.true;
-          clock.tick(1);
-          expect(fnSpy.calledTwice).to.be.true;
-        });
-
-        it('should execute on the original interval if this is a repeated wake and the current execution is not rescheduled', () => {
-          executor = new MonitorInterval(fnSpy, {
-            minHeartbeatFrequencyMS: 10,
-            heartbeatFrequencyMS: 30
-          });
-          // tick the environment clock so that less than minInterval is left
-          clock.tick(21);
-          executor.wake();
-          // tick the environment clock some more so that the next wake is called at a different time
-          clock.tick(2);
-          executor.wake();
-          // tick to just before the expected execution time
-          clock.tick(6);
-          expect(fnSpy.callCount).to.equal(0);
-          // tick up to 20 for the expected execution
-          clock.tick(1);
-          expect(fnSpy.calledOnce).to.be.true;
-          // check to make sure the next execution runs as expected
-          clock.tick(29);
-          expect(fnSpy.calledOnce).to.be.true;
-          clock.tick(1);
-          expect(fnSpy.calledTwice).to.be.true;
-        });
-
-        it('should execute on the minInterval from the first wake if this is a repeated wake and the current execution is rescheduled', () => {
-          executor = new MonitorInterval(fnSpy, {
-            minHeartbeatFrequencyMS: 10,
-            heartbeatFrequencyMS: 30
-          });
-          // tick the environment clock so that more than minInterval is left
-          clock.tick(13);
-          executor.wake();
-          // the first wake should move up the execution to occur at 23 ticks from the start
-          // we tick 8 to get to 21, so that less than minInterval is left on the original interval expected execution
-          clock.tick(8);
-          executor.wake();
-          // now we tick to just before the rescheduled execution time
-          clock.tick(1);
-          expect(fnSpy.callCount).to.equal(0);
-          // tick up to 23 for the expected execution
-          clock.tick(1);
-          expect(fnSpy.calledOnce).to.be.true;
-          // check to make sure the next execution runs as expected
-          clock.tick(29);
-          expect(fnSpy.calledOnce).to.be.true;
-          clock.tick(1);
-          expect(fnSpy.calledTwice).to.be.true;
-        });
-      });
-
-      context('when the time until next call is more than the minInterval', () => {
-        // expedite the execution to minInterval
-
-        it('should execute on the minInterval if this is the first wake', () => {
-          executor = new MonitorInterval(fnSpy, {
-            minHeartbeatFrequencyMS: 10,
-            heartbeatFrequencyMS: 30
-          });
-          // tick the environment clock so that more than minInterval is left
-          clock.tick(3);
-          executor.wake();
-          // the first wake should move up the execution to occur at 13 ticks from the start
-          // we tick to just before the rescheduled execution time
-          clock.tick(9);
-          expect(fnSpy.callCount).to.equal(0);
-          // tick up to 13 for the expected execution
-          clock.tick(1);
-          expect(fnSpy.calledOnce).to.be.true;
-          // check to make sure the next execution runs as expected
-          clock.tick(29);
-          expect(fnSpy.calledOnce).to.be.true;
-          clock.tick(1);
-          expect(fnSpy.calledTwice).to.be.true;
-        });
-
-        it('should execute on the minInterval from the first wake if this is a repeated wake', () => {
-          // NOTE: under regular circumstances, if the second wake is early enough to warrant a reschedule
-          // then the first wake must have already warranted a reschedule
-          executor = new MonitorInterval(fnSpy, {
-            minHeartbeatFrequencyMS: 10,
-            heartbeatFrequencyMS: 30
-          });
-          // tick the environment clock so that more than minInterval is left
-          clock.tick(3);
-          executor.wake();
-          // the first wake should move up the execution to occur at 13 ticks from the start
-          // we tick a bit more so that more than minInterval is still left and call our repeated wake
-          clock.tick(2);
-          executor.wake();
-          // tick up to just before the expected execution
-          clock.tick(7);
-          expect(fnSpy.callCount).to.equal(0);
-          // now go up to 13
-          clock.tick(1);
-          expect(fnSpy.calledOnce).to.be.true;
-          // check to make sure the next execution runs as expected
-          clock.tick(29);
-          expect(fnSpy.calledOnce).to.be.true;
-          clock.tick(1);
-          expect(fnSpy.calledTwice).to.be.true;
-        });
       });
     });
   });


### PR DESCRIPTION
### Description

#### What is changing?

The monitor has been refactored to more closely align the spec.  Additionally, this PR also prevents the monitor from re-executing the `fn` while `fn` is currently executing.

The unit tests have been reworked to match the new behavior.  The passing unit tests have the following output (included to help demonstrate the behavior of the monitor):

<img width="685" alt="Screen Shot 2022-09-29 at 1 16 30 PM" src="https://user-images.githubusercontent.com/23407842/193098722-a0482ef2-2420-437a-92ab-d662233d7d3e.png">


##### Is there new documentation needed for these changes?

No.

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
