### PR TITLE
docs(NODE-4554): remove experimental tag from disambiguatedPaths

### DIFF
--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -511,7 +511,6 @@ export interface UpdateDescription<TSchema extends Document = Document> {
    * This field is only present when there are ambiguous paths that are updated as a part of the update event and `showExpandedEvents`
    * is enabled for the change stream.
    * @sinceServerVersion 6.1.0
-   * @experimental
    */
   disambiguatedPaths?: Document;
 }


### PR DESCRIPTION
### Description

#### What is changing?

6.1.0 is now released

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
