### PR TITLE
perf(NODE-4635): migrate deque to js-sdsl

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "bson": "^4.7.0",
-        "denque": "^2.1.0",
+        "js-sdsl": "^4.1.4",
         "mongodb-connection-string-url": "^2.5.3",
         "socks": "^2.7.0"
       },
@@ -2596,14 +2596,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/denque": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
-      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -4730,6 +4722,11 @@
       "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
       "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
       "dev": true
+    },
+    "node_modules/js-sdsl": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.4.tgz",
+      "integrity": "sha512-Y2/yD55y5jteOAmY50JbUZYwk3CP3wnLPEZnlR1w9oKhITrBEtAxwuWKebFf8hMrPMgbYwFoWK/lH2sBkErELw=="
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -10086,11 +10083,6 @@
         "object-keys": "^1.1.1"
       }
     },
-    "denque": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
-      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="
-    },
     "depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -11679,6 +11671,11 @@
       "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
       "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
       "dev": true
+    },
+    "js-sdsl": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.4.tgz",
+      "integrity": "sha512-Y2/yD55y5jteOAmY50JbUZYwk3CP3wnLPEZnlR1w9oKhITrBEtAxwuWKebFf8hMrPMgbYwFoWK/lH2sBkErELw=="
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "bson": "^4.7.0",
-    "denque": "^2.1.0",
+    "js-sdsl": "^4.1.4",
     "mongodb-connection-string-url": "^2.5.3",
     "socks": "^2.7.0"
   },

--- a/src/cmap/connection_pool.ts
+++ b/src/cmap/connection_pool.ts
@@ -1,4 +1,4 @@
-import Denque = require('denque');
+import { Deque } from 'js-sdsl';
 import { clearTimeout, setTimeout } from 'timers';
 
 import type { ObjectId } from '../bson';
@@ -128,7 +128,7 @@ export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
   /** @internal */
   [kLogger]: Logger;
   /** @internal */
-  [kConnections]: Denque<Connection>;
+  [kConnections]: Deque<Connection>;
   /** @internal */
   [kPending]: number;
   /** @internal */
@@ -149,7 +149,7 @@ export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
   /** @internal */
   [kCancellationToken]: CancellationToken;
   /** @internal */
-  [kWaitQueue]: Denque<WaitQueueMember>;
+  [kWaitQueue]: Deque<WaitQueueMember>;
   /** @internal */
   [kMetrics]: ConnectionPoolMetrics;
   /** @internal */
@@ -235,7 +235,7 @@ export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
 
     this[kPoolState] = PoolState.paused;
     this[kLogger] = new Logger('ConnectionPool');
-    this[kConnections] = new Denque();
+    this[kConnections] = new Deque();
     this[kPending] = 0;
     this[kCheckedOut] = 0;
     this[kMinPoolSizeTimer] = undefined;
@@ -244,7 +244,7 @@ export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
     this[kConnectionCounter] = makeCounter(1);
     this[kCancellationToken] = new CancellationToken();
     this[kCancellationToken].setMaxListeners(Infinity);
-    this[kWaitQueue] = new Denque();
+    this[kWaitQueue] = new Deque();
     this[kMetrics] = new ConnectionPoolMetrics();
     this[kProcessingWaitQueue] = false;
 
@@ -281,7 +281,7 @@ export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
 
   /** An integer expressing how many connections are currently available in the pool. */
   get availableConnectionCount(): number {
-    return this[kConnections].length;
+    return this[kConnections].size();
   }
 
   get pendingConnectionCount(): number {
@@ -293,7 +293,7 @@ export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
   }
 
   get waitQueueSize(): number {
-    return this[kWaitQueue].length;
+    return this[kWaitQueue].size();
   }
 
   get loadBalanced(): boolean {
@@ -357,7 +357,7 @@ export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
       }, waitQueueTimeoutMS);
     }
 
-    this[kWaitQueue].push(waitQueueMember);
+    this[kWaitQueue].pushBack(waitQueueMember);
     process.nextTick(() => this.processWaitQueue());
   }
 
