### PR TITLE
feat(NODE-4683): make ChangeStream an async iterable

### DIFF
--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -737,7 +737,8 @@ export class ChangeStream<
     }, callback);
   }
 
-  async *[Symbol.asyncIterator](): AsyncIterator<TChange, void> {
+  // TODO(andymina): ask about never as third template parameter
+  async *[Symbol.asyncIterator](): AsyncGenerator<TChange, void, never> {
     if (this.closed) {
       return;
     }
@@ -747,7 +748,11 @@ export class ChangeStream<
         yield await this.next();
       }
     } finally {
-      await this.close();
+      try {
+        await this.close();
+      } catch (error) {
+        // we're not concerned with errors from close()
+      }
     }
   }
 

--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -737,13 +737,15 @@ export class ChangeStream<
     }, callback);
   }
 
-  async *[Symbol.asyncIterator](): AsyncGenerator<TChange, void, never> {
+  async *[Symbol.asyncIterator](): AsyncGenerator<TChange, void, void> {
     if (this.closed) {
       return;
     }
 
     try {
-      while (await this.hasNext()) {
+      // Change streams run indefinitely as long as errors are resumable
+      // So the only loop breaking condition is if `next()` throws
+      while (true) {
         yield await this.next();
       }
     } finally {

--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -737,7 +737,6 @@ export class ChangeStream<
     }, callback);
   }
 
-  // TODO(andymina): ask about never as third template parameter
   async *[Symbol.asyncIterator](): AsyncGenerator<TChange, void, never> {
     if (this.closed) {
       return;

--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -742,11 +742,7 @@ export class ChangeStream<
       return;
     }
 
-    while (true) {
-      if (!(await this.hasNext())) {
-        break;
-      }
-
+    while (await this.hasNext()) {
       yield await this.next();
     }
   }

--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -751,7 +751,7 @@ export class ChangeStream<
     } finally {
       try {
         await this.close();
-      } catch (error) {
+      } catch {
         // we're not concerned with errors from close()
       }
     }

--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -742,8 +742,12 @@ export class ChangeStream<
       return;
     }
 
-    while (await this.hasNext()) {
-      yield await this.next();
+    try {
+      while (await this.hasNext()) {
+        yield await this.next();
+      }
+    } finally {
+      await this.close();
     }
   }
 

--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -737,26 +737,18 @@ export class ChangeStream<
     }, callback);
   }
 
-  [Symbol.asyncIterator](): AsyncIterator<TChange, void> {
-    async function* nativeAsyncIterator(this: ChangeStream<TSchema, TChange>) {
-      if (this.closed) {
-        return;
-      }
-
-      while (true) {
-        if (!(await this.hasNext())) {
-          break;
-        }
-
-        yield await this.next();
-      }
+  async *[Symbol.asyncIterator](): AsyncIterator<TChange, void> {
+    if (this.closed) {
+      return;
     }
 
-    const iterator = nativeAsyncIterator.call(this);
+    while (true) {
+      if (!(await this.hasNext())) {
+        break;
+      }
 
-    return {
-      next: () => iterator.next()
-    };
+      yield await this.next();
+    }
   }
 
   /** Is the cursor closed */

--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -737,6 +737,28 @@ export class ChangeStream<
     }, callback);
   }
 
+  [Symbol.asyncIterator](): AsyncIterator<TChange, void> {
+    async function* nativeAsyncIterator(this: ChangeStream<TSchema, TChange>) {
+      if (this.closed) {
+        return;
+      }
+
+      while (true) {
+        if (!(await this.hasNext())) {
+          break;
+        }
+
+        yield await this.next();
+      }
+    }
+
+    const iterator = nativeAsyncIterator.call(this);
+
+    return {
+      next: () => iterator.next()
+    };
+  }
+
   /** Is the cursor closed */
   get closed(): boolean {
     return this[kClosed] || this.cursor.closed;

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -297,7 +297,7 @@ export abstract class AbstractCursor<
     return bufferedDocs;
   }
 
