### PR TITLE
refactor(NODE-4690): update cmap and test runners to support interruptInUseConnections

### DIFF
--- a/src/cmap/connection_pool.ts
+++ b/src/cmap/connection_pool.ts
@@ -428,7 +428,7 @@ export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
       }
       this.emit(
         ConnectionPool.CONNECTION_POOL_CLEARED,
-        new ConnectionPoolClearedEvent(this, serviceId)
+        new ConnectionPoolClearedEvent(this, { serviceId })
       );
       return;
     }

--- a/src/cmap/connection_pool_events.ts
+++ b/src/cmap/connection_pool_events.ts
@@ -192,13 +192,10 @@ export class ConnectionPoolClearedEvent extends ConnectionPoolMonitoringEvent {
   /** @internal */
   constructor(
     pool: ConnectionPool,
-    {
-      serviceId,
-      interruptInUseConnections
-    }: { serviceId?: ObjectId; interruptInUseConnections?: boolean } = {}
+    options: { serviceId?: ObjectId; interruptInUseConnections?: boolean } = {}
   ) {
     super(pool);
-    this.serviceId = serviceId;
-    this.interruptInUseConnections = interruptInUseConnections;
+    this.serviceId = options.serviceId;
+    this.interruptInUseConnections = options.interruptInUseConnections;
   }
 }

--- a/src/cmap/connection_pool_events.ts
+++ b/src/cmap/connection_pool_events.ts
@@ -187,9 +187,18 @@ export class ConnectionPoolClearedEvent extends ConnectionPoolMonitoringEvent {
   /** @internal */
   serviceId?: ObjectId;
 
+  interruptInUseConnections?: boolean;
+
   /** @internal */
-  constructor(pool: ConnectionPool, serviceId?: ObjectId) {
+  constructor(
+    pool: ConnectionPool,
+    {
+      serviceId,
+      interruptInUseConnections
+    }: { serviceId?: ObjectId; interruptInUseConnections?: boolean } = {}
+  ) {
     super(pool);
     this.serviceId = serviceId;
+    this.interruptInUseConnections = interruptInUseConnections;
   }
 }

--- a/test/integration/connection-monitoring-and-pooling/connection_monitoring_and_pooling.spec.test.ts
+++ b/test/integration/connection-monitoring-and-pooling/connection_monitoring_and_pooling.spec.test.ts
@@ -19,6 +19,16 @@ const LB_SKIP_TESTS: SkipDescription[] = [
   skipReason: 'cannot run against a load balanced environment'
 }));
 
+const INTERRUPT_IN_USE_CONNECTIONS_TESTS: SkipDescription[] = [
+  'Connections MUST be interrupted as soon as possible (interruptInUseConnections=true)',
+  'Pool clear SHOULD schedule the next background thread run immediately (interruptInUseConnections: false)',
+  'clear with interruptInUseConnections = true closes pending connections'
+].map(description => ({
+  description,
+  skipIfCondition: 'always',
+  skipReason: 'TODO(NODE-4691): cancel inflight operations when heartbeat fails'
+}));
+
 describe('Connection Monitoring and Pooling Spec Tests (Integration)', function () {
   const tests: CmapTest[] = loadSpecTests('connection-monitoring-and-pooling');
 
@@ -30,6 +40,6 @@ describe('Connection Monitoring and Pooling Spec Tests (Integration)', function 
         skipReason:
           'not applicable: waitQueueTimeoutMS limits connection establishment time in our driver'
       }
-    ])
+    ]).concat(INTERRUPT_IN_USE_CONNECTIONS_TESTS)
   });
 });

--- a/test/integration/server-discovery-and-monitoring/server_discovery_and_monitoring.spec.test.ts
+++ b/test/integration/server-discovery-and-monitoring/server_discovery_and_monitoring.spec.test.ts
@@ -4,5 +4,16 @@ import { loadSpecTests } from '../../spec';
 import { runUnifiedSuite } from '../../tools/unified-spec-runner/runner';
 
 describe('SDAM Unified Tests', function () {
-  runUnifiedSuite(loadSpecTests(path.join('server-discovery-and-monitoring', 'unified')));
+  const sdamPoolClearedTests = [
+    'Connection pool clear uses interruptInUseConnections=true after monitor timeout',
+    'Error returned from connection pool clear with interruptInUseConnections=true is retryable',
+    'Error returned from connection pool clear with interruptInUseConnections=true is retryable for write'
+  ];
+  runUnifiedSuite(
+    loadSpecTests(path.join('server-discovery-and-monitoring', 'unified')),
+    ({ description }) =>
+      sdamPoolClearedTests.includes(description)
+        ? 'TODO(NODE-4691): interrupt in-use operations on heartbeat failure'
+        : false
+  );
 });

