### PR TITLE
feat(NODE-4721): add aws-sdk as optional dependency

### DIFF
--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -351,7 +351,7 @@ functions:
         working_dir: "src"
         script: |
           ${PREPARE_SHELL}
-          NODE_LTS_NAME=${NODE_LTS_NAME} MSVS_VERSION=${MSVS_VERSION} \
+          NODE_LTS_NAME=${NODE_LTS_NAME} MSVS_VERSION=${MSVS_VERSION} NPM_OPTIONS=${NPM_OPTIONS}\
             bash ${PROJECT_DIRECTORY}/.evergreen/install-dependencies.sh
     - command: expansions.update
       params:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -309,7 +309,7 @@ functions:
         working_dir: src
         script: |
           ${PREPARE_SHELL}
-          NODE_LTS_NAME=${NODE_LTS_NAME} MSVS_VERSION=${MSVS_VERSION} \
+          NODE_LTS_NAME=${NODE_LTS_NAME} MSVS_VERSION=${MSVS_VERSION} NPM_OPTIONS=${NPM_OPTIONS}\
             bash ${PROJECT_DIRECTORY}/.evergreen/install-dependencies.sh
     - command: expansions.update
       params:
@@ -1375,7 +1375,8 @@ tasks:
           TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
-      - func: run aws auth test with regular aws credentials
+      - &ref_0
+        func: run aws auth test with regular aws credentials
   - name: aws-latest-auth-test-run-aws-auth-test-with-assume-role-credentials
     commands:
       - func: install dependencies
@@ -1387,7 +1388,8 @@ tasks:
           TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
-      - func: run aws auth test with assume role credentials
+      - &ref_1
+        func: run aws auth test with assume role credentials
   - name: aws-latest-auth-test-run-aws-auth-test-with-aws-EC2-credentials
     commands:
       - func: install dependencies
@@ -1399,7 +1401,8 @@ tasks:
           TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
-      - func: run aws auth test with aws EC2 credentials
+      - &ref_2
+        func: run aws auth test with aws EC2 credentials
   - name: aws-latest-auth-test-run-aws-auth-test-with-aws-credentials-as-environment-variables
     commands:
       - func: install dependencies
@@ -1411,7 +1414,8 @@ tasks:
           TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
-      - func: run aws auth test with aws credentials as environment variables
+      - &ref_3
+        func: run aws auth test with aws credentials as environment variables
   - name: aws-latest-auth-test-run-aws-auth-test-with-aws-credentials-and-session-token-as-environment-variables
     commands:
       - func: install dependencies
@@ -1423,7 +1427,8 @@ tasks:
           TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
-      - func: run aws auth test with aws credentials and session token as environment variables
+      - &ref_4
+        func: run aws auth test with aws credentials and session token as environment variables
   - name: aws-latest-auth-test-run-aws-ECS-auth-test
     commands:
       - func: install dependencies
@@ -1435,7 +1440,92 @@ tasks:
           TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
-      - func: run aws ECS auth test
+      - &ref_5
+        func: run aws ECS auth test
+  - name: aws-latest-auth-test-run-aws-auth-test-with-regular-aws-credentials-no-optional
+    commands:
+      - func: install dependencies
+        vars:
+          NPM_OPTIONS: '--no-optional'
+      - func: bootstrap mongo-orchestration
+        vars:
+          VERSION: latest
+          AUTH: auth
+          ORCHESTRATION_FILE: auth-aws.json
+          TOPOLOGY: server
+      - func: add aws auth variables to file
+      - func: setup aws env
+      - *ref_0
+  - name: aws-latest-auth-test-run-aws-auth-test-with-assume-role-credentials-no-optional
+    commands:
+      - func: install dependencies
+        vars:
+          NPM_OPTIONS: '--no-optional'
+      - func: bootstrap mongo-orchestration
+        vars:
+          VERSION: latest
+          AUTH: auth
+          ORCHESTRATION_FILE: auth-aws.json
+          TOPOLOGY: server
+      - func: add aws auth variables to file
+      - func: setup aws env
+      - *ref_1
+  - name: aws-latest-auth-test-run-aws-auth-test-with-aws-EC2-credentials-no-optional
+    commands:
+      - func: install dependencies
+        vars:
+          NPM_OPTIONS: '--no-optional'
+      - func: bootstrap mongo-orchestration
+        vars:
+          VERSION: latest
+          AUTH: auth
+          ORCHESTRATION_FILE: auth-aws.json
+          TOPOLOGY: server
+      - func: add aws auth variables to file
+      - func: setup aws env
+      - *ref_2
+  - name: aws-latest-auth-test-run-aws-auth-test-with-aws-credentials-as-environment-variables-no-optional
+    commands:
+      - func: install dependencies
+        vars:
+          NPM_OPTIONS: '--no-optional'
+      - func: bootstrap mongo-orchestration
+        vars:
+          VERSION: latest
+          AUTH: auth
+          ORCHESTRATION_FILE: auth-aws.json
+          TOPOLOGY: server
+      - func: add aws auth variables to file
+      - func: setup aws env
+      - *ref_3
+  - name: aws-latest-auth-test-run-aws-auth-test-with-aws-credentials-and-session-token-as-environment-variables-no-optional
+    commands:
+      - func: install dependencies
+        vars:
+          NPM_OPTIONS: '--no-optional'
+      - func: bootstrap mongo-orchestration
+        vars:
+          VERSION: latest
+          AUTH: auth
+          ORCHESTRATION_FILE: auth-aws.json
+          TOPOLOGY: server
+      - func: add aws auth variables to file
+      - func: setup aws env
+      - *ref_4
+  - name: aws-latest-auth-test-run-aws-ECS-auth-test-no-optional
+    commands:
+      - func: install dependencies
+        vars:
+          NPM_OPTIONS: '--no-optional'
+      - func: bootstrap mongo-orchestration
+        vars:
+          VERSION: latest
+          AUTH: auth
+          ORCHESTRATION_FILE: auth-aws.json
+          TOPOLOGY: server
+      - func: add aws auth variables to file
+      - func: setup aws env
+      - *ref_5
   - name: aws-6.0-auth-test-run-aws-auth-test-with-regular-aws-credentials
     commands:
       - func: install dependencies
@@ -1447,7 +1537,8 @@ tasks:
           TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
-      - func: run aws auth test with regular aws credentials
+      - &ref_6
+        func: run aws auth test with regular aws credentials
   - name: aws-6.0-auth-test-run-aws-auth-test-with-assume-role-credentials
     commands:
       - func: install dependencies
@@ -1459,7 +1550,8 @@ tasks:
           TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
-      - func: run aws auth test with assume role credentials
+      - &ref_7
+        func: run aws auth test with assume role credentials
   - name: aws-6.0-auth-test-run-aws-auth-test-with-aws-EC2-credentials
     commands:
       - func: install dependencies
@@ -1471,7 +1563,8 @@ tasks:
           TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
-      - func: run aws auth test with aws EC2 credentials
+      - &ref_8
+        func: run aws auth test with aws EC2 credentials
   - name: aws-6.0-auth-test-run-aws-auth-test-with-aws-credentials-as-environment-variables
     commands:
       - func: install dependencies
@@ -1483,7 +1576,8 @@ tasks:
           TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
-      - func: run aws auth test with aws credentials as environment variables
+      - &ref_9
+        func: run aws auth test with aws credentials as environment variables
   - name: aws-6.0-auth-test-run-aws-auth-test-with-aws-credentials-and-session-token-as-environment-variables
     commands:
       - func: install dependencies
@@ -1495,7 +1589,8 @@ tasks:
           TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
-      - func: run aws auth test with aws credentials and session token as environment variables
+      - &ref_10
+        func: run aws auth test with aws credentials and session token as environment variables
   - name: aws-6.0-auth-test-run-aws-ECS-auth-test
     commands:
       - func: install dependencies
@@ -1507,7 +1602,92 @@ tasks:
           TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
-      - func: run aws ECS auth test
+      - &ref_11
+        func: run aws ECS auth test
+  - name: aws-6.0-auth-test-run-aws-auth-test-with-regular-aws-credentials-no-optional
+    commands:
+      - func: install dependencies
+        vars:
+          NPM_OPTIONS: '--no-optional'
+      - func: bootstrap mongo-orchestration
+        vars:
+          VERSION: '6.0'
+          AUTH: auth
+          ORCHESTRATION_FILE: auth-aws.json
+          TOPOLOGY: server
+      - func: add aws auth variables to file
+      - func: setup aws env
+      - *ref_6
+  - name: aws-6.0-auth-test-run-aws-auth-test-with-assume-role-credentials-no-optional
+    commands:
+      - func: install dependencies
+        vars:
+          NPM_OPTIONS: '--no-optional'
+      - func: bootstrap mongo-orchestration
+        vars:
+          VERSION: '6.0'
+          AUTH: auth
+          ORCHESTRATION_FILE: auth-aws.json
+          TOPOLOGY: server
+      - func: add aws auth variables to file
+      - func: setup aws env
+      - *ref_7
+  - name: aws-6.0-auth-test-run-aws-auth-test-with-aws-EC2-credentials-no-optional
+    commands:
+      - func: install dependencies
+        vars:
+          NPM_OPTIONS: '--no-optional'
+      - func: bootstrap mongo-orchestration
+        vars:
+          VERSION: '6.0'
+          AUTH: auth
+          ORCHESTRATION_FILE: auth-aws.json
+          TOPOLOGY: server
+      - func: add aws auth variables to file
+      - func: setup aws env
+      - *ref_8
+  - name: aws-6.0-auth-test-run-aws-auth-test-with-aws-credentials-as-environment-variables-no-optional
+    commands:
+      - func: install dependencies
+        vars:
+          NPM_OPTIONS: '--no-optional'
+      - func: bootstrap mongo-orchestration
+        vars:
+          VERSION: '6.0'
+          AUTH: auth
+          ORCHESTRATION_FILE: auth-aws.json
+          TOPOLOGY: server
+      - func: add aws auth variables to file
+      - func: setup aws env
+      - *ref_9
+  - name: aws-6.0-auth-test-run-aws-auth-test-with-aws-credentials-and-session-token-as-environment-variables-no-optional
+    commands:
+      - func: install dependencies
+        vars:
+          NPM_OPTIONS: '--no-optional'
+      - func: bootstrap mongo-orchestration
+        vars:
+          VERSION: '6.0'
+          AUTH: auth
+          ORCHESTRATION_FILE: auth-aws.json
+          TOPOLOGY: server
+      - func: add aws auth variables to file
+      - func: setup aws env
+      - *ref_10
+  - name: aws-6.0-auth-test-run-aws-ECS-auth-test-no-optional
+    commands:
+      - func: install dependencies
+        vars:
+          NPM_OPTIONS: '--no-optional'
+      - func: bootstrap mongo-orchestration
+        vars:
+          VERSION: '6.0'
+          AUTH: auth
+          ORCHESTRATION_FILE: auth-aws.json
+          TOPOLOGY: server
+      - func: add aws auth variables to file
+      - func: setup aws env
+      - *ref_11
   - name: aws-5.0-auth-test-run-aws-auth-test-with-regular-aws-credentials
     commands:
       - func: install dependencies
@@ -1519,7 +1699,8 @@ tasks:
           TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
-      - func: run aws auth test with regular aws credentials
+      - &ref_12
+        func: run aws auth test with regular aws credentials
   - name: aws-5.0-auth-test-run-aws-auth-test-with-assume-role-credentials
     commands:
       - func: install dependencies
