### PR TITLE
test(NODE-4628, NODE-4640): sync fle and change stream spec tests

### DIFF
--- a/test/spec/change-streams/unified/change-streams-clusterTime.json
+++ b/test/spec/change-streams/unified/change-streams-clusterTime.json
@@ -1,6 +1,6 @@
 {
   "description": "change-streams-clusterTime",
-  "schemaVersion": "1.3",
+  "schemaVersion": "1.4",
   "createEntities": [
     {
       "client": {
@@ -31,7 +31,8 @@
         "sharded-replicaset",
         "load-balanced",
         "sharded"
-      ]
+      ],
+      "serverless": "forbid"
     }
   ],
   "initialData": [

--- a/test/spec/change-streams/unified/change-streams-clusterTime.yml
+++ b/test/spec/change-streams/unified/change-streams-clusterTime.yml
@@ -1,5 +1,5 @@
 description: "change-streams-clusterTime"
-schemaVersion: "1.3"
+schemaVersion: "1.4"
 createEntities:
   - client:
       id: &client0 client0
@@ -16,6 +16,7 @@ createEntities:
 runOnRequirements:
   - minServerVersion: "4.0.0"
     topologies: [ replicaset, sharded-replicaset, load-balanced, sharded ]
+    serverless: forbid
 
 initialData:
   - collectionName: *collection0

--- a/test/spec/change-streams/unified/change-streams-showExpandedEvents.json
+++ b/test/spec/change-streams/unified/change-streams-showExpandedEvents.json
@@ -8,7 +8,8 @@
         "replicaset",
         "sharded-replicaset",
         "sharded"
-      ]
+      ],
+      "serverless": "forbid"
     }
   ],
   "createEntities": [

--- a/test/spec/change-streams/unified/change-streams-showExpandedEvents.yml
+++ b/test/spec/change-streams/unified/change-streams-showExpandedEvents.yml
@@ -3,6 +3,7 @@ schemaVersion: "1.7"
 runOnRequirements:
   - minServerVersion: "6.0.0"
     topologies: [ replicaset, sharded-replicaset, sharded ]
+    serverless: forbid
 createEntities:
   - client:
       id: &client0 client0

--- a/test/spec/client-side-encryption/tests/legacy/maxWireVersion.json
+++ b/test/spec/client-side-encryption/tests/legacy/maxWireVersion.json
@@ -1,7 +1,7 @@
 {
   "runOn": [
     {
-      "maxServerVersion": "4.0"
+      "maxServerVersion": "4.0.99"
     }
   ],
   "database_name": "default",

--- a/test/spec/client-side-encryption/tests/legacy/maxWireVersion.yml
+++ b/test/spec/client-side-encryption/tests/legacy/maxWireVersion.yml
@@ -1,5 +1,5 @@
 runOn:
-  - maxServerVersion: "4.0"
+  - maxServerVersion: "4.0.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 


### PR DESCRIPTION
### Description

#### What is changing?

Small spec sync addressing both NODE-4628 and NODE-4640.

##### Is there new documentation needed for these changes?

No.

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