--- a/test/spec/connection-monitoring-and-pooling/pool-clear-interrupt-immediately.json
+++ b/test/spec/connection-monitoring-and-pooling/pool-clear-interrupt-immediately.json
@@ -1,0 +1,77 @@
+{
+  "version": 1,
+  "style": "unit",
+  "description": "Connections MUST be interrupted as soon as possible (interruptInUseConnections=true)",
+  "poolOptions": {
+    "backgroundThreadIntervalMS": 10000
+  },
+  "operations": [
+    {
+      "name": "ready"
+    },
+    {
+      "name": "checkOut"
+    },
+    {
+      "name": "checkOut",
+      "label": "conn"
+    },
+    {
+      "name": "clear",
+      "interruptInUseConnections": true
+    },
+    {
+      "name": "waitForEvent",
+      "event": "ConnectionPoolCleared",
+      "count": 1,
+      "timeout": 1000      
+    },
+    {
+      "name": "waitForEvent",
+      "event": "ConnectionClosed",
+      "count": 2,
+      "timeout": 1000
+    },
+    {
+      "name": "close"
+    }
+  ],
+  "events": [
+    {
+      "type": "ConnectionCheckedOut",
+      "connectionId": 1,
+      "address": 42
+    },
+    {
+      "type": "ConnectionCheckedOut",
+      "connectionId": 2,
+      "address": 42
+    },
+    {
+      "type": "ConnectionPoolCleared",
+      "interruptInUseConnections": true
+    },
+    {
+      "type": "ConnectionClosed",
+      "reason": "stale",
+      "address": 42
+    },
+    {
+      "type": "ConnectionClosed",
+      "reason": "stale",
+      "address": 42
+    },
+    {
+      "type": "ConnectionPoolClosed",
+      "address": 42
+    }
+  ],
+  "ignore": [
+    "ConnectionCreated",
+    "ConnectionPoolReady",
+    "ConnectionReady",
+    "ConnectionCheckOutStarted",
+    "ConnectionPoolCreated",
+    "ConnectionCheckedIn"
+  ]
+}

--- a/test/spec/connection-monitoring-and-pooling/pool-clear-interrupt-immediately.yml
+++ b/test/spec/connection-monitoring-and-pooling/pool-clear-interrupt-immediately.yml
@@ -1,0 +1,46 @@
+version: 1
+style: unit
+description: Connections MUST be interrupted as soon as possible (interruptInUseConnections=true)
+poolOptions:
+  # ensure it's not involved by default
+  backgroundThreadIntervalMS: 10000
+operations:
+  - name: ready
+  - name: checkOut
+  - name: checkOut
+    label: conn
+  - name: clear
+    interruptInUseConnections: true
+  - name: waitForEvent
+    event: ConnectionPoolCleared
+    count: 1
+    timeout: 1000
+  - name: waitForEvent
+    event: ConnectionClosed
+    count: 2
+    timeout: 1000
+  - name: close
+events:
+  - type: ConnectionCheckedOut
+    connectionId: 1
+    address: 42
+  - type: ConnectionCheckedOut
+    connectionId: 2
+    address: 42
+  - type: ConnectionPoolCleared
+    interruptInUseConnections: true
+  - type: ConnectionClosed
+    reason: stale
+    address: 42
+  - type: ConnectionClosed
+    reason: stale
+    address: 42
+  - type: ConnectionPoolClosed
+    address: 42
+ignore:
+  - ConnectionCreated
+  - ConnectionPoolReady
+  - ConnectionReady
+  - ConnectionCheckOutStarted
+  - ConnectionPoolCreated
+  - ConnectionCheckedIn

