### PR TITLE
feat(NODE-4681): deprecate modify result

### DIFF
--- a/src/collection.ts
+++ b/src/collection.ts
@@ -101,7 +101,9 @@ import { WriteConcern, WriteConcernOptions } from './write_concern';
 
 /**
  * @public
- * @deprecated Will return the actual result document in 5.0
+ * @deprecated This type will be completely removed in 5.0 and findOneAndUpdate,
+ *             findOneAndDelete, and findOneAndReplace will then return the
+ *             actual result document.
  */
 export interface ModifyResult<TSchema = Document> {
   value: WithId<TSchema> | null;

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -99,7 +99,10 @@ import {
 } from './utils';
 import { WriteConcern, WriteConcernOptions } from './write_concern';
 
-/** @public */
+/**
+ * @public
+ * @deprecated Will return the actual result document in 5.0
+ */
 export interface ModifyResult<TSchema = Document> {
   value: WithId<TSchema> | null;
   lastErrorObject?: Document;

--- a/test/types/community/collection/findX.test-d.ts
+++ b/test/types/community/collection/findX.test-d.ts
@@ -348,3 +348,21 @@ expectType<WithId<{ a: number; b: string }> | null>(
 expectType<WithId<{ a: number; b: string }> | null>(
   (await coll.findOneAndDelete({ a: 3 }, { projection: { _id: 0 } })).value
 );
+
+// NODE-3568: Uncomment when ModifyResult is removed in 5.0
+// expectType<Document> | null>((await coll.findOneAndDelete({ a: 3 })));
+// expectType<Document | null>(
+//   (await coll.findOneAndReplace({ a: 3 }, { a: 5, b: 'new string' }))
+// );
+// expectType<Document | null>(
+//   (
+//     await coll.findOneAndUpdate(
+//       { a: 3 },
+//       {
+//         $set: {
+//           a: 5
+//         }
+//       }
+//     )
+//   )
+// );

--- a/test/types/community/collection/findX.test-d.ts
+++ b/test/types/community/collection/findX.test-d.ts
@@ -350,11 +350,11 @@ expectType<WithId<{ a: number; b: string }> | null>(
 );
 
 // NODE-3568: Uncomment when ModifyResult is removed in 5.0
-// expectType<Document> | null>((await coll.findOneAndDelete({ a: 3 })));
-// expectType<Document | null>(
+// expectType<WithId<TSchema> | null> | null>((await coll.findOneAndDelete({ a: 3 })));
+// expectType<WithId<TSchema> | null>(
 //   (await coll.findOneAndReplace({ a: 3 }, { a: 5, b: 'new string' }))
 // );
-// expectType<Document | null>(
+// expectType<WithId<TSchema> | null>(
 //   (
 //     await coll.findOneAndUpdate(
 //       { a: 3 },


### PR DESCRIPTION
### Description

Deprecates the `ModifyResult` type.

#### What is changing?

- Deprecates the `ModifyResult` type.
- Adds commented out type tests to use later when returning the actual result document.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-4681

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
