### PR TITLE
docs(NODE-4798): move deprecated overloads to the bottom

### DIFF
--- a/src/admin.ts
+++ b/src/admin.ts
@@ -60,9 +60,9 @@ export class Admin {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   command(command: Document): Promise<Document>;
+  command(command: Document, options: RunCommandOptions): Promise<Document>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   command(command: Document, callback: Callback<Document>): void;
-  command(command: Document, options: RunCommandOptions): Promise<Document>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   command(command: Document, options: RunCommandOptions, callback: Callback<Document>): void;
   command(
@@ -87,9 +87,9 @@ export class Admin {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   buildInfo(): Promise<Document>;
+  buildInfo(options: CommandOperationOptions): Promise<Document>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   buildInfo(callback: Callback<Document>): void;
-  buildInfo(options: CommandOperationOptions): Promise<Document>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   buildInfo(options: CommandOperationOptions, callback: Callback<Document>): void;
   buildInfo(
@@ -108,9 +108,9 @@ export class Admin {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   serverInfo(): Promise<Document>;
+  serverInfo(options: CommandOperationOptions): Promise<Document>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   serverInfo(callback: Callback<Document>): void;
-  serverInfo(options: CommandOperationOptions): Promise<Document>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   serverInfo(options: CommandOperationOptions, callback: Callback<Document>): void;
   serverInfo(
@@ -129,9 +129,9 @@ export class Admin {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   serverStatus(): Promise<Document>;
+  serverStatus(options: CommandOperationOptions): Promise<Document>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   serverStatus(callback: Callback<Document>): void;
-  serverStatus(options: CommandOperationOptions): Promise<Document>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   serverStatus(options: CommandOperationOptions, callback: Callback<Document>): void;
   serverStatus(
@@ -150,9 +150,9 @@ export class Admin {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   ping(): Promise<Document>;
+  ping(options: CommandOperationOptions): Promise<Document>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   ping(callback: Callback<Document>): void;
-  ping(options: CommandOperationOptions): Promise<Document>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   ping(options: CommandOperationOptions, callback: Callback<Document>): void;
   ping(
@@ -173,15 +173,15 @@ export class Admin {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   addUser(username: string): Promise<Document>;
+  addUser(username: string, password: string): Promise<Document>;
+  addUser(username: string, options: AddUserOptions): Promise<Document>;
+  addUser(username: string, password: string, options: AddUserOptions): Promise<Document>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   addUser(username: string, callback: Callback<Document>): void;
-  addUser(username: string, password: string): Promise<Document>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   addUser(username: string, password: string, callback: Callback<Document>): void;
-  addUser(username: string, options: AddUserOptions): Promise<Document>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   addUser(username: string, options: AddUserOptions, callback: Callback<Document>): void;
-  addUser(username: string, password: string, options: AddUserOptions): Promise<Document>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   addUser(
     username: string,
@@ -224,9 +224,9 @@ export class Admin {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   removeUser(username: string): Promise<boolean>;
+  removeUser(username: string, options: RemoveUserOptions): Promise<boolean>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   removeUser(username: string, callback: Callback<boolean>): void;
-  removeUser(username: string, options: RemoveUserOptions): Promise<boolean>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   removeUser(username: string, options: RemoveUserOptions, callback: Callback<boolean>): void;
   removeUser(
@@ -252,9 +252,9 @@ export class Admin {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   validateCollection(collectionName: string): Promise<Document>;
+  validateCollection(collectionName: string, options: ValidateCollectionOptions): Promise<Document>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   validateCollection(collectionName: string, callback: Callback<Document>): void;
-  validateCollection(collectionName: string, options: ValidateCollectionOptions): Promise<Document>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   validateCollection(
     collectionName: string,
@@ -283,9 +283,9 @@ export class Admin {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   listDatabases(): Promise<ListDatabasesResult>;
+  listDatabases(options: ListDatabasesOptions): Promise<ListDatabasesResult>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   listDatabases(callback: Callback<ListDatabasesResult>): void;
-  listDatabases(options: ListDatabasesOptions): Promise<ListDatabasesResult>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   listDatabases(options: ListDatabasesOptions, callback: Callback<ListDatabasesResult>): void;
   listDatabases(
@@ -309,9 +309,9 @@ export class Admin {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   replSetGetStatus(): Promise<Document>;
+  replSetGetStatus(options: CommandOperationOptions): Promise<Document>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   replSetGetStatus(callback: Callback<Document>): void;
-  replSetGetStatus(options: CommandOperationOptions): Promise<Document>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   replSetGetStatus(options: CommandOperationOptions, callback: Callback<Document>): void;
   replSetGetStatus(

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -263,15 +263,15 @@ export class Collection<TSchema extends Document = Document> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   insertOne(doc: OptionalUnlessRequiredId<TSchema>): Promise<InsertOneResult<TSchema>>;
+  insertOne(
+    doc: OptionalUnlessRequiredId<TSchema>,
+    options: InsertOneOptions
+  ): Promise<InsertOneResult<TSchema>>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   insertOne(
     doc: OptionalUnlessRequiredId<TSchema>,
     callback: Callback<InsertOneResult<TSchema>>
   ): void;
-  insertOne(
-    doc: OptionalUnlessRequiredId<TSchema>,
-    options: InsertOneOptions
-  ): Promise<InsertOneResult<TSchema>>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   insertOne(
     doc: OptionalUnlessRequiredId<TSchema>,
@@ -315,15 +315,15 @@ export class Collection<TSchema extends Document = Document> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   insertMany(docs: OptionalUnlessRequiredId<TSchema>[]): Promise<InsertManyResult<TSchema>>;
+  insertMany(
+    docs: OptionalUnlessRequiredId<TSchema>[],
+    options: BulkWriteOptions
+  ): Promise<InsertManyResult<TSchema>>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   insertMany(
     docs: OptionalUnlessRequiredId<TSchema>[],
     callback: Callback<InsertManyResult<TSchema>>
   ): void;
-  insertMany(
-    docs: OptionalUnlessRequiredId<TSchema>[],
-    options: BulkWriteOptions
-  ): Promise<InsertManyResult<TSchema>>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   insertMany(
     docs: OptionalUnlessRequiredId<TSchema>[],
@@ -372,15 +372,15 @@ export class Collection<TSchema extends Document = Document> {
    * @throws MongoDriverError if operations is not an array
    */
   bulkWrite(operations: AnyBulkWriteOperation<TSchema>[]): Promise<BulkWriteResult>;
+  bulkWrite(
+    operations: AnyBulkWriteOperation<TSchema>[],
+    options: BulkWriteOptions
+  ): Promise<BulkWriteResult>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   bulkWrite(
     operations: AnyBulkWriteOperation<TSchema>[],
     callback: Callback<BulkWriteResult>
   ): void;
-  bulkWrite(
-    operations: AnyBulkWriteOperation<TSchema>[],
-    options: BulkWriteOptions
-  ): Promise<BulkWriteResult>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   bulkWrite(
     operations: AnyBulkWriteOperation<TSchema>[],
@@ -422,17 +422,17 @@ export class Collection<TSchema extends Document = Document> {
     filter: Filter<TSchema>,
     update: UpdateFilter<TSchema> | Partial<TSchema>
   ): Promise<UpdateResult>;
+  updateOne(
+    filter: Filter<TSchema>,
+    update: UpdateFilter<TSchema> | Partial<TSchema>,
+    options: UpdateOptions
+  ): Promise<UpdateResult>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   updateOne(
     filter: Filter<TSchema>,
     update: UpdateFilter<TSchema> | Partial<TSchema>,
     callback: Callback<UpdateResult>
   ): void;
-  updateOne(
-    filter: Filter<TSchema>,
-    update: UpdateFilter<TSchema> | Partial<TSchema>,
-    options: UpdateOptions
-  ): Promise<UpdateResult>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   updateOne(
     filter: Filter<TSchema>,
@@ -472,17 +472,17 @@ export class Collection<TSchema extends Document = Document> {
     filter: Filter<TSchema>,
     replacement: WithoutId<TSchema>
   ): Promise<UpdateResult | Document>;
+  replaceOne(
+    filter: Filter<TSchema>,
+    replacement: WithoutId<TSchema>,
+    options: ReplaceOptions
+  ): Promise<UpdateResult | Document>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   replaceOne(
     filter: Filter<TSchema>,
     replacement: WithoutId<TSchema>,
     callback: Callback<UpdateResult | Document>
   ): void;
-  replaceOne(
-    filter: Filter<TSchema>,
-    replacement: WithoutId<TSchema>,
-    options: ReplaceOptions
-  ): Promise<UpdateResult | Document>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   replaceOne(
     filter: Filter<TSchema>,
@@ -522,17 +522,17 @@ export class Collection<TSchema extends Document = Document> {
     filter: Filter<TSchema>,
     update: UpdateFilter<TSchema>
   ): Promise<UpdateResult | Document>;
+  updateMany(
+    filter: Filter<TSchema>,
+    update: UpdateFilter<TSchema>,
+    options: UpdateOptions
+  ): Promise<UpdateResult | Document>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   updateMany(
     filter: Filter<TSchema>,
     update: UpdateFilter<TSchema>,
     callback: Callback<UpdateResult | Document>
   ): void;
-  updateMany(
-    filter: Filter<TSchema>,
-    update: UpdateFilter<TSchema>,
-    options: UpdateOptions
-  ): Promise<UpdateResult | Document>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   updateMany(
     filter: Filter<TSchema>,
@@ -568,9 +568,9 @@ export class Collection<TSchema extends Document = Document> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   deleteOne(filter: Filter<TSchema>): Promise<DeleteResult>;
+  deleteOne(filter: Filter<TSchema>, options: DeleteOptions): Promise<DeleteResult>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   deleteOne(filter: Filter<TSchema>, callback: Callback<DeleteResult>): void;
-  deleteOne(filter: Filter<TSchema>, options: DeleteOptions): Promise<DeleteResult>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   deleteOne(
     filter: Filter<TSchema>,
@@ -599,9 +599,9 @@ export class Collection<TSchema extends Document = Document> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   deleteMany(filter: Filter<TSchema>): Promise<DeleteResult>;
+  deleteMany(filter: Filter<TSchema>, options: DeleteOptions): Promise<DeleteResult>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   deleteMany(filter: Filter<TSchema>, callback: Callback<DeleteResult>): void;
-  deleteMany(filter: Filter<TSchema>, options: DeleteOptions): Promise<DeleteResult>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   deleteMany(
     filter: Filter<TSchema>,
@@ -644,9 +644,9 @@ export class Collection<TSchema extends Document = Document> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   rename(newName: string): Promise<Collection>;
+  rename(newName: string, options: RenameOptions): Promise<Collection>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   rename(newName: string, callback: Callback<Collection>): void;
-  rename(newName: string, options: RenameOptions): Promise<Collection>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   rename(newName: string, options: RenameOptions, callback: Callback<Collection>): void;
   rename(
@@ -674,9 +674,9 @@ export class Collection<TSchema extends Document = Document> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   drop(): Promise<boolean>;
+  drop(options: DropCollectionOptions): Promise<boolean>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   drop(callback: Callback<boolean>): void;
-  drop(options: DropCollectionOptions): Promise<boolean>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   drop(options: DropCollectionOptions, callback: Callback<boolean>): void;
   drop(
@@ -701,12 +701,12 @@ export class Collection<TSchema extends Document = Document> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   findOne(): Promise<WithId<TSchema> | null>;
+  findOne(filter: Filter<TSchema>): Promise<WithId<TSchema> | null>;
+  findOne(filter: Filter<TSchema>, options: FindOptions): Promise<WithId<TSchema> | null>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   findOne(callback: Callback<WithId<TSchema> | null>): void;
-  findOne(filter: Filter<TSchema>): Promise<WithId<TSchema> | null>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   findOne(filter: Filter<TSchema>, callback: Callback<WithId<TSchema> | null>): void;
-  findOne(filter: Filter<TSchema>, options: FindOptions): Promise<WithId<TSchema> | null>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   findOne(
     filter: Filter<TSchema>,
@@ -716,10 +716,10 @@ export class Collection<TSchema extends Document = Document> {
 
   // allow an override of the schema.
   findOne<T = TSchema>(): Promise<T | null>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
-  findOne<T = TSchema>(callback: Callback<T | null>): void;
   findOne<T = TSchema>(filter: Filter<TSchema>): Promise<T | null>;
   findOne<T = TSchema>(filter: Filter<TSchema>, options?: FindOptions): Promise<T | null>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
+  findOne<T = TSchema>(callback: Callback<T | null>): void;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   findOne<T = TSchema>(
     filter: Filter<TSchema>,
@@ -786,9 +786,9 @@ export class Collection<TSchema extends Document = Document> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   options(): Promise<Document>;
+  options(options: OperationOptions): Promise<Document>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   options(callback: Callback<Document>): void;
-  options(options: OperationOptions): Promise<Document>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   options(options: OperationOptions, callback: Callback<Document>): void;
   options(
@@ -811,9 +811,9 @@ export class Collection<TSchema extends Document = Document> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   isCapped(): Promise<boolean>;
+  isCapped(options: OperationOptions): Promise<boolean>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   isCapped(callback: Callback<boolean>): void;
-  isCapped(options: OperationOptions): Promise<boolean>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   isCapped(options: OperationOptions, callback: Callback<boolean>): void;
   isCapped(
@@ -859,9 +859,9 @@ export class Collection<TSchema extends Document = Document> {
    * ```
    */
   createIndex(indexSpec: IndexSpecification): Promise<string>;
+  createIndex(indexSpec: IndexSpecification, options: CreateIndexesOptions): Promise<string>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   createIndex(indexSpec: IndexSpecification, callback: Callback<string>): void;
-  createIndex(indexSpec: IndexSpecification, options: CreateIndexesOptions): Promise<string>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   createIndex(
     indexSpec: IndexSpecification,
@@ -920,9 +920,9 @@ export class Collection<TSchema extends Document = Document> {
    * ```
    */
   createIndexes(indexSpecs: IndexDescription[]): Promise<string[]>;
+  createIndexes(indexSpecs: IndexDescription[], options: CreateIndexesOptions): Promise<string[]>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   createIndexes(indexSpecs: IndexDescription[], callback: Callback<string[]>): void;
-  createIndexes(indexSpecs: IndexDescription[], options: CreateIndexesOptions): Promise<string[]>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   createIndexes(
     indexSpecs: IndexDescription[],
@@ -958,9 +958,9 @@ export class Collection<TSchema extends Document = Document> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   dropIndex(indexName: string): Promise<Document>;
+  dropIndex(indexName: string, options: DropIndexesOptions): Promise<Document>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   dropIndex(indexName: string, callback: Callback<Document>): void;
-  dropIndex(indexName: string, options: DropIndexesOptions): Promise<Document>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   dropIndex(indexName: string, options: DropIndexesOptions, callback: Callback<Document>): void;
   dropIndex(
@@ -988,9 +988,9 @@ export class Collection<TSchema extends Document = Document> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   dropIndexes(): Promise<Document>;
+  dropIndexes(options: DropIndexesOptions): Promise<Document>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   dropIndexes(callback: Callback<Document>): void;
-  dropIndexes(options: DropIndexesOptions): Promise<Document>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   dropIndexes(options: DropIndexesOptions, callback: Callback<Document>): void;
   dropIndexes(
@@ -1023,9 +1023,9 @@ export class Collection<TSchema extends Document = Document> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   indexExists(indexes: string | string[]): Promise<boolean>;
+  indexExists(indexes: string | string[], options: IndexInformationOptions): Promise<boolean>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   indexExists(indexes: string | string[], callback: Callback<boolean>): void;
-  indexExists(indexes: string | string[], options: IndexInformationOptions): Promise<boolean>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   indexExists(
     indexes: string | string[],
@@ -1053,9 +1053,9 @@ export class Collection<TSchema extends Document = Document> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   indexInformation(): Promise<Document>;
+  indexInformation(options: IndexInformationOptions): Promise<Document>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   indexInformation(callback: Callback<Document>): void;
-  indexInformation(options: IndexInformationOptions): Promise<Document>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   indexInformation(options: IndexInformationOptions, callback: Callback<Document>): void;
   indexInformation(
@@ -1086,9 +1086,9 @@ export class Collection<TSchema extends Document = Document> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   estimatedDocumentCount(): Promise<number>;
+  estimatedDocumentCount(options: EstimatedDocumentCountOptions): Promise<number>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   estimatedDocumentCount(callback: Callback<number>): void;
-  estimatedDocumentCount(options: EstimatedDocumentCountOptions): Promise<number>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   estimatedDocumentCount(options: EstimatedDocumentCountOptions, callback: Callback<number>): void;
   estimatedDocumentCount(
@@ -1130,20 +1130,18 @@ export class Collection<TSchema extends Document = Document> {
    * @see https://docs.mongodb.com/manual/reference/operator/query/centerSphere/#op._S_centerSphere
    */
   countDocuments(): Promise<number>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
-  countDocuments(callback: Callback<number>): void;
   countDocuments(filter: Filter<TSchema>): Promise<number>;
+  countDocuments(filter: Filter<TSchema>, options: CountDocumentsOptions): Promise<number>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   countDocuments(callback: Callback<number>): void;
-  countDocuments(filter: Filter<TSchema>, options: CountDocumentsOptions): Promise<number>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
+  countDocuments(filter: Filter<TSchema>, callback: Callback<number>): void;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   countDocuments(
     filter: Filter<TSchema>,
     options: CountDocumentsOptions,
     callback: Callback<number>
   ): void;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
-  countDocuments(filter: Filter<TSchema>, callback: Callback<number>): void;
   countDocuments(
     filter?: Document | CountDocumentsOptions | Callback<number>,
     options?: CountDocumentsOptions | Callback<number>,
@@ -1182,26 +1180,26 @@ export class Collection<TSchema extends Document = Document> {
   distinct<Key extends keyof WithId<TSchema>>(
     key: Key
   ): Promise<Array<Flatten<WithId<TSchema>[Key]>>>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
-  distinct<Key extends keyof WithId<TSchema>>(
-    key: Key,
-    callback: Callback<Array<Flatten<WithId<TSchema>[Key]>>>
-  ): void;
   distinct<Key extends keyof WithId<TSchema>>(
     key: Key,
     filter: Filter<TSchema>
   ): Promise<Array<Flatten<WithId<TSchema>[Key]>>>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
-  distinct<Key extends keyof WithId<TSchema>>(
-    key: Key,
-    filter: Filter<TSchema>,
-    callback: Callback<Array<Flatten<WithId<TSchema>[Key]>>>
-  ): void;
   distinct<Key extends keyof WithId<TSchema>>(
     key: Key,
     filter: Filter<TSchema>,
     options: DistinctOptions
   ): Promise<Array<Flatten<WithId<TSchema>[Key]>>>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
+  distinct<Key extends keyof WithId<TSchema>>(
+    key: Key,
+    callback: Callback<Array<Flatten<WithId<TSchema>[Key]>>>
+  ): void;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
+  distinct<Key extends keyof WithId<TSchema>>(
+    key: Key,
+    filter: Filter<TSchema>,
+    callback: Callback<Array<Flatten<WithId<TSchema>[Key]>>>
+  ): void;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   distinct<Key extends keyof WithId<TSchema>>(
     key: Key,
@@ -1212,12 +1210,12 @@ export class Collection<TSchema extends Document = Document> {
 
   // Embedded documents overload
   distinct(key: string): Promise<any[]>;
+  distinct(key: string, filter: Filter<TSchema>): Promise<any[]>;
+  distinct(key: string, filter: Filter<TSchema>, options: DistinctOptions): Promise<any[]>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   distinct(key: string, callback: Callback<any[]>): void;
-  distinct(key: string, filter: Filter<TSchema>): Promise<any[]>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   distinct(key: string, filter: Filter<TSchema>, callback: Callback<any[]>): void;
-  distinct(key: string, filter: Filter<TSchema>, options: DistinctOptions): Promise<any[]>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   distinct(
     key: string,
@@ -1260,9 +1258,9 @@ export class Collection<TSchema extends Document = Document> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   indexes(): Promise<Document[]>;
+  indexes(options: IndexInformationOptions): Promise<Document[]>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   indexes(callback: Callback<Document[]>): void;
-  indexes(options: IndexInformationOptions): Promise<Document[]>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   indexes(options: IndexInformationOptions, callback: Callback<Document[]>): void;
   indexes(
@@ -1285,9 +1283,9 @@ export class Collection<TSchema extends Document = Document> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   stats(): Promise<CollStats>;
+  stats(options: CollStatsOptions): Promise<CollStats>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   stats(callback: Callback<CollStats>): void;
-  stats(options: CollStatsOptions): Promise<CollStats>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   stats(options: CollStatsOptions, callback: Callback<CollStats>): void;
   stats(
@@ -1354,17 +1352,17 @@ export class Collection<TSchema extends Document = Document> {
     filter: Filter<TSchema>,
     replacement: WithoutId<TSchema>
   ): Promise<ModifyResult<TSchema>>;
+  findOneAndReplace(
+    filter: Filter<TSchema>,
+    replacement: WithoutId<TSchema>,
+    options: FindOneAndReplaceOptions
+  ): Promise<ModifyResult<TSchema>>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   findOneAndReplace(
     filter: Filter<TSchema>,
     replacement: WithoutId<TSchema>,
     callback: Callback<ModifyResult<TSchema>>
   ): void;
-  findOneAndReplace(
-    filter: Filter<TSchema>,
-    replacement: WithoutId<TSchema>,
-    options: FindOneAndReplaceOptions
-  ): Promise<ModifyResult<TSchema>>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   findOneAndReplace(
     filter: Filter<TSchema>,
@@ -1404,17 +1402,17 @@ export class Collection<TSchema extends Document = Document> {
     filter: Filter<TSchema>,
     update: UpdateFilter<TSchema>
   ): Promise<ModifyResult<TSchema>>;
+  findOneAndUpdate(
+    filter: Filter<TSchema>,
+    update: UpdateFilter<TSchema>,
+    options: FindOneAndUpdateOptions
+  ): Promise<ModifyResult<TSchema>>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   findOneAndUpdate(
     filter: Filter<TSchema>,
     update: UpdateFilter<TSchema>,
     callback: Callback<ModifyResult<TSchema>>
   ): void;
-  findOneAndUpdate(
-    filter: Filter<TSchema>,
-    update: UpdateFilter<TSchema>,
-    options: FindOneAndUpdateOptions
-  ): Promise<ModifyResult<TSchema>>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   findOneAndUpdate(
     filter: Filter<TSchema>,
@@ -1538,17 +1536,17 @@ export class Collection<TSchema extends Document = Document> {
     map: string | MapFunction<TSchema>,
     reduce: string | ReduceFunction<TKey, TValue>
   ): Promise<Document | Document[]>;
+  mapReduce<TKey = any, TValue = any>(
+    map: string | MapFunction<TSchema>,
+    reduce: string | ReduceFunction<TKey, TValue>,
+    options: MapReduceOptions<TKey, TValue>
+  ): Promise<Document | Document[]>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   mapReduce<TKey = any, TValue = any>(
     map: string | MapFunction<TSchema>,
     reduce: string | ReduceFunction<TKey, TValue>,
     callback: Callback<Document | Document[]>
   ): void;
-  mapReduce<TKey = any, TValue = any>(
-    map: string | MapFunction<TSchema>,
-    reduce: string | ReduceFunction<TKey, TValue>,
-    options: MapReduceOptions<TKey, TValue>
-  ): Promise<Document | Document[]>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   mapReduce<TKey = any, TValue = any>(
     map: string | MapFunction<TSchema>,
@@ -1720,12 +1718,12 @@ export class Collection<TSchema extends Document = Document> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   count(): Promise<number>;
+  count(filter: Filter<TSchema>): Promise<number>;
+  count(filter: Filter<TSchema>, options: CountOptions): Promise<number>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   count(callback: Callback<number>): void;
-  count(filter: Filter<TSchema>): Promise<number>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   count(filter: Filter<TSchema>, callback: Callback<number>): void;
-  count(filter: Filter<TSchema>, options: CountOptions): Promise<number>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   count(
     filter: Filter<TSchema>,

--- a/src/cursor/aggregation_cursor.ts
+++ b/src/cursor/aggregation_cursor.ts
@@ -78,9 +78,9 @@ export class AggregationCursor<TSchema = any> extends AbstractCursor<TSchema> {
 
   /** Execute the explain for the cursor */
   explain(): Promise<Document>;
+  explain(verbosity: ExplainVerbosityLike): Promise<Document>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   explain(callback: Callback): void;
-  explain(verbosity: ExplainVerbosityLike): Promise<Document>;
   explain(
     verbosity?: ExplainVerbosityLike | Callback,
     callback?: Callback<Document>

--- a/src/cursor/find_cursor.ts
+++ b/src/cursor/find_cursor.ts
@@ -122,10 +122,10 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
    * @deprecated Use `collection.estimatedDocumentCount` or `collection.countDocuments` instead
    */
   count(): Promise<number>;
-  /** @deprecated Use `collection.estimatedDocumentCount` or `collection.countDocuments` instead. Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
-  count(callback: Callback<number>): void;
   /** @deprecated Use `collection.estimatedDocumentCount` or `collection.countDocuments` instead. */
   count(options: CountOptions): Promise<number>;
+  /** @deprecated Use `collection.estimatedDocumentCount` or `collection.countDocuments` instead. Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
+  count(callback: Callback<number>): void;
   /** @deprecated Use `collection.estimatedDocumentCount` or `collection.countDocuments` instead. Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   count(options: CountOptions, callback: Callback<number>): void;
   count(
@@ -155,9 +155,9 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
 
   /** Execute the explain for the cursor */
   explain(): Promise<Document>;
+  explain(verbosity?: ExplainVerbosityLike): Promise<Document>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   explain(callback: Callback): void;
-  explain(verbosity?: ExplainVerbosityLike): Promise<Document>;
   explain(
     verbosity?: ExplainVerbosityLike | Callback,
     callback?: Callback<Document>

--- a/src/db.ts
+++ b/src/db.ts
@@ -277,9 +277,9 @@ export class Db {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   command(command: Document): Promise<Document>;
+  command(command: Document, options: RunCommandOptions): Promise<Document>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   command(command: Document, callback: Callback<Document>): void;
-  command(command: Document, options: RunCommandOptions): Promise<Document>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   command(command: Document, options: RunCommandOptions, callback: Callback<Document>): void;
   command(
@@ -354,9 +354,9 @@ export class Db {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   stats(): Promise<Document>;
+  stats(options: DbStatsOptions): Promise<Document>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   stats(callback: Callback<Document>): void;
-  stats(options: DbStatsOptions): Promise<Document>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   stats(options: DbStatsOptions, callback: Callback<Document>): void;
   stats(
@@ -413,17 +413,17 @@ export class Db {
     fromCollection: string,
     toCollection: string
   ): Promise<Collection<TSchema>>;
+  renameCollection<TSchema extends Document = Document>(
+    fromCollection: string,
+    toCollection: string,
+    options: RenameOptions
+  ): Promise<Collection<TSchema>>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   renameCollection<TSchema extends Document = Document>(
     fromCollection: string,
     toCollection: string,
     callback: Callback<Collection<TSchema>>
   ): void;
-  renameCollection<TSchema extends Document = Document>(
-    fromCollection: string,
-    toCollection: string,
-    options: RenameOptions
-  ): Promise<Collection<TSchema>>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   renameCollection<TSchema extends Document = Document>(
     fromCollection: string,
@@ -464,9 +464,9 @@ export class Db {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   dropCollection(name: string): Promise<boolean>;
+  dropCollection(name: string, options: DropCollectionOptions): Promise<boolean>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   dropCollection(name: string, callback: Callback<boolean>): void;
-  dropCollection(name: string, options: DropCollectionOptions): Promise<boolean>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   dropCollection(name: string, options: DropCollectionOptions, callback: Callback<boolean>): void;
   dropCollection(
@@ -490,9 +490,9 @@ export class Db {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   dropDatabase(): Promise<boolean>;
+  dropDatabase(options: DropDatabaseOptions): Promise<boolean>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   dropDatabase(callback: Callback<boolean>): void;
-  dropDatabase(options: DropDatabaseOptions): Promise<boolean>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   dropDatabase(options: DropDatabaseOptions, callback: Callback<boolean>): void;
   dropDatabase(
@@ -515,9 +515,9 @@ export class Db {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   collections(): Promise<Collection[]>;
+  collections(options: ListCollectionsOptions): Promise<Collection[]>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   collections(callback: Callback<Collection[]>): void;
-  collections(options: ListCollectionsOptions): Promise<Collection[]>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   collections(options: ListCollectionsOptions, callback: Callback<Collection[]>): void;
   collections(
@@ -542,13 +542,13 @@ export class Db {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   createIndex(name: string, indexSpec: IndexSpecification): Promise<string>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
-  createIndex(name: string, indexSpec: IndexSpecification, callback: Callback<string>): void;
   createIndex(
     name: string,
     indexSpec: IndexSpecification,
     options: CreateIndexesOptions
   ): Promise<string>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
+  createIndex(name: string, indexSpec: IndexSpecification, callback: Callback<string>): void;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   createIndex(
     name: string,
@@ -580,15 +580,15 @@ export class Db {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   addUser(username: string): Promise<Document>;
+  addUser(username: string, password: string): Promise<Document>;
+  addUser(username: string, options: AddUserOptions): Promise<Document>;
+  addUser(username: string, password: string, options: AddUserOptions): Promise<Document>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   addUser(username: string, callback: Callback<Document>): void;
-  addUser(username: string, password: string): Promise<Document>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   addUser(username: string, password: string, callback: Callback<Document>): void;
-  addUser(username: string, options: AddUserOptions): Promise<Document>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   addUser(username: string, options: AddUserOptions, callback: Callback<Document>): void;
-  addUser(username: string, password: string, options: AddUserOptions): Promise<Document>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   addUser(
     username: string,
@@ -629,9 +629,9 @@ export class Db {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   removeUser(username: string): Promise<boolean>;
+  removeUser(username: string, options: RemoveUserOptions): Promise<boolean>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   removeUser(username: string, callback: Callback<boolean>): void;
-  removeUser(username: string, options: RemoveUserOptions): Promise<boolean>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   removeUser(username: string, options: RemoveUserOptions, callback: Callback<boolean>): void;
   removeUser(
@@ -656,12 +656,12 @@ export class Db {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   setProfilingLevel(level: ProfilingLevel): Promise<ProfilingLevel>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
-  setProfilingLevel(level: ProfilingLevel, callback: Callback<ProfilingLevel>): void;
   setProfilingLevel(
     level: ProfilingLevel,
     options: SetProfilingLevelOptions
   ): Promise<ProfilingLevel>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
+  setProfilingLevel(level: ProfilingLevel, callback: Callback<ProfilingLevel>): void;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   setProfilingLevel(
     level: ProfilingLevel,
@@ -689,9 +689,9 @@ export class Db {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   profilingLevel(): Promise<string>;
+  profilingLevel(options: ProfilingLevelOptions): Promise<string>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   profilingLevel(callback: Callback<string>): void;
-  profilingLevel(options: ProfilingLevelOptions): Promise<string>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   profilingLevel(options: ProfilingLevelOptions, callback: Callback<string>): void;
   profilingLevel(
@@ -715,9 +715,9 @@ export class Db {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   indexInformation(name: string): Promise<Document>;
+  indexInformation(name: string, options: IndexInformationOptions): Promise<Document>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   indexInformation(name: string, callback: Callback<Document>): void;
-  indexInformation(name: string, options: IndexInformationOptions): Promise<Document>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   indexInformation(
     name: string,

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -492,9 +492,9 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> {
    * @param callback - An optional callback, a Promise will be returned if none is provided
    */
   close(): Promise<void>;
+  close(force: boolean): Promise<void>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   close(callback: Callback<void>): void;
-  close(force: boolean): Promise<void>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   close(force: boolean, callback: Callback<void>): void;
   close(
@@ -596,9 +596,9 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> {
    * @see https://docs.mongodb.org/manual/reference/connection-string/
    */
   static connect(url: string): Promise<MongoClient>;
+  static connect(url: string, options: MongoClientOptions): Promise<MongoClient>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   static connect(url: string, callback: Callback<MongoClient>): void;
-  static connect(url: string, options: MongoClientOptions): Promise<MongoClient>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   static connect(url: string, options: MongoClientOptions, callback: Callback<MongoClient>): void;
   static connect(

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -248,9 +248,9 @@ export class ClientSession extends TypedEventEmitter<ClientSessionEvents> {
    * @param callback - Optional callback for completion of this operation
    */
   endSession(): Promise<void>;
+  endSession(options: EndSessionOptions): Promise<void>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   endSession(callback: Callback<void>): void;
-  endSession(options: EndSessionOptions): Promise<void>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   endSession(options: EndSessionOptions, callback: Callback<void>): void;
   endSession(


### PR DESCRIPTION
### Description

#### What is changing?

This PR simply moves all deprecated function overloads to the bottom of their signatures so that the overloads that should be used come up first and are preferred by TS

#### Is there new documentation needed for these changes?

No, they were already documented in the PR that introduced the deprecations

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->
When using TS's built-in types such as ReturnType or others, TS will usually grab the first overload of the function. Along with that, if you ever had an error in some of your function's arguments, the overload would often fallback to the callback one since, in the presence of an error, TS fins the first overload that matches the amount of parameters passed, causing your function's return type to be `void`. Also by doing this it will make it easier to remove all of these overloads when the time comes for that, and it will also make the diff look nicer

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->
https://jira.mongodb.org/browse/NODE-4798

### Double check the following

- [X] Ran `npm run check:lint` script
Got this error when running it but I believe that's not my fault
![image](https://user-images.githubusercontent.com/38259440/199806403-2ce93269-797c-4ed3-aa51-11c5016460d3.png)
- [X] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [X] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