@@ -373,7 +373,7 @@ export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
 
     if (!willDestroy) {
       connection.markAvailable();
-      this[kConnections].unshift(connection);
+      this[kConnections].pushFront(connection);
     }
 
     this[kCheckedOut]--;
@@ -455,9 +455,10 @@ export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
     this[kPoolState] = PoolState.closed;
     this.clearMinPoolSizeTimer();
     this.processWaitQueue();
-
+    const arr: Connection[] = [];
+    this[kConnections].forEach(val => arr.push(val));
     eachAsync<Connection>(
-      this[kConnections].toArray(),
+      arr,
       (conn, cb) => {
         this.emit(
           ConnectionPool.CONNECTION_CLOSED,
@@ -636,11 +637,14 @@ export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
       return;
     }
 
-    for (let i = 0; i < this[kConnections].length; i++) {
-      const connection = this[kConnections].peekAt(i);
+    const queue = this[kConnections];
+    let index = queue.size() - 1;
+    while (index !== -1) {
+      const connection = queue.getElementByPos(index);
       if (connection && this.connectionIsPerished(connection)) {
-        this[kConnections].removeOne(i);
+        queue.eraseElementByPos(index);
       }
+      --index;
     }
 
     if (
@@ -652,7 +656,7 @@ export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
       // the connection to a checkout request
       this.createConnection((err, connection) => {
         if (!err && connection) {
-          this[kConnections].push(connection);
+          this[kConnections].pushBack(connection);
           process.nextTick(() => this.processWaitQueue());
         }
         if (this[kPoolState] === PoolState.ready) {
@@ -673,14 +677,14 @@ export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
     this[kProcessingWaitQueue] = true;
 
     while (this.waitQueueSize) {
-      const waitQueueMember = this[kWaitQueue].peekFront();
+      const waitQueueMember = this[kWaitQueue].front();
       if (!waitQueueMember) {
-        this[kWaitQueue].shift();
+        this[kWaitQueue].popFront();
         continue;
       }
 
       if (waitQueueMember[kCancelled]) {
-        this[kWaitQueue].shift();
+        this[kWaitQueue].popFront();
         continue;
       }
 
@@ -694,7 +698,7 @@ export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
         if (waitQueueMember.timer) {
           clearTimeout(waitQueueMember.timer);
         }
-        this[kWaitQueue].shift();
+        this[kWaitQueue].popFront();
         waitQueueMember.callback(error);
         continue;
       }
@@ -703,7 +707,8 @@ export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
         break;
       }
 
-      const connection = this[kConnections].shift();
+      const connection = this[kConnections].front();
+      this[kConnections].popFront();
       if (!connection) {
         break;
       }
@@ -718,7 +723,7 @@ export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
           clearTimeout(waitQueueMember.timer);
         }
 
-        this[kWaitQueue].shift();
+        this[kWaitQueue].popFront();
         waitQueueMember.callback(undefined, connection);
       }
     }
@@ -729,14 +734,15 @@ export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
       this.pendingConnectionCount < maxConnecting &&
       (maxPoolSize === 0 || this.totalConnectionCount < maxPoolSize)
     ) {
-      const waitQueueMember = this[kWaitQueue].shift();
+      const waitQueueMember = this[kWaitQueue].front();
+      this[kWaitQueue].popFront();
       if (!waitQueueMember || waitQueueMember[kCancelled]) {
         continue;
       }
       this.createConnection((err, connection) => {
         if (waitQueueMember[kCancelled]) {
           if (!err && connection) {
-            this[kConnections].push(connection);
+            this[kConnections].pushBack(connection);
           }
         } else {
           if (err) {

--- a/src/cmap/connection_pool.ts
+++ b/src/cmap/connection_pool.ts
@@ -638,13 +638,20 @@ export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
     }
 
     const queue = this[kConnections];
-    let index = queue.size() - 1;
-    while (index !== -1) {
-      const connection = queue.getElementByPos(index);
-      if (connection && this.connectionIsPerished(connection)) {
-        queue.eraseElementByPos(index);
-      }
-      --index;
+    const length = queue.size();
+    // null 1 2 3 null
+    // remove 2 then it be
+    // 3 null null null 1
+    // the elements order will not be changed
+    // because the first element is 1 (just move pointer)
+    // this is O(n) here
+    for (let i = 0; i < length; ++i) {
+      // here will not be undefined
+      const connection = queue.front() as Connection;
+      queue.popFront();
+      // no need to check undefined
+      if (this.connectionIsPerished(connection)) continue;
+      queue.pushBack(connection);
     }
 
     if (

--- a/test/action/dependency.test.ts
+++ b/test/action/dependency.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 
 import { dependencies } from '../../package.json';
 
-const EXPECTED_DEPENDENCIES = ['bson', 'denque', 'mongodb-connection-string-url', 'socks'];
+const EXPECTED_DEPENDENCIES = ['bson', 'js-sdsl', 'mongodb-connection-string-url', 'socks'];
 
 describe('package.json', function () {
   describe('dependencies', function () {


### PR DESCRIPTION
### Description

#### What is changing?

Migrate deque from`denque` to `js-sdsl`.

##### Is there new documentation needed for these changes?

Yes, because I changed deque's source.

#### What is the motivation for this change?

Hey! I'm the developer of Js-sdsl. Official website: https://js-sdsl.github.io/.

Now, we published the version 4.1.4.

I see you are using denque.

In [benchmark](https://js-sdsl.github.io/#/test/benchmark-result?id=deque), we have confirmed that Js-sdsl is *several times faster* than `denque` and *nearly equal* to `Array.push` in the case of push elements.

We would like to invite you to migrate deque related functions to Js-sdsl v4.1.4.

Here are the benmarks:
 * main

https://github.com/ZLY201/node-mongodb-native/actions/runs/3060269558/jobs/4938575049

```bash
{
  microBench: {
    bsonBench: {
      flatBsonEncoding: 94.25118920101988,
      flatBsonDecoding: 82.87358886201503,
      deepBsonEncoding: 25.001962953249738,
      deepBsonDecoding: 24.653867111950653,
      fullBsonEncoding: 50.021585046736845,
      fullBsonDecoding: 55.68924843838592
    },
    singleBench: {
      runCommand: 0.040064720730158744,
      findOne: 2.5369494102430736,
      smallDocInsertOne: 0.528170445690162,
      largeDocInsertOne: 13.681842865860268
    },
    multiBench: {
      findManyAndEmptyCursor: 33.56057421596245,
      smallDocBulkInsert: 13.402725334538117,
      largeDocBulkInsert: 16.841357236728616,
      gridFsUpload: 255.17269063702042,
      gridFsDownload: 480.75867257973243
    }
  },
  bsonBench: 55.41524026889301,
  singleBench: 5.582320907264502,
  multiBench: 159.9472040007964,
  parallelBench: NaN,
  readBench: 172.28539873531267,
  writeBench: 59.925357303967516,
  driverBench: 116.10537801964009,
  bsonType: 'js-bson'
}
```
 
 * perf/migrate-deque

https://github.com/ZLY201/node-mongodb-native/actions/runs/3060363980/jobs/4938787566

```bash
{
  microBench: {
    bsonBench: {
      flatBsonEncoding: 116.1402016879238,
      flatBsonDecoding: 105.61033779223237,
      deepBsonEncoding: 30.501721686298122,
      deepBsonDecoding: 31.369037681697147,
      fullBsonEncoding: 58.73530768775185,
      fullBsonDecoding: 76.3827782555276
    },
    singleBench: {
      runCommand: 0.06605681122165877,
      findOne: 4.00111914410605,
      smallDocInsertOne: 0.820494770454103,
      largeDocInsertOne: 18.72604194153827
    },
    multiBench: {
      findManyAndEmptyCursor: 45.29806933931308,
      smallDocBulkInsert: 16.440118643374323,
      largeDocBulkInsert: 22.128555133680806,
      gridFsUpload: 400.0434088682383,
      gridFsDownload: 702.5095912389725
    }
  },
  bsonBench: 69.78989746523848,
  singleBench: 7.849218618699474,
  multiBench: 237.2839486447158,
  parallelBench: NaN,
  readBench: 250.60292657413052,
  writeBench: 91.63172387145717,
  driverBench: 171.11732522279385,
  bsonType: 'js-bson'
}
```

You can see all the results are improved.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
