### PR TITLE
refactor(NODE-4754): remove unused QueryOptions export

### DIFF
--- a/src/cmap/connection.ts
+++ b/src/cmap/connection.ts
@@ -22,7 +22,7 @@ import {
 } from '../error';
 import type { ServerApi, SupportedNodeConnectionOptions } from '../mongo_client';
 import { CancellationToken, TypedEventEmitter } from '../mongo_types';
-import type { ReadPreference, ReadPreferenceLike } from '../read_preference';
+import type { ReadPreferenceLike } from '../read_preference';
 import { applySession, ClientSession, updateSessionFromResponse } from '../sessions';
 import {
   calculateDurationInMs,

--- a/src/cmap/connection.ts
+++ b/src/cmap/connection.ts
@@ -69,23 +69,6 @@ const kAutoEncrypter = Symbol('autoEncrypter');
 const kDelayedTimeoutId = Symbol('delayedTimeoutId');
 
 /** @internal */
-export interface QueryOptions extends BSONSerializeOptions {
-  readPreference: ReadPreference;
-  documentsReturnedIn?: string;
-  batchSize?: number;
-  limit?: number;
-  skip?: number;
-  projection?: Document;
-  tailable?: boolean;
-  awaitData?: boolean;
-  noCursorTimeout?: boolean;
-  /** @deprecated use `noCursorTimeout` instead */
-  timeout?: boolean;
-  partial?: boolean;
-  oplogReplay?: boolean;
-}
-
-/** @internal */
 export interface CommandOptions extends BSONSerializeOptions {
   command?: boolean;
   secondaryOk?: boolean;

--- a/src/index.ts
+++ b/src/index.ts
@@ -237,8 +237,7 @@ export type {
   ConnectionOptions,
   DestroyOptions,
   GetMoreOptions,
-  ProxyOptions,
-  QueryOptions
+  ProxyOptions
 } from './cmap/connection';
 export type {
   CloseOptions,


### PR DESCRIPTION
### Description

#### What is changing?

Removes the internal, unused `QueryOptions` definition and export

##### Is there new documentation needed for these changes?

No.

#### What is the motivation for this change?

Code clean up.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
