### PR TITLE
ci(NODE-4629): run csfle tests on serverless

### DIFF
--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -148,11 +148,47 @@ functions:
     - command: shell.exec
       type: test
       params:
-        working_dir: "src"
+        silent: true
+        working_dir: src
+        script: |
+          cat <<EOT > prepare_client_encryption.sh
+            export CLIENT_ENCRYPTION=${CLIENT_ENCRYPTION}
+            export CSFLE_KMS_PROVIDERS='${CSFLE_KMS_PROVIDERS}'
+            export AWS_ACCESS_KEY_ID='${AWS_ACCESS_KEY_ID}'
+            export AWS_SECRET_ACCESS_KEY='${AWS_SECRET_ACCESS_KEY}'
+            export AWS_DEFAULT_REGION='us-east-1'
+            export KMIP_TLS_CA_FILE="${DRIVERS_TOOLS}/.evergreen/x509gen/ca.pem"
+            export KMIP_TLS_CERT_FILE="${DRIVERS_TOOLS}/.evergreen/x509gen/client.pem"
+          EOT
+    - command: shell.exec
+      type: test
+      params:
+        working_dir: src
+        timeout_secs: 300
+        shell: bash
         script: |
           ${PREPARE_SHELL}
+
           # Disable xtrace (just in case it was accidentally set).
           set +x
+          source ./prepare_client_encryption.sh
+          rm -f ./prepare_client_encryption.sh
+
+          export VERSION=${VERSION}
+          export DRIVERS_TOOLS=${DRIVERS_TOOLS}
+
+          source ${PROJECT_DIRECTORY}/.evergreen/prepare-crypt-shared-lib.sh
+
+          echo "CRYPT_SHARED_LIB_PATH: $CRYPT_SHARED_LIB_PATH"
+
+          # Get access to the AWS temporary credentials:
+          echo "adding temporary AWS credentials to environment"
+          # CSFLE_AWS_TEMP_ACCESS_KEY_ID, CSFLE_AWS_TEMP_SECRET_ACCESS_KEY, CSFLE_AWS_TEMP_SESSION_TOKEN
+          . "$DRIVERS_TOOLS"/.evergreen/csfle/set-temp-creds.sh
+
+          MONGODB_URI="${MONGODB_URI}" \
+          AUTH=${AUTH} SSL=${SSL} TEST_CSFLE=true \
+          MONGODB_API_VERSION="${MONGODB_API_VERSION}"
 
           export MONGODB_API_VERSION="${MONGODB_API_VERSION}"
           export AUTH="auth"
@@ -917,6 +953,8 @@ tasks:
   - name: "test-serverless"
     tags: ["serverless"]
     commands:
+      - func: install dependencies
+      - func: bootstrap kms servers
       - func: "run serverless tests"
 
   - name: run-spec-benchmark-tests

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -121,11 +121,47 @@ functions:
     - command: shell.exec
       type: test
       params:
+        silent: true
         working_dir: src
         script: |
+          cat <<EOT > prepare_client_encryption.sh
+            export CLIENT_ENCRYPTION=${CLIENT_ENCRYPTION}
+            export CSFLE_KMS_PROVIDERS='${CSFLE_KMS_PROVIDERS}'
+            export AWS_ACCESS_KEY_ID='${AWS_ACCESS_KEY_ID}'
+            export AWS_SECRET_ACCESS_KEY='${AWS_SECRET_ACCESS_KEY}'
+            export AWS_DEFAULT_REGION='us-east-1'
+            export KMIP_TLS_CA_FILE="${DRIVERS_TOOLS}/.evergreen/x509gen/ca.pem"
+            export KMIP_TLS_CERT_FILE="${DRIVERS_TOOLS}/.evergreen/x509gen/client.pem"
+          EOT
+    - command: shell.exec
+      type: test
+      params:
+        working_dir: src
+        timeout_secs: 300
+        shell: bash
+        script: |
           ${PREPARE_SHELL}
+
           # Disable xtrace (just in case it was accidentally set).
           set +x
