### PR TITLE
feat(NODE-3255): add minPoolSizeCheckIntervalMS option to connection pool

### DIFF
--- a/src/cmap/connection_pool.ts
+++ b/src/cmap/connection_pool.ts
@@ -90,6 +90,8 @@ export interface ConnectionPoolOptions extends Omit<ConnectionOptions, 'id' | 'g
   waitQueueTimeoutMS: number;
   /** If we are in load balancer mode. */
   loadBalanced: boolean;
+  /** @experimental */
+  minPoolSizeCheckIntervalMS: number;
 }
 
 /** @internal */
@@ -234,6 +236,7 @@ export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
       maxConnecting: options.maxConnecting ?? 2,
       maxIdleTimeMS: options.maxIdleTimeMS ?? 0,
       waitQueueTimeoutMS: options.waitQueueTimeoutMS ?? 0,
+      minPoolSizeCheckIntervalMS: options.minPoolSizeCheckIntervalMS ?? 100,
       autoEncrypter: options.autoEncrypter,
       metadata: options.metadata
     });
@@ -683,12 +686,18 @@ export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
         }
         if (this[kPoolState] === PoolState.ready) {
           clearTimeout(this[kMinPoolSizeTimer]);
-          this[kMinPoolSizeTimer] = setTimeout(() => this.ensureMinPoolSize(), 10);
+          this[kMinPoolSizeTimer] = setTimeout(
+            () => this.ensureMinPoolSize(),
+            this.options.minPoolSizeCheckIntervalMS
+          );
         }
       });
     } else {
       clearTimeout(this[kMinPoolSizeTimer]);
-      this[kMinPoolSizeTimer] = setTimeout(() => this.ensureMinPoolSize(), 100);
+      this[kMinPoolSizeTimer] = setTimeout(
+        () => this.ensureMinPoolSize(),
+        this.options.minPoolSizeCheckIntervalMS
+      );
     }
   }
 

--- a/src/cmap/connection_pool.ts
+++ b/src/cmap/connection_pool.ts
@@ -91,7 +91,7 @@ export interface ConnectionPoolOptions extends Omit<ConnectionOptions, 'id' | 'g
   /** If we are in load balancer mode. */
   loadBalanced: boolean;
   /** @internal */
-  minPoolSizeCheckIntervalMS?: number;
+  minPoolSizeCheckFrequencyMS?: number;
 }
 
 /** @internal */
@@ -236,7 +236,7 @@ export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
       maxConnecting: options.maxConnecting ?? 2,
       maxIdleTimeMS: options.maxIdleTimeMS ?? 0,
       waitQueueTimeoutMS: options.waitQueueTimeoutMS ?? 0,
-      minPoolSizeCheckIntervalMS: options.minPoolSizeCheckIntervalMS ?? 100,
+      minPoolSizeCheckFrequencyMS: options.minPoolSizeCheckFrequencyMS ?? 100,
       autoEncrypter: options.autoEncrypter,
       metadata: options.metadata
     });
@@ -688,7 +688,7 @@ export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
           clearTimeout(this[kMinPoolSizeTimer]);
           this[kMinPoolSizeTimer] = setTimeout(
             () => this.ensureMinPoolSize(),
-            this.options.minPoolSizeCheckIntervalMS
+            this.options.minPoolSizeCheckFrequencyMS
           );
         }
       });
@@ -696,7 +696,7 @@ export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
       clearTimeout(this[kMinPoolSizeTimer]);
       this[kMinPoolSizeTimer] = setTimeout(
         () => this.ensureMinPoolSize(),
-        this.options.minPoolSizeCheckIntervalMS
+        this.options.minPoolSizeCheckFrequencyMS
       );
     }
   }

--- a/src/cmap/connection_pool.ts
+++ b/src/cmap/connection_pool.ts
@@ -90,7 +90,7 @@ export interface ConnectionPoolOptions extends Omit<ConnectionOptions, 'id' | 'g
   waitQueueTimeoutMS: number;
   /** If we are in load balancer mode. */
   loadBalanced: boolean;
-  /** @experimental */
+  /** @internal */
   minPoolSizeCheckIntervalMS?: number;
 }
 

--- a/src/cmap/connection_pool.ts
+++ b/src/cmap/connection_pool.ts
@@ -91,7 +91,7 @@ export interface ConnectionPoolOptions extends Omit<ConnectionOptions, 'id' | 'g
   /** If we are in load balancer mode. */
   loadBalanced: boolean;
   /** @experimental */
-  minPoolSizeCheckIntervalMS: number;
+  minPoolSizeCheckIntervalMS?: number;
 }
 
 /** @internal */

--- a/test/integration/server-selection/server_selection.prose.operation_count.test.ts
+++ b/test/integration/server-selection/server_selection.prose.operation_count.test.ts
@@ -1,6 +1,5 @@
 import { expect } from 'chai';
