### PR TITLE
fix(NODE-4649): use SDAM handling for errors from min pool size population

### DIFF
--- a/src/cmap/connection_pool.ts
+++ b/src/cmap/connection_pool.ts
@@ -597,6 +597,10 @@ export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
       if (err || !connection) {
         this[kLogger].debug(`connection attempt failed with error [${JSON.stringify(err)}]`);
         this[kPending]--;
+        this.emit(
+          ConnectionPool.CONNECTION_CLOSED,
+          new ConnectionClosedEvent(this, { id: connectOptions.id } as Connection, 'error')
+        );
         callback(err ?? new MongoRuntimeError('Connection creation failed without error'));
         return;
       }

--- a/src/cmap/connection_pool.ts
+++ b/src/cmap/connection_pool.ts
@@ -661,18 +661,21 @@ export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
       // connection permits because that potentially delays the availability of
       // the connection to a checkout request
       this.createConnection((err, connection) => {
+        if (err) {
+          this[kServer].handleError(err);
+        }
         if (!err && connection) {
           this[kConnections].push(connection);
           process.nextTick(() => this.processWaitQueue());
         }
         if (this[kPoolState] === PoolState.ready) {
           clearTimeout(this[kMinPoolSizeTimer]);
-          this[kMinPoolSizeTimer] = setTimeout(() => this.ensureMinPoolSize(), 10);
+          this[kMinPoolSizeTimer] = setTimeout(() => this.ensureMinPoolSize(), 5000);
         }
       });
     } else {
       clearTimeout(this[kMinPoolSizeTimer]);
-      this[kMinPoolSizeTimer] = setTimeout(() => this.ensureMinPoolSize(), 100);
+      this[kMinPoolSizeTimer] = setTimeout(() => this.ensureMinPoolSize(), 10000);
     }
   }
 

--- a/src/cmap/connection_pool.ts
+++ b/src/cmap/connection_pool.ts
@@ -310,6 +310,10 @@ export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
     return this[kServiceGenerations];
   }
 
+  get serverError() {
+    return this[kServer].description.error;
+  }
+
   /**
    * Get the metrics information for the pool when a wait queue timeout occurs.
    */

--- a/src/cmap/connection_pool.ts
+++ b/src/cmap/connection_pool.ts
@@ -599,7 +599,7 @@ export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
         this[kPending]--;
         this.emit(
           ConnectionPool.CONNECTION_CLOSED,
-          new ConnectionClosedEvent(this, { id: connectOptions.id } as Connection, 'error')
+          new ConnectionClosedEvent(this, { id: connectOptions.id, serviceId: undefined }, 'error')
         );
         callback(err ?? new MongoRuntimeError('Connection creation failed without error'));
         return;

--- a/src/cmap/connection_pool.ts
+++ b/src/cmap/connection_pool.ts
@@ -670,12 +670,12 @@ export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
         }
         if (this[kPoolState] === PoolState.ready) {
           clearTimeout(this[kMinPoolSizeTimer]);
-          this[kMinPoolSizeTimer] = setTimeout(() => this.ensureMinPoolSize(), 5000);
+          this[kMinPoolSizeTimer] = setTimeout(() => this.ensureMinPoolSize(), 10);
         }
       });
     } else {
       clearTimeout(this[kMinPoolSizeTimer]);
-      this[kMinPoolSizeTimer] = setTimeout(() => this.ensureMinPoolSize(), 10000);
+      this[kMinPoolSizeTimer] = setTimeout(() => this.ensureMinPoolSize(), 100);
     }
   }
 

