### PR TITLE
docs(NODE-4724): update fle docs to use "in use encryption" terminology

### DIFF
--- a/src/collection.ts
+++ b/src/collection.ts
@@ -288,8 +288,8 @@ export class Collection<TSchema extends Document = Document> {
       options = {};
     }
 
-    // In use encryption passes in { w: 'majority' } to ensure the lib works in both 3.x and 4.x
-    // we support that option style here only
+    // Older versions of mongodb-client-encryption passes in hardcoded { w: 'majority' }
+    // specifically to an insertOne call, so we want to just support this here
     if (options && Reflect.get(options, 'w')) {
       options.writeConcern = WriteConcern.fromOptions(Reflect.get(options, 'w'));
     }

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -288,7 +288,7 @@ export class Collection<TSchema extends Document = Document> {
       options = {};
     }
 
-    // versions of mongodb-client-encryption before 1.2.1 pass in hardcoded { w: 'majority' }
+    // versions of mongodb-client-encryption before v1.2.6 pass in hardcoded { w: 'majority' }
     // specifically to an insertOne call in createDataKey, so we want to support this only here
     if (options && Reflect.get(options, 'w')) {
       options.writeConcern = WriteConcern.fromOptions(Reflect.get(options, 'w'));

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -288,7 +288,7 @@ export class Collection<TSchema extends Document = Document> {
       options = {};
     }
 
-    // CSFLE passes in { w: 'majority' } to ensure the lib works in both 3.x and 4.x
+    // In use encryption passes in { w: 'majority' } to ensure the lib works in both 3.x and 4.x
     // we support that option style here only
     if (options && Reflect.get(options, 'w')) {
       options.writeConcern = WriteConcern.fromOptions(Reflect.get(options, 'w'));

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -288,8 +288,8 @@ export class Collection<TSchema extends Document = Document> {
       options = {};
     }
 
-    // Older versions of mongodb-client-encryption passes in hardcoded { w: 'majority' }
-    // specifically to an insertOne call, so we want to just support this here
+    // versions of mongodb-client-encryption before 1.2.1 pass in hardcoded { w: 'majority' }
+    // specifically to an insertOne call in createDataKey, so we want to support this only here
     if (options && Reflect.get(options, 'w')) {
       options.writeConcern = WriteConcern.fromOptions(Reflect.get(options, 'w'));
     }

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -288,7 +288,7 @@ export interface AutoEncryptionOptions {
    *
    * **NOTE**: Supplying options.schemaMap provides more security than relying on JSON Schemas obtained from the server.
    * It protects against a malicious server advertising a false JSON Schema, which could trick the client into sending decrypted data that should be encrypted.
-   * Schemas supplied in the schemaMap only apply to configuring automatic encryption for client side encryption.
+   * Schemas supplied in the schemaMap only apply to configuring automatic encryption for in use encryption.
    * Other validation rules in the JSON schema will not be enforced by the driver and will result in an error.
    */
   schemaMap?: Document;

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -288,7 +288,7 @@ export interface AutoEncryptionOptions {
    *
    * **NOTE**: Supplying options.schemaMap provides more security than relying on JSON Schemas obtained from the server.
    * It protects against a malicious server advertising a false JSON Schema, which could trick the client into sending decrypted data that should be encrypted.
-   * Schemas supplied in the schemaMap only apply to configuring automatic encryption for in use encryption.
+   * Schemas supplied in the schemaMap only apply to configuring automatic encryption for Client-Side Field Level Encryption.
    * Other validation rules in the JSON schema will not be enforced by the driver and will result in an error.
    */
   schemaMap?: Document;

--- a/src/error.ts
+++ b/src/error.ts
@@ -111,7 +111,7 @@ export interface ErrorDescription extends Document {
  * @category Error
  *
  * @privateRemarks
- * CSFLE has a dependency on this error, it uses the constructor with a string argument
+ * In use encryption has a dependency on this error, it uses the constructor with a string argument
  */
 export class MongoError extends Error {
   /** @internal */
@@ -568,7 +568,7 @@ export class MongoNetworkError extends MongoError {
  * @category Error
  *
  * @privateRemarks
- * CSFLE has a dependency on this error with an instanceof check
+ * In use encryption has a dependency on this error with an instanceof check
  */
 export class MongoNetworkTimeoutError extends MongoNetworkError {
   constructor(message: string, options?: MongoNetworkErrorOptions) {

--- a/src/error.ts
+++ b/src/error.ts
@@ -111,7 +111,7 @@ export interface ErrorDescription extends Document {
  * @category Error
  *
  * @privateRemarks
- * In use encryption has a dependency on this error, it uses the constructor with a string argument
+ * mongodb-client-encryption has a dependency on this error, it uses the constructor with a string argument
  */
 export class MongoError extends Error {
   /** @internal */
@@ -568,7 +568,7 @@ export class MongoNetworkError extends MongoError {
  * @category Error
  *
  * @privateRemarks
- * In use encryption has a dependency on this error with an instanceof check
+ * mongodb-client-encryption has a dependency on this error with an instanceof check
  */
 export class MongoNetworkTimeoutError extends MongoNetworkError {
   constructor(message: string, options?: MongoNetworkErrorOptions) {

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -243,7 +243,7 @@ export interface MongoClientOptions extends BSONSerializeOptions, SupportedNodeC
   /** Server API version */
   serverApi?: ServerApi | ServerApiVersion;
   /**
-   * Optionally enable client side auto encryption
+   * Optionally enable in use auto encryption
    *
    * @remarks
    *  Automatic encryption is an enterprise only feature that only applies to operations on a collection. Automatic encryption is not supported for operations on a database or view, and operations that are not bypassed will result in error

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -243,7 +243,7 @@ export interface MongoClientOptions extends BSONSerializeOptions, SupportedNodeC
   /** Server API version */
   serverApi?: ServerApi | ServerApiVersion;
   /**
-   * Optionally enable in use auto encryption
+   * Optionally enable in-use auto encryption
    *
    * @remarks
    *  Automatic encryption is an enterprise only feature that only applies to operations on a collection. Automatic encryption is not supported for operations on a database or view, and operations that are not bypassed will result in error

--- a/src/sdam/topology.ts
+++ b/src/sdam/topology.ts
@@ -252,7 +252,7 @@ export class Topology extends TypedEventEmitter<TopologyEvents> {
       ) => this.selectServer(selector, options, callback as any)
     );
 
-    // Legacy CSFLE support
+    // Legacy in use encryption support
     this.bson = Object.create(null);
     this.bson.serialize = serialize;
     this.bson.deserialize = deserialize;

--- a/src/sdam/topology.ts
+++ b/src/sdam/topology.ts
@@ -252,7 +252,8 @@ export class Topology extends TypedEventEmitter<TopologyEvents> {
       ) => this.selectServer(selector, options, callback as any)
     );
 
-    // Keeping a reference to these BSON functions supports older mongodb-client-encryption versions
+    // Saving a reference to these BSON functions
+    // supports v2.2.0 and older versions of mongodb-client-encryption
     this.bson = Object.create(null);
     this.bson.serialize = serialize;
     this.bson.deserialize = deserialize;

--- a/src/sdam/topology.ts
+++ b/src/sdam/topology.ts
@@ -252,7 +252,7 @@ export class Topology extends TypedEventEmitter<TopologyEvents> {
       ) => this.selectServer(selector, options, callback as any)
     );
 
-    // Legacy in use encryption support
+    // Keeping a reference to these BSON functions supports older mongodb-client-encryption versions
     this.bson = Object.create(null);
     this.bson.serialize = serialize;
     this.bson.deserialize = deserialize;


### PR DESCRIPTION
### Description

#### What is changing?

Docs

#### What is the motivation for this change?

Consistency across documentation

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
