### PR TITLE
feat(NODE-4733): deprecate result and getLastOp

### DIFF
--- a/src/bulk/common.ts
+++ b/src/bulk/common.ts
@@ -327,6 +327,7 @@ export class BulkWriteResult {
     }
   }
 
+  /* @deprecated Will be removed in 5.0 release */
   toJSON(): BulkResult {
     return this.result;
   }

--- a/src/bulk/common.ts
+++ b/src/bulk/common.ts
@@ -176,6 +176,7 @@ export class Batch<T = Document> {
  * The result of a bulk write.
  */
 export class BulkWriteResult {
+  /** @deprecated Will be removed in 5.0 */
   result: BulkResult;
 
   /**
@@ -295,7 +296,11 @@ export class BulkWriteResult {
     return this.result.writeErrors;
   }
 
-  /** Retrieve lastOp if available */
+  /**
+   * Retrieve lastOp if available
+   *
+   * @deprecated Will be removed in 5.0
+   */
   getLastOp(): Document | undefined {
     return this.result.opTime;
   }

--- a/src/bulk/common.ts
+++ b/src/bulk/common.ts
@@ -130,7 +130,11 @@ export type AnyBulkWriteOperation<TSchema extends Document = Document> =
   | { deleteOne: DeleteOneModel<TSchema> }
   | { deleteMany: DeleteManyModel<TSchema> };
 
-/** @public */
+/**
+ * @public
+ *
+ * @deprecated Will be made internal in 5.0
+ */
 export interface BulkResult {
   ok: number;
   writeErrors: WriteError[];


### PR DESCRIPTION
### Description

Deprecates `BulkWriteResult`'s `result` and `getLastOp`.

#### What is changing?

Deprecates `BulkWriteResult`'s `result` and `getLastOp`.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-4733

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