+          source ./prepare_client_encryption.sh
+          rm -f ./prepare_client_encryption.sh
+
+          export VERSION=${VERSION}
+          export DRIVERS_TOOLS=${DRIVERS_TOOLS}
+
+          source ${PROJECT_DIRECTORY}/.evergreen/prepare-crypt-shared-lib.sh
+
+          echo "CRYPT_SHARED_LIB_PATH: $CRYPT_SHARED_LIB_PATH"
+
+          # Get access to the AWS temporary credentials:
+          echo "adding temporary AWS credentials to environment"
+          # CSFLE_AWS_TEMP_ACCESS_KEY_ID, CSFLE_AWS_TEMP_SECRET_ACCESS_KEY, CSFLE_AWS_TEMP_SESSION_TOKEN
+          . "$DRIVERS_TOOLS"/.evergreen/csfle/set-temp-creds.sh
+
+          MONGODB_URI="${MONGODB_URI}" \
+          AUTH=${AUTH} SSL=${SSL} TEST_CSFLE=true \
+          MONGODB_API_VERSION="${MONGODB_API_VERSION}"
 
           export MONGODB_API_VERSION="${MONGODB_API_VERSION}"
           export AUTH="auth"
@@ -864,6 +900,8 @@ tasks:
     tags:
       - serverless
     commands:
+      - func: install dependencies
+      - func: bootstrap kms servers
       - func: run serverless tests
   - name: run-spec-benchmark-tests
     tags:

--- a/.evergreen/run-serverless-tests.sh
+++ b/.evergreen/run-serverless-tests.sh
@@ -10,6 +10,8 @@ if [ -z ${MONGODB_URI+omitted} ]; then echo "MONGODB_URI is unset" && exit 1; fi
 if [ -z ${SERVERLESS_ATLAS_USER+omitted} ]; then echo "SERVERLESS_ATLAS_USER is unset" && exit 1; fi
 if [ -z ${SERVERLESS_ATLAS_PASSWORD+omitted} ]; then echo "SERVERLESS_ATLAS_PASSWORD is unset" && exit 1; fi
 
+npm install mongodb-client-encryption@">=2.3.0"
+
 npx mocha \
   --config test/mocha_mongodb.json \
   test/integration/crud/crud.spec.test.js \
@@ -21,4 +23,5 @@ npx mocha \
   test/integration/transactions/transactions.spec.test.js \
   test/integration/transactions/transactions.test.ts \
   test/integration/versioned-api/versioned_api.spec.test.js \
-  test/integration/load-balancers/load_balancers.spec.test.js
+  test/integration/load-balancers/load_balancers.spec.test.js \
+  test/integration/client-side-encryption/client_side_encryption.spec.test.ts

--- a/test/integration/client-side-encryption/client_side_encryption.spec.test.ts
+++ b/test/integration/client-side-encryption/client_side_encryption.spec.test.ts
@@ -64,6 +64,8 @@ const SKIPPED_TESTS = new Set([
   ...(isAuthEnabled ? skippedAuthTests.concat(skippedNoAuthTests) : skippedNoAuthTests)
 ]);
 
