### PR TITLE
ci(NODE-4662): remove ubuntu in favor of rhel8

### DIFF
--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -903,7 +903,7 @@ tasks:
     commands:
       - func: install dependencies
         vars:
-          NODE_LTS_NAME: gallium
+          NODE_LTS_NAME: hydrogen
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: rapid
@@ -965,6 +965,6 @@ ignore:
 buildvariants:
   - name: performance-tests
     display_name: Performance Test
-    run_on: ubuntu1804-large
+    run_on: rhel80-large
     tasks:
       - run-spec-benchmark-tests

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -849,7 +849,7 @@ tasks:
     commands:
       - func: install dependencies
         vars:
-          NODE_LTS_NAME: gallium
+          NODE_LTS_NAME: hydrogen
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: rapid
@@ -2246,7 +2246,7 @@ ignore:
 buildvariants:
   - name: performance-tests
     display_name: Performance Test
-    run_on: ubuntu1804-large
+    run_on: rhel80-large
     tasks:
       - run-spec-benchmark-tests
   - name: rhel80-large-erbium

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2249,9 +2249,9 @@ buildvariants:
     run_on: ubuntu1804-large
     tasks:
       - run-spec-benchmark-tests
-  - name: ubuntu-18.04-erbium
-    display_name: Ubuntu 18.04 Node Erbium
-    run_on: ubuntu1804-large
+  - name: rhel80-large-erbium
+    display_name: rhel8 Node Erbium
+    run_on: rhel80-large
     expansions:
       NODE_LTS_NAME: erbium
       CLIENT_ENCRYPTION: true
@@ -2297,9 +2297,9 @@ buildvariants:
       - test-tls-support-5.0
       - test-tls-support-4.4
       - test-tls-support-4.2
-  - name: ubuntu-18.04-fermium
-    display_name: Ubuntu 18.04 Node Fermium
-    run_on: ubuntu1804-large
+  - name: rhel80-large-fermium
+    display_name: rhel8 Node Fermium
+    run_on: rhel80-large
     expansions:
       NODE_LTS_NAME: fermium
       CLIENT_ENCRYPTION: true
@@ -2345,9 +2345,9 @@ buildvariants:
       - test-tls-support-5.0
       - test-tls-support-4.4
       - test-tls-support-4.2
-  - name: ubuntu-18.04-gallium
-    display_name: Ubuntu 18.04 Node Gallium
-    run_on: ubuntu1804-large
+  - name: rhel80-large-gallium
+    display_name: rhel8 Node Gallium
+    run_on: rhel80-large
     expansions:
       NODE_LTS_NAME: gallium
       CLIENT_ENCRYPTION: true
@@ -2525,7 +2525,7 @@ buildvariants:
       - test-rapid-server
   - name: lint
     display_name: lint
-    run_on: ubuntu1804-large
+    run_on: rhel80-large
     tasks:
       - run-unit-tests
       - run-lint-checks
@@ -2534,12 +2534,12 @@ buildvariants:
       - run-typescript-next
   - name: mongosh_integration_tests
     display_name: mongosh integration tests
-    run_on: ubuntu1804-test
+    run_on: ubuntu1804-large
     tasks:
       - run-mongosh-integration-tests
   - name: ubuntu1804-test-mongodb-aws
     display_name: MONGODB-AWS Auth test
-    run_on: ubuntu1804-test
+    run_on: ubuntu1804-large
     expansions:
       NODE_LTS_NAME: erbium
     tasks:
@@ -2567,9 +2567,9 @@ buildvariants:
       - aws-4.4-auth-test-run-aws-auth-test-with-aws-credentials-as-environment-variables
       - aws-4.4-auth-test-run-aws-auth-test-with-aws-credentials-and-session-token-as-environment-variables
       - aws-4.4-auth-test-run-aws-ECS-auth-test
-  - name: ubuntu1804-custom-dependency-tests
+  - name: rhel8-custom-dependency-tests
     display_name: Custom Dependency Version Test
-    run_on: ubuntu1804-large
+    run_on: rhel80-large
     tasks:
       - run-custom-snappy-tests
       - run-bson-ext-integration
@@ -2580,16 +2580,16 @@ buildvariants:
       - run-custom-csfle-tests-rapid-master
       - run-custom-csfle-tests-latest-pinned-commit
       - run-custom-csfle-tests-latest-master
-  - name: ubuntu1804-test-serverless
+  - name: rhel8-test-serverless
     display_name: Serverless Test
-    run_on: ubuntu1804-test
+    run_on: rhel80-large
     expansions:
       NODE_LTS_NAME: erbium
     tasks:
       - serverless_task_group
-  - name: ubuntu1804-no-auth-tests
+  - name: rhel8-no-auth-tests
     display_name: No Auth Tests
-    run_on: ubuntu1804-large
+    run_on: rhel80-large
     expansions:
       CLIENT_ENCRYPTION: true
     tasks:
@@ -2617,9 +2617,9 @@ buildvariants:
       - test-3.6-server-noauth
       - test-3.6-replica_set-noauth
       - test-3.6-sharded_cluster-noauth
-  - name: ubuntu1804-test-lambda
+  - name: rhel8-test-lambda
     display_name: AWS Lambda handler tests
