### PR TITLE
fix(NODE-4609): allow mapping to falsey non-null values in cursors

### DIFF
--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -745,7 +745,7 @@ export function next<T>(
     // All cursors must operate within a session, one must be made implicitly if not explicitly provided
     cursor[kInit]((err, value) => {
       if (err) return callback(err);
-      if (value) {
+      if (value != null) {
         return callback(undefined, value);
       }
       return next(cursor, blocking, callback);

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -306,7 +306,10 @@ export abstract class AbstractCursor<
       while (true) {
         const document = await this.next();
 
-        if (document == null) {
+        // Intentional strict null check, because users can map cursors to falsey values.
+        // We allow mapping to all values except for null.
+        // eslint-disable-next-line no-restricted-syntax
+        if (document === null) {
           if (!this.closed) {
             const message =
               'Cursor returned a `null` document, but the cursor is not exhausted.  Mapping documents to `null` is not supported in the cursor transform.';
@@ -777,7 +780,10 @@ export function next<T>(
     // All cursors must operate within a session, one must be made implicitly if not explicitly provided
     cursor[kInit]((err, value) => {
       if (err) return callback(err);
-      if (value != null) {
+      // Intentional strict null check, because users can map cursors to falsey values.
+      // We allow mapping to all values except for null.
+      // eslint-disable-next-line no-restricted-syntax
+      if (value !== null) {
         return callback(undefined, value);
       }
       return next(cursor, blocking, callback);

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -310,6 +310,9 @@ export abstract class AbstractCursor<
           if (!this.closed) {
             const message =
               'Cursor returned a `null` document, but the cursor is not exhausted.  Mapping documents to `null` is not supported in the cursor transform.';
+
+            await cleanupCursorAsync(this, { needsToEmitClosed: true }).catch(() => null);
+
             throw new MongoAPIError(message);
           }
           break;

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -4,6 +4,7 @@ import { promisify } from 'util';
 import { BSONSerializeOptions, Document, Long, pluckBSONSerializeOptions } from '../bson';
 import {
   AnyError,
+  MongoAPIError,
   MongoCursorExhaustedError,
   MongoCursorInUseError,
   MongoInvalidArgumentError,
@@ -306,6 +307,11 @@ export abstract class AbstractCursor<
         const document = await this.next();
 
         if (document == null) {
+          if (!this.closed) {
+            const message =
+              'Cursor returned a `null` document, but the cursor is not exhausted.  Mapping documents to `null` is not supported in the cursor transform.';
+            throw new MongoAPIError(message);
+          }
           break;
         }
 

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -504,6 +504,29 @@ export abstract class AbstractCursor<
    * this function's transform.
    *
    * @remarks
+   *
+   * **Note** Cursors use `null` internally to indicate that there are no more documents in the cursor. Providing a mapping
+   * function that maps values to `null` will result in the cursor closing itself before it has finished iterating
+   * all documents.  This will **not** result in a memory leak, just surprising behavior.  For example:
+   *
+   * ```typescript
+   * const cursor = collection.find({});
+   * cursor.map(() => null);
+   *
+   * const documents = await cursor.toArray();
+   * // documents is always [], regardless of how many documents are in the collection.
+   * ```
+   *
+   * Other falsey values are allowed:
+   *
+   * ```typescript
+   * const cursor = collection.find({});
+   * cursor.map(() => '');
+   *
+   * const documents = await cursor.toArray();
+   * // documents is now an array of empty strings
+   * ```
+   *
    * **Note for Typescript Users:** adding a transform changes the return type of the iteration of this cursor,
    * it **does not** return a new instance of a cursor. This means when calling map,
    * you should always assign the result to a new variable in order to get a correctly typed cursor variable.

--- a/test/integration/node-specific/abstract_cursor.test.ts
+++ b/test/integration/node-specific/abstract_cursor.test.ts
@@ -1,0 +1,106 @@
+import { expect } from 'chai';
+
+import { Collection, MongoClient } from '../../../src';
+
+describe('class AbstractCursor', function () {
+  let client: MongoClient;
+
+  let collection: Collection;
+  beforeEach(async function () {
+    client = await this.configuration.newClient().connect();
+
+    collection = client.db('abstract_cursor_integration').collection('test');
+
+    await collection.insertMany(Array.from({ length: 5 }, (_, index) => ({ index })));
+  });
+
+  afterEach(async function () {
+    await collection.deleteMany({});
+    await client.close();
+  });
+
+  context('toArray() with custom transforms', function () {
+    const falseyValues = [0, NaN, '', false];
+    for (const value of falseyValues) {
+      it(`supports mapping to falsey value '${value}'`, async function () {
+        const cursor = collection.find();
+        cursor.map(() => value);
+
+        const result = await cursor.toArray();
+
+        const expected = Array.from({ length: 5 }, () => value);
+        expect(result).to.deep.equal(expected);
+      });
+    }
+
+    it('does not support mapping to `null`', async function () {
+      const cursor = collection.find();
+      cursor.map(() => null);
+
+      const result = await cursor.toArray();
+
+      expect(result).to.deep.equal([]);
+    });
+  });
+
+  context('Symbol.asyncIterator() with custom transforms', function () {
+    const falseyValues = [0, NaN, '', false];
+    for (const value of falseyValues) {
+      it(`supports mapping to falsey value '${value}'`, async function () {
+        const cursor = collection.find();
+        cursor.map(() => value);
+
+        let count = 0;
+
+        for await (const document of cursor) {
+          expect(document).to.deep.equal(value);
+          count++;
+        }
+
+        expect(count).to.equal(5);
+      });
+    }
+
+    it('does not support mapping to `null`', async function () {
+      const cursor = collection.find();
+      cursor.map(() => null);
+
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      for await (const document of cursor) {
+        expect.fail('Expected no documents from cursor, received at least one.');
+      }
+    });
+  });
+
+  context('forEach() with custom transforms', function () {
+    const falseyValues = [0, NaN, '', false];
+    for (const value of falseyValues) {
+      it(`supports mapping to falsey value '${value}'`, async function () {
+        const cursor = collection.find();
+        cursor.map(() => value);
+
+        let count = 0;
+
+        function transform(value) {
+          expect(value).to.deep.equal(value);
+          count++;
+        }
+
+        await cursor.forEach(transform);
+
+        expect(count).to.equal(5);
+      });
+    }
+
+    it('does not support mapping to `null`', async function () {
+      const cursor = collection.find();
+      cursor.map(() => null);
+
+      function transform() {
+        expect.fail('Expected no documents from cursor, received at least one.');
+      }
+
+      await cursor.forEach(transform);
+    });
+  });
+});

--- a/test/integration/node-specific/abstract_cursor.test.ts
+++ b/test/integration/node-specific/abstract_cursor.test.ts
@@ -1,13 +1,16 @@
 import { expect } from 'chai';
+import { inspect } from 'util';
 
 import { Collection, MongoAPIError, MongoClient } from '../../../src';
+
+const falseyValues = [0, 0n, NaN, '', false, undefined];
 
 describe('class AbstractCursor', function () {
   let client: MongoClient;
 
   let collection: Collection;
   beforeEach(async function () {
-    client = await this.configuration.newClient().connect();
+    client = this.configuration.newClient();
 
     collection = client.db('abstract_cursor_integration').collection('test');
 
@@ -20,9 +23,8 @@ describe('class AbstractCursor', function () {
   });
 
   context('toArray() with custom transforms', function () {
-    const falseyValues = [0, NaN, '', false];
     for (const value of falseyValues) {
-      it(`supports mapping to falsey value '${value}'`, async function () {
+      it(`supports mapping to falsey value '${inspect(value)}'`, async function () {
         const cursor = collection.find();
         cursor.map(() => value);
 
@@ -33,7 +35,7 @@ describe('class AbstractCursor', function () {
       });
     }
 
-    it('does not support mapping to `null`', async function () {
+    it('throws when mapping to `null` and cleans up cursor', async function () {
       const cursor = collection.find();
       cursor.map(() => null);
 
@@ -45,9 +47,8 @@ describe('class AbstractCursor', function () {
   });
 
   context('Symbol.asyncIterator() with custom transforms', function () {
-    const falseyValues = [0, NaN, '', false];
     for (const value of falseyValues) {
-      it(`supports mapping to falsey value '${value}'`, async function () {
+      it(`supports mapping to falsey value '${inspect(value)}'`, async function () {
         const cursor = collection.find();
         cursor.map(() => value);
 
@@ -62,7 +63,7 @@ describe('class AbstractCursor', function () {
       });
     }
 
-    it('does not support mapping to `null`', async function () {
+    it('throws when mapping to `null` and cleans up cursor', async function () {
       const cursor = collection.find();
       cursor.map(() => null);
 
@@ -79,9 +80,8 @@ describe('class AbstractCursor', function () {
   });
 
   context('forEach() with custom transforms', function () {
-    const falseyValues = [0, NaN, '', false];
     for (const value of falseyValues) {
-      it(`supports mapping to falsey value '${value}'`, async function () {
+      it(`supports mapping to falsey value '${inspect(value)}'`, async function () {
         const cursor = collection.find();
         cursor.map(() => value);
 
@@ -98,15 +98,15 @@ describe('class AbstractCursor', function () {
       });
     }
 
-    it('does not support mapping to `null`', async function () {
+    it('throws when mapping to `null` and cleans up cursor', async function () {
       const cursor = collection.find();
       cursor.map(() => null);
 
-      function transform() {
+      function iterator() {
         expect.fail('Expected no documents from cursor, received at least one.');
       }
 
-      const error = await cursor.forEach(transform).catch(e => e);
+      const error = await cursor.forEach(iterator).catch(e => e);
       expect(error).to.be.instanceOf(MongoAPIError);
       expect(cursor.closed).to.be.true;
     });

--- a/test/integration/node-specific/abstract_cursor.test.ts
+++ b/test/integration/node-specific/abstract_cursor.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 
 import { Collection, MongoAPIError, MongoClient } from '../../../src';
 
-describe.only('class AbstractCursor', function () {
+describe('class AbstractCursor', function () {
   let client: MongoClient;
 
   let collection: Collection;
@@ -40,6 +40,7 @@ describe.only('class AbstractCursor', function () {
       const error = await cursor.toArray().catch(e => e);
 
       expect(error).be.instanceOf(MongoAPIError);
+      expect(cursor.closed).to.be.true;
     });
   });
 
@@ -72,6 +73,7 @@ describe.only('class AbstractCursor', function () {
         }
       } catch (error) {
         expect(error).to.be.instanceOf(MongoAPIError);
+        expect(cursor.closed).to.be.true;
       }
     });
   });
@@ -106,6 +108,7 @@ describe.only('class AbstractCursor', function () {
 
       const error = await cursor.forEach(transform).catch(e => e);
       expect(error).to.be.instanceOf(MongoAPIError);
+      expect(cursor.closed).to.be.true;
     });
   });
 });

--- a/test/integration/node-specific/abstract_cursor.test.ts
+++ b/test/integration/node-specific/abstract_cursor.test.ts
@@ -1,8 +1,8 @@
 import { expect } from 'chai';
 
-import { Collection, MongoClient } from '../../../src';
+import { Collection, MongoAPIError, MongoClient } from '../../../src';
 
-describe('class AbstractCursor', function () {
+describe.only('class AbstractCursor', function () {
   let client: MongoClient;
 
   let collection: Collection;
@@ -37,9 +37,9 @@ describe('class AbstractCursor', function () {
       const cursor = collection.find();
       cursor.map(() => null);
 
-      const result = await cursor.toArray();
+      const error = await cursor.toArray().catch(e => e);
 
-      expect(result).to.deep.equal([]);
+      expect(error).be.instanceOf(MongoAPIError);
     });
   });
 
@@ -65,9 +65,13 @@ describe('class AbstractCursor', function () {
       const cursor = collection.find();
       cursor.map(() => null);
 
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      for await (const document of cursor) {
-        expect.fail('Expected no documents from cursor, received at least one.');
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        for await (const document of cursor) {
+          expect.fail('Expected error to be thrown');
+        }
+      } catch (error) {
+        expect(error).to.be.instanceOf(MongoAPIError);
       }
     });
   });
@@ -100,7 +104,8 @@ describe('class AbstractCursor', function () {
         expect.fail('Expected no documents from cursor, received at least one.');
       }
 
-      await cursor.forEach(transform);
+      const error = await cursor.forEach(transform).catch(e => e);
+      expect(error).to.be.instanceOf(MongoAPIError);
     });
   });
 });


### PR DESCRIPTION
### Description

#### What is changing?

This PR allows mapping to falsey values in cursors.

##### Is there new documentation needed for these changes?

No.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