-  [Symbol.asyncIterator](): AsyncIterator<TSchema, void> {
+  [Symbol.asyncIterator](): AsyncIterator<TSchema, void, never> {
     async function* nativeAsyncIterator(this: AbstractCursor<TSchema>) {
       if (this.closed) {
         return;

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -297,7 +297,7 @@ export abstract class AbstractCursor<
     return bufferedDocs;
   }
 
-  [Symbol.asyncIterator](): AsyncIterator<TSchema, void, never> {
+  [Symbol.asyncIterator](): AsyncIterator<TSchema, void> {
     async function* nativeAsyncIterator(this: AbstractCursor<TSchema>) {
       if (this.closed) {
         return;

--- a/test/integration/change-streams/change_stream.test.ts
+++ b/test/integration/change-streams/change_stream.test.ts
@@ -10,7 +10,6 @@ import { promisify } from 'util';
 import {
   AbstractCursor,
   ChangeStream,
-  ChangeStreamDocument,
   ChangeStreamOptions,
   Collection,
   CommandStartedEvent,
@@ -2208,8 +2207,50 @@ describe('ChangeStream resumability', function () {
        * unhappy path - it errors out
        * resumable error - continues but also throws the error out
        */
+      for (const { error, code, message } of resumableErrorCodes) {
+        it(
+          `resumes on error code ${code} (${error})`,
+          { requires: { topology: '!single', mongodb: '<4.2' } },
+          async function () {
+            changeStream = collection.watch([]);
+            await initIteratorMode(changeStream);
+
+            // on 3.6 servers, no postBatchResumeToken is sent back in the initial aggregate response.
+            // This means that a resume token isn't cached until the first change has been iterated.
+            // In order to test the resume, we need to ensure that at least one document has
+            // been iterated so we have a resume token to resume on.
+
+            // insert the doc
+            await collection.insertOne({ city: 'New York City' });
+
+            // fail the call
+            const mock = sinon
+              .stub(changeStream.cursor, '_getMore')
+              .callsFake((_batchSize, callback) => {
+                mock.restore();
+                const error = new MongoServerError({ message });
+                error.code = code;
+                callback(error);
+              });
+
+            // insert another doc
+            await collection.insertOne({ city: 'New York City' });
+
+            let total_changes = 0;
+            for await (const change of changeStream) {
+              total_changes++;
+              if (total_changes === 2) {
+                changeStream.close();
+              }
+            }
+
+            expect(aggregateEvents).to.have.lengthOf(2);
+          }
+        );
+      }
+
       // happy path
-      it('happy path', async function () {
+      it('happy path', { requires: { topology: '!single', mongodb: '>=4.2' } }, async function () {
         changeStream = collection.watch([]);
         await initIteratorMode(changeStream);
 
@@ -2223,10 +2264,43 @@ describe('ChangeStream resumability', function () {
 
           count++;
           if (count === 3) {
+            expect(docs.length).to.equal(count);
             changeStream.close();
           }
         }
       });
+
+      // unhappy path
+      it(
+        'unhappy path',
+        { requires: { topology: '!single', mongodb: '>=4.2' } },
+        async function () {
+          changeStream = collection.watch([]);
+          await initIteratorMode(changeStream);
+
+          const unresumableErrorCode = 1000;
+          await client.db('admin').command({
+            configureFailPoint: is4_2Server(this.configuration.version)
+              ? 'failCommand'
+              : 'failGetMoreAfterCursorCheckout',
+            mode: { times: 1 },
+            data: {
+              failCommands: ['getMore'],
+              errorCode: unresumableErrorCode
+            }
+          } as FailPoint);
+
+          await collection.insertOne({ city: 'New York City' });
+
+          try {
+            for await (const change of changeStream) {
+              // should not run
+            }
+          } catch (error) {
+            expect(error).to.be.instanceOf(MongoServerError);
+          }
+        }
+      );
     });
   });
 

--- a/test/integration/change-streams/change_stream.test.ts
+++ b/test/integration/change-streams/change_stream.test.ts
@@ -2373,7 +2373,7 @@ describe('ChangeStream resumability', function () {
       });
     });
 
-    context.only('#asyncIterator', function () {
+    context('#asyncIterator', function () {
       for (const { error, code, message } of resumableErrorCodes) {
         it(
           `resumes on error code ${code} (${error})`,

--- a/test/integration/change-streams/change_stream.test.ts
+++ b/test/integration/change-streams/change_stream.test.ts
@@ -22,7 +22,6 @@ import {
   ReadPreference,
   ResumeToken
 } from '../../../src';
-import { next } from '../../../src/cursor/abstract_cursor';
 import { isHello } from '../../../src/utils';
 import * as mock from '../../tools/mongodb-mock/index';
 import {
@@ -953,7 +952,6 @@ describe('Change Streams', function () {
       'This test only worked because of timing, changeStream.close does not remove the change listener';
   });
 
-  // TODO(andymina): ask about testing word semantics here
   context('iterator api', function () {
     describe('#tryNext()', function () {
       it('should return null on single iteration of empty cursor', {
@@ -1092,7 +1090,7 @@ describe('Change Streams', function () {
         }
       );
 
-      it.only(
+      it(
         'can be used with raw iterator API',
         { requires: { topology: '!single' } },
         async function () {
@@ -1112,7 +1110,7 @@ describe('Change Streams', function () {
             const { fullDocument } = change.value;
             expect(fullDocument.city).to.equal(docs[1].city);
           } catch (error) {
-            expect.fail('Async could not be used with raw iterator API')
+            expect.fail('Async could not be used with raw iterator API');
           }
         }
       );
@@ -2464,7 +2462,7 @@ describe('ChangeStream resumability', function () {
 
             await collection.insertOne({ city: 'New York City' });
             try {
-              const change = await changeStreamIterator.next();
+              await changeStreamIterator.next();
               expect.fail(
                 'Change stream did not throw unresumable error and did not produce any events'
               );

--- a/test/integration/change-streams/change_stream.test.ts
+++ b/test/integration/change-streams/change_stream.test.ts
@@ -1688,6 +1688,7 @@ describe('ChangeStream resumability', function () {
     aggregateEvents = [];
   });
 
+  // TODO(andymina): resumable error tests here
   context('iterator api', function () {
     context('#next', function () {
       for (const { error, code, message } of resumableErrorCodes) {
@@ -2196,6 +2197,35 @@ describe('ChangeStream resumability', function () {
             expect(aggregateEvents).to.have.lengthOf(1);
           }
         );
+      });
+    });
+
+    context.only('#asyncIterator', function () {
+      /**
+       * TODO(andymina): three test cases to cover
+       * 
+       * happy path - asyncIterable works
+       * unhappy path - it errors out
+       * resumable error - continues but also throws the error out
+       */
+      // happy path
+      it('happy path', async function () {
+        changeStream = collection.watch([]);
+        await initIteratorMode(changeStream);
+
+        const docs = [{ city: 'New York City' }, { city: 'Seattle' }, { city: 'Boston' }];
+        await collection.insertMany(docs);
+
+        let count = 0;
+        for await (const change of changeStream) {
+          const { fullDocument } = change;
+          expect(fullDocument.city).to.equal(docs[count].city);
+
+          count++;
+          if (count === 3) {
+            changeStream.close();
+          }
+        }
       });
     });
   });

--- a/test/integration/change-streams/change_stream.test.ts
+++ b/test/integration/change-streams/change_stream.test.ts
@@ -367,7 +367,7 @@ describe('Change Streams', function () {
 
           // Check the cursor is closed
           expect(changeStream.closed).to.be.true;
-          expect(changeStream.cursor.closed).to.be.true;
+          expect(changeStream.cursor).property('closed', true);
           done();
         });
       });
@@ -1016,7 +1016,7 @@ describe('Change Streams', function () {
           await changeStreamIterator.next();
           await changeStreamIterator.return();
           expect(changeStream.closed).to.be.true;
-          expect(changeStream.cursor.closed).to.be.true;
+          expect(changeStream.cursor).property('closed', true);
         }
       );
 
@@ -1048,7 +1048,7 @@ describe('Change Streams', function () {
             );
           } catch (error) {
             expect(changeStream.closed).to.be.true;
-            expect(changeStream.cursor.closed).to.be.true;
+            expect(changeStream.cursor).property('closed', true);
           }
         }
       );

--- a/test/integration/change-streams/change_stream.test.ts
+++ b/test/integration/change-streams/change_stream.test.ts
@@ -41,6 +41,9 @@ const initIteratorMode = async (cs: ChangeStream) => {
   return;
 };
 
+const is4_2Server = (serverVersion: string) =>
+  gte(serverVersion, '4.2.0') && lt(serverVersion, '4.3.0');
+
 // Define the pipeline processing changes
 const pipeline = [
   { $addFields: { addedField: 'This is a field added using $addFields' } },
@@ -53,9 +56,6 @@ describe('Change Streams', function () {
   let collection: Collection;
   let changeStream: ChangeStream;
   let db: Db;
-
-  const is4_2Server = (serverVersion: string) =>
-    gte(serverVersion, '4.2.0') && lt(serverVersion, '4.3.0');
 
   beforeEach(async function () {
     const configuration = this.configuration;
@@ -1790,9 +1790,6 @@ describe('ChangeStream resumability', function () {
     },
     { error: 'CursorNotFound', code: 43, message: 'cursor not found' }
   ];
-
-  const is4_2Server = (serverVersion: string) =>
-    gte(serverVersion, '4.2.0') && lt(serverVersion, '4.3.0');
 
   beforeEach(function () {
     assert(this.currentTest != null);

--- a/test/integration/change-streams/change_stream.test.ts
+++ b/test/integration/change-streams/change_stream.test.ts
@@ -2339,7 +2339,7 @@ describe('ChangeStream resumability', function () {
       );
 
       context('when the error is not a resumable error', function () {
-        it.only(
+        it(
           'does not resume',
           { requires: { topology: '!single', mongodb: '>=4.2' } },
           async function () {
@@ -2362,7 +2362,7 @@ describe('ChangeStream resumability', function () {
             await collection.insertOne({ city: 'New York City' });
             try {
               for await (const change of changeStream) {
-                expect.fail('Change stream produced changes on an unresumable error');
+                expect.fail('Change stream produced events on an unresumable error');
               }
 
               expect.fail(

--- a/test/integration/change-streams/change_stream.test.ts
+++ b/test/integration/change-streams/change_stream.test.ts
@@ -1143,7 +1143,7 @@ describe('Change Streams', function () {
             expect(fullDocument.city).to.equal(expectedDoc.city);
             break;
           }
-
+          // eslint-disable-next-line no-unused-vars
           for await (const change of changeStream) {
             expect.fail('Change stream was resumed after partial iteration');
           }
@@ -2512,6 +2512,7 @@ describe('ChangeStream resumability', function () {
             } as FailPoint);
 
             try {
+              // eslint-disable-next-line no-unused-vars
               for await (const change of changeStream) {
                 expect.fail('Change stream produced events on an unresumable error');
               }

--- a/test/integration/change-streams/change_stream.test.ts
+++ b/test/integration/change-streams/change_stream.test.ts
@@ -1143,7 +1143,7 @@ describe('Change Streams', function () {
             expect(fullDocument.city).to.equal(expectedDoc.city);
             break;
           }
-          // eslint-disable-next-line no-unused-vars
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
           for await (const change of changeStream) {
             expect.fail('Change stream was resumed after partial iteration');
           }
@@ -2512,7 +2512,7 @@ describe('ChangeStream resumability', function () {
             } as FailPoint);
 
             try {
-              // eslint-disable-next-line no-unused-vars
+              // eslint-disable-next-line @typescript-eslint/no-unused-vars
               for await (const change of changeStream) {
                 expect.fail('Change stream produced events on an unresumable error');
               }

--- a/test/integration/change-streams/change_stream.test.ts
+++ b/test/integration/change-streams/change_stream.test.ts
@@ -2199,7 +2199,7 @@ describe('ChangeStream resumability', function () {
       });
     });
 
-    context.only('#asyncIterator', function () {
+    context('#asyncIterator', function () {
       for (const { error, code, message } of resumableErrorCodes) {
         it(
           `resumes on error code ${code} (${error})`,
@@ -2332,7 +2332,6 @@ describe('ChangeStream resumability', function () {
           }
         );
       });
-
     });
   });
 

--- a/test/integration/change-streams/change_stream.test.ts
+++ b/test/integration/change-streams/change_stream.test.ts
@@ -2198,7 +2198,7 @@ describe('ChangeStream resumability', function () {
       });
     });
 
-    context.only('#asyncIterator', function () {
+    context('#asyncIterator', function () {
       for (const { error, code, message } of resumableErrorCodes) {
         it(
           `resumes on error code ${code} (${error})`,
@@ -2339,7 +2339,7 @@ describe('ChangeStream resumability', function () {
       );
 
       context('when the error is not a resumable error', function () {
-        it(
+        it.only(
           'does not resume',
           { requires: { topology: '!single', mongodb: '>=4.2' } },
           async function () {
@@ -2362,15 +2362,16 @@ describe('ChangeStream resumability', function () {
             await collection.insertOne({ city: 'New York City' });
             try {
               for await (const change of changeStream) {
-                // DOESN'T REACH
                 expect.fail('Change stream produced changes on an unresumable error');
               }
+
+              expect.fail(
+                'Change stream did not throw unresumable error and did not produce any events'
+              );
             } catch (error) {
               expect(error).to.be.instanceOf(MongoServerError);
               expect(aggregateEvents).to.have.lengthOf(1);
             }
-            // fails here
-            expect.fail('Change stream did not throw unresumable error');
           }
         );
       });

--- a/test/integration/change-streams/change_stream.test.ts
+++ b/test/integration/change-streams/change_stream.test.ts
@@ -2372,6 +2372,8 @@ describe('ChangeStream resumability', function () {
               expect(error).to.be.instanceOf(MongoServerError);
               expect(aggregateEvents).to.have.lengthOf(1);
             }
+
+            changeStream.close();
           }
         );
       });

--- a/test/types/change_stream.test-d.ts
+++ b/test/types/change_stream.test-d.ts
@@ -214,3 +214,7 @@ expectError(collection.watch<number, number>());
 collection
   .watch<{ a: number }, { b: boolean }>()
   .on('change', change => expectType<{ b: boolean }>(change));
+
+expectType<AsyncGenerator<ChangeStreamDocument<Schema>, void, void>>(
+  collection.watch()[Symbol.asyncIterator]()
+);


### PR DESCRIPTION
### Description

#### What is changing?

Adds the `asyncIterator` symbol to the ChangeStream class.

##### Is there new documentation needed for these changes?

Yes.

#### What is the motivation for this change?

Currently, Change streams support manual promise-based iteration using `next`, `hasNext` and `tryNext`.  Making the ChangeStream an async iterable allows for idiomatic use in for-await loops.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