@@ -1531,7 +1712,8 @@ tasks:
           TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
-      - func: run aws auth test with assume role credentials
+      - &ref_13
+        func: run aws auth test with assume role credentials
   - name: aws-5.0-auth-test-run-aws-auth-test-with-aws-EC2-credentials
     commands:
       - func: install dependencies
@@ -1543,7 +1725,8 @@ tasks:
           TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
-      - func: run aws auth test with aws EC2 credentials
+      - &ref_14
+        func: run aws auth test with aws EC2 credentials
   - name: aws-5.0-auth-test-run-aws-auth-test-with-aws-credentials-as-environment-variables
     commands:
       - func: install dependencies
@@ -1555,7 +1738,8 @@ tasks:
           TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
-      - func: run aws auth test with aws credentials as environment variables
+      - &ref_15
+        func: run aws auth test with aws credentials as environment variables
   - name: aws-5.0-auth-test-run-aws-auth-test-with-aws-credentials-and-session-token-as-environment-variables
     commands:
       - func: install dependencies
@@ -1567,7 +1751,8 @@ tasks:
           TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
-      - func: run aws auth test with aws credentials and session token as environment variables
+      - &ref_16
+        func: run aws auth test with aws credentials and session token as environment variables
   - name: aws-5.0-auth-test-run-aws-ECS-auth-test
     commands:
       - func: install dependencies
@@ -1579,7 +1764,92 @@ tasks:
           TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
-      - func: run aws ECS auth test
+      - &ref_17
+        func: run aws ECS auth test
+  - name: aws-5.0-auth-test-run-aws-auth-test-with-regular-aws-credentials-no-optional
+    commands:
+      - func: install dependencies
+        vars:
+          NPM_OPTIONS: '--no-optional'
+      - func: bootstrap mongo-orchestration
+        vars:
+          VERSION: '5.0'
+          AUTH: auth
+          ORCHESTRATION_FILE: auth-aws.json
+          TOPOLOGY: server
+      - func: add aws auth variables to file
+      - func: setup aws env
+      - *ref_12
+  - name: aws-5.0-auth-test-run-aws-auth-test-with-assume-role-credentials-no-optional
+    commands:
+      - func: install dependencies
+        vars:
+          NPM_OPTIONS: '--no-optional'
+      - func: bootstrap mongo-orchestration
+        vars:
+          VERSION: '5.0'
+          AUTH: auth
+          ORCHESTRATION_FILE: auth-aws.json
+          TOPOLOGY: server
+      - func: add aws auth variables to file
+      - func: setup aws env
+      - *ref_13
+  - name: aws-5.0-auth-test-run-aws-auth-test-with-aws-EC2-credentials-no-optional
+    commands:
+      - func: install dependencies
+        vars:
+          NPM_OPTIONS: '--no-optional'
+      - func: bootstrap mongo-orchestration
+        vars:
+          VERSION: '5.0'
+          AUTH: auth
+          ORCHESTRATION_FILE: auth-aws.json
+          TOPOLOGY: server
+      - func: add aws auth variables to file
+      - func: setup aws env
+      - *ref_14
+  - name: aws-5.0-auth-test-run-aws-auth-test-with-aws-credentials-as-environment-variables-no-optional
+    commands:
+      - func: install dependencies
+        vars:
+          NPM_OPTIONS: '--no-optional'
+      - func: bootstrap mongo-orchestration
+        vars:
+          VERSION: '5.0'
+          AUTH: auth
+          ORCHESTRATION_FILE: auth-aws.json
+          TOPOLOGY: server
+      - func: add aws auth variables to file
+      - func: setup aws env
+      - *ref_15
+  - name: aws-5.0-auth-test-run-aws-auth-test-with-aws-credentials-and-session-token-as-environment-variables-no-optional
+    commands:
+      - func: install dependencies
+        vars:
+          NPM_OPTIONS: '--no-optional'
+      - func: bootstrap mongo-orchestration
+        vars:
+          VERSION: '5.0'
+          AUTH: auth
+          ORCHESTRATION_FILE: auth-aws.json
+          TOPOLOGY: server
+      - func: add aws auth variables to file
+      - func: setup aws env
+      - *ref_16
+  - name: aws-5.0-auth-test-run-aws-ECS-auth-test-no-optional
+    commands:
+      - func: install dependencies
+        vars:
+          NPM_OPTIONS: '--no-optional'
+      - func: bootstrap mongo-orchestration
+        vars:
+          VERSION: '5.0'
+          AUTH: auth
+          ORCHESTRATION_FILE: auth-aws.json
+          TOPOLOGY: server
+      - func: add aws auth variables to file
+      - func: setup aws env
+      - *ref_17
   - name: aws-4.4-auth-test-run-aws-auth-test-with-regular-aws-credentials
     commands:
       - func: install dependencies
@@ -1591,7 +1861,8 @@ tasks:
           TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
-      - func: run aws auth test with regular aws credentials
+      - &ref_18
+        func: run aws auth test with regular aws credentials
   - name: aws-4.4-auth-test-run-aws-auth-test-with-assume-role-credentials
     commands:
       - func: install dependencies
@@ -1603,7 +1874,8 @@ tasks:
           TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
-      - func: run aws auth test with assume role credentials
+      - &ref_19
+        func: run aws auth test with assume role credentials
   - name: aws-4.4-auth-test-run-aws-auth-test-with-aws-EC2-credentials
     commands:
       - func: install dependencies
@@ -1615,7 +1887,8 @@ tasks:
           TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
-      - func: run aws auth test with aws EC2 credentials
+      - &ref_20
+        func: run aws auth test with aws EC2 credentials
   - name: aws-4.4-auth-test-run-aws-auth-test-with-aws-credentials-as-environment-variables
     commands:
       - func: install dependencies
@@ -1627,7 +1900,8 @@ tasks:
           TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
-      - func: run aws auth test with aws credentials as environment variables
+      - &ref_21
+        func: run aws auth test with aws credentials as environment variables
   - name: aws-4.4-auth-test-run-aws-auth-test-with-aws-credentials-and-session-token-as-environment-variables
     commands:
       - func: install dependencies
@@ -1639,7 +1913,8 @@ tasks:
           TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
-      - func: run aws auth test with aws credentials and session token as environment variables
+      - &ref_22
+        func: run aws auth test with aws credentials and session token as environment variables
   - name: aws-4.4-auth-test-run-aws-ECS-auth-test
     commands:
       - func: install dependencies
@@ -1651,7 +1926,92 @@ tasks:
           TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
-      - func: run aws ECS auth test
+      - &ref_23
+        func: run aws ECS auth test
+  - name: aws-4.4-auth-test-run-aws-auth-test-with-regular-aws-credentials-no-optional
+    commands:
+      - func: install dependencies
+        vars:
+          NPM_OPTIONS: '--no-optional'
+      - func: bootstrap mongo-orchestration
+        vars:
+          VERSION: '4.4'
+          AUTH: auth
+          ORCHESTRATION_FILE: auth-aws.json
+          TOPOLOGY: server
+      - func: add aws auth variables to file
+      - func: setup aws env
+      - *ref_18
+  - name: aws-4.4-auth-test-run-aws-auth-test-with-assume-role-credentials-no-optional
+    commands:
+      - func: install dependencies
+        vars:
+          NPM_OPTIONS: '--no-optional'
+      - func: bootstrap mongo-orchestration
+        vars:
+          VERSION: '4.4'
+          AUTH: auth
+          ORCHESTRATION_FILE: auth-aws.json
+          TOPOLOGY: server
+      - func: add aws auth variables to file
+      - func: setup aws env
+      - *ref_19
+  - name: aws-4.4-auth-test-run-aws-auth-test-with-aws-EC2-credentials-no-optional
+    commands:
+      - func: install dependencies
+        vars:
+          NPM_OPTIONS: '--no-optional'
+      - func: bootstrap mongo-orchestration
+        vars:
+          VERSION: '4.4'
+          AUTH: auth
+          ORCHESTRATION_FILE: auth-aws.json
+          TOPOLOGY: server
+      - func: add aws auth variables to file
+      - func: setup aws env
+      - *ref_20
+  - name: aws-4.4-auth-test-run-aws-auth-test-with-aws-credentials-as-environment-variables-no-optional
+    commands:
+      - func: install dependencies
+        vars:
+          NPM_OPTIONS: '--no-optional'
+      - func: bootstrap mongo-orchestration
+        vars:
+          VERSION: '4.4'
+          AUTH: auth
+          ORCHESTRATION_FILE: auth-aws.json
+          TOPOLOGY: server
+      - func: add aws auth variables to file
+      - func: setup aws env
+      - *ref_21
+  - name: aws-4.4-auth-test-run-aws-auth-test-with-aws-credentials-and-session-token-as-environment-variables-no-optional
+    commands:
+      - func: install dependencies
+        vars:
+          NPM_OPTIONS: '--no-optional'
+      - func: bootstrap mongo-orchestration
+        vars:
+          VERSION: '4.4'
+          AUTH: auth
+          ORCHESTRATION_FILE: auth-aws.json
+          TOPOLOGY: server
+      - func: add aws auth variables to file
+      - func: setup aws env
+      - *ref_22
+  - name: aws-4.4-auth-test-run-aws-ECS-auth-test-no-optional
+    commands:
+      - func: install dependencies
+        vars:
+          NPM_OPTIONS: '--no-optional'
+      - func: bootstrap mongo-orchestration
+        vars:
+          VERSION: '4.4'
+          AUTH: auth
+          ORCHESTRATION_FILE: auth-aws.json
+          TOPOLOGY: server
+      - func: add aws auth variables to file
+      - func: setup aws env
+      - *ref_23
   - name: run-unit-tests
     tags:
       - run-unit-tests
@@ -2631,24 +2991,49 @@ buildvariants:
       - aws-latest-auth-test-run-aws-auth-test-with-aws-credentials-as-environment-variables
       - aws-latest-auth-test-run-aws-auth-test-with-aws-credentials-and-session-token-as-environment-variables
       - aws-latest-auth-test-run-aws-ECS-auth-test
+      - aws-latest-auth-test-run-aws-auth-test-with-regular-aws-credentials-no-optional
+      - aws-latest-auth-test-run-aws-auth-test-with-assume-role-credentials-no-optional
+      - aws-latest-auth-test-run-aws-auth-test-with-aws-EC2-credentials-no-optional
+      - aws-latest-auth-test-run-aws-auth-test-with-aws-credentials-as-environment-variables-no-optional
+      - >-
+        aws-latest-auth-test-run-aws-auth-test-with-aws-credentials-and-session-token-as-environment-variables-no-optional
+      - aws-latest-auth-test-run-aws-ECS-auth-test-no-optional
       - aws-6.0-auth-test-run-aws-auth-test-with-regular-aws-credentials
       - aws-6.0-auth-test-run-aws-auth-test-with-assume-role-credentials
       - aws-6.0-auth-test-run-aws-auth-test-with-aws-EC2-credentials
       - aws-6.0-auth-test-run-aws-auth-test-with-aws-credentials-as-environment-variables
       - aws-6.0-auth-test-run-aws-auth-test-with-aws-credentials-and-session-token-as-environment-variables
       - aws-6.0-auth-test-run-aws-ECS-auth-test