+const isServerless = !!process.env.SERVERLESS;
+
 describe('Client Side Encryption (Legacy)', function () {
   const testContext = new TestRunnerContext({ requiresCSFLE: true });
   const testSuites = gatherTestSuites(
@@ -78,12 +80,24 @@ describe('Client Side Encryption (Legacy)', function () {
     return testContext.setup(this.configuration);
   });
 
-  generateTopologyTests(testSuites, testContext, spec => {
-    return !SKIPPED_TESTS.has(spec.description);
+  generateTopologyTests(testSuites, testContext, ({ description }) => {
+    if (SKIPPED_TESTS.has(description)) {
+      return false;
+    }
+    if (isServerless) {
+      // TODO(NODE-4730): Fix failing csfle tests against serverless
+      return [
+        'BypassQueryAnalysis decrypts',
+        'encryptedFieldsMap is preferred over remote encryptedFields'
+      ].includes(description);
+    }
+    return true;
   });
 });
 
 describe('Client Side Encryption (Unified)', function () {
   installNode18DNSHooks();
-  runUnifiedSuite(loadSpecTests(path.join('client-side-encryption', 'tests', 'unified')));
+  runUnifiedSuite(loadSpecTests(path.join('client-side-encryption', 'tests', 'unified')), () =>
+    isServerless ? 'Unified CSFLE tests to not run on serverless' : false
+  );
 });

--- a/test/integration/client-side-encryption/client_side_encryption.spec.test.ts
+++ b/test/integration/client-side-encryption/client_side_encryption.spec.test.ts
@@ -86,10 +86,12 @@ describe('Client Side Encryption (Legacy)', function () {
     }
     if (isServerless) {
       // TODO(NODE-4730): Fix failing csfle tests against serverless
-      return [
+      const isSkippedTest = [
         'BypassQueryAnalysis decrypts',
         'encryptedFieldsMap is preferred over remote encryptedFields'
       ].includes(description);
+
+      return !isSkippedTest;
     }
     return true;
   });

--- a/test/spec/client-side-encryption/tests/legacy/fle2-BypassQueryAnalysis.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2-BypassQueryAnalysis.json
@@ -4,7 +4,8 @@
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/test/spec/client-side-encryption/tests/legacy/fle2-BypassQueryAnalysis.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2-BypassQueryAnalysis.yml
@@ -1,7 +1,7 @@
 runOn:
   - minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
-    topology: [ "replicaset", "sharded" ]
+    topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/test/spec/client-side-encryption/tests/legacy/fle2-Compact.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2-Compact.json
@@ -4,7 +4,8 @@
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/test/spec/client-side-encryption/tests/legacy/fle2-Compact.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2-Compact.yml
@@ -1,7 +1,7 @@
 runOn:
   - minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
-    topology: [ "replicaset", "sharded" ]
+    topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/test/spec/client-side-encryption/tests/legacy/fle2-CreateCollection.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2-CreateCollection.json
@@ -4,7 +4,8 @@
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/test/spec/client-side-encryption/tests/legacy/fle2-CreateCollection.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2-CreateCollection.yml
@@ -2,7 +2,7 @@
 runOn:
   - minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
-    topology: [ "replicaset", "sharded" ]
+    topology: [ "replicaset", "sharded", "load-balanced" ]
     
 database_name: &database_name "default"
 collection_name: &collection_name "default"

--- a/test/spec/client-side-encryption/tests/legacy/fle2-DecryptExistingData.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2-DecryptExistingData.json
@@ -4,7 +4,8 @@
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/test/spec/client-side-encryption/tests/legacy/fle2-DecryptExistingData.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2-DecryptExistingData.yml
@@ -1,7 +1,7 @@
 runOn:
   - minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
-    topology: [ "replicaset", "sharded" ]
+    topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: [

--- a/test/spec/client-side-encryption/tests/legacy/fle2-Delete.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2-Delete.json
@@ -4,7 +4,8 @@
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/test/spec/client-side-encryption/tests/legacy/fle2-Delete.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2-Delete.yml
@@ -1,7 +1,7 @@
 runOn:
   - minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
-    topology: [ "replicaset", "sharded" ]
+    topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/test/spec/client-side-encryption/tests/legacy/fle2-EncryptedFields-vs-EncryptedFieldsMap.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2-EncryptedFields-vs-EncryptedFieldsMap.json
@@ -4,7 +4,8 @@
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/test/spec/client-side-encryption/tests/legacy/fle2-EncryptedFields-vs-EncryptedFieldsMap.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2-EncryptedFields-vs-EncryptedFieldsMap.yml
@@ -1,7 +1,7 @@
 runOn:
   - minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
-    topology: [ "replicaset", "sharded" ]
+    topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/test/spec/client-side-encryption/tests/legacy/fle2-EncryptedFields-vs-jsonSchema.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2-EncryptedFields-vs-jsonSchema.json
@@ -4,7 +4,8 @@
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/test/spec/client-side-encryption/tests/legacy/fle2-EncryptedFields-vs-jsonSchema.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2-EncryptedFields-vs-jsonSchema.yml
@@ -1,7 +1,7 @@
 runOn:
   - minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
-    topology: [ "replicaset", "sharded" ]
+    topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/test/spec/client-side-encryption/tests/legacy/fle2-EncryptedFieldsMap-defaults.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2-EncryptedFieldsMap-defaults.json
@@ -4,7 +4,8 @@
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/test/spec/client-side-encryption/tests/legacy/fle2-EncryptedFieldsMap-defaults.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2-EncryptedFieldsMap-defaults.yml
@@ -1,7 +1,7 @@
 runOn:
   - minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
-    topology: [ "replicaset", "sharded" ]
+    topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/test/spec/client-side-encryption/tests/legacy/fle2-FindOneAndUpdate.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2-FindOneAndUpdate.json
@@ -4,7 +4,8 @@
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/test/spec/client-side-encryption/tests/legacy/fle2-FindOneAndUpdate.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2-FindOneAndUpdate.yml
@@ -1,7 +1,7 @@
 runOn:
   - minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
-    topology: [ "replicaset", "sharded" ]
+    topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/test/spec/client-side-encryption/tests/legacy/fle2-InsertFind-Indexed.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2-InsertFind-Indexed.json
@@ -4,7 +4,8 @@
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/test/spec/client-side-encryption/tests/legacy/fle2-InsertFind-Indexed.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2-InsertFind-Indexed.yml
@@ -1,7 +1,7 @@
 runOn:
   - minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
-    topology: [ "replicaset", "sharded" ]
+    topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/test/spec/client-side-encryption/tests/legacy/fle2-InsertFind-Unindexed.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2-InsertFind-Unindexed.json
@@ -4,7 +4,8 @@
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/test/spec/client-side-encryption/tests/legacy/fle2-InsertFind-Unindexed.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2-InsertFind-Unindexed.yml
@@ -1,7 +1,7 @@
 runOn:
   - minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
-    topology: [ "replicaset", "sharded" ]
+    topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/test/spec/client-side-encryption/tests/legacy/fle2-MissingKey.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2-MissingKey.json
@@ -4,7 +4,8 @@
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/test/spec/client-side-encryption/tests/legacy/fle2-MissingKey.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2-MissingKey.yml
@@ -1,7 +1,7 @@
 runOn:
   - minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
-    topology: [ "replicaset", "sharded" ]
+    topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: [

--- a/test/spec/client-side-encryption/tests/legacy/fle2-NoEncryption.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2-NoEncryption.json
@@ -4,7 +4,8 @@
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/test/spec/client-side-encryption/tests/legacy/fle2-NoEncryption.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2-NoEncryption.yml
@@ -1,7 +1,7 @@
 runOn:
   - minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
-    topology: [ "replicaset", "sharded" ]
+    topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/test/spec/client-side-encryption/tests/legacy/fle2-Update.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2-Update.json
@@ -4,7 +4,8 @@
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/test/spec/client-side-encryption/tests/legacy/fle2-Update.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2-Update.yml
@@ -1,7 +1,7 @@
 runOn:
   - minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
-    topology: [ "replicaset", "sharded" ]
+    topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/test/spec/client-side-encryption/tests/legacy/fle2-validatorAndPartialFieldExpression.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2-validatorAndPartialFieldExpression.json
@@ -4,7 +4,8 @@
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/test/spec/client-side-encryption/tests/legacy/fle2-validatorAndPartialFieldExpression.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2-validatorAndPartialFieldExpression.yml
@@ -3,7 +3,7 @@ runOn:
     # Require server version 6.0.0 to get behavior added in SERVER-64911.
     - minServerVersion: "6.0.0"
       # FLE 2 Encrypted collections are not supported on standalone.
-      topology: [ "replicaset", "sharded" ]
+      topology: [ "replicaset", "sharded", "load-balanced" ]
 
 database_name: &database_name "default"
 collection_name: &collection_name "default"


### PR DESCRIPTION
https://jira.mongodb.org/browse/NODE-4629

### Description

#### What is changing?

Legacy csfle tests now run on serverless.

##### Is there new documentation needed for these changes?

No.

#### What is the motivation for this change?

Good testing.

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
