### PR TITLE
feat(NODE-3651): add hashed index type

### DIFF
--- a/src/operations/indexes.ts
+++ b/src/operations/indexes.ts
@@ -50,7 +50,7 @@ const VALID_INDEX_OPTIONS = new Set([
 ]);
 
 /** @public */
-export type IndexDirection = -1 | 1 | '2d' | '2dsphere' | 'text' | 'geoHaystack' | number;
+export type IndexDirection = -1 | 1 | '2d' | '2dsphere' | 'text' | 'geoHaystack' | 'hashed' | number;
 function isIndexDirection(x: unknown): x is IndexDirection {
   return (
     typeof x === 'number' || x === '2d' || x === '2dsphere' || x === 'text' || x === 'geoHaystack'

--- a/src/operations/indexes.ts
+++ b/src/operations/indexes.ts
@@ -50,7 +50,16 @@ const VALID_INDEX_OPTIONS = new Set([
 ]);
 
 /** @public */
-export type IndexDirection = -1 | 1 | '2d' | '2dsphere' | 'text' | 'geoHaystack' | 'hashed' | number;
+export type IndexDirection =
+  | -1
+  | 1
+  | '2d'
+  | '2dsphere'
+  | 'text'
+  | 'geoHaystack'
+  | 'hashed'
+  | number;
+
 function isIndexDirection(x: unknown): x is IndexDirection {
   return (
     typeof x === 'number' || x === '2d' || x === '2dsphere' || x === 'text' || x === 'geoHaystack'

--- a/test/types/community/createIndex.test-d.ts
+++ b/test/types/community/createIndex.test-d.ts
@@ -18,6 +18,7 @@ collection.createIndex(['someKey', 1]);
 collection.createIndex(new Map([['someKey', 1]]));
 collection.createIndex({ a: 1, b: -1 });
 collection.createIndex({ a: '2dsphere', b: -1 });
+collection.createIndex({ a: 'hashed' });
 // OrMore
 collection.createIndex(['someKey']);
 collection.createIndex([['someKey', 1]]);
@@ -28,6 +29,7 @@ collection.createIndex([
   { a: 'geoHaystack', b: 1 }
 ]);
 collection.createIndex(['a', ['b', 1], { a: 'geoHaystack', b: 1 }, new Map([['someKey', 1]])]);
+collection.createIndex([{ a: 'hashed' }]);
 
 // @ts-expect-error: CreateIndexes now asserts the object value types as of NODE-3517
 collection.createIndexes([{ key: { a: 34n } }]);


### PR DESCRIPTION
### Description

#### What is changing?
Add 'hashed' to IndexDirection.

##### Is there new documentation needed for these changes?
Should be auto generated [here](https://mongodb.github.io/node-mongodb-native/4.10/modules.html#IndexDirection)

#### What is the motivation for this change?
Type system is currently not working for hashed index.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
