### PR TITLE
test(NODE-2988): monitors wait minHeartbeatFrequencyMS between checks

### DIFF
--- a/test/integration/server-discovery-and-monitoring/server_discovery_and_monitoring.prose.test.ts
+++ b/test/integration/server-discovery-and-monitoring/server_discovery_and_monitoring.prose.test.ts
@@ -35,7 +35,7 @@ describe('Server Discovery and Monitoring Prose Tests', function () {
 
     let client: MongoClient;
     beforeEach(async function () {
-      const utilClient = this.configuration.newClient();
+      const utilClient = this.configuration.newClient({ directConnection: true });
 
       // 1.
       await utilClient.db('admin').command({

--- a/test/integration/server-discovery-and-monitoring/server_discovery_and_monitoring.prose.test.ts
+++ b/test/integration/server-discovery-and-monitoring/server_discovery_and_monitoring.prose.test.ts
@@ -74,7 +74,7 @@ describe('Server Discovery and Monitoring Prose Tests', function () {
     });
 
     it('ensure monitors sleep for an appropriate amount of time between pings', {
-      metadata: { requires: { mongodb: '>=4.9.0' } },
+      metadata: { requires: { mongodb: '>=4.9.0', topology: '!load-balanced' } },
       test: async function () {
         // 3.
         const startTime = Date.now();

--- a/test/integration/server-discovery-and-monitoring/server_discovery_and_monitoring.prose.test.ts
+++ b/test/integration/server-discovery-and-monitoring/server_discovery_and_monitoring.prose.test.ts
@@ -10,6 +10,84 @@ import {
 } from '../../../src/constants';
 
 describe('Server Discovery and Monitoring Prose Tests', function () {
+  context('Monitors sleep at least minHeartbeatFrequencyMS between checks', function () {
+    /*
+      This test will be used to ensure monitors sleep for an appropriate amount of time between failed server checks
+      so as to not flood the server with new connection creations.
+
+      This test requires MongoDB 4.9.0+.
+
+      1. Enable the following failpoint:
+          {
+              configureFailPoint: "failCommand",
+              mode: { times: 5 },
+              data: {
+                  failCommands: ["hello"], // or legacy hello command
+                  errorCode: 1234,
+                  appName: "SDAMMinHeartbeatFrequencyTest"
+              }
+          }
+      2. Create a client with directConnection=true, appName="SDAMMinHeartbeatFrequencyTest", and serverSelectionTimeoutMS=5000.
+      3. Start a timer.
+      4. Execute a ping command.
+      5. Stop the timer. Assert that the ping took between 2 seconds and 3.5 seconds to complete.
+    */
+
+    let client: MongoClient;
+    beforeEach(async function () {
+      const utilClient = this.configuration.newClient();
+
+      // 1.
+      await utilClient.db('admin').command({
+        configureFailPoint: 'failCommand',
+        mode: { times: 5 },
+        data: {
+          failCommands: ['hello', 'ismaster'],
+          errorCode: 1234,
+          appName: 'SDAMMinHeartbeatFrequencyTest'
+        }
+      });
+      await utilClient.close();
+
+      // 2.
+      client = this.configuration.newClient({
+        directConnection: true,
+        appName: 'SDAMMinHeartbeatFrequencyTest',
+        serverSelectionTimeoutMS: 5000
+      });
+    });
+
+    afterEach(async function () {
+      await client.db('admin').command({
+        configureFailPoint: 'failCommand',
+        mode: 'off',
+        data: {
+          failCommands: ['hello', 'ismaster'],
+          errorCode: 1234,
+          appName: 'SDAMMinHeartbeatFrequencyTest'
+        }
+      });
+    });
+
+    afterEach(async function () {
+      await client.close();
+    });
+
+    it('ensure monitors sleep for an appropriate amount of time between pings', {
+      metadata: { requires: { mongodb: '>=4.9.0' } },
+      test: async function () {
+        // 3.
+        const startTime = Date.now();
+        // 4.
+        await client.db().command({ ping: 1 });
+        // 5.
+        const timeTaken = Date.now() - startTime;
+        const secondsTaken = timeTaken / 1000;
+        expect(secondsTaken).to.be.within(2, 3.5);
+      }
+    });
+  });
+
   context('Connection Pool Management', function () {
     /* 
       This test will be used to ensure monitors properly create and unpause connection pools when they discover servers.

--- a/test/tools/runner/config.ts
+++ b/test/tools/runner/config.ts
@@ -150,11 +150,7 @@ export class TestConfiguration {
   }
 
   newClient(dbOptions?: string | Record<string, any>, serverOptions?: Record<string, any>) {
-    serverOptions = Object.assign(
-      { minHeartbeatFrequencyMS: 100 },
-      getEnvironmentalOptions(),
-      serverOptions
-    );
+    serverOptions = Object.assign({}, getEnvironmentalOptions(), serverOptions);
 
     // support MongoClient constructor form (url, options) for `newClient`
     if (typeof dbOptions === 'string') {


### PR DESCRIPTION
### Description
NODE-2988
- Adding an SDAM prose test to make sure monitors wait minHeartbeatFrequencyMS between checks

Note: the new test is currently failing, possibly due to work not yet done in: #3404 

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