-    run_on: ubuntu1804-test
+    run_on: rhel80-large
     tasks:
       - test-lambda-example
       - test-lambda-aws-auth-example

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -11,13 +11,13 @@ const TOPOLOGIES = ['server', 'replica_set', 'sharded_cluster'];
 const AWS_AUTH_VERSIONS = ['latest', '6.0', '5.0', '4.4'];
 const TLS_VERSIONS = ['latest', '6.0', '5.0', '4.4', '4.2'];
 
-const DEFAULT_OS = 'ubuntu1804-large';
+const DEFAULT_OS = 'rhel80-large';
 
 const OPERATING_SYSTEMS = [
   {
-    name: 'ubuntu-18.04',
-    display_name: 'Ubuntu 18.04',
-    run_on: 'ubuntu1804-large'
+    name: 'rhel80-large',
+    display_name: 'rhel8',
+    run_on: DEFAULT_OS
   },
   {
     name: 'windows-64-vs2019',
@@ -496,7 +496,7 @@ SINGLETON_TASKS.push({
 BUILD_VARIANTS.push({
   name: 'mongosh_integration_tests',
   display_name: 'mongosh integration tests',
-  run_on: 'ubuntu1804-test',
+  run_on: 'ubuntu1804-large',
   tasks: ['run-mongosh-integration-tests']
 });
 
@@ -504,7 +504,7 @@ BUILD_VARIANTS.push({
 BUILD_VARIANTS.push({
   name: 'ubuntu1804-test-mongodb-aws',
   display_name: 'MONGODB-AWS Auth test',
-  run_on: 'ubuntu1804-test',
+  run_on: 'ubuntu1804-large',
   expansions: {
     NODE_LTS_NAME: LOWEST_LTS
   },
@@ -602,7 +602,7 @@ const coverageTask = {
 SINGLETON_TASKS.push(...oneOffFuncAsTasks);
 
 BUILD_VARIANTS.push({
-  name: 'ubuntu1804-custom-dependency-tests',
+  name: 'rhel8-custom-dependency-tests',
   display_name: 'Custom Dependency Version Test',
   run_on: DEFAULT_OS,
   tasks: oneOffFuncAsTasks.map(({ name }) => name)
@@ -610,9 +610,9 @@ BUILD_VARIANTS.push({
 
 // special case for serverless testing
 BUILD_VARIANTS.push({
-  name: 'ubuntu1804-test-serverless',
+  name: 'rhel8-test-serverless',
   display_name: 'Serverless Test',
-  run_on: 'ubuntu1804-test',
+  run_on: DEFAULT_OS,
   expansions: {
     NODE_LTS_NAME: LOWEST_LTS
   },
@@ -620,7 +620,7 @@ BUILD_VARIANTS.push({
 });
 
 BUILD_VARIANTS.push({
-  name: 'ubuntu1804-no-auth-tests',
+  name: 'rhel8-no-auth-tests',
   display_name: 'No Auth Tests',
   run_on: DEFAULT_OS,
   expansions: {
@@ -630,9 +630,9 @@ BUILD_VARIANTS.push({
 });
 
 BUILD_VARIANTS.push({
-  name: 'ubuntu1804-test-lambda',
+  name: 'rhel8-test-lambda',
   display_name: 'AWS Lambda handler tests',
-  run_on: 'ubuntu1804-test',
+  run_on: DEFAULT_OS,
   tasks: ['test-lambda-example', 'test-lambda-aws-auth-example']
 });
 

--- a/.evergreen/prepare-shell.sh
+++ b/.evergreen/prepare-shell.sh
@@ -31,7 +31,7 @@ export PATH="$MONGODB_BINARIES:$PATH"
 
 if [ ! -d "$DRIVERS_TOOLS" ]; then
   # Only clone driver tools if it does not exist
-  git clone --depth=1 "https://github.com/baileympearson/drivers-evergreen-tools.git" "${DRIVERS_TOOLS}"
+  git clone --depth=1 "https://github.com/mongodb-labs/drivers-evergreen-tools.git" "${DRIVERS_TOOLS}"
 fi
 
 cat <<EOT > "$MONGO_ORCHESTRATION_HOME/orchestration.config"

--- a/.evergreen/prepare-shell.sh
+++ b/.evergreen/prepare-shell.sh
@@ -31,7 +31,7 @@ export PATH="$MONGODB_BINARIES:$PATH"
 
 if [ ! -d "$DRIVERS_TOOLS" ]; then
   # Only clone driver tools if it does not exist
-  git clone --depth=1 "https://github.com/mongodb-labs/drivers-evergreen-tools.git" "${DRIVERS_TOOLS}"
+  git clone --depth=1 "https://github.com/baileympearson/drivers-evergreen-tools.git" "${DRIVERS_TOOLS}"
 fi
 
 cat <<EOT > "$MONGO_ORCHESTRATION_HOME/orchestration.config"


### PR DESCRIPTION
### Description

#### What is changing?

CI uses rhel8 instead of ubuntu20 for the majority of tasks. 

Exceptions are

- mongosh tests
- aws auth tests

##### Is there new documentation needed for these changes?

No.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