--- a/test/spec/connection-monitoring-and-pooling/pool-clear-interrupting-pending-connections.json
+++ b/test/spec/connection-monitoring-and-pooling/pool-clear-interrupting-pending-connections.json
@@ -1,0 +1,77 @@
+{
+  "version": 1,
+  "style": "integration",
+  "description": "clear with interruptInUseConnections = true closes pending connections",
+  "runOn": [
+    {
+      "minServerVersion": "4.9.0"
+    }
+  ],
+  "failPoint": {
+    "configureFailPoint": "failCommand",
+    "mode": "alwaysOn",
+    "data": {
+      "failCommands": [
+        "isMaster",
+        "hello"
+      ],
+      "closeConnection": false,
+      "blockConnection": true,
+      "blockTimeMS": 1000
+    }
+  },
+  "poolOptions": {
+    "minPoolSize": 0
+  },
+  "operations": [
+    {
+      "name": "ready"
+    },
+    {
+      "name": "start",
+      "target": "thread1"
+    },
+    {
+      "name": "checkOut",
+      "thread": "thread1"
+    },
+    {
+      "name": "waitForEvent",
+      "event": "ConnectionCreated",
+      "count": 1
+    },
+    {
+      "name": "clear",
+      "interruptInUseConnections": true
+    },
+    {
+      "name": "waitForEvent",
+      "event": "ConnectionCheckOutFailed",
+      "count": 1
+    }
+  ],
+  "events": [
+    {
+      "type": "ConnectionCheckOutStarted"
+    },
+    {
+      "type": "ConnectionCreated"
+    },    
+    {
+      "type": "ConnectionPoolCleared",
+      "interruptInUseConnections": true
+    },
+    {
+      "type": "ConnectionClosed"
+    },
+    {
+      "type": "ConnectionCheckOutFailed"
+    }
+  ],
+  "ignore": [
+    "ConnectionCheckedIn",
+    "ConnectionCheckedOut",
+    "ConnectionPoolCreated",
+    "ConnectionPoolReady"
+  ]
+}

--- a/test/spec/connection-monitoring-and-pooling/pool-clear-interrupting-pending-connections.yml
+++ b/test/spec/connection-monitoring-and-pooling/pool-clear-interrupting-pending-connections.yml
@@ -1,0 +1,42 @@
+version: 1
+style: integration
+description: clear with interruptInUseConnections = true closes pending connections
+runOn:
+  -
+    minServerVersion: "4.9.0"
+failPoint:
+  configureFailPoint: failCommand
+  mode: "alwaysOn"
+  data:
+    failCommands: ["isMaster","hello"]
+    closeConnection: false
+    blockConnection: true
+    blockTimeMS: 1000
+poolOptions:
+  minPoolSize: 0
+operations:
+  - name: ready
+  - name: start
+    target: thread1
+  - name: checkOut
+    thread: thread1
+  - name: waitForEvent
+    event: ConnectionCreated
+    count: 1
+  - name: clear
+    interruptInUseConnections: true
+  - name: waitForEvent
+    event: ConnectionCheckOutFailed
+    count: 1
+events:
+  - type: ConnectionCheckOutStarted
+  - type: ConnectionCreated
+  - type: ConnectionPoolCleared
+    interruptInUseConnections: true
+  - type: ConnectionClosed
+  - type: ConnectionCheckOutFailed
+ignore:
+  - ConnectionCheckedIn
+  - ConnectionCheckedOut
+  - ConnectionPoolCreated
+  - ConnectionPoolReady

--- a/test/spec/connection-monitoring-and-pooling/pool-clear-schedule-run-interruptInUseConnections-false.json
+++ b/test/spec/connection-monitoring-and-pooling/pool-clear-schedule-run-interruptInUseConnections-false.json
@@ -1,0 +1,81 @@
+{
+  "version": 1,
+  "style": "unit",
+  "description": "Pool clear SHOULD schedule the next background thread run immediately (interruptInUseConnections: false)",
+  "poolOptions": {
+    "backgroundThreadIntervalMS": 10000
+  },
+  "operations": [
+    {
+      "name": "ready"
+    },
+    {
+      "name": "checkOut"
+    },
+    {
+      "name": "checkOut",
+      "label": "conn"
+    },
+    {
+      "name": "checkIn",
+      "connection": "conn"
+    },
+    {
+      "name": "clear",
+      "interruptInUseConnections": false
+    },
+    {
+      "name": "waitForEvent",
+      "event": "ConnectionPoolCleared",
+      "count": 1,
+      "timeout": 1000      
+    },
+    {
+      "name": "waitForEvent",
+      "event": "ConnectionClosed",
+      "count": 1,
+      "timeout": 1000
+    },
+    {
+      "name": "close"
+    }
+  ],
+  "events": [
+    {
+      "type": "ConnectionCheckedOut",
+      "connectionId": 1,
+      "address": 42
+    },
+    {
+      "type": "ConnectionCheckedOut",
+      "connectionId": 2,
+      "address": 42
+    },
+    {
+      "type": "ConnectionCheckedIn",
+      "connectionId": 2,
+      "address": 42
+    },
+    {
+      "type": "ConnectionPoolCleared",
+      "interruptInUseConnections": false
+    },
+    {
+      "type": "ConnectionClosed",
+      "connectionId": 2,
+      "reason": "stale",
+      "address": 42
+    },
+    {
+      "type": "ConnectionPoolClosed",
+      "address": 42
+    }
+  ],
+  "ignore": [
+    "ConnectionCreated",
+    "ConnectionPoolReady",
+    "ConnectionReady",
+    "ConnectionCheckOutStarted",
+    "ConnectionPoolCreated"
+  ]
+}