-import { setTimeout } from 'timers';
-import { promisify } from 'util';
+import { on } from 'events';
 
 import { CommandStartedEvent } from '../../../src';
 import { Collection } from '../../../src/collection';
@@ -27,19 +26,12 @@ async function runTaskGroup(collection: Collection, count: 10 | 100 | 1000) {
 
 async function ensurePoolIsFull(client: MongoClient) {
   let connectionCount = 0;
-  const onConnectionCreated = () => connectionCount++;
-  client.on('connectionCreated', onConnectionCreated);
-
-  // 250ms should be plenty of time to fill the connection pool,
-  // but just in case we'll loop a couple of times.
-  for (let i = 0; connectionCount < POOL_SIZE * 2 && i < 10; ++i) {
-    await promisify(setTimeout)(250);
-  }
-
-  client.removeListener('connectionCreated', onConnectionCreated);
-
-  if (connectionCount !== POOL_SIZE * 2) {
-    throw new Error('Connection pool did not fill up');
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  for await (const _event of on(client, 'connectionCreated')) {
+    connectionCount++;
+    if (connectionCount === POOL_SIZE * 2) {
+      break;
+    }
   }
 }
 

--- a/test/tools/cmap_spec_runner.ts
+++ b/test/tools/cmap_spec_runner.ts
@@ -351,8 +351,11 @@ async function runCmapTest(test: CmapTest, threadContext: ThreadContext) {
   const poolOptions = test.poolOptions || {};
   expect(CMAP_POOL_OPTION_NAMES).to.include.members(Object.keys(poolOptions));
 
-  // TODO(NODE-3255): update condition to only remove option if set to -1
+  let minPoolSizeCheckIntervalMS;
   if (poolOptions.backgroundThreadIntervalMS) {
+    if (poolOptions.backgroundThreadIntervalMS !== -1) {
+      minPoolSizeCheckIntervalMS = poolOptions.backgroundThreadIntervalMS;
+    }
     delete poolOptions.backgroundThreadIntervalMS;
   }
 
@@ -373,7 +376,7 @@ async function runCmapTest(test: CmapTest, threadContext: ThreadContext) {
   const mainThread = threadContext.getThread(MAIN_THREAD_KEY);
   mainThread.start();
 
-  threadContext.createPool({ ...poolOptions, metadata });
+  threadContext.createPool({ ...poolOptions, metadata, minPoolSizeCheckIntervalMS });
   // yield control back to the event loop so that the ConnectionPoolCreatedEvent
   // has a chance to be fired before any synchronously-emitted events from
   // the queued operations

--- a/test/tools/cmap_spec_runner.ts
+++ b/test/tools/cmap_spec_runner.ts
@@ -351,10 +351,10 @@ async function runCmapTest(test: CmapTest, threadContext: ThreadContext) {
   const poolOptions = test.poolOptions || {};
   expect(CMAP_POOL_OPTION_NAMES).to.include.members(Object.keys(poolOptions));
 
-  let minPoolSizeCheckIntervalMS;
+  let minPoolSizeCheckFrequencyMS;
   if (poolOptions.backgroundThreadIntervalMS) {
     if (poolOptions.backgroundThreadIntervalMS !== -1) {
-      minPoolSizeCheckIntervalMS = poolOptions.backgroundThreadIntervalMS;
+      minPoolSizeCheckFrequencyMS = poolOptions.backgroundThreadIntervalMS;
     }
     delete poolOptions.backgroundThreadIntervalMS;
   }
@@ -376,7 +376,7 @@ async function runCmapTest(test: CmapTest, threadContext: ThreadContext) {
   const mainThread = threadContext.getThread(MAIN_THREAD_KEY);
   mainThread.start();
 
-  threadContext.createPool({ ...poolOptions, metadata, minPoolSizeCheckIntervalMS });
+  threadContext.createPool({ ...poolOptions, metadata, minPoolSizeCheckFrequencyMS });
   // yield control back to the event loop so that the ConnectionPoolCreatedEvent
   // has a chance to be fired before any synchronously-emitted events from
   // the queued operations

--- a/test/unit/cmap/connection_pool.test.js
+++ b/test/unit/cmap/connection_pool.test.js
@@ -9,6 +9,7 @@ const { expect } = require('chai');
 const { setImmediate } = require('timers');
 const { ns, isHello } = require('../../../src/utils');
 const { LEGACY_HELLO_COMMAND } = require('../../../src/constants');
+const { createTimerSandbox } = require('../timer_sandbox');
 
 describe('Connection Pool', function () {
   let server;
@@ -125,6 +126,93 @@ describe('Connection Pool', function () {
         setImmediate(() => expect(pool).property('waitQueueSize').to.equal(0));
         done();
       });
+    });
+  });
+
+  describe('minPoolSize population', function () {
+    let clock, timerSandbox;
+    beforeEach(() => {
+      timerSandbox = createTimerSandbox();
+      clock = sinon.useFakeTimers();
+    });
+
+    afterEach(() => {
+      if (clock) {
+        timerSandbox.restore();
+        clock.restore();
+        clock = undefined;
+      }
+    });
+
+    it('should respect the minPoolSizeCheckIntervalMS option', function () {
+      const pool = new ConnectionPool(server, {
+        minPoolSize: 2,
+        minPoolSizeCheckIntervalMS: 42,
+        hostAddress: server.hostAddress()
+      });
+      const ensureSpy = sinon.spy(pool, 'ensureMinPoolSize');
+
+      // return a fake connection that won't get identified as perished
+      const createConnStub = sinon
+        .stub(pool, 'createConnection')
+        .yields(null, { destroy: () => null, generation: 0 });
+
+      pool.ready();
+
+      // expect ensureMinPoolSize to execute immediately
+      expect(ensureSpy).to.have.been.calledOnce;
+      expect(createConnStub).to.have.been.calledOnce;
+
+      // check that the successful connection return schedules another run
+      clock.tick(42);
+      expect(ensureSpy).to.have.been.calledTwice;
+      expect(createConnStub).to.have.been.calledTwice;
+
+      // check that the 2nd successful connection return schedules another run
+      // but don't expect to get a new connection since we are at minPoolSize
+      clock.tick(42);
+      expect(ensureSpy).to.have.been.calledThrice;
+      expect(createConnStub).to.have.been.calledTwice;
+
+      // check that the next scheduled check runs even after we're at minPoolSize
+      clock.tick(42);
+      expect(ensureSpy).to.have.callCount(4);
+      expect(createConnStub).to.have.been.calledTwice;
+    });
+
+    it('should default minPoolSizeCheckIntervalMS to 100ms', function () {
+      const pool = new ConnectionPool(server, {
+        minPoolSize: 2,
+        hostAddress: server.hostAddress()
+      });
+      const ensureSpy = sinon.spy(pool, 'ensureMinPoolSize');
+
+      // return a fake connection that won't get identified as perished
+      const createConnStub = sinon
+        .stub(pool, 'createConnection')
+        .yields(null, { destroy: () => null, generation: 0 });
+
+      pool.ready();
+
+      // expect ensureMinPoolSize to execute immediately
+      expect(ensureSpy).to.have.been.calledOnce;
+      expect(createConnStub).to.have.been.calledOnce;
+
+      // check that the successful connection return schedules another run
+      clock.tick(100);
+      expect(ensureSpy).to.have.been.calledTwice;
+      expect(createConnStub).to.have.been.calledTwice;
+
+      // check that the 2nd successful connection return schedules another run
+      // but don't expect to get a new connection since we are at minPoolSize
+      clock.tick(100);
+      expect(ensureSpy).to.have.been.calledThrice;
+      expect(createConnStub).to.have.been.calledTwice;
+
+      // check that the next scheduled check runs even after we're at minPoolSize
+      clock.tick(100);
+      expect(ensureSpy).to.have.callCount(4);
+      expect(createConnStub).to.have.been.calledTwice;
     });
   });
 

--- a/test/unit/cmap/connection_pool.test.js
+++ b/test/unit/cmap/connection_pool.test.js
@@ -144,10 +144,10 @@ describe('Connection Pool', function () {
       }
     });
 
-    it('should respect the minPoolSizeCheckIntervalMS option', function () {
+    it('should respect the minPoolSizeCheckFrequencyMS option', function () {
       const pool = new ConnectionPool(server, {
         minPoolSize: 2,
-        minPoolSizeCheckIntervalMS: 42,
+        minPoolSizeCheckFrequencyMS: 42,
         hostAddress: server.hostAddress()
       });
       const ensureSpy = sinon.spy(pool, 'ensureMinPoolSize');
@@ -180,7 +180,7 @@ describe('Connection Pool', function () {
       expect(createConnStub).to.have.been.calledTwice;
     });
 
-    it('should default minPoolSizeCheckIntervalMS to 100ms', function () {
+    it('should default minPoolSizeCheckFrequencyMS to 100ms', function () {
       const pool = new ConnectionPool(server, {
         minPoolSize: 2,
         hostAddress: server.hostAddress()


### PR DESCRIPTION
### Description
NODE-3255

#### What is changing?
- Added `minPoolSizeCheckIntervalMS` option to the connection pool which controls how frequently the `ensureMinPoolSize` runs
  - Added a unit test for the option and the default of 100ms
- The corresponding `backgroundThreadIntervalMS` option in the CMAP test runner is now correctly parsed and passed to the test pools

##### Is there new documentation needed for these changes?
No

#### What is the motivation for this change?
Better spec testing

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