+      - aws-6.0-auth-test-run-aws-auth-test-with-regular-aws-credentials-no-optional
+      - aws-6.0-auth-test-run-aws-auth-test-with-assume-role-credentials-no-optional
+      - aws-6.0-auth-test-run-aws-auth-test-with-aws-EC2-credentials-no-optional
+      - aws-6.0-auth-test-run-aws-auth-test-with-aws-credentials-as-environment-variables-no-optional
+      - aws-6.0-auth-test-run-aws-auth-test-with-aws-credentials-and-session-token-as-environment-variables-no-optional
+      - aws-6.0-auth-test-run-aws-ECS-auth-test-no-optional
       - aws-5.0-auth-test-run-aws-auth-test-with-regular-aws-credentials
       - aws-5.0-auth-test-run-aws-auth-test-with-assume-role-credentials
       - aws-5.0-auth-test-run-aws-auth-test-with-aws-EC2-credentials
       - aws-5.0-auth-test-run-aws-auth-test-with-aws-credentials-as-environment-variables
       - aws-5.0-auth-test-run-aws-auth-test-with-aws-credentials-and-session-token-as-environment-variables
       - aws-5.0-auth-test-run-aws-ECS-auth-test
+      - aws-5.0-auth-test-run-aws-auth-test-with-regular-aws-credentials-no-optional
+      - aws-5.0-auth-test-run-aws-auth-test-with-assume-role-credentials-no-optional
+      - aws-5.0-auth-test-run-aws-auth-test-with-aws-EC2-credentials-no-optional
+      - aws-5.0-auth-test-run-aws-auth-test-with-aws-credentials-as-environment-variables-no-optional
+      - aws-5.0-auth-test-run-aws-auth-test-with-aws-credentials-and-session-token-as-environment-variables-no-optional
+      - aws-5.0-auth-test-run-aws-ECS-auth-test-no-optional
       - aws-4.4-auth-test-run-aws-auth-test-with-regular-aws-credentials
       - aws-4.4-auth-test-run-aws-auth-test-with-assume-role-credentials
       - aws-4.4-auth-test-run-aws-auth-test-with-aws-EC2-credentials
       - aws-4.4-auth-test-run-aws-auth-test-with-aws-credentials-as-environment-variables
       - aws-4.4-auth-test-run-aws-auth-test-with-aws-credentials-and-session-token-as-environment-variables
       - aws-4.4-auth-test-run-aws-ECS-auth-test