--- a/test/spec/connection-monitoring-and-pooling/pool-clear-schedule-run-interruptInUseConnections-false.yml
+++ b/test/spec/connection-monitoring-and-pooling/pool-clear-schedule-run-interruptInUseConnections-false.yml
@@ -1,0 +1,48 @@
+version: 1
+style: unit
+description: Pool clear SHOULD schedule the next background thread run immediately (interruptInUseConnections: false)
+poolOptions:
+  # ensure it's not involved by default
+  backgroundThreadIntervalMS: 10000
+operations:
+  - name: ready
+  - name: checkOut
+  - name: checkOut
+    label: conn
+  - name: checkIn
+    connection: conn
+  - name: clear
+    interruptInUseConnections: false
+  - name: waitForEvent
+    event: ConnectionPoolCleared
+    count: 1
+    timeout: 1000
+  - name: waitForEvent
+    event: ConnectionClosed
+    count: 1
+    timeout: 1000
+  - name: close
+events:
+  - type: ConnectionCheckedOut
+    connectionId: 1
+    address: 42
+  - type: ConnectionCheckedOut
+    connectionId: 2
+    address: 42
+  - type: ConnectionCheckedIn
+    connectionId: 2
+    address: 42
+  - type: ConnectionPoolCleared
+    interruptInUseConnections: false
+  - type: ConnectionClosed
+    connectionId: 2
+    reason: stale
+    address: 42
+  - type: ConnectionPoolClosed
+    address: 42
+ignore:
+  - ConnectionCreated
+  - ConnectionPoolReady
+  - ConnectionReady
+  - ConnectionCheckOutStarted
+  - ConnectionPoolCreated