--- a/src/cmap/connection_pool_events.ts
+++ b/src/cmap/connection_pool_events.ts
@@ -106,7 +106,11 @@ export class ConnectionClosedEvent extends ConnectionPoolMonitoringEvent {
   serviceId?: ObjectId;
 
   /** @internal */
-  constructor(pool: ConnectionPool, connection: Connection, reason: string) {
+  constructor(
+    pool: ConnectionPool,
+    connection: Pick<Connection, 'id' | 'serviceId'>,
+    reason: string
+  ) {
     super(pool);
     this.connectionId = connection.id;
     this.reason = reason || 'unknown';

--- a/src/cmap/errors.ts
+++ b/src/cmap/errors.ts
@@ -28,9 +28,9 @@ export class PoolClearedError extends MongoNetworkError {
   address: string;
 
   constructor(pool: ConnectionPool) {
-    // TODO(NODE-3135): pass in original pool-clearing error and use in message
-    // "failed with: <original error which cleared the pool>"
-    super(`Connection pool for ${pool.address} was cleared because another operation failed`);
+    super(
+      `Connection pool for ${pool.address} was cleared because another operation failed with: "${pool.serverError?.message}"`
+    );
     this.address = pool.address;
   }
 

--- a/src/sdam/server.ts
+++ b/src/sdam/server.ts
@@ -151,7 +151,7 @@ export class Server extends TypedEventEmitter<ServerEvents> {
       logger: new Logger('Server'),
       state: STATE_CLOSED,
       topology,
-      pool: new ConnectionPool(poolOptions),
+      pool: new ConnectionPool(this, poolOptions),
       operationCount: 0
     };
 

--- a/test/integration/connection-monitoring-and-pooling/connection_monitoring_and_pooling.spec.test.ts
+++ b/test/integration/connection-monitoring-and-pooling/connection_monitoring_and_pooling.spec.test.ts
@@ -11,7 +11,8 @@ const LB_SKIP_TESTS: SkipDescription[] = [
   'pool clear halts background minPoolSize establishments',
   'clearing a paused pool emits no events',
   'after clear, cannot check out connections until pool ready',
-  'readying a ready pool emits no events'
+  'readying a ready pool emits no events',
+  'error during minPoolSize population clears pool'
 ].map(description => ({
   description,
   skipIfCondition: 'loadBalanced',

--- a/test/integration/connection-monitoring-and-pooling/connection_monitoring_and_pooling.spec.test.ts
+++ b/test/integration/connection-monitoring-and-pooling/connection_monitoring_and_pooling.spec.test.ts
@@ -18,28 +18,17 @@ const LB_SKIP_TESTS: SkipDescription[] = [
   skipReason: 'cannot run against a load balanced environment'
 }));
 
-const POOL_PAUSED_SKIP_TESTS: SkipDescription[] = [
-  'error during minPoolSize population clears pool'
-].map(description => ({
-  description,
-  skipIfCondition: 'always',
-  skipReason: 'TODO(NODE-3135): make connection pool SDAM aware'
-}));
-
 describe('Connection Monitoring and Pooling Spec Tests (Integration)', function () {
   const tests: CmapTest[] = loadSpecTests('connection-monitoring-and-pooling');
 
   runCmapTestSuite(tests, {
-    testsToSkip: LB_SKIP_TESTS.concat(
-      [
-        {
-          description: 'waiting on maxConnecting is limited by WaitQueueTimeoutMS',
-          skipIfCondition: 'always',
-          skipReason:
-            'not applicable: waitQueueTimeoutMS limits connection establishment time in our driver'
-        }
-      ],
-      POOL_PAUSED_SKIP_TESTS
-    )
+    testsToSkip: LB_SKIP_TESTS.concat([
+      {
+        description: 'waiting on maxConnecting is limited by WaitQueueTimeoutMS',
+        skipIfCondition: 'always',
+        skipReason:
+          'not applicable: waitQueueTimeoutMS limits connection establishment time in our driver'
+      }
+    ])
   });
 });

--- a/test/unit/cmap/connection_pool.test.js
+++ b/test/unit/cmap/connection_pool.test.js
@@ -26,7 +26,7 @@ describe('Connection Pool', function () {
       }
     });
 
-    const pool = new ConnectionPool({ maxPoolSize: 1, hostAddress: server.hostAddress() });
+    const pool = new ConnectionPool(server, { maxPoolSize: 1, hostAddress: server.hostAddress() });
     pool.ready();
 
     const events = [];
@@ -69,7 +69,7 @@ describe('Connection Pool', function () {
       }
     });
 
-    const pool = new ConnectionPool({
+    const pool = new ConnectionPool(server, {
       maxPoolSize: 1,
       socketTimeoutMS: 200,
       hostAddress: server.hostAddress()
@@ -99,7 +99,7 @@ describe('Connection Pool', function () {
       }
     });
 
-    const pool = new ConnectionPool({
+    const pool = new ConnectionPool(server, {
       maxPoolSize: 1,
       waitQueueTimeoutMS: 200,
       hostAddress: server.hostAddress()
@@ -137,7 +137,7 @@ describe('Connection Pool', function () {
         }
       });
 
-      const pool = new ConnectionPool({ hostAddress: server.hostAddress() });
+      const pool = new ConnectionPool(server, { hostAddress: server.hostAddress() });
       pool.ready();
 
       const callback = (err, result) => {
@@ -169,7 +169,7 @@ describe('Connection Pool', function () {
         }
       });
 
-      const pool = new ConnectionPool({
+      const pool = new ConnectionPool(server, {
         waitQueueTimeoutMS: 200,
         hostAddress: server.hostAddress()
       });
@@ -201,7 +201,7 @@ describe('Connection Pool', function () {
         }
       });
 
-      const pool = new ConnectionPool({ hostAddress: server.hostAddress() });
+      const pool = new ConnectionPool(server, { hostAddress: server.hostAddress() });
       pool.ready();
 
       const callback = (err, result) => {
@@ -229,7 +229,10 @@ describe('Connection Pool', function () {
         }
       });
 
-      const pool = new ConnectionPool({ maxPoolSize: 1, hostAddress: server.hostAddress() });
+      const pool = new ConnectionPool(server, {
+        maxPoolSize: 1,
+        hostAddress: server.hostAddress()
+      });
       pool.ready();
 
       const events = [];


### PR DESCRIPTION
### Description
NODE-4649/NODE-3135

#### What is changing?
CMAP
- connection pool now saves a reference to the server that it is attached to
- new `serverError` property on the pool allows access to the server description error for the purpose of generating a more descriptive pool cleared error
- per the spec, connection establishment should emit a connection closed event on error, this is now implemented
- min pool size errors are now handled via SDAM error handling (using the new `handleError` server class method)

SDAM
- makeOperationDescription was refactored to pull out SDAM-specific error handling logic (corresponding to `handleError` in the spec) into a class method on the server
- the new server class method `handleError` is as spec compliant as it can be while still handling the load balancer logic alongside the non-loadbalanced logic
  - TODO (added to next subtask): we should update the staleness check to read connection generation from the error instead of the connection, since we want it to be able to handle errors that occur *while* establishing a connection, too; this requires injecting the connection generation into the error in the `createConnection` method (or elsewhere down the chain); the staleness check should be added to the `handleError` logic

CMAP Tests
- The runner now requires a server to be passed in; due to the reuse of the client in the failpoint establishment, we have to juggle the original "real" server pool established by the client with the one we generate for testing, hence the new `#originalServerPool` property
- The `'error during minPoolSize population clears pool'` test is unskipped since the functionality is now implemented

##### Is there new documentation needed for these changes?
No

#### What is the motivation for this change?
Spec compliance

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