+      - aws-4.4-auth-test-run-aws-auth-test-with-regular-aws-credentials-no-optional
+      - aws-4.4-auth-test-run-aws-auth-test-with-assume-role-credentials-no-optional
+      - aws-4.4-auth-test-run-aws-auth-test-with-aws-EC2-credentials-no-optional
+      - aws-4.4-auth-test-run-aws-auth-test-with-aws-credentials-as-environment-variables-no-optional
+      - aws-4.4-auth-test-run-aws-auth-test-with-aws-credentials-and-session-token-as-environment-variables-no-optional
+      - aws-4.4-auth-test-run-aws-ECS-auth-test-no-optional
   - name: rhel8-custom-dependency-tests
     display_name: Custom Dependency Version Test
     run_on: rhel80-large

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -308,7 +308,7 @@ const AWS_AUTH_TASKS = [];
 
 for (const VERSION of AWS_AUTH_VERSIONS) {
   const name = ex => `aws-${VERSION}-auth-test-${ex.split(' ').join('-')}`;
-  const aws_funcs = [
+  const awsFuncs = [
     { func: 'run aws auth test with regular aws credentials' },
     { func: 'run aws auth test with assume role credentials' },
     { func: 'run aws auth test with aws EC2 credentials' },
@@ -317,7 +317,7 @@ for (const VERSION of AWS_AUTH_VERSIONS) {
     { func: 'run aws ECS auth test' }
   ];
 
-  const aws_tasks = aws_funcs.map(fn => ({
+  const awsTasks = awsFuncs.map(fn => ({
     name: name(fn.func),
     commands: [
       { func: 'install dependencies' },
@@ -336,8 +336,34 @@ for (const VERSION of AWS_AUTH_VERSIONS) {
     ]
   }));
 
-  TASKS.push(...aws_tasks);
-  AWS_AUTH_TASKS.push(...aws_tasks.map(t => t.name));
+  const awsNoOptionalTasks = awsFuncs.map(fn => ({
+    name: `${name(fn.func)}-no-optional`,
+    commands: [
+      {
+        func: 'install dependencies',
+        vars: {
+          NPM_OPTIONS: '--no-optional'
+        }
+      },
+      {
+        func: 'bootstrap mongo-orchestration',
+        vars: {
+          VERSION: VERSION,
+          AUTH: 'auth',
+          ORCHESTRATION_FILE: 'auth-aws.json',
+          TOPOLOGY: 'server'
+        }
+      },
+      { func: 'add aws auth variables to file' },
+      { func: 'setup aws env' },
+      fn
+    ]
+  }));
+
+  const allAwsTasks = awsTasks.concat(awsNoOptionalTasks);
+
+  TASKS.push(...allAwsTasks);
+  AWS_AUTH_TASKS.push(...allAwsTasks.map(t => t.name));
 }
 
 const BUILD_VARIANTS = [];

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -110,4 +110,4 @@ tmp=${NPM_TMP_DIR}
 EOT
 fi
 
-npm install
+npm install ${NPM_OPTIONS}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "4.10.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@aws-sdk/credential-providers": "*",
         "bson": "^4.7.0",
         "denque": "^2.1.0",
         "mongodb-connection-string-url": "^2.5.3",
@@ -66,6 +67,7 @@
         "node": ">=12.9.0"
       },
       "optionalDependencies": {
+        "@aws-sdk/credential-providers": "^3.186.0",
         "saslprep": "^1.0.3"
       }
     },
@@ -81,6 +83,1259 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/@aws-crypto/ie11-detection": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.2.tgz",
+      "integrity": "sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
+      "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/ie11-detection": "^2.0.0",
+        "@aws-crypto/sha256-js": "^2.0.0",
+        "@aws-crypto/supports-web-crypto": "^2.0.0",
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
+      "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.2.tgz",
+      "integrity": "sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.2.tgz",
+      "integrity": "sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.110.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/abort-controller": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.186.0.tgz",
+      "integrity": "sha512-JFvvvtEcbYOvVRRXasi64Dd1VcOz5kJmPvtzsJ+HzMHvPbGGs/aopOJAZQJMJttzJmJwVTay0QL6yag9Kk8nYA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/abort-controller/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/client-cognito-identity": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.186.0.tgz",
+      "integrity": "sha512-WGWGAozf4f+znTmV3UC7F/3wvZeO2Hcza1v4zy/yD83yoYtMoSc+X71lDw6SS56snPsxHkXRSppvqliOL7J0kA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/client-sts": "3.186.0",
+        "@aws-sdk/config-resolver": "3.186.0",
+        "@aws-sdk/credential-provider-node": "3.186.0",
+        "@aws-sdk/fetch-http-handler": "3.186.0",
+        "@aws-sdk/hash-node": "3.186.0",
+        "@aws-sdk/invalid-dependency": "3.186.0",
+        "@aws-sdk/middleware-content-length": "3.186.0",
+        "@aws-sdk/middleware-host-header": "3.186.0",
+        "@aws-sdk/middleware-logger": "3.186.0",
+        "@aws-sdk/middleware-recursion-detection": "3.186.0",
+        "@aws-sdk/middleware-retry": "3.186.0",
+        "@aws-sdk/middleware-serde": "3.186.0",
+        "@aws-sdk/middleware-signing": "3.186.0",
+        "@aws-sdk/middleware-stack": "3.186.0",
+        "@aws-sdk/middleware-user-agent": "3.186.0",
+        "@aws-sdk/node-config-provider": "3.186.0",
+        "@aws-sdk/node-http-handler": "3.186.0",
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/smithy-client": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/url-parser": "3.186.0",
+        "@aws-sdk/util-base64-browser": "3.186.0",
+        "@aws-sdk/util-base64-node": "3.186.0",
+        "@aws-sdk/util-body-length-browser": "3.186.0",
+        "@aws-sdk/util-body-length-node": "3.186.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.186.0",
+        "@aws-sdk/util-defaults-mode-node": "3.186.0",
+        "@aws-sdk/util-user-agent-browser": "3.186.0",
+        "@aws-sdk/util-user-agent-node": "3.186.0",
+        "@aws-sdk/util-utf8-browser": "3.186.0",
+        "@aws-sdk/util-utf8-node": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/client-sso": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.186.0.tgz",
+      "integrity": "sha512-qwLPomqq+fjvp42izzEpBEtGL2+dIlWH5pUCteV55hTEwHgo+m9LJPIrMWkPeoMBzqbNiu5n6+zihnwYlCIlEA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.186.0",
+        "@aws-sdk/fetch-http-handler": "3.186.0",
+        "@aws-sdk/hash-node": "3.186.0",
+        "@aws-sdk/invalid-dependency": "3.186.0",
+        "@aws-sdk/middleware-content-length": "3.186.0",
+        "@aws-sdk/middleware-host-header": "3.186.0",
+        "@aws-sdk/middleware-logger": "3.186.0",
+        "@aws-sdk/middleware-recursion-detection": "3.186.0",
+        "@aws-sdk/middleware-retry": "3.186.0",
+        "@aws-sdk/middleware-serde": "3.186.0",
+        "@aws-sdk/middleware-stack": "3.186.0",
+        "@aws-sdk/middleware-user-agent": "3.186.0",
+        "@aws-sdk/node-config-provider": "3.186.0",
+        "@aws-sdk/node-http-handler": "3.186.0",
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/smithy-client": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/url-parser": "3.186.0",
+        "@aws-sdk/util-base64-browser": "3.186.0",
+        "@aws-sdk/util-base64-node": "3.186.0",
+        "@aws-sdk/util-body-length-browser": "3.186.0",
+        "@aws-sdk/util-body-length-node": "3.186.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.186.0",
+        "@aws-sdk/util-defaults-mode-node": "3.186.0",
+        "@aws-sdk/util-user-agent-browser": "3.186.0",
+        "@aws-sdk/util-user-agent-node": "3.186.0",
+        "@aws-sdk/util-utf8-browser": "3.186.0",
+        "@aws-sdk/util-utf8-node": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/client-sts": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.186.0.tgz",
+      "integrity": "sha512-lyAPI6YmIWWYZHQ9fBZ7QgXjGMTtktL5fk8kOcZ98ja+8Vu0STH1/u837uxqvZta8/k0wijunIL3jWUhjsNRcg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.186.0",
+        "@aws-sdk/credential-provider-node": "3.186.0",
+        "@aws-sdk/fetch-http-handler": "3.186.0",
+        "@aws-sdk/hash-node": "3.186.0",
+        "@aws-sdk/invalid-dependency": "3.186.0",
+        "@aws-sdk/middleware-content-length": "3.186.0",
+        "@aws-sdk/middleware-host-header": "3.186.0",
+        "@aws-sdk/middleware-logger": "3.186.0",
+        "@aws-sdk/middleware-recursion-detection": "3.186.0",
+        "@aws-sdk/middleware-retry": "3.186.0",
+        "@aws-sdk/middleware-sdk-sts": "3.186.0",
+        "@aws-sdk/middleware-serde": "3.186.0",
+        "@aws-sdk/middleware-signing": "3.186.0",
+        "@aws-sdk/middleware-stack": "3.186.0",
+        "@aws-sdk/middleware-user-agent": "3.186.0",
+        "@aws-sdk/node-config-provider": "3.186.0",
+        "@aws-sdk/node-http-handler": "3.186.0",
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/smithy-client": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/url-parser": "3.186.0",
+        "@aws-sdk/util-base64-browser": "3.186.0",
+        "@aws-sdk/util-base64-node": "3.186.0",
+        "@aws-sdk/util-body-length-browser": "3.186.0",
+        "@aws-sdk/util-body-length-node": "3.186.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.186.0",
+        "@aws-sdk/util-defaults-mode-node": "3.186.0",
+        "@aws-sdk/util-user-agent-browser": "3.186.0",
+        "@aws-sdk/util-user-agent-node": "3.186.0",
+        "@aws-sdk/util-utf8-browser": "3.186.0",
+        "@aws-sdk/util-utf8-node": "3.186.0",
+        "entities": "2.2.0",
+        "fast-xml-parser": "3.19.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/config-resolver": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.186.0.tgz",
+      "integrity": "sha512-l8DR7Q4grEn1fgo2/KvtIfIHJS33HGKPQnht8OPxkl0dMzOJ0jxjOw/tMbrIcPnr2T3Fi7LLcj3dY1Fo1poruQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/signature-v4": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/util-config-provider": "3.186.0",
+        "@aws-sdk/util-middleware": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/config-resolver/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/credential-provider-cognito-identity": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.186.0.tgz",
+      "integrity": "sha512-5Zk1DT0EFYBqXqkggnaGTnwSh5L7dGm7S2dQbbopMxzS9pmZNxQtixOVp6F1bRPq5skqgQoiPk5OkSbvD3tSIA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/client-cognito-identity": "3.186.0",
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.186.0.tgz",
+      "integrity": "sha512-N9LPAqi1lsQWgxzmU4NPvLPnCN5+IQ3Ai1IFf3wM6FFPNoSUd1kIA2c6xaf0BE7j5Kelm0raZOb4LnV3TBAv+g==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/credential-provider-imds": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.186.0.tgz",
+      "integrity": "sha512-iJeC7KrEgPPAuXjCZ3ExYZrRQvzpSdTZopYgUm5TnNZ8S1NU/4nvv5xVy61JvMj3JQAeG8UDYYgC421Foc8wQw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.186.0",
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/url-parser": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-imds/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.186.0.tgz",
+      "integrity": "sha512-ecrFh3MoZhAj5P2k/HXo/hMJQ3sfmvlommzXuZ/D1Bj2yMcyWuBhF1A83Fwd2gtYrWRrllsK3IOMM5Jr8UIVZA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.186.0",
+        "@aws-sdk/credential-provider-imds": "3.186.0",
+        "@aws-sdk/credential-provider-sso": "3.186.0",
+        "@aws-sdk/credential-provider-web-identity": "3.186.0",
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/shared-ini-file-loader": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.186.0.tgz",
+      "integrity": "sha512-HIt2XhSRhEvVgRxTveLCzIkd/SzEBQfkQ6xMJhkBtfJw1o3+jeCk+VysXM0idqmXytctL0O3g9cvvTHOsUgxOA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.186.0",
+        "@aws-sdk/credential-provider-imds": "3.186.0",
+        "@aws-sdk/credential-provider-ini": "3.186.0",
+        "@aws-sdk/credential-provider-process": "3.186.0",
+        "@aws-sdk/credential-provider-sso": "3.186.0",
+        "@aws-sdk/credential-provider-web-identity": "3.186.0",
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/shared-ini-file-loader": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.186.0.tgz",
+      "integrity": "sha512-ATRU6gbXvWC1TLnjOEZugC/PBXHBoZgBADid4fDcEQY1vF5e5Ux1kmqkJxyHtV5Wl8sE2uJfwWn+FlpUHRX67g==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/shared-ini-file-loader": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.186.0.tgz",
+      "integrity": "sha512-mJ+IZljgXPx99HCmuLgBVDPLepHrwqnEEC/0wigrLCx6uz3SrAWmGZsNbxSEtb2CFSAaczlTHcU/kIl7XZIyeQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.186.0",
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/shared-ini-file-loader": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.186.0.tgz",
+      "integrity": "sha512-KqzI5eBV72FE+8SuOQAu+r53RXGVHg4AuDJmdXyo7Gc4wS/B9FNElA8jVUjjYgVnf0FSiri+l41VzQ44dCopSA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/credential-providers": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.186.0.tgz",
+      "integrity": "sha512-Jw/oIqbdjXp4+FUt0GoHwSJsqGkkaZ7pOjblcVM4uXyZJTKYeXc7o5w/NefnfPyyx/aoBnRZkPCTv87woI/WQg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/client-cognito-identity": "3.186.0",
+        "@aws-sdk/client-sso": "3.186.0",
+        "@aws-sdk/client-sts": "3.186.0",
+        "@aws-sdk/credential-provider-cognito-identity": "3.186.0",
+        "@aws-sdk/credential-provider-env": "3.186.0",
+        "@aws-sdk/credential-provider-imds": "3.186.0",
+        "@aws-sdk/credential-provider-ini": "3.186.0",
+        "@aws-sdk/credential-provider-node": "3.186.0",
+        "@aws-sdk/credential-provider-process": "3.186.0",
+        "@aws-sdk/credential-provider-sso": "3.186.0",
+        "@aws-sdk/credential-provider-web-identity": "3.186.0",
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/shared-ini-file-loader": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/fetch-http-handler": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.186.0.tgz",
+      "integrity": "sha512-k2v4AAHRD76WnLg7arH94EvIclClo/YfuqO7NoQ6/KwOxjRhs4G6TgIsAZ9E0xmqoJoV81Xqy8H8ldfy9F8LEw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/querystring-builder": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/util-base64-browser": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/fetch-http-handler/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/hash-node": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.186.0.tgz",
+      "integrity": "sha512-G3zuK8/3KExDTxqrGqko+opOMLRF0BwcwekV/wm3GKIM/NnLhHblBs2zd/yi7VsEoWmuzibfp6uzxgFpEoJ87w==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/util-buffer-from": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/hash-node/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/invalid-dependency": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.186.0.tgz",
+      "integrity": "sha512-hjeZKqORhG2DPWYZ776lQ9YO3gjw166vZHZCZU/43kEYaCZHsF4mexHwHzreAY6RfS25cH60Um7dUh1aeVIpkw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/invalid-dependency/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.186.0.tgz",
+      "integrity": "sha512-fObm+P6mjWYzxoFY4y2STHBmSdgKbIAXez0xope563mox62I8I4hhVPUCaDVydXvDpJv8tbedJMk0meJl22+xA==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/is-array-buffer/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/middleware-content-length": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.186.0.tgz",
+      "integrity": "sha512-Ol3c1ks3IK1s+Okc/rHIX7w2WpXofuQdoAEme37gHeml+8FtUlWH/881h62xfMdf+0YZpRuYv/eM7lBmJBPNJw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-content-length/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.186.0.tgz",
+      "integrity": "sha512-5bTzrRzP2IGwyF3QCyMGtSXpOOud537x32htZf344IvVjrqZF/P8CDfGTkHkeBCIH+wnJxjK+l/QBb3ypAMIqQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.186.0.tgz",
+      "integrity": "sha512-/1gGBImQT8xYh80pB7QtyzA799TqXtLZYQUohWAsFReYB7fdh5o+mu2rX0FNzZnrLIh2zBUNs4yaWGsnab4uXg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.186.0.tgz",
+      "integrity": "sha512-Za7k26Kovb4LuV5tmC6wcVILDCt0kwztwSlB991xk4vwNTja8kKxSt53WsYG8Q2wSaW6UOIbSoguZVyxbIY07Q==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/middleware-retry": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.186.0.tgz",
+      "integrity": "sha512-/VI9emEKhhDzlNv9lQMmkyxx3GjJ8yPfXH3HuAeOgM1wx1BjCTLRYEWnTbQwq7BDzVENdneleCsGAp7yaj80Aw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/service-error-classification": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/util-middleware": "3.186.0",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-retry/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sts": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.186.0.tgz",
+      "integrity": "sha512-GDcK0O8rjtnd+XRGnxzheq1V2jk4Sj4HtjrxW/ROyhzLOAOyyxutBt+/zOpDD6Gba3qxc69wE+Cf/qngOkEkDw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/middleware-signing": "3.186.0",
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/signature-v4": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sts/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/middleware-serde": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.186.0.tgz",
+      "integrity": "sha512-6FEAz70RNf18fKL5O7CepPSwTKJEIoyG9zU6p17GzKMgPeFsxS5xO94Hcq5tV2/CqeHliebjqhKY7yi+Pgok7g==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-serde/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.186.0.tgz",
+      "integrity": "sha512-riCJYG/LlF/rkgVbHkr4xJscc0/sECzDivzTaUmfb9kJhAwGxCyNqnTvg0q6UO00kxSdEB9zNZI2/iJYVBijBQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/signature-v4": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/util-middleware": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-signing/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/middleware-stack": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.186.0.tgz",
+      "integrity": "sha512-fENMoo0pW7UBrbuycPf+3WZ+fcUgP9PnQ0jcOK3WWZlZ9d2ewh4HNxLh4EE3NkNYj4VIUFXtTUuVNHlG8trXjQ==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-stack/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.186.0.tgz",
+      "integrity": "sha512-fb+F2PF9DLKOVMgmhkr+ltN8ZhNJavTla9aqmbd01846OLEaN1n5xEnV7p8q5+EznVBWDF38Oz9Ae5BMt3Hs7w==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/node-config-provider": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.186.0.tgz",
+      "integrity": "sha512-De93mgmtuUUeoiKXU8pVHXWKPBfJQlS/lh1k2H9T2Pd9Tzi0l7p5ttddx4BsEx4gk+Pc5flNz+DeptiSjZpa4A==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/shared-ini-file-loader": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-config-provider/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.186.0.tgz",
+      "integrity": "sha512-CbkbDuPZT9UNJ4dAZJWB3BV+Z65wFy7OduqGkzNNrKq6ZYMUfehthhUOTk8vU6RMe/0FkN+J0fFXlBx/bs/cHw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.186.0",
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/querystring-builder": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-http-handler/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/property-provider": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.186.0.tgz",
+      "integrity": "sha512-nWKqt36UW3xV23RlHUmat+yevw9up+T+953nfjcmCBKtgWlCWu/aUzewTRhKj3VRscbN+Wer95SBw9Lr/MMOlQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/property-provider/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/protocol-http": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.186.0.tgz",
+      "integrity": "sha512-l/KYr/UBDUU5ginqTgHtFfHR3X6ljf/1J1ThIiUg3C3kVC/Zwztm7BEOw8hHRWnWQGU/jYasGYcrcPLdQqFZyQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/protocol-http/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.186.0.tgz",
+      "integrity": "sha512-mweCpuLufImxfq/rRBTEpjGuB4xhQvbokA+otjnUxlPdIobytLqEs7pCGQfLzQ7+1ZMo8LBXt70RH4A2nSX/JQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/util-uri-escape": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/querystring-builder/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/querystring-parser": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.186.0.tgz",
+      "integrity": "sha512-0iYfEloghzPVXJjmnzHamNx1F1jIiTW9Svy5ZF9LVqyr/uHZcQuiWYsuhWloBMLs8mfWarkZM02WfxZ8buAuhg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/querystring-parser/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/service-error-classification": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.186.0.tgz",
+      "integrity": "sha512-DRl3ORk4tF+jmH5uvftlfaq0IeKKpt0UPAOAFQ/JFWe+TjOcQd/K+VC0iiIG97YFp3aeFmH1JbEgsNxd+8fdxw==",
+      "optional": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.186.0.tgz",
+      "integrity": "sha512-2FZqxmICtwN9CYid4dwfJSz/gGFHyStFQ3HCOQ8DsJUf2yREMSBsVmKqsyWgOrYcQ98gPcD5GIa7QO5yl3XF6A==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/shared-ini-file-loader/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/signature-v4": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.186.0.tgz",
+      "integrity": "sha512-18i96P5c4suMqwSNhnEOqhq4doqqyjH4fn0YV3F8TkekHPIWP4mtIJ0PWAN4eievqdtcKgD/GqVO6FaJG9texw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/util-hex-encoding": "3.186.0",
+        "@aws-sdk/util-middleware": "3.186.0",
+        "@aws-sdk/util-uri-escape": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/smithy-client": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.186.0.tgz",
+      "integrity": "sha512-rdAxSFGSnrSprVJ6i1BXi65r4X14cuya6fYe8dSdgmFSa+U2ZevT97lb3tSINCUxBGeMXhENIzbVGkRZuMh+DQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/middleware-stack": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/smithy-client/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.186.0.tgz",
+      "integrity": "sha512-NatmSU37U+XauMFJCdFI6nougC20JUFZar+ump5wVv0i54H+2Refg1YbFDxSs0FY28TSB9jfhWIpfFBmXgL5MQ==",
+      "optional": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/url-parser": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.186.0.tgz",
+      "integrity": "sha512-jfdJkKqJZp8qjjwEjIGDqbqTuajBsddw02f86WiL8bPqD8W13/hdqbG4Fpwc+Bm6GwR6/4MY6xWXFnk8jDUKeA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/querystring-parser": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/url-parser/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/util-base64-browser": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.186.0.tgz",
+      "integrity": "sha512-TpQL8opoFfzTwUDxKeon/vuc83kGXpYqjl6hR8WzmHoQgmFfdFlV+0KXZOohra1001OP3FhqvMqaYbO8p9vXVQ==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-base64-browser/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/util-base64-node": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.186.0.tgz",
+      "integrity": "sha512-wH5Y/EQNBfGS4VkkmiMyZXU+Ak6VCoFM1GKWopV+sj03zR2D4FHexi4SxWwEBMpZCd6foMtihhbNBuPA5fnh6w==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-base64-node/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/util-body-length-browser": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.186.0.tgz",
+      "integrity": "sha512-zKtjkI/dkj9oGkjo+7fIz+I9KuHrVt1ROAeL4OmDESS8UZi3/O8uMDFMuCp8jft6H+WFuYH6qRVWAVwXMiasXw==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-body-length-browser/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/util-body-length-node": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.186.0.tgz",
+      "integrity": "sha512-U7Ii8u8Wvu9EnBWKKeuwkdrWto3c0j7LG677Spe6vtwWkvY70n9WGfiKHTgBpVeLNv8jvfcx5+H0UOPQK1o9SQ==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-body-length-node/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.186.0.tgz",
+      "integrity": "sha512-be2GCk2lsLWg/2V5Y+S4/9pOMXhOQo4DR4dIqBdR2R+jrMMHN9Xsr5QrkT6chcqLaJ/SBlwiAEEi3StMRmCOXA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-buffer-from/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/util-config-provider": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.186.0.tgz",
+      "integrity": "sha512-71Qwu/PN02XsRLApyxG0EUy/NxWh/CXxtl2C7qY14t+KTiRapwbDkdJ1cMsqYqghYP4BwJoj1M+EFMQSSlkZQQ==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-config-provider/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.186.0.tgz",
+      "integrity": "sha512-U8GOfIdQ0dZ7RRVpPynGteAHx4URtEh+JfWHHVfS6xLPthPHWTbyRhkQX++K/F8Jk+T5U8Anrrqlea4TlcO2DA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-defaults-mode-browser/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/util-defaults-mode-node": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.186.0.tgz",
+      "integrity": "sha512-N6O5bpwCiE4z8y7SPHd7KYlszmNOYREa+mMgtOIXRU3VXSEHVKVWTZsHKvNTTHpW0qMqtgIvjvXCo3vsch5l3A==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/config-resolver": "3.186.0",
+        "@aws-sdk/credential-provider-imds": "3.186.0",
+        "@aws-sdk/node-config-provider": "3.186.0",
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-defaults-mode-node/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.186.0.tgz",
+      "integrity": "sha512-UL9rdgIZz1E/jpAfaKH8QgUxNK9VP5JPgoR0bSiaefMjnsoBh0x/VVMsfUyziOoJCMLebhJzFowtwrSKEGsxNg==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-hex-encoding/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.186.0.tgz",
+      "integrity": "sha512-fmQLkH16ga6c5fWsA+kBYklQJjlPlcc8uayTR4avi5g3Nxqm6wPpyUwo5CppwjwWMeS+NXG0HgITtkkGntcRNg==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/util-middleware": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.186.0.tgz",
+      "integrity": "sha512-fddwDgXtnHyL9mEZ4s1tBBsKnVQHqTUmFbZKUUKPrg9CxOh0Y/zZxEa5Olg/8dS/LzM1tvg0ATkcyd4/kEHIhg==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-middleware/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.186.0.tgz",
+      "integrity": "sha512-imtOrJFpIZAipAg8VmRqYwv1G/x4xzyoxOJ48ZSn1/ZGnKEEnB6n6E9gwYRebi4mlRuMSVeZwCPLq0ey5hReeQ==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-uri-escape/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.186.0.tgz",
+      "integrity": "sha512-fbRcTTutMk4YXY3A2LePI4jWSIeHOT8DaYavpc/9Xshz/WH9RTGMmokeVOcClRNBeDSi5cELPJJ7gx6SFD3ZlQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.186.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.186.0.tgz",
+      "integrity": "sha512-oWZR7hN6NtOgnT6fUvHaafgbipQc2xJCRB93XHiF9aZGptGNLJzznIOP7uURdn0bTnF73ejbUXWLQIm8/6ue6w==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/util-utf8-browser": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.186.0.tgz",
+      "integrity": "sha512-n+IdFYF/4qT2WxhMOCeig8LndDggaYHw3BJJtfIBZRiS16lgwcGYvOUmhCkn0aSlG1f/eyg9YZHQG0iz9eLdHQ==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8-browser/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/util-utf8-node": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.186.0.tgz",
+      "integrity": "sha512-7qlE0dOVdjuRbZTb7HFywnHHCrsN7AeQiTnsWT63mjXGDbPeUWQQw3TrdI20um3cxZXnKoeudGq8K6zbXyQ4iA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8-node/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "optional": true
     },
     "node_modules/@babel/code-frame": {
       "version": "7.18.6",
@@ -1780,6 +3035,12 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true
     },
+    "node_modules/bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+      "optional": true
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -2787,6 +4048,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+      "optional": true,
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -3439,6 +4709,19 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
+      "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg==",
+      "optional": true,
+      "bin": {
+        "xml2js": "cli.js"
+      },
+      "funding": {
+        "type": "paypal",
+        "url": "https://paypal.me/naturalintelligence"
+      }
     },
     "node_modules/fastq": {
       "version": "1.13.0",
@@ -7603,7 +8886,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -7828,7 +9111,7 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -8167,6 +9450,1212 @@
       "requires": {
         "@jridgewell/gen-mapping": "^0.1.0",
         "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "@aws-crypto/ie11-detection": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.2.tgz",
+      "integrity": "sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==",
+      "optional": true,
+      "requires": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "@aws-crypto/sha256-browser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
+      "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+      "optional": true,
+      "requires": {
+        "@aws-crypto/ie11-detection": "^2.0.0",
+        "@aws-crypto/sha256-js": "^2.0.0",
+        "@aws-crypto/supports-web-crypto": "^2.0.0",
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "@aws-crypto/sha256-js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
+      "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+      "optional": true,
+      "requires": {
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "@aws-crypto/supports-web-crypto": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.2.tgz",
+      "integrity": "sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==",
+      "optional": true,
+      "requires": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "@aws-crypto/util": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.2.tgz",
+      "integrity": "sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "^3.110.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "@aws-sdk/abort-controller": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.186.0.tgz",
+      "integrity": "sha512-JFvvvtEcbYOvVRRXasi64Dd1VcOz5kJmPvtzsJ+HzMHvPbGGs/aopOJAZQJMJttzJmJwVTay0QL6yag9Kk8nYA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/client-cognito-identity": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.186.0.tgz",
+      "integrity": "sha512-WGWGAozf4f+znTmV3UC7F/3wvZeO2Hcza1v4zy/yD83yoYtMoSc+X71lDw6SS56snPsxHkXRSppvqliOL7J0kA==",
+      "optional": true,
+      "requires": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/client-sts": "3.186.0",
+        "@aws-sdk/config-resolver": "3.186.0",
+        "@aws-sdk/credential-provider-node": "3.186.0",
+        "@aws-sdk/fetch-http-handler": "3.186.0",
+        "@aws-sdk/hash-node": "3.186.0",
+        "@aws-sdk/invalid-dependency": "3.186.0",
+        "@aws-sdk/middleware-content-length": "3.186.0",
+        "@aws-sdk/middleware-host-header": "3.186.0",
+        "@aws-sdk/middleware-logger": "3.186.0",
+        "@aws-sdk/middleware-recursion-detection": "3.186.0",
+        "@aws-sdk/middleware-retry": "3.186.0",
+        "@aws-sdk/middleware-serde": "3.186.0",
+        "@aws-sdk/middleware-signing": "3.186.0",
+        "@aws-sdk/middleware-stack": "3.186.0",
+        "@aws-sdk/middleware-user-agent": "3.186.0",
+        "@aws-sdk/node-config-provider": "3.186.0",
+        "@aws-sdk/node-http-handler": "3.186.0",
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/smithy-client": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/url-parser": "3.186.0",
+        "@aws-sdk/util-base64-browser": "3.186.0",
+        "@aws-sdk/util-base64-node": "3.186.0",
+        "@aws-sdk/util-body-length-browser": "3.186.0",
+        "@aws-sdk/util-body-length-node": "3.186.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.186.0",
+        "@aws-sdk/util-defaults-mode-node": "3.186.0",
+        "@aws-sdk/util-user-agent-browser": "3.186.0",
+        "@aws-sdk/util-user-agent-node": "3.186.0",
+        "@aws-sdk/util-utf8-browser": "3.186.0",
+        "@aws-sdk/util-utf8-node": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/client-sso": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.186.0.tgz",
+      "integrity": "sha512-qwLPomqq+fjvp42izzEpBEtGL2+dIlWH5pUCteV55hTEwHgo+m9LJPIrMWkPeoMBzqbNiu5n6+zihnwYlCIlEA==",
+      "optional": true,
+      "requires": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.186.0",
+        "@aws-sdk/fetch-http-handler": "3.186.0",
+        "@aws-sdk/hash-node": "3.186.0",
+        "@aws-sdk/invalid-dependency": "3.186.0",
+        "@aws-sdk/middleware-content-length": "3.186.0",
+        "@aws-sdk/middleware-host-header": "3.186.0",
+        "@aws-sdk/middleware-logger": "3.186.0",
+        "@aws-sdk/middleware-recursion-detection": "3.186.0",
+        "@aws-sdk/middleware-retry": "3.186.0",
+        "@aws-sdk/middleware-serde": "3.186.0",
+        "@aws-sdk/middleware-stack": "3.186.0",
+        "@aws-sdk/middleware-user-agent": "3.186.0",
+        "@aws-sdk/node-config-provider": "3.186.0",
+        "@aws-sdk/node-http-handler": "3.186.0",
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/smithy-client": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/url-parser": "3.186.0",
+        "@aws-sdk/util-base64-browser": "3.186.0",
+        "@aws-sdk/util-base64-node": "3.186.0",
+        "@aws-sdk/util-body-length-browser": "3.186.0",
+        "@aws-sdk/util-body-length-node": "3.186.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.186.0",
+        "@aws-sdk/util-defaults-mode-node": "3.186.0",
+        "@aws-sdk/util-user-agent-browser": "3.186.0",
+        "@aws-sdk/util-user-agent-node": "3.186.0",
+        "@aws-sdk/util-utf8-browser": "3.186.0",
+        "@aws-sdk/util-utf8-node": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/client-sts": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.186.0.tgz",
+      "integrity": "sha512-lyAPI6YmIWWYZHQ9fBZ7QgXjGMTtktL5fk8kOcZ98ja+8Vu0STH1/u837uxqvZta8/k0wijunIL3jWUhjsNRcg==",
+      "optional": true,
+      "requires": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.186.0",
+        "@aws-sdk/credential-provider-node": "3.186.0",
+        "@aws-sdk/fetch-http-handler": "3.186.0",
+        "@aws-sdk/hash-node": "3.186.0",
+        "@aws-sdk/invalid-dependency": "3.186.0",
+        "@aws-sdk/middleware-content-length": "3.186.0",
+        "@aws-sdk/middleware-host-header": "3.186.0",
+        "@aws-sdk/middleware-logger": "3.186.0",
+        "@aws-sdk/middleware-recursion-detection": "3.186.0",
+        "@aws-sdk/middleware-retry": "3.186.0",
+        "@aws-sdk/middleware-sdk-sts": "3.186.0",
+        "@aws-sdk/middleware-serde": "3.186.0",
+        "@aws-sdk/middleware-signing": "3.186.0",
+        "@aws-sdk/middleware-stack": "3.186.0",
+        "@aws-sdk/middleware-user-agent": "3.186.0",
+        "@aws-sdk/node-config-provider": "3.186.0",
+        "@aws-sdk/node-http-handler": "3.186.0",
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/smithy-client": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/url-parser": "3.186.0",
+        "@aws-sdk/util-base64-browser": "3.186.0",
+        "@aws-sdk/util-base64-node": "3.186.0",
+        "@aws-sdk/util-body-length-browser": "3.186.0",
+        "@aws-sdk/util-body-length-node": "3.186.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.186.0",
+        "@aws-sdk/util-defaults-mode-node": "3.186.0",
+        "@aws-sdk/util-user-agent-browser": "3.186.0",
+        "@aws-sdk/util-user-agent-node": "3.186.0",
+        "@aws-sdk/util-utf8-browser": "3.186.0",
+        "@aws-sdk/util-utf8-node": "3.186.0",
+        "entities": "2.2.0",
+        "fast-xml-parser": "3.19.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/config-resolver": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.186.0.tgz",
+      "integrity": "sha512-l8DR7Q4grEn1fgo2/KvtIfIHJS33HGKPQnht8OPxkl0dMzOJ0jxjOw/tMbrIcPnr2T3Fi7LLcj3dY1Fo1poruQ==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/signature-v4": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/util-config-provider": "3.186.0",
+        "@aws-sdk/util-middleware": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-cognito-identity": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.186.0.tgz",
+      "integrity": "sha512-5Zk1DT0EFYBqXqkggnaGTnwSh5L7dGm7S2dQbbopMxzS9pmZNxQtixOVp6F1bRPq5skqgQoiPk5OkSbvD3tSIA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/client-cognito-identity": "3.186.0",
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-env": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.186.0.tgz",
+      "integrity": "sha512-N9LPAqi1lsQWgxzmU4NPvLPnCN5+IQ3Ai1IFf3wM6FFPNoSUd1kIA2c6xaf0BE7j5Kelm0raZOb4LnV3TBAv+g==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-imds": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.186.0.tgz",
+      "integrity": "sha512-iJeC7KrEgPPAuXjCZ3ExYZrRQvzpSdTZopYgUm5TnNZ8S1NU/4nvv5xVy61JvMj3JQAeG8UDYYgC421Foc8wQw==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/node-config-provider": "3.186.0",
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/url-parser": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-ini": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.186.0.tgz",
+      "integrity": "sha512-ecrFh3MoZhAj5P2k/HXo/hMJQ3sfmvlommzXuZ/D1Bj2yMcyWuBhF1A83Fwd2gtYrWRrllsK3IOMM5Jr8UIVZA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/credential-provider-env": "3.186.0",
+        "@aws-sdk/credential-provider-imds": "3.186.0",
+        "@aws-sdk/credential-provider-sso": "3.186.0",
+        "@aws-sdk/credential-provider-web-identity": "3.186.0",
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/shared-ini-file-loader": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-node": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.186.0.tgz",
+      "integrity": "sha512-HIt2XhSRhEvVgRxTveLCzIkd/SzEBQfkQ6xMJhkBtfJw1o3+jeCk+VysXM0idqmXytctL0O3g9cvvTHOsUgxOA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/credential-provider-env": "3.186.0",
+        "@aws-sdk/credential-provider-imds": "3.186.0",
+        "@aws-sdk/credential-provider-ini": "3.186.0",
+        "@aws-sdk/credential-provider-process": "3.186.0",
+        "@aws-sdk/credential-provider-sso": "3.186.0",
+        "@aws-sdk/credential-provider-web-identity": "3.186.0",
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/shared-ini-file-loader": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-process": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.186.0.tgz",
+      "integrity": "sha512-ATRU6gbXvWC1TLnjOEZugC/PBXHBoZgBADid4fDcEQY1vF5e5Ux1kmqkJxyHtV5Wl8sE2uJfwWn+FlpUHRX67g==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/shared-ini-file-loader": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-sso": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.186.0.tgz",
+      "integrity": "sha512-mJ+IZljgXPx99HCmuLgBVDPLepHrwqnEEC/0wigrLCx6uz3SrAWmGZsNbxSEtb2CFSAaczlTHcU/kIl7XZIyeQ==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/client-sso": "3.186.0",
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/shared-ini-file-loader": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-web-identity": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.186.0.tgz",
+      "integrity": "sha512-KqzI5eBV72FE+8SuOQAu+r53RXGVHg4AuDJmdXyo7Gc4wS/B9FNElA8jVUjjYgVnf0FSiri+l41VzQ44dCopSA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/credential-providers": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.186.0.tgz",
+      "integrity": "sha512-Jw/oIqbdjXp4+FUt0GoHwSJsqGkkaZ7pOjblcVM4uXyZJTKYeXc7o5w/NefnfPyyx/aoBnRZkPCTv87woI/WQg==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/client-cognito-identity": "3.186.0",
+        "@aws-sdk/client-sso": "3.186.0",
+        "@aws-sdk/client-sts": "3.186.0",
+        "@aws-sdk/credential-provider-cognito-identity": "3.186.0",
+        "@aws-sdk/credential-provider-env": "3.186.0",
+        "@aws-sdk/credential-provider-imds": "3.186.0",
+        "@aws-sdk/credential-provider-ini": "3.186.0",
+        "@aws-sdk/credential-provider-node": "3.186.0",
+        "@aws-sdk/credential-provider-process": "3.186.0",
+        "@aws-sdk/credential-provider-sso": "3.186.0",
+        "@aws-sdk/credential-provider-web-identity": "3.186.0",
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/shared-ini-file-loader": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/fetch-http-handler": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.186.0.tgz",
+      "integrity": "sha512-k2v4AAHRD76WnLg7arH94EvIclClo/YfuqO7NoQ6/KwOxjRhs4G6TgIsAZ9E0xmqoJoV81Xqy8H8ldfy9F8LEw==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/querystring-builder": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/util-base64-browser": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/hash-node": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.186.0.tgz",
+      "integrity": "sha512-G3zuK8/3KExDTxqrGqko+opOMLRF0BwcwekV/wm3GKIM/NnLhHblBs2zd/yi7VsEoWmuzibfp6uzxgFpEoJ87w==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/util-buffer-from": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/invalid-dependency": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.186.0.tgz",
+      "integrity": "sha512-hjeZKqORhG2DPWYZ776lQ9YO3gjw166vZHZCZU/43kEYaCZHsF4mexHwHzreAY6RfS25cH60Um7dUh1aeVIpkw==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/is-array-buffer": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.186.0.tgz",
+      "integrity": "sha512-fObm+P6mjWYzxoFY4y2STHBmSdgKbIAXez0xope563mox62I8I4hhVPUCaDVydXvDpJv8tbedJMk0meJl22+xA==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/middleware-content-length": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.186.0.tgz",
+      "integrity": "sha512-Ol3c1ks3IK1s+Okc/rHIX7w2WpXofuQdoAEme37gHeml+8FtUlWH/881h62xfMdf+0YZpRuYv/eM7lBmJBPNJw==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/middleware-host-header": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.186.0.tgz",
+      "integrity": "sha512-5bTzrRzP2IGwyF3QCyMGtSXpOOud537x32htZf344IvVjrqZF/P8CDfGTkHkeBCIH+wnJxjK+l/QBb3ypAMIqQ==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/middleware-logger": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.186.0.tgz",
+      "integrity": "sha512-/1gGBImQT8xYh80pB7QtyzA799TqXtLZYQUohWAsFReYB7fdh5o+mu2rX0FNzZnrLIh2zBUNs4yaWGsnab4uXg==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/middleware-recursion-detection": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.186.0.tgz",
+      "integrity": "sha512-Za7k26Kovb4LuV5tmC6wcVILDCt0kwztwSlB991xk4vwNTja8kKxSt53WsYG8Q2wSaW6UOIbSoguZVyxbIY07Q==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/middleware-retry": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.186.0.tgz",
+      "integrity": "sha512-/VI9emEKhhDzlNv9lQMmkyxx3GjJ8yPfXH3HuAeOgM1wx1BjCTLRYEWnTbQwq7BDzVENdneleCsGAp7yaj80Aw==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/service-error-classification": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/util-middleware": "3.186.0",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/middleware-sdk-sts": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.186.0.tgz",
+      "integrity": "sha512-GDcK0O8rjtnd+XRGnxzheq1V2jk4Sj4HtjrxW/ROyhzLOAOyyxutBt+/zOpDD6Gba3qxc69wE+Cf/qngOkEkDw==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/middleware-signing": "3.186.0",
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/signature-v4": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/middleware-serde": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.186.0.tgz",
+      "integrity": "sha512-6FEAz70RNf18fKL5O7CepPSwTKJEIoyG9zU6p17GzKMgPeFsxS5xO94Hcq5tV2/CqeHliebjqhKY7yi+Pgok7g==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/middleware-signing": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.186.0.tgz",
+      "integrity": "sha512-riCJYG/LlF/rkgVbHkr4xJscc0/sECzDivzTaUmfb9kJhAwGxCyNqnTvg0q6UO00kxSdEB9zNZI2/iJYVBijBQ==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/signature-v4": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/util-middleware": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/middleware-stack": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.186.0.tgz",
+      "integrity": "sha512-fENMoo0pW7UBrbuycPf+3WZ+fcUgP9PnQ0jcOK3WWZlZ9d2ewh4HNxLh4EE3NkNYj4VIUFXtTUuVNHlG8trXjQ==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/middleware-user-agent": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.186.0.tgz",
+      "integrity": "sha512-fb+F2PF9DLKOVMgmhkr+ltN8ZhNJavTla9aqmbd01846OLEaN1n5xEnV7p8q5+EznVBWDF38Oz9Ae5BMt3Hs7w==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/node-config-provider": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.186.0.tgz",
+      "integrity": "sha512-De93mgmtuUUeoiKXU8pVHXWKPBfJQlS/lh1k2H9T2Pd9Tzi0l7p5ttddx4BsEx4gk+Pc5flNz+DeptiSjZpa4A==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/shared-ini-file-loader": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/node-http-handler": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.186.0.tgz",
+      "integrity": "sha512-CbkbDuPZT9UNJ4dAZJWB3BV+Z65wFy7OduqGkzNNrKq6ZYMUfehthhUOTk8vU6RMe/0FkN+J0fFXlBx/bs/cHw==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/abort-controller": "3.186.0",
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/querystring-builder": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/property-provider": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.186.0.tgz",
+      "integrity": "sha512-nWKqt36UW3xV23RlHUmat+yevw9up+T+953nfjcmCBKtgWlCWu/aUzewTRhKj3VRscbN+Wer95SBw9Lr/MMOlQ==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/protocol-http": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.186.0.tgz",
+      "integrity": "sha512-l/KYr/UBDUU5ginqTgHtFfHR3X6ljf/1J1ThIiUg3C3kVC/Zwztm7BEOw8hHRWnWQGU/jYasGYcrcPLdQqFZyQ==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/querystring-builder": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.186.0.tgz",
+      "integrity": "sha512-mweCpuLufImxfq/rRBTEpjGuB4xhQvbokA+otjnUxlPdIobytLqEs7pCGQfLzQ7+1ZMo8LBXt70RH4A2nSX/JQ==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/util-uri-escape": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/querystring-parser": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.186.0.tgz",
+      "integrity": "sha512-0iYfEloghzPVXJjmnzHamNx1F1jIiTW9Svy5ZF9LVqyr/uHZcQuiWYsuhWloBMLs8mfWarkZM02WfxZ8buAuhg==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/service-error-classification": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.186.0.tgz",
+      "integrity": "sha512-DRl3ORk4tF+jmH5uvftlfaq0IeKKpt0UPAOAFQ/JFWe+TjOcQd/K+VC0iiIG97YFp3aeFmH1JbEgsNxd+8fdxw==",
+      "optional": true
+    },
+    "@aws-sdk/shared-ini-file-loader": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.186.0.tgz",
+      "integrity": "sha512-2FZqxmICtwN9CYid4dwfJSz/gGFHyStFQ3HCOQ8DsJUf2yREMSBsVmKqsyWgOrYcQ98gPcD5GIa7QO5yl3XF6A==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/signature-v4": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.186.0.tgz",
+      "integrity": "sha512-18i96P5c4suMqwSNhnEOqhq4doqqyjH4fn0YV3F8TkekHPIWP4mtIJ0PWAN4eievqdtcKgD/GqVO6FaJG9texw==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/is-array-buffer": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/util-hex-encoding": "3.186.0",
+        "@aws-sdk/util-middleware": "3.186.0",
+        "@aws-sdk/util-uri-escape": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/smithy-client": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.186.0.tgz",
+      "integrity": "sha512-rdAxSFGSnrSprVJ6i1BXi65r4X14cuya6fYe8dSdgmFSa+U2ZevT97lb3tSINCUxBGeMXhENIzbVGkRZuMh+DQ==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/middleware-stack": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/types": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.186.0.tgz",
+      "integrity": "sha512-NatmSU37U+XauMFJCdFI6nougC20JUFZar+ump5wVv0i54H+2Refg1YbFDxSs0FY28TSB9jfhWIpfFBmXgL5MQ==",
+      "optional": true
+    },
+    "@aws-sdk/url-parser": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.186.0.tgz",
+      "integrity": "sha512-jfdJkKqJZp8qjjwEjIGDqbqTuajBsddw02f86WiL8bPqD8W13/hdqbG4Fpwc+Bm6GwR6/4MY6xWXFnk8jDUKeA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/querystring-parser": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/util-base64-browser": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.186.0.tgz",
+      "integrity": "sha512-TpQL8opoFfzTwUDxKeon/vuc83kGXpYqjl6hR8WzmHoQgmFfdFlV+0KXZOohra1001OP3FhqvMqaYbO8p9vXVQ==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/util-base64-node": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.186.0.tgz",
+      "integrity": "sha512-wH5Y/EQNBfGS4VkkmiMyZXU+Ak6VCoFM1GKWopV+sj03zR2D4FHexi4SxWwEBMpZCd6foMtihhbNBuPA5fnh6w==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/util-body-length-browser": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.186.0.tgz",
+      "integrity": "sha512-zKtjkI/dkj9oGkjo+7fIz+I9KuHrVt1ROAeL4OmDESS8UZi3/O8uMDFMuCp8jft6H+WFuYH6qRVWAVwXMiasXw==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/util-body-length-node": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.186.0.tgz",
+      "integrity": "sha512-U7Ii8u8Wvu9EnBWKKeuwkdrWto3c0j7LG677Spe6vtwWkvY70n9WGfiKHTgBpVeLNv8jvfcx5+H0UOPQK1o9SQ==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/util-buffer-from": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.186.0.tgz",
+      "integrity": "sha512-be2GCk2lsLWg/2V5Y+S4/9pOMXhOQo4DR4dIqBdR2R+jrMMHN9Xsr5QrkT6chcqLaJ/SBlwiAEEi3StMRmCOXA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/is-array-buffer": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/util-config-provider": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.186.0.tgz",
+      "integrity": "sha512-71Qwu/PN02XsRLApyxG0EUy/NxWh/CXxtl2C7qY14t+KTiRapwbDkdJ1cMsqYqghYP4BwJoj1M+EFMQSSlkZQQ==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.186.0.tgz",
+      "integrity": "sha512-U8GOfIdQ0dZ7RRVpPynGteAHx4URtEh+JfWHHVfS6xLPthPHWTbyRhkQX++K/F8Jk+T5U8Anrrqlea4TlcO2DA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/util-defaults-mode-node": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.186.0.tgz",
+      "integrity": "sha512-N6O5bpwCiE4z8y7SPHd7KYlszmNOYREa+mMgtOIXRU3VXSEHVKVWTZsHKvNTTHpW0qMqtgIvjvXCo3vsch5l3A==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/config-resolver": "3.186.0",
+        "@aws-sdk/credential-provider-imds": "3.186.0",
+        "@aws-sdk/node-config-provider": "3.186.0",
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/util-hex-encoding": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.186.0.tgz",
+      "integrity": "sha512-UL9rdgIZz1E/jpAfaKH8QgUxNK9VP5JPgoR0bSiaefMjnsoBh0x/VVMsfUyziOoJCMLebhJzFowtwrSKEGsxNg==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/util-locate-window": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.186.0.tgz",
+      "integrity": "sha512-fmQLkH16ga6c5fWsA+kBYklQJjlPlcc8uayTR4avi5g3Nxqm6wPpyUwo5CppwjwWMeS+NXG0HgITtkkGntcRNg==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/util-middleware": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.186.0.tgz",
+      "integrity": "sha512-fddwDgXtnHyL9mEZ4s1tBBsKnVQHqTUmFbZKUUKPrg9CxOh0Y/zZxEa5Olg/8dS/LzM1tvg0ATkcyd4/kEHIhg==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/util-uri-escape": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.186.0.tgz",
+      "integrity": "sha512-imtOrJFpIZAipAg8VmRqYwv1G/x4xzyoxOJ48ZSn1/ZGnKEEnB6n6E9gwYRebi4mlRuMSVeZwCPLq0ey5hReeQ==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/util-user-agent-browser": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.186.0.tgz",
+      "integrity": "sha512-fbRcTTutMk4YXY3A2LePI4jWSIeHOT8DaYavpc/9Xshz/WH9RTGMmokeVOcClRNBeDSi5cELPJJ7gx6SFD3ZlQ==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.186.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/util-user-agent-node": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.186.0.tgz",
+      "integrity": "sha512-oWZR7hN6NtOgnT6fUvHaafgbipQc2xJCRB93XHiF9aZGptGNLJzznIOP7uURdn0bTnF73ejbUXWLQIm8/6ue6w==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/node-config-provider": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/util-utf8-browser": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.186.0.tgz",
+      "integrity": "sha512-n+IdFYF/4qT2WxhMOCeig8LndDggaYHw3BJJtfIBZRiS16lgwcGYvOUmhCkn0aSlG1f/eyg9YZHQG0iz9eLdHQ==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/util-utf8-node": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.186.0.tgz",
+      "integrity": "sha512-7qlE0dOVdjuRbZTb7HFywnHHCrsN7AeQiTnsWT63mjXGDbPeUWQQw3TrdI20um3cxZXnKoeudGq8K6zbXyQ4iA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "optional": true
+        }
       }
     },
     "@babel/code-frame": {
@@ -9477,6 +11966,12 @@
         }
       }
     },