--- a/test/spec/server-discovery-and-monitoring/unified/interruptInUse-pool-clear.json
+++ b/test/spec/server-discovery-and-monitoring/unified/interruptInUse-pool-clear.json
@@ -1,0 +1,593 @@
+{
+  "description": "interruptInUse",
+  "schemaVersion": "1.11",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "4.9",
+      "topologies": [
+        "replicaset",
+        "sharded"
+      ],
+      "serverless": "forbid"
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "setupClient",
+        "useMultipleMongoses": false
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "interruptInUse",
+      "databaseName": "sdam-tests",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "Connection pool clear uses interruptInUseConnections=true after monitor timeout",
+      "operations": [
+        {
+          "name": "createEntities",
+          "object": "testRunner",
+          "arguments": {
+            "entities": [
+              {
+                "client": {
+                  "id": "client",
+                  "useMultipleMongoses": false,
+                  "uriOptions": {
+                    "connectTimeoutMS": 500,
+                    "heartbeatFrequencyMS": 500,
+                    "appname": "interruptInUse",
+                    "retryReads": false,
+                    "minPoolSize": 0
+                  },
+                  "observeEvents": [
+                    "poolClearedEvent",
+                    "connectionClosedEvent",
+                    "commandStartedEvent",
+                    "commandSucceededEvent",
+                    "commandFailedEvent",
+                    "connectionCheckedOutEvent",
+                    "connectionCheckedInEvent"
+                  ]
+                }
+              },
+              {
+                "database": {
+                  "id": "database",
+                  "client": "client",
+                  "databaseName": "sdam-tests"
+                }
+              },
+              {
+                "collection": {
+                  "id": "collection",
+                  "database": "database",
+                  "collectionName": "interruptInUse"
+                }
+              },
+              {
+                "thread": {
+                  "id": "thread1"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "document": {
+              "_id": 1
+            }
+          }
+        },
+        {
+          "name": "runOnThread",
+          "object": "testRunner",
+          "arguments": {
+            "thread": "thread1",
+            "operation": {
+              "name": "find",
+              "object": "collection",
+              "arguments": {
+                "filter": {
+                  "$where": "sleep(2000) || true"
+                }
+              },
+              "expectError": {
+                "isError": true
+              }
+            }
+          }
+        },
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 4
+              },
+              "data": {
+                "failCommands": [
+                  "hello",
+                  "isMaster"
+                ],
+                "blockConnection": true,
+                "blockTimeMS": 1500,
+                "appName": "interruptInUse"
+              }
+            },
+            "client": "setupClient"
+          }
+        },
+        {
+          "name": "waitForThread",
+          "object": "testRunner",
+          "arguments": {
+            "thread": "thread1"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "eventType": "command",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "insert"
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "insert"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "find"
+              }
+            },
+            {
+              "commandFailedEvent": {
+                "commandName": "find"
+              }
+            }
+          ]
+        },
+        {
+          "client": "client",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "poolClearedEvent": {
+                "interruptInUseConnections": true
+              }
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionClosedEvent": {}
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "interruptInUse",
+          "databaseName": "sdam-tests",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Error returned from connection pool clear with interruptInUseConnections=true is retryable",
+      "operations": [
+        {
+          "name": "createEntities",
+          "object": "testRunner",
+          "arguments": {
+            "entities": [
+              {
+                "client": {
+                  "id": "client",
+                  "useMultipleMongoses": false,
+                  "uriOptions": {
+                    "connectTimeoutMS": 500,
+                    "heartbeatFrequencyMS": 500,
+                    "appname": "interruptInUseRetryable",
+                    "retryReads": true,
+                    "minPoolSize": 0
+                  },
+                  "observeEvents": [
+                    "poolClearedEvent",
+                    "connectionClosedEvent",
+                    "commandFailedEvent",
+                    "commandStartedEvent",
+                    "commandSucceededEvent",
+                    "connectionCheckedOutEvent",
+                    "connectionCheckedInEvent"
+                  ]
+                }
+              },
+              {
+                "database": {
+                  "id": "database",
+                  "client": "client",
+                  "databaseName": "sdam-tests"
+                }
+              },
+              {
+                "collection": {
+                  "id": "collection",
+                  "database": "database",
+                  "collectionName": "interruptInUse"
+                }
+              },
+              {
+                "thread": {
+                  "id": "thread1"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "document": {
+              "_id": 1
+            }
+          }
+        },
+        {
+          "name": "runOnThread",
+          "object": "testRunner",
+          "arguments": {
+            "thread": "thread1",
+            "operation": {
+              "name": "find",
+              "object": "collection",
+              "arguments": {
+                "filter": {
+                  "$where": "sleep(2000) || true"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 4
+              },
+              "data": {
+                "failCommands": [
+                  "hello",
+                  "isMaster"
+                ],
+                "blockConnection": true,
+                "blockTimeMS": 1500,
+                "appName": "interruptInUseRetryable"
+              }
+            },
+            "client": "setupClient"
+          }
+        },
+        {
+          "name": "waitForThread",
+          "object": "testRunner",
+          "arguments": {
+            "thread": "thread1"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "eventType": "command",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "insert"
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "insert"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "find"
+              }
+            },
+            {
+              "commandFailedEvent": {
+                "commandName": "find"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "find"
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "find"
+              }
+            }
+          ]
+        },
+        {
+          "client": "client",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "poolClearedEvent": {
+                "interruptInUseConnections": true
+              }
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionClosedEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "interruptInUse",
+          "databaseName": "sdam-tests",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Error returned from connection pool clear with interruptInUseConnections=true is retryable for write",
+      "operations": [
+        {
+          "name": "createEntities",
+          "object": "testRunner",
+          "arguments": {
+            "entities": [
+              {
+                "client": {
+                  "id": "client",
+                  "useMultipleMongoses": false,
+                  "uriOptions": {
+                    "connectTimeoutMS": 500,
+                    "heartbeatFrequencyMS": 500,
+                    "appname": "interruptInUseRetryableWrite",
+                    "retryWrites": true,
+                    "minPoolSize": 0
+                  },
+                  "observeEvents": [
+                    "poolClearedEvent",
+                    "connectionClosedEvent",
+                    "commandFailedEvent",
+                    "commandStartedEvent",
+                    "commandSucceededEvent",
+                    "connectionCheckedOutEvent",
+                    "connectionCheckedInEvent"
+                  ]
+                }
+              },
+              {
+                "database": {
+                  "id": "database",
+                  "client": "client",
+                  "databaseName": "sdam-tests"
+                }
+              },
+              {
+                "collection": {
+                  "id": "collection",
+                  "database": "database",
+                  "collectionName": "interruptInUse"
+                }
+              },
+              {
+                "thread": {
+                  "id": "thread1"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "document": {
+              "_id": 1
+            }
+          }
+        },
+        {
+          "name": "runOnThread",
+          "object": "testRunner",
+          "arguments": {
+            "thread": "thread1",
+            "operation": {
+              "name": "updateOne",
+              "object": "collection",
+              "arguments": {
+                "filter": {
+                  "$where": "sleep(2000) || true"
+                },
+                "update": [
+                  {
+                    "$set": {
+                      "a": "bar"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 4
+              },
+              "data": {
+                "failCommands": [
+                  "hello",
+                  "isMaster"
+                ],
+                "blockConnection": true,
+                "blockTimeMS": 1500,
+                "appName": "interruptInUseRetryableWrite"
+              }
+            },
+            "client": "setupClient"
+          }
+        },
+        {
+          "name": "waitForThread",
+          "object": "testRunner",
+          "arguments": {
+            "thread": "thread1"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "eventType": "command",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "insert"
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "insert"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "update"
+              }
+            },
+            {
+              "commandFailedEvent": {
+                "commandName": "update"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "update"
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "update"
+              }
+            }
+          ]
+        },
+        {
+          "client": "client",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "poolClearedEvent": {
+                "interruptInUseConnections": true
+              }
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionClosedEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "interruptInUse",
+          "databaseName": "sdam-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "a": "bar"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/server-discovery-and-monitoring/unified/interruptInUse-pool-clear.yml
+++ b/test/spec/server-discovery-and-monitoring/unified/interruptInUse-pool-clear.yml
@@ -1,0 +1,339 @@
+---
+description: interruptInUse
+
+schemaVersion: "1.11"
+
+runOnRequirements:
+  # failCommand appName requirements
+  - minServerVersion: "4.9"
+    serverless: forbid
+    topologies: [ replicaset, sharded ]
+
+createEntities:
+  - client:
+      id: &setupClient setupClient
+      useMultipleMongoses: false
+
+initialData: &initialData
+  - collectionName: &collectionName interruptInUse
+    databaseName: &databaseName sdam-tests
+    documents: []
+
+tests:
+  - description: Connection pool clear uses interruptInUseConnections=true after monitor timeout
+    operations:
+      - name: createEntities
+        object: testRunner
+        arguments:
+          entities:
+            - client:
+                id: &client client
+                useMultipleMongoses: false
+                observeEvents:
+                  - poolClearedEvent
+                  - connectionClosedEvent
+                  - commandStartedEvent
+                  - commandSucceededEvent
+                  - commandFailedEvent
+                  - connectionCheckedOutEvent
+                  - connectionCheckedInEvent
+                uriOptions:
+                  connectTimeoutMS: 500
+                  heartbeatFrequencyMS: 500
+                  appname: interruptInUse
+                  retryReads: false
+                  minPoolSize: 0
+            - database:
+                id: &database database
+                client: *client
+                databaseName: *databaseName
+            - collection:
+                id: &collection collection
+                database: *database
+                collectionName: *collectionName
+            - thread:
+                id: &thread1 thread1
+      - name: insertOne
+        object: *collection
+        arguments:
+          document: { _id: 1 }
+      # simulate a long-running query
+      - name: runOnThread
+        object: testRunner
+        arguments:
+          thread: *thread1
+          operation:
+            name: find
+            object: *collection
+            arguments:
+              filter:
+                $where : sleep(2000) || true
+            expectError:
+              isError: true
+        # Configure the monitor check to fail with a timeout.
+        # Use "times: 4" to increase the probability that the Monitor check triggers
+        # the failpoint, since the RTT hello may trigger this failpoint one or many 
+        # times as well.
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *setupClient
+          failPoint:
+            configureFailPoint: failCommand
+            mode:
+              times: 4
+            data:
+              failCommands:
+                - hello
+                - isMaster
+              blockConnection:  true,
+              blockTimeMS: 1500,                
+              appName: interruptInUse        
+      - name: waitForThread
+        object: testRunner,
+        arguments:
+          thread: *thread1
+
+    expectEvents:
+      - client: *client
+        eventType: command
+        events:
+          - commandStartedEvent:
+              commandName: insert
+          - commandStartedEvent:
+              commandName: find
+          - commandFailedEvent:
+              commandName: find
+      - client: *client
+        eventType: cmap
+        events:
+          - connectionCheckedOutEvent: {}
+          - connectionCheckedInEvent: {}
+          - connectionCheckedOutEvent: {}
+          - poolClearedEvent:
+              interruptInUseConnections: true
+          - connectionCheckedInEvent: {}
+          - connectionClosedEvent: {}
+
+    outcome:
+      - collectionName: *collectionName
+        databaseName: *databaseName
+        documents:
+          - _id: 1
+
+  - description: Error returned from connection pool clear with interruptInUseConnections=true is retryable
+    operations:
+      - name: createEntities
+        object: testRunner
+        arguments:
+          entities:
+            - client:
+                id: &client client
+                useMultipleMongoses: false
+                observeEvents:
+                  - poolClearedEvent
+                  - connectionClosedEvent
+                  - commandStartedEvent
+                  - commandFailedEvent
+                  - commandSucceededEvent
+                  - connectionCheckedOutEvent
+                  - connectionCheckedInEvent
+                uriOptions:
+                  connectTimeoutMS: 500
+                  heartbeatFrequencyMS: 500
+                  appname: interruptInUseRetryable
+                  retryReads: true
+                  minPoolSize: 0
+            - database:
+                id: &database database
+                client: *client
+                databaseName: *databaseName
+            - collection:
+                id: &collection collection
+                database: *database
+                collectionName: *collectionName
+            - thread:
+                id: &thread1 thread1
+      - name: insertOne
+        object: *collection
+        arguments:
+          document: { _id: 1 }
+      # simulate a long-running query
+      - name: runOnThread
+        object: testRunner
+        arguments:
+          thread: *thread1
+          operation:
+            name: find
+            object: *collection
+            arguments:
+              filter:
+                $where : sleep(2000) || true
+        # Configure the monitor check to fail with a timeout.
+        # Use "times: 4" to increase the probability that the Monitor check triggers
+        # the failpoint, since the RTT hello may trigger this failpoint one or many 
+        # times as well.
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *setupClient
+          failPoint:
+            configureFailPoint: failCommand
+            mode:
+              times: 4
+            data:
+              failCommands:
+                - hello
+                - isMaster
+              blockConnection:  true,
+              blockTimeMS: 1500,                
+              appName: interruptInUseRetryable
+      - name: waitForThread
+        object: testRunner,
+        arguments:
+          thread: *thread1
+
+    expectEvents:
+      - client: *client
+        eventType: command
+        events:
+          - commandStartedEvent:
+              commandName: insert
+          - commandSucceededEvent:
+              commandName: insert
+          - commandStartedEvent:
+              commandName: find
+          - commandFailedEvent:
+              commandName: find
+          - commandStartedEvent:
+              commandName: find
+          - commandSucceededEvent:
+              commandName: find
+      - client: *client
+        eventType: cmap
+        events:
+          - connectionCheckedOutEvent: {}
+          - connectionCheckedInEvent: {}
+          - connectionCheckedOutEvent: {}
+          - poolClearedEvent:
+              interruptInUseConnections: true
+          - connectionCheckedInEvent: {}
+          - connectionClosedEvent: {}
+          - connectionCheckedOutEvent: {}
+          - connectionCheckedInEvent: {}
+     
+    outcome:
+      - collectionName: *collectionName
+        databaseName: *databaseName
+        documents:
+          - _id: 1
+  - description: Error returned from connection pool clear with interruptInUseConnections=true is retryable for write
+    operations:
+      - name: createEntities
+        object: testRunner
+        arguments:
+          entities:
+            - client:
+                id: &client client
+                useMultipleMongoses: false
+                observeEvents:
+                  - poolClearedEvent
+                  - connectionClosedEvent
+                  - commandStartedEvent
+                  - commandFailedEvent
+                  - commandSucceededEvent
+                  - connectionCheckedOutEvent
+                  - connectionCheckedInEvent
+                uriOptions:
+                  connectTimeoutMS: 500
+                  heartbeatFrequencyMS: 500
+                  appname: interruptInUseRetryableWrite
+                  retryWrites: true
+                  minPoolSize: 0
+            - database:
+                id: &database database
+                client: *client
+                databaseName: *databaseName
+            - collection:
+                id: &collection collection
+                database: *database
+                collectionName: *collectionName
+            - thread:
+                id: &thread1 thread1
+      # ensure the primary is discovered                
+      - name: insertOne
+        object: *collection
+        arguments:
+          document: { _id: 1 }
+      # simulate a long-running query
+      - name: runOnThread
+        object: testRunner
+        arguments:
+          thread: *thread1
+          operation:
+            name: updateOne
+            object: *collection
+            arguments:
+              filter: 
+                $where": sleep(2000) || true
+              update: 
+                "$set": { "a": "bar" } 
+        # Configure the monitor check to fail with a timeout.
+        # Use "times: 4" to increase the probability that the Monitor check triggers
+        # the failpoint, since the RTT hello may trigger this failpoint one or many 
+        # times as well.
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *setupClient
+          failPoint:
+            configureFailPoint: failCommand
+            mode:
+              times: 4
+            data:
+              failCommands:
+                - hello
+                - isMaster
+              blockConnection:  true,
+              blockTimeMS: 1500,                
+              appName: interruptInUseRetryableWrite
+      - name: waitForThread
+        object: testRunner,
+        arguments:
+          thread: *thread1
+
+    expectEvents:
+      - client: *client
+        eventType: command
+        events:
+          - commandStartedEvent:
+              commandName: insert
+          - commandSucceededEvent:
+              commandName: insert
+          - commandStartedEvent:
+              commandName: update
+          - commandFailedEvent:
+              commandName: update
+          - commandStartedEvent:
+              commandName: update
+          - commandSucceededEvent:
+              commandName: update
+      - client: *client
+        eventType: cmap
+        events:
+          - connectionCheckedOutEvent: {}
+          - connectionCheckedInEvent: {}
+          - connectionCheckedOutEvent: {}
+          - poolClearedEvent:
+              interruptInUseConnections: true
+          - connectionCheckedInEvent: {}
+          - connectionClosedEvent: {}
+          - connectionCheckedOutEvent: {}
+          - connectionCheckedInEvent: {}
+     
+    outcome:
+      - collectionName: *collectionName
+        databaseName: *databaseName
+        documents:
+          - { _id: 1, a : bar }
+

--- a/test/spec/unified-test-format/invalid/expectedCmapEvent-poolClearedEvent-interruptInUseConnections-type.json
+++ b/test/spec/unified-test-format/invalid/expectedCmapEvent-poolClearedEvent-interruptInUseConnections-type.json
@@ -1,0 +1,23 @@
+{
+  "description": "expectedCmapEvent-poolClearedEvent-interruptInUseConnections-type",
+  "schemaVersion": "1.11",
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "eventType": "cmap",
+          "events": [
+            {
+              "poolClearedEvent": {
+                "interruptInUseConnections": "foo"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/expectedCmapEvent-poolClearedEvent-interruptInUseConnections-type.yml
+++ b/test/spec/unified-test-format/invalid/expectedCmapEvent-poolClearedEvent-interruptInUseConnections-type.yml
@@ -1,0 +1,13 @@
+description: expectedCmapEvent-poolClearedEvent-interruptInUseConnections-type
+
+schemaVersion: '1.11'
+
+tests:
+  - description: foo
+    operations: []
+    expectEvents:
+      - client: client0
+        eventType: cmap
+        events:
+          - poolClearedEvent:
+              interruptInUseConnections: foo

--- a/test/tools/cmap_spec_runner.ts
+++ b/test/tools/cmap_spec_runner.ts
@@ -16,7 +16,8 @@ type CmapOperation =
   | { name: 'waitForEvent'; event: string; count: number; timeout?: number }
   | { name: 'checkOut'; thread: string; label: string }
   | { name: 'checkIn'; connection: string }
-  | { name: 'clear' | 'close' | 'ready' };
+  | { name: 'clear'; interruptInUseConnections?: boolean }
+  | { name: 'close' | 'ready' };
 
 const CMAP_POOL_OPTION_NAMES: Array<keyof CmapPoolOptions> = [
   'appName',
@@ -196,7 +197,9 @@ const getTestOpDefinitions = (threadContext: ThreadContext) => ({
 
     return threadContext.pool.checkIn(connection);
   },
-  clear: function () {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  clear: function (interruptInUseConnections: boolean) {
+    // TODO(NODE-4619): pass interruptInUseConnections into clear pool method
     return threadContext.pool.clear();
   },
   close: async function () {
@@ -205,7 +208,7 @@ const getTestOpDefinitions = (threadContext: ThreadContext) => ({
   ready: function () {
     return threadContext.pool.ready();
   },
-  wait: async function (options) {
+  wait: function (options) {
     const ms = options.ms;
     return sleep(ms);
   },

--- a/test/tools/unified-spec-runner/match.ts
+++ b/test/tools/unified-spec-runner/match.ts
@@ -467,6 +467,11 @@ function compareEvents(
       if (expectedEvent.poolClearedEvent.hasServiceId) {
         expect(actualEvent).property('serviceId').to.exist;
       }
+      if (expectedEvent.poolClearedEvent.interruptInUseConnections != null) {
+        expect(actualEvent)
+          .property('interruptInUseConnections')
+          .to.equal(expectedEvent.poolClearedEvent.interruptInUseConnections);
+      }
     } else if (validEmptyCmapEvent(expectedEvent as ExpectedCmapEvent)) {
       const expectedEventName = Object.keys(expectedEvent)[0];
       const expectedEventInstance = EMPTY_CMAP_EVENTS[expectedEventName];

--- a/test/tools/unified-spec-runner/schema.ts
+++ b/test/tools/unified-spec-runner/schema.ts
@@ -269,6 +269,7 @@ export interface ExpectedCmapEvent {
   poolClearedEvent?: {
     serviceId?: ObjectId;
     hasServiceId?: boolean;
+    interruptInUseConnections?: boolean;
   };
   poolClosedEvent?: Record<string, never>;
   connectionCreatedEvent?: Record<string, never>;


### PR DESCRIPTION
### Description

#### What is changing?

This PR does the following:

- syncs new unified and cmap unit tests from [this](https://github.com/mongodb/specifications/commit/23bd4db8fcfc1dbd5d5c123f936134913720e85b) spec change
- updates the cmap runner to support passing `interruptInUseConnections` to `pool.clear()`
- updates the unified runner to support `interruptInUseConnections`
- Updates the PoolClearedEvent to support `interruptInUseConnections` (necessary for the tests)

##### Is there new documentation needed for these changes?

No.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
