### PR TITLE
ci: bump mongodb-client-encryption version

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1760,7 +1760,7 @@ tasks:
       - func: bootstrap kms servers
       - func: run custom csfle tests
         vars:
-          CSFLE_GIT_REF: c071d5a8d59ddcad40f22887a12bdb374c2f86af
+          CSFLE_GIT_REF: 5745f374109346a2597405f2251a178d463a14e1
   - name: run-custom-csfle-tests-5.0-master
     tags:
       - run-custom-dependency-tests
@@ -1790,7 +1790,7 @@ tasks:
       - func: bootstrap kms servers
       - func: run custom csfle tests
         vars:
-          CSFLE_GIT_REF: c071d5a8d59ddcad40f22887a12bdb374c2f86af
+          CSFLE_GIT_REF: 5745f374109346a2597405f2251a178d463a14e1
   - name: run-custom-csfle-tests-rapid-master
     tags:
       - run-custom-dependency-tests
@@ -1820,7 +1820,7 @@ tasks:
       - func: bootstrap kms servers
       - func: run custom csfle tests
         vars:
-          CSFLE_GIT_REF: c071d5a8d59ddcad40f22887a12bdb374c2f86af
+          CSFLE_GIT_REF: 5745f374109346a2597405f2251a178d463a14e1
   - name: run-custom-csfle-tests-latest-master
     tags:
       - run-custom-dependency-tests

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -564,7 +564,7 @@ const oneOffFuncAsTasks = oneOffFuncs.map(oneOffFunc => ({
 }));
 
 for (const version of ['5.0', 'rapid', 'latest']) {
-  for (const ref of ['c071d5a8d59ddcad40f22887a12bdb374c2f86af', 'master']) {
+  for (const ref of ['5745f374109346a2597405f2251a178d463a14e1', 'master']) {
     oneOffFuncAsTasks.push({
       name: `run-custom-csfle-tests-${version}-${ref === 'master' ? ref : 'pinned-commit'}`,
       tags: ['run-custom-dependency-tests'],

--- a/.evergreen/run-bson-ext-test.sh
+++ b/.evergreen/run-bson-ext-test.sh
@@ -23,7 +23,7 @@ fi
 # run tests
 echo "Running $AUTH tests over $SSL, connecting to $MONGODB_URI"
 
-npm install mongodb-client-encryption@">=2.2.0"
+npm install mongodb-client-encryption@">=2.3.0"
 npm install bson-ext
 
 export MONGODB_API_VERSION=${MONGODB_API_VERSION}

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -52,7 +52,7 @@ else
   source "$DRIVERS_TOOLS"/.evergreen/csfle/set-temp-creds.sh
 fi
 
-npm install mongodb-client-encryption@">=2.2.0"
+npm install mongodb-client-encryption@">=2.3.0"
 npm install @mongodb-js/zstd
 npm install snappy
 


### PR DESCRIPTION
### Description

#### What is changing?

Bumps mongodb-client-encryption in the driver CI to 2.3.0.