### PR TITLE
refactor(NODE-4689): track checked out connections

### DIFF
--- a/src/cmap/connection_pool.ts
+++ b/src/cmap/connection_pool.ts
@@ -324,9 +324,11 @@ export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
   }
 
   /**
-   * This is exposed ONLY for use in mongosh, so they can
-   * kill connections if a user quits the shell with operations
-   * in progress.
+   * This is exposed ONLY for use in mongosh, to enable
+   * killing all connections if a user quits the shell with
+   * operations in progress.
+   *
+   * This property may be removed as a part of NODE-3263.
    */
   get checkedOutConnections() {
     return this[kCheckedOut];

--- a/src/cmap/connection_pool.ts
+++ b/src/cmap/connection_pool.ts
@@ -324,6 +324,15 @@ export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
   }
 
   /**
+   * This is exposed ONLY for use on mongosh, so they can
+   * kill connections if a user quits the shell with operations
+   * in progress.
+   */
+  get checkedOutConnections() {
+    return this[kCheckedOut];
+  }
+
+  /**
    * Get the metrics information for the pool when a wait queue timeout occurs.
    */
   private waitQueueErrorMetrics(): string {

--- a/src/cmap/connection_pool.ts
+++ b/src/cmap/connection_pool.ts
@@ -324,7 +324,7 @@ export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
   }
 
   /**
-   * This is exposed ONLY for use on mongosh, so they can
+   * This is exposed ONLY for use in mongosh, so they can
    * kill connections if a user quits the shell with operations
    * in progress.
    */

--- a/src/cmap/connection_pool.ts
+++ b/src/cmap/connection_pool.ts
@@ -134,38 +134,25 @@ export type ConnectionPoolEvents = {
  */
 export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
   options: Readonly<ConnectionPoolOptions>;
-  /** @internal */
   [kPoolState]: typeof PoolState[keyof typeof PoolState];
-  /** @internal */
   [kServer]: Server;
-  /** @internal */
   [kLogger]: Logger;
-  /** @internal */
   [kConnections]: Denque<Connection>;
-  /** @internal */
   [kPending]: number;
-  /** @internal */
   [kCheckedOut]: Set<Connection>;
-  /** @internal */
   [kMinPoolSizeTimer]?: NodeJS.Timeout;
   /**
    * An integer representing the SDAM generation of the pool
-   * @internal
    */
   [kGeneration]: number;
-  /** A map of generations to service ids
-   * @internal
+  /**
+   * A map of generations to service ids
    */
   [kServiceGenerations]: Map<string, number>;
-  /** @internal */
   [kConnectionCounter]: Generator<number>;
-  /** @internal */
   [kCancellationToken]: CancellationToken;
-  /** @internal */
   [kWaitQueue]: Denque<WaitQueueMember>;
-  /** @internal */
   [kMetrics]: ConnectionPoolMetrics;
-  /** @internal */
   [kProcessingWaitQueue]: boolean;
 
   /**
@@ -224,7 +211,6 @@ export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
    */
   static readonly CONNECTION_CHECKED_IN = CONNECTION_CHECKED_IN;
 
-  /** @internal */
   constructor(server: Server, options: ConnectionPoolOptions) {
     super();
 


### PR DESCRIPTION
https://jira.mongodb.org/browse/NODE-4094

### Description

#### What is changing?

The connection pool now tracks checked out connections instead of only keeping track of the number of checked out connections.

##### Is there new documentation needed for these changes?

No.

#### What is the motivation for this change?

https://jira.mongodb.org/browse/NODE-4094

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
