### PR TITLE
fix(NODE-4186): accept ReadPreferenceLike in TransactionOptions type

### DIFF
--- a/src/transactions.ts
+++ b/src/transactions.ts
@@ -2,6 +2,7 @@ import type { Document } from './bson';
 import { MongoRuntimeError, MongoTransactionError } from './error';
 import type { CommandOperationOptions } from './operations/command';
 import { ReadConcern, ReadConcernLike } from './read_concern';
+import type { ReadPreferenceLike } from './read_preference';
 import { ReadPreference } from './read_preference';
 import type { Server } from './sdam/server';
 import { WriteConcern } from './write_concern';
@@ -67,7 +68,7 @@ export interface TransactionOptions extends CommandOperationOptions {
   /** A default writeConcern for commands in this transaction */
   writeConcern?: WriteConcern;
   /** A default read preference for commands in this transaction */
-  readPreference?: ReadPreference;
+  readPreference?: ReadPreferenceLike;
   /** Specifies the maximum amount of time to allow a commit action on a transaction to run in milliseconds */
   maxCommitTimeMS?: number;
 }

--- a/test/types/community/transaction.test-d.ts
+++ b/test/types/community/transaction.test-d.ts
@@ -48,6 +48,7 @@ async function runTransactionWithRetry(
 
 async function updateEmployeeInfo(client: MongoClient, session: ClientSession) {
   session.startTransaction({
+    readPreference: 'primary',
     readConcern: new ReadConcern('available'), // NODE-3297
     writeConcern: { w: 'majority' }
   });

--- a/test/unit/transactions.test.ts
+++ b/test/unit/transactions.test.ts
@@ -1,0 +1,28 @@
+import { expect } from 'chai';
+
+import { ReadPreference } from '../../src';
+import { Transaction } from '../../src/transactions';
+
+describe('class Transaction', () => {
+  describe('constructor()', () => {
+    it('uses ReadPreference instance', () => {
+      const transaction = new Transaction({
+        readPreference: ReadPreference.nearest
+      });
+      expect(transaction.options)
+        .to.have.property('readPreference')
+        .that.is.instanceOf(ReadPreference)
+        .that.has.property('mode', 'nearest');
+    });
+
+    it('transforms ReadPreferenceLike string', () => {
+      const transaction = new Transaction({
+        readPreference: 'nearest'
+      });
+      expect(transaction.options)
+        .to.have.property('readPreference')
+        .that.is.instanceOf(ReadPreference)
+        .that.has.property('mode', 'nearest');
+    });
+  });
+});


### PR DESCRIPTION
### Description

This commit expands the TransactionOptions type definition to allow values like `'primary'`.

#### What is changing?

Before, the type definition only allowed passing an instance of the `ReadPreference` class. This differs from documented and common usage. We expand the type definition from `ReadPreference` to `ReadPreferenceLike`.

Updating this type annotation will reduce confusion for Typescipt users of the library.

##### Is there new documentation needed for these changes?

No, this makes the types match the existing documentation more closely.  For instance, in https://www.mongodb.com/docs/drivers/node/current/fundamentals/transactions/#transaction-settings, this API is documented as accepting a string: 

> const transactionOptions = {
>   readPreference: 'primary',
>   readConcern: { level: 'local' },
>   writeConcern: { w: 'majority' },
>   maxCommitTimeMS: 1000
> };
> session.startTransaction(transactionOptions);

#### What is the motivation for this change?

The documented code snippet above should not cause a Typescript error.

We can also see in https://github.com/mongodb/node-mongodb-native/blob/48fa588362/src/transactions.ts#L108 that the transaction constructor will pass its options through to `ReadPreference.fromOptions`, which will handle coercing a string into a ReadPreference instance, so the documentation appears to be correct while the type definition is lacking.

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
