### PR TITLE
chore(NODE-4661): bump @types/node version to fix ts next

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@types/express": "^4.17.13",
         "@types/kerberos": "^1.1.1",
         "@types/mocha": "^9.1.1",
-        "@types/node": "^18.7.13",
+        "@types/node": "^18.7.22",
         "@types/saslprep": "^1.0.1",
         "@types/semver": "^7.3.12",
         "@types/sinon": "^10.0.11",
@@ -1168,9 +1168,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.7.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.13.tgz",
-      "integrity": "sha512-46yIhxSe5xEaJZXWdIBP7GU4HDTG8/eo0qd9atdiL+lFpA03y8KS+lkTN834TWJj5767GbWv4n/P6efyTFt1Dw=="
+      "version": "18.7.22",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.22.tgz",
+      "integrity": "sha512-TsmoXYd4zrkkKjJB0URF/mTIKPl+kVcbqClB2F/ykU7vil1BfWZVndOnpEIozPv4fURD28gyPFeIkW2G+KXOvw=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -9043,9 +9043,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.7.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.13.tgz",
-      "integrity": "sha512-46yIhxSe5xEaJZXWdIBP7GU4HDTG8/eo0qd9atdiL+lFpA03y8KS+lkTN834TWJj5767GbWv4n/P6efyTFt1Dw=="
+      "version": "18.7.22",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.22.tgz",
+      "integrity": "sha512-TsmoXYd4zrkkKjJB0URF/mTIKPl+kVcbqClB2F/ykU7vil1BfWZVndOnpEIozPv4fURD28gyPFeIkW2G+KXOvw=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@types/express": "^4.17.13",
     "@types/kerberos": "^1.1.1",
     "@types/mocha": "^9.1.1",
-    "@types/node": "^18.7.13",
+    "@types/node": "^18.7.22",
     "@types/saslprep": "^1.0.1",
     "@types/semver": "^7.3.12",
     "@types/sinon": "^10.0.11",


### PR DESCRIPTION
### Description

#### What is changing?

Bumps the nodejs types...

#### What is the motivation for this change?

...to fix our lint task.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
