### PR TITLE
docs: Note special case in `AbstractCursor.forEach()` iterator

### DIFF
--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -400,6 +400,8 @@ export abstract class AbstractCursor<
   /**
    * Iterates over all the documents for this cursor using the iterator, callback pattern.
    *
+   * If the iterator returns `false`, iteration will stop.
+   *
    * @param iterator - The iteration callback.
    * @param callback - The end callback.
    */


### PR DESCRIPTION
This undocumented behavior is surprising. Adding a note here may help future users.