+    "bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+      "optional": true
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -10227,6 +12722,12 @@
       "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
       "dev": true
     },
+    "entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+      "optional": true
+    },
     "error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -10746,6 +13247,12 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
+    },
+    "fast-xml-parser": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
+      "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg==",
+      "optional": true
     },
     "fastq": {
       "version": "1.13.0",
@@ -13861,7 +16368,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "devOptional": true
     },
     "tsutils": {
       "version": "3.21.0",
@@ -14020,7 +16527,7 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true
+      "devOptional": true
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "4.10.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-providers": "*",
         "bson": "^4.7.0",
         "denque": "^2.1.0",
         "mongodb-connection-string-url": "^2.5.3",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
   },
   "homepage": "https://github.com/mongodb/node-mongodb-native",
   "optionalDependencies": {
+    "@aws-sdk/credential-providers": "^3.186.0",
     "saslprep": "^1.0.3"
   },
   "scripts": {

--- a/src/cmap/auth/mongodb_aws.ts
+++ b/src/cmap/auth/mongodb_aws.ts
@@ -264,7 +264,7 @@ function makeTempCredentials(credentials: MongoCredentials, callback: Callback<M
       .catch(error => {
         /* eslint no-console: 0 */
         console.log('AWS ERROR', error);
-        callback(error);
+        callback(new MongoAwsError(error.message));
       });
   }
 }

