### PR TITLE
chore(NODE-4641): remove wire version checks for unsupported servers

### DIFF
--- a/src/cmap/connection.ts
+++ b/src/cmap/connection.ts
@@ -645,7 +645,7 @@ function supportsOpMsg(conn: Connection) {
     return false;
   }
 
-  return !description.__nodejs_mock_server__;
+  return maxWireVersion(conn) >= 6 && !description.__nodejs_mock_server__;
 }
 
 function streamIdentifier(stream: Stream, options: ConnectionOptions): string {

--- a/src/cmap/connection.ts
+++ b/src/cmap/connection.ts
@@ -645,7 +645,7 @@ function supportsOpMsg(conn: Connection) {
     return false;
   }
 
-  return maxWireVersion(conn) >= 6 && !description.__nodejs_mock_server__;
+  return !description.__nodejs_mock_server__;
 }
 
 function streamIdentifier(stream: Stream, options: ConnectionOptions): string {

--- a/src/operations/aggregate.ts
+++ b/src/operations/aggregate.ts
@@ -99,10 +99,8 @@ export class AggregateOperation<T = Document> extends CommandOperation<T> {
       this.readConcern = undefined;
     }
 
-    if (serverWireVersion >= 5) {
-      if (this.hasWriteStage && this.writeConcern) {
-        Object.assign(command, { writeConcern: this.writeConcern });
-      }
+    if (this.hasWriteStage && this.writeConcern) {
+      Object.assign(command, { writeConcern: this.writeConcern });
     }
 
     if (options.bypassDocumentValidation === true) {

--- a/src/operations/command.ts
+++ b/src/operations/command.ts
@@ -1,5 +1,5 @@
 import type { BSONSerializeOptions, Document } from '../bson';
-import { MongoCompatibilityError, MongoInvalidArgumentError } from '../error';
+import { MongoInvalidArgumentError } from '../error';
 import { Explain, ExplainOptions } from '../explain';
 import type { Logger } from '../logger';
 import { ReadConcern } from '../read_concern';
@@ -17,8 +17,6 @@ import {
 import { WriteConcern, WriteConcernOptions } from '../write_concern';
 import type { ReadConcernLike } from './../read_concern';
 import { AbstractOperation, Aspect, OperationOptions } from './operation';
-
-const SUPPORTS_WRITE_CONCERN_AND_COLLATION = 5;
 
 /** @public */
 export interface CollationOptions {
@@ -152,27 +150,16 @@ export abstract class CommandOperation<T> extends AbstractOperation<T> {
       options.omitReadPreference = true;
     }
 
-    if (options.collation && serverWireVersion < SUPPORTS_WRITE_CONCERN_AND_COLLATION) {
-      callback(
-        new MongoCompatibilityError(
-          `Server ${server.name}, which reports wire version ${serverWireVersion}, does not support collation`
-        )
-      );
-      return;
-    }
-
     if (this.writeConcern && this.hasAspect(Aspect.WRITE_OPERATION) && !inTransaction) {
       Object.assign(cmd, { writeConcern: this.writeConcern });
     }
 
-    if (serverWireVersion >= SUPPORTS_WRITE_CONCERN_AND_COLLATION) {
-      if (
-        options.collation &&
-        typeof options.collation === 'object' &&
-        !this.hasAspect(Aspect.SKIP_COLLATION)
-      ) {
-        Object.assign(cmd, { collation: options.collation });
-      }
+    if (
+      options.collation &&
+      typeof options.collation === 'object' &&
+      !this.hasAspect(Aspect.SKIP_COLLATION)
+    ) {
+      Object.assign(cmd, { collation: options.collation });
     }
 
     if (typeof options.maxTimeMS === 'number') {
@@ -180,12 +167,7 @@ export abstract class CommandOperation<T> extends AbstractOperation<T> {
     }
 
     if (this.hasAspect(Aspect.EXPLAINABLE) && this.explain) {
-      if (serverWireVersion < 6 && cmd.aggregate) {
-        // Prior to 3.6, with aggregate, verbosity is ignored, and we must pass in "explain: true"
-        cmd.explain = true;
-      } else {
-        cmd = decorateWithExplain(cmd, this.explain);
-      }
+      cmd = decorateWithExplain(cmd, this.explain);
     }
 
     server.command(this.ns, cmd, options, callback);

--- a/src/operations/delete.ts
+++ b/src/operations/delete.ts
@@ -3,7 +3,7 @@ import type { Collection } from '../collection';
 import { MongoCompatibilityError, MongoServerError } from '../error';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
-import { Callback, maxWireVersion, MongoDBNamespace } from '../utils';
+import type { Callback, MongoDBNamespace } from '../utils';
 import type { WriteConcernOptions } from '../write_concern';
 import { CollationOptions, CommandOperation, CommandOperationOptions } from './command';
 import { Aspect, defineAspects, Hint } from './operation';
@@ -83,7 +83,7 @@ export class DeleteOperation extends CommandOperation<Document> {
     }
 
     const unacknowledgedWrite = this.writeConcern && this.writeConcern.w === 0;
-    if (unacknowledgedWrite || maxWireVersion(server) < 5) {
+    if (unacknowledgedWrite) {
       if (this.statements.find((o: Document) => o.hint)) {
         callback(new MongoCompatibilityError(`Servers < 3.4 do not support hint on delete`));
         return;

--- a/src/operations/delete.ts
+++ b/src/operations/delete.ts
@@ -3,7 +3,7 @@ import type { Collection } from '../collection';
 import { MongoCompatibilityError, MongoServerError } from '../error';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
-import { Callback, collationNotSupported, maxWireVersion, MongoDBNamespace } from '../utils';
+import { Callback, maxWireVersion, MongoDBNamespace } from '../utils';
 import type { WriteConcernOptions } from '../write_concern';
 import { CollationOptions, CommandOperation, CommandOperationOptions } from './command';
 import { Aspect, defineAspects, Hint } from './operation';
@@ -82,26 +82,12 @@ export class DeleteOperation extends CommandOperation<Document> {
       command.comment = options.comment;
     }
 
-    if (options.explain != null && maxWireVersion(server) < 3) {
-      return callback
-        ? callback(
-            new MongoCompatibilityError(`Server ${server.name} does not support explain on delete`)
-          )
-        : undefined;
-    }
-
     const unacknowledgedWrite = this.writeConcern && this.writeConcern.w === 0;
     if (unacknowledgedWrite || maxWireVersion(server) < 5) {
       if (this.statements.find((o: Document) => o.hint)) {
         callback(new MongoCompatibilityError(`Servers < 3.4 do not support hint on delete`));
         return;
       }
-    }
-
-    const statementWithCollation = this.statements.find(statement => !!statement.collation);
-    if (statementWithCollation && collationNotSupported(server, statementWithCollation)) {
-      callback(new MongoCompatibilityError(`Server ${server.name} does not support collation`));
-      return;
     }
 
     super.executeCommand(server, session, command, callback);

--- a/src/operations/find_and_modify.ts
+++ b/src/operations/find_and_modify.ts
@@ -202,15 +202,6 @@ class FindAndModifyOperation extends CommandOperation<Document> {
       cmd.hint = options.hint;
     }
 
-    if (this.explain && maxWireVersion(server) < 4) {
-      callback(
-        new MongoCompatibilityError(
-          `Server ${server.name} does not support explain on findAndModify`
-        )
-      );
-      return;
-    }
-
     // Execute the command
     super.executeCommand(server, session, cmd, (err, result) => {
       if (err) return callback(err);

--- a/src/operations/update.ts
+++ b/src/operations/update.ts
@@ -3,7 +3,7 @@ import type { Collection } from '../collection';
 import { MongoCompatibilityError, MongoInvalidArgumentError, MongoServerError } from '../error';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
-import { Callback, hasAtomicOperators, maxWireVersion, MongoDBNamespace } from '../utils';
+import { Callback, hasAtomicOperators, MongoDBNamespace } from '../utils';
 import { CollationOptions, CommandOperation, CommandOperationOptions } from './command';
 import { Aspect, defineAspects, Hint } from './operation';
 
@@ -108,7 +108,7 @@ export class UpdateOperation extends CommandOperation<Document> {
     }
 
     const unacknowledgedWrite = this.writeConcern && this.writeConcern.w === 0;
-    if (unacknowledgedWrite || maxWireVersion(server) < 5) {
+    if (unacknowledgedWrite) {
       if (this.statements.find((o: Document) => o.hint)) {
         callback(new MongoCompatibilityError(`Servers < 3.4 do not support hint on update`));
         return;

--- a/src/operations/update.ts
+++ b/src/operations/update.ts
@@ -3,13 +3,7 @@ import type { Collection } from '../collection';
 import { MongoCompatibilityError, MongoInvalidArgumentError, MongoServerError } from '../error';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
-import {
-  Callback,
-  collationNotSupported,
-  hasAtomicOperators,
-  maxWireVersion,
-  MongoDBNamespace
-} from '../utils';
+import { Callback, hasAtomicOperators, maxWireVersion, MongoDBNamespace } from '../utils';
 import { CollationOptions, CommandOperation, CommandOperationOptions } from './command';
 import { Aspect, defineAspects, Hint } from './operation';
 
@@ -113,35 +107,12 @@ export class UpdateOperation extends CommandOperation<Document> {
       command.comment = options.comment;
     }
 
-    const statementWithCollation = this.statements.find(statement => !!statement.collation);
-    if (
-      collationNotSupported(server, options) ||
-      (statementWithCollation && collationNotSupported(server, statementWithCollation))
-    ) {
-      callback(new MongoCompatibilityError(`Server ${server.name} does not support collation`));
-      return;
-    }
-
     const unacknowledgedWrite = this.writeConcern && this.writeConcern.w === 0;
     if (unacknowledgedWrite || maxWireVersion(server) < 5) {
       if (this.statements.find((o: Document) => o.hint)) {
         callback(new MongoCompatibilityError(`Servers < 3.4 do not support hint on update`));
         return;
       }
-    }
-
-    if (this.explain && maxWireVersion(server) < 3) {
-      callback(
-        new MongoCompatibilityError(`Server ${server.name} does not support explain on update`)
-      );
-      return;
-    }
-
-    if (this.statements.some(statement => !!statement.arrayFilters) && maxWireVersion(server) < 6) {
-      callback(
-        new MongoCompatibilityError('Option "arrayFilters" is only supported on MongoDB 3.6+')
-      );
-      return;
     }
 
     super.executeCommand(server, session, command, callback);

--- a/src/sdam/server.ts
+++ b/src/sdam/server.ts
@@ -23,7 +23,6 @@ import {
   isNetworkErrorBeforeHandshake,
   isNodeShuttingDownError,
   isSDAMUnrecoverableError,
-  MongoCompatibilityError,
   MongoError,
   MongoErrorLabel,
   MongoInvalidArgumentError,
@@ -41,7 +40,6 @@ import type { ClientSession } from '../sessions';
 import { isTransactionCommand } from '../transactions';
 import {
   Callback,
-  collationNotSupported,
   EventEmitterWithState,
   makeStateMachine,
   maxWireVersion,
@@ -312,12 +310,6 @@ export class Server extends TypedEventEmitter<ServerEvents> {
     // (primary) is not the same as the provided and must be removed completely.
     if (finalOptions.omitReadPreference) {
       delete finalOptions.readPreference;
-    }
-
-    // error if collation not supported
-    if (collationNotSupported(this, cmd)) {
-      callback(new MongoCompatibilityError(`Server ${this.name} does not support collation`));
-      return;
     }
 
     const session = finalOptions.session;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -564,17 +564,6 @@ export function maxWireVersion(topologyOrServer?: Connection | Topology | Server
 }
 
 /**
- * Checks that collation is supported by server.
- * @internal
- *
- * @param server - to check against
- * @param cmd - object where collation may be specified
- */
-export function collationNotSupported(server: Server, cmd: Document): boolean {
-  return cmd && cmd.collation && maxWireVersion(server) < 5;
-}
-
-/**
  * Applies the function `eachFn` to each item in `arr`, in parallel.
  * @internal
  *


### PR DESCRIPTION
### Description

As a follow up to #3409, this removes all wire version checks which check for a version that is no longer supported by this driver.

#### What is changing?

Code that wasn't used is being removed.

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

My motivation behind this was to clean up the code, and remove unnecessary checks.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>` **I think so, there is no issue number for this but saw other commits that omitted this**
- [x] Changes are covered by tests **no current tests should fail since this code wasn't used**
- [x] New TODOs have a related JIRA ticket