--- a/src/cmap/auth/mongodb_aws.ts
+++ b/src/cmap/auth/mongodb_aws.ts
@@ -54,22 +54,6 @@ export class MongoDBAWS extends AuthProvider {
       return;
     }
 
-    if ('kModuleError' in credentialProvider) {
-      // Use our way of getting credentials.
-    } else {
-      const { fromNodeProviderChain } = credentialProvider;
-      const provider = fromNodeProviderChain();
-      provider()
-        .then(creds => {
-          /* eslint no-console: 0 */
-          console.log('AWS CREDS', creds);
-        })
-        .catch(error => {
-          /* eslint no-console: 0 */
-          console.log('AWS ERROR', error);
-        });
-    }
-
     if (!credentials.username) {
       makeTempCredentials(credentials, (err, tempCredentials) => {
         if (err || !tempCredentials) return callback(err);
@@ -206,50 +190,83 @@ function makeTempCredentials(credentials: MongoCredentials, callback: Callback<M
     );
   }
 
-  // If the environment variable AWS_CONTAINER_CREDENTIALS_RELATIVE_URI
-  // is set then drivers MUST assume that it was set by an AWS ECS agent
-  if (process.env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI) {
-    request(
-      `${AWS_RELATIVE_URI}${process.env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI}`,
-      undefined,
-      (err, res) => {
-        if (err) return callback(err);
-        done(res);
-      }
-    );
-
-    return;
-  }
-
-  // Otherwise assume we are on an EC2 instance
-
-  // get a token
-  request(
-    `${AWS_EC2_URI}/latest/api/token`,
-    { method: 'PUT', json: false, headers: { 'X-aws-ec2-metadata-token-ttl-seconds': 30 } },
-    (err, token) => {
-      if (err) return callback(err);
-
-      // get role name
+  // Check if the AWS credential provider from the SDK is present. If not,
+  // use the old method.
+  if ('kModuleError' in credentialProvider) {
+    // If the environment variable AWS_CONTAINER_CREDENTIALS_RELATIVE_URI
+    // is set then drivers MUST assume that it was set by an AWS ECS agent
+    if (process.env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI) {
       request(
-        `${AWS_EC2_URI}/${AWS_EC2_PATH}`,
-        { json: false, headers: { 'X-aws-ec2-metadata-token': token } },
-        (err, roleName) => {
+        `${AWS_RELATIVE_URI}${process.env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI}`,
+        undefined,
+        (err, res) => {
           if (err) return callback(err);
-
-          // get temp credentials
-          request(
-            `${AWS_EC2_URI}/${AWS_EC2_PATH}/${roleName}`,
-            { headers: { 'X-aws-ec2-metadata-token': token } },
-            (err, creds) => {
-              if (err) return callback(err);
-              done(creds);
-            }
-          );
+          done(res);
         }
       );
+
+      return;
     }
-  );
+
+    // Otherwise assume we are on an EC2 instance
+
+    // get a token
+    request(
+      `${AWS_EC2_URI}/latest/api/token`,
+      { method: 'PUT', json: false, headers: { 'X-aws-ec2-metadata-token-ttl-seconds': 30 } },
+      (err, token) => {
+        if (err) return callback(err);
+
+        // get role name
+        request(
+          `${AWS_EC2_URI}/${AWS_EC2_PATH}`,
+          { json: false, headers: { 'X-aws-ec2-metadata-token': token } },
+          (err, roleName) => {
+            if (err) return callback(err);
+
+            // get temp credentials
+            request(
+              `${AWS_EC2_URI}/${AWS_EC2_PATH}/${roleName}`,
+              { headers: { 'X-aws-ec2-metadata-token': token } },
+              (err, creds) => {
+                if (err) return callback(err);
+                done(creds);
+              }
+            );
+          }
+        );
+      }
+    );
+  } else {
+    /*
+     * Creates a credential provider that will attempt to find credentials from the
+     * following sources (listed in order of precedence):
+     *
+     * - Environment variables exposed via process.env
+     * - SSO credentials from token cache
+     * - Web identity token credentials
+     * - Shared credentials and config ini files
+     * - The EC2/ECS Instance Metadata Service
+     */
+    const { fromNodeProviderChain } = credentialProvider;
+    const provider = fromNodeProviderChain();
+    provider()
+      .then(creds => {
+        /* eslint no-console: 0 */
+        console.log('AWS CREDS', creds);
+        done({
+          AccessKeyId: creds.accessKeyId,
+          SecretAccessKey: creds.secretAccessKey,
+          Token: creds.sessionToken,
+          Expiration: creds.expiration
+        });
+      })
+      .catch(error => {
+        /* eslint no-console: 0 */
+        console.log('AWS ERROR', error);
+        callback(error);
+      });
+  }
 }
 
 function deriveRegion(host: string) {

--- a/src/cmap/auth/mongodb_aws.ts
+++ b/src/cmap/auth/mongodb_aws.ts
@@ -167,6 +167,13 @@ interface AWSTempCredentials {
   Expiration?: Date;
 }
 
+interface AWSCredentials {
+  accessKeyId?: string;
+  secretAccessKey?: string;
+  sessionToken?: string;
+  expiration?: Date;
+}
+
 function makeTempCredentials(credentials: MongoCredentials, callback: Callback<MongoCredentials>) {
   function done(creds: AWSTempCredentials) {
     if (!creds.AccessKeyId || !creds.SecretAccessKey || !creds.Token) {
@@ -251,9 +258,7 @@ function makeTempCredentials(credentials: MongoCredentials, callback: Callback<M
     const { fromNodeProviderChain } = credentialProvider;
     const provider = fromNodeProviderChain();
     provider()
-      .then(creds => {
-        /* eslint no-console: 0 */
-        console.log('AWS CREDS', creds);
+      .then((creds: AWSCredentials) => {
         done({
           AccessKeyId: creds.accessKeyId,
           SecretAccessKey: creds.secretAccessKey,
@@ -261,9 +266,7 @@ function makeTempCredentials(credentials: MongoCredentials, callback: Callback<M
           Expiration: creds.expiration
         });
       })
-      .catch(error => {
-        /* eslint no-console: 0 */
-        console.log('AWS ERROR', error);
+      .catch((error: Error) => {
         callback(new MongoAWSError(error.message));
       });
   }

--- a/src/cmap/auth/mongodb_aws.ts
+++ b/src/cmap/auth/mongodb_aws.ts
@@ -4,7 +4,7 @@ import * as url from 'url';
 
 import type { Binary, BSONSerializeOptions } from '../../bson';
 import * as BSON from '../../bson';
-import { aws4 } from '../../deps';
+import { aws4, credentialProvider } from '../../deps';
 import {
   MongoAWSError,
   MongoCompatibilityError,
@@ -52,6 +52,14 @@ export class MongoDBAWS extends AuthProvider {
         )
       );
       return;
+    }
+
+    if ('kModuleError' in credentialProvider) {
+      // Use our way of getting credentials.
+    } else {
+      const { fromNodeProviderChain } = credentialProvider;
+      /* eslint no-console: 0 */
+      console.log('AWS CREDS', fromNodeProviderChain());
     }
 
     if (!credentials.username) {

--- a/src/cmap/auth/mongodb_aws.ts
+++ b/src/cmap/auth/mongodb_aws.ts
@@ -58,8 +58,16 @@ export class MongoDBAWS extends AuthProvider {
       // Use our way of getting credentials.
     } else {
       const { fromNodeProviderChain } = credentialProvider;
-      /* eslint no-console: 0 */
-      console.log('AWS CREDS', fromNodeProviderChain());
+      const provider = fromNodeProviderChain();
+      provider()
+        .then(creds => {
+          /* eslint no-console: 0 */
+          console.log('AWS CREDS', creds);
+        })
+        .catch(error => {
+          /* eslint no-console: 0 */
+          console.log('AWS ERROR', error);
+        });
     }
 
     if (!credentials.username) {

--- a/src/cmap/auth/mongodb_aws.ts
+++ b/src/cmap/auth/mongodb_aws.ts
@@ -167,7 +167,8 @@ interface AWSTempCredentials {
   Expiration?: Date;
 }
 
-interface AWSCredentials {
+/* @internal */
+export interface AWSCredentials {
   accessKeyId?: string;
   secretAccessKey?: string;
   sessionToken?: string;

--- a/src/cmap/auth/mongodb_aws.ts
+++ b/src/cmap/auth/mongodb_aws.ts
@@ -264,7 +264,7 @@ function makeTempCredentials(credentials: MongoCredentials, callback: Callback<M
       .catch(error => {
         /* eslint no-console: 0 */
         console.log('AWS ERROR', error);
-        callback(new MongoAwsError(error.message));
+        callback(new MongoAWSError(error.message));
       });
   }
 }

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -124,6 +124,20 @@ try {
   saslprep = require('saslprep');
 } catch {} // eslint-disable-line
 
+export let credentialProvider:
+  | typeof import('@aws-sdk/credential-providers')
+  | { kModuleError: MongoMissingDependencyError } = makeErrorModule(
+  new MongoMissingDependencyError(
+    'Optional module `@aws-sdk/credential-providers` not found.' +
+      ' Please install it to enable getting aws credentials via the official sdk.'
+  )
+);
+
+try {
+  // Ensure you always wrap an optional require in the try block NODE-3199
+  credentialProvider = require('@aws-sdk/credential-providers');
+} catch {} // eslint-disable-line
+
 interface AWS4 {
   /**
    * Created these inline types to better assert future usage of this API

--- a/test/integration/auth/mongodb_aws.test.ts
+++ b/test/integration/auth/mongodb_aws.test.ts
@@ -97,7 +97,10 @@ describe('MONGODB-AWS', function () {
       expect(caughtError)
         .property('message')
         .match(/(timed out after)|(Could not load credentials)/);
-      expect(timeTaken).to.be.within(10000, 12000);
+      // Credentials provider from the SDeK does not allow to configure the timeout
+      // and defaults to 2 seconds - so we ensure this timeout happens below 12s
+      // instead of the 10s-12s range previously.
+      expect(timeTaken).to.be.below(12000);
     });
   });
 });

--- a/test/integration/auth/mongodb_aws.test.ts
+++ b/test/integration/auth/mongodb_aws.test.ts
@@ -97,7 +97,7 @@ describe('MONGODB-AWS', function () {
       expect(caughtError)
         .property('message')
         .match(/(timed out after)|(Could not load credentials)/);
-      // Credentials provider from the SDeK does not allow to configure the timeout
+      // Credentials provider from the SDK does not allow to configure the timeout
       // and defaults to 2 seconds - so we ensure this timeout happens below 12s
       // instead of the 10s-12s range previously.
       expect(timeTaken).to.be.below(12000);

--- a/test/integration/auth/mongodb_aws.test.ts
+++ b/test/integration/auth/mongodb_aws.test.ts
@@ -96,7 +96,7 @@ describe('MONGODB-AWS', function () {
       expect(caughtError).to.be.instanceOf(MongoAWSError);
       expect(caughtError)
         .property('message')
-        .match(/timed out after/);
+        .match(/(timed out after)|(Could not load credentials)/);
       expect(timeTaken).to.be.within(10000, 12000);
     });
   });


### PR DESCRIPTION
### Description

Uses the AWS-SDK for finding credentials when present in dependencies, otherwise uses the internal implementation.

#### What is changing?

- Adds @aws-sdk/credential-providers as an optional dependency.
- Uses the SDK when installed to find credentials from the environment when missing.

Patch build with AWS tests for with and without the optional dependencies: 

https://spruce.mongodb.com/version/634d68f92fbabe2d0a6b964f/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

##### Is there new documentation needed for these changes?

Can make a note to users that they can install the SDK to have it be used.

#### What is the motivation for this change?

NODE-4721

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
