### PR TITLE
fix(NODE-4783): handle orphaned operation descriptions

### DIFF
--- a/src/cmap/connection.ts
+++ b/src/cmap/connection.ts
@@ -405,7 +405,7 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
     // making the `responseTo` change on each response
     this[kQueue].delete(message.responseTo);
     if ('moreToCome' in message && message.moreToCome) {
-      // NODE-4783: If the operation description check above does find an orphaned
+      // If the operation description check above does find an orphaned
       // description and sets the operationDescription then this line will put one
       // back in the queue with the correct requestId and will resolve not being able
       // to find the next one via the responseTo of the next streaming hello.

--- a/src/cmap/connection.ts
+++ b/src/cmap/connection.ts
@@ -374,24 +374,23 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
     this.emit('message', message);
     let operationDescription = this[kQueue].get(message.responseTo);
 
-    // Protect against multiplexing.
-    if (this[kQueue].size > 1) {
-      this.onError(new MongoRuntimeError(INVALID_QUEUE_SIZE));
-      return;
-    }
-
     if (!operationDescription && this.isMonitoringConnection) {
       // This is how we recover when the initial hello's requestId is not
       // the responseTo when hello responses have been skipped:
 
-      // Get the first orphaned operation description.
-      const entry = this[kQueue].entries().next();
-      if (entry) {
-        const [requestId, orphaned]: [number, OperationDescription] = entry.value;
-        // If the orphaned operation description exists then set it.
-        operationDescription = orphaned;
-        // Remove the entry with the bad request id from the queue.
-        this[kQueue].delete(requestId);
+      // First check if the map is of invalid size
+      if (this[kQueue].size > 1) {
+        this.onError(new MongoRuntimeError(INVALID_QUEUE_SIZE));
+      } else {
+        // Get the first orphaned operation description.
+        const entry = this[kQueue].entries().next();
+        if (entry) {
+          const [requestId, orphaned]: [number, OperationDescription] = entry.value;
+          // If the orphaned operation description exists then set it.
+          operationDescription = orphaned;
+          // Remove the entry with the bad request id from the queue.
+          this[kQueue].delete(requestId);
+        }
       }
     }
 

--- a/src/cmap/connection.ts
+++ b/src/cmap/connection.ts
@@ -375,8 +375,8 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
     let operationDescription = this[kQueue].get(message.responseTo);
 
     if (!operationDescription && this.isMonitoringConnection) {
-      // NODE-4783: How do we recover from this when the initial hello's requestId is not
-      // the responseTo when hello responses have been skipped?
+      // This is how we recover when the initial hello's requestId is not
+      // the responseTo when hello responses have been skipped:
 
       // First check if the map is of invalid size
       if (this[kQueue].size > 1) {

--- a/test/tools/utils.ts
+++ b/test/tools/utils.ts
@@ -1,6 +1,7 @@
 import { EJSON } from 'bson';
 import * as BSON from 'bson';
 import { expect } from 'chai';
+import { Readable } from 'stream';
 import { setTimeout } from 'timers';
 import { inspect, promisify } from 'util';
 

--- a/test/tools/utils.ts
+++ b/test/tools/utils.ts
@@ -354,6 +354,18 @@ export class TestBuilder {
   }
 }
 
+export function bufferToStream(buffer) {
+  const stream = new Readable();
+  if (Array.isArray(buffer)) {
+    buffer.forEach(b => stream.push(b));
+  } else {
+    stream.push(buffer);
+  }
+
+  stream.push(null);
+  return stream;
+}
+
 export function generateOpMsgBuffer(document: Document): Buffer {
   const header = Buffer.alloc(4 * 4 + 4);
 

--- a/test/unit/cmap/connection.test.ts
+++ b/test/unit/cmap/connection.test.ts
@@ -180,7 +180,6 @@ describe('new Connection()', function () {
           const thirdHello = generateOpMsgBuffer(document);
           const buffer = Buffer.concat([firstHello, secondHello, thirdHello]);
 
-          // @ts-expect-error: driverSocket does not fully satisfy the stream type, but that's okay
           connection = sinon.spy(new Connection(inputStream, connectionOptionsDefaults));
           connection.isMonitoringConnection = true;
           const queueSymbol = getSymbolFrom(connection, 'queue');

--- a/test/unit/cmap/connection.test.ts
+++ b/test/unit/cmap/connection.test.ts
@@ -234,7 +234,7 @@ describe('new Connection()', function () {
         });
 
         it('calls the operation description callback with the document', function () {
-          expect(callbackSpy).to.be.calledWith(undefined, document);
+          expect(callbackSpy).to.be.calledExactlyOnceWith(undefined, document);
         });
       });
     });

--- a/test/unit/cmap/connection.test.ts
+++ b/test/unit/cmap/connection.test.ts
@@ -159,67 +159,6 @@ describe('new Connection()', function () {
   });
 
   describe('#onMessage', function () {
-    context('when the connection is not a monitoring connection', function () {
-      let queue: Map<number, OperationDescription>;
-      let driverSocket: FakeSocket;
-      let connection: Connection;
-
-      beforeEach(function () {
-        driverSocket = sinon.spy(new FakeSocket());
-      });
-
-      context('when more than one operation description is in the queue', function () {
-        let spyOne;
-        let spyTwo;
-        const document = { ok: 1 };
-
-        beforeEach(function () {
-          spyOne = sinon.spy();
-          spyTwo = sinon.spy();
-
-          // @ts-expect-error: driverSocket does not fully satisfy the stream type, but that's okay
-          connection = new Connection(driverSocket, connectionOptionsDefaults);
-          const queueSymbol = getSymbolFrom(connection, 'queue');
-          queue = connection[queueSymbol];
-
-          // Create the operation descriptions.
-          const descriptionOne: OperationDescription = {
-            requestId: 1,
-            cb: spyOne
-          };
-          const descriptionTwo: OperationDescription = {
-            requestId: 2,
-            cb: spyTwo
-          };
-
-          // Stick an operation description in the queue.
-          queue.set(2, descriptionOne);
-          queue.set(3, descriptionTwo);
-          // Emit a message that matches the existing operation description.
-          const msg = generateOpMsgBuffer(document);
-          const msgHeader: MessageHeader = {
-            length: msg.readInt32LE(0),
-            requestId: 2,
-            responseTo: 1,
-            opCode: msg.readInt32LE(12)
-          };
-          const msgBody = msg.subarray(16);
-
-          const message = new BinMsg(msg, msgHeader, msgBody);
-          connection.onMessage(message);
-        });
-
-        it('calls all operation description callbacks with an error', function () {
-          expect(spyOne).to.be.calledOnce;
-          expect(spyTwo).to.be.calledOnce;
-          const errorOne = spyOne.firstCall.args[0];
-          const errorTwo = spyTwo.firstCall.args[0];
-          expect(errorOne).to.be.instanceof(MongoRuntimeError);
-          expect(errorTwo).to.be.instanceof(MongoRuntimeError);
-        });
-      });
-    });
-
     context('when the connection is a monitoring connection', function () {
       let queue: Map<number, OperationDescription>;
       let driverSocket: FakeSocket;

--- a/test/unit/cmap/connection.test.ts
+++ b/test/unit/cmap/connection.test.ts
@@ -201,7 +201,7 @@ describe('new Connection()', function () {
         });
 
         it('calls the operation description callback with the document', function () {
-          expect(callbackSpy).to.be.calledWith(undefined, document);
+          expect(callbackSpy).to.be.calledExactlyOnceWith(undefined, document);
         });
       });
 

--- a/test/unit/cmap/connection.test.ts
+++ b/test/unit/cmap/connection.test.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { EventEmitter, on } from 'events';
+import { EventEmitter, once } from 'events';
 import { Socket } from 'net';
 import * as sinon from 'sinon';
 import { Readable } from 'stream';
@@ -9,7 +9,7 @@ import { BinMsg } from '../../../src/cmap/commands';
 import { connect } from '../../../src/cmap/connect';
 import { Connection, hasSessionSupport } from '../../../src/cmap/connection';
 import { MessageStream } from '../../../src/cmap/message_stream';
-import { MongoNetworkTimeoutError } from '../../../src/error';
+import { MongoNetworkTimeoutError, MongoRuntimeError } from '../../../src/error';
 import { isHello, ns } from '../../../src/utils';
 import * as mock from '../../tools/mongodb-mock/index';
 import { generateOpMsgBuffer, getSymbolFrom } from '../../tools/utils';
@@ -172,12 +172,13 @@ describe('new Connection()', function () {
         let callbackSpy;
         const inputStream = new Readable();
         const document = { ok: 1 };
+        const last = { isWritablePrimary: true };
 
         beforeEach(function () {
           callbackSpy = sinon.spy();
           const firstHello = generateOpMsgBuffer(document);
           const secondHello = generateOpMsgBuffer(document);
-          const thirdHello = generateOpMsgBuffer(document);
+          const thirdHello = generateOpMsgBuffer(last);
           const buffer = Buffer.concat([firstHello, secondHello, thirdHello]);
 
           connection = sinon.spy(new Connection(inputStream, connectionOptionsDefaults));
@@ -199,9 +200,10 @@ describe('new Connection()', function () {
           inputStream.push(null);
         });
 
-        it('calls the operation description callback with the document', async function () {
-          await on(inputStream, 'message');
-          expect(callbackSpy).to.be.calledOnceWith(undefined, document);
+        it('calls the callback with the last hello document', async function () {
+          const messages = await once(connection, 'message');
+          expect(messages[0].responseTo).to.equal(0);
+          expect(callbackSpy).to.be.calledOnceWith(undefined, last);
         });
       });
 
@@ -230,8 +232,8 @@ describe('new Connection()', function () {
           const msg = generateOpMsgBuffer(document);
           const msgHeader: MessageHeader = {
             length: msg.readInt32LE(0),
-            requestId: msg.readInt32LE(4),
-            responseTo: msg.readInt32LE(8),
+            requestId: 1,
+            responseTo: 0, // This will not match.
             opCode: msg.readInt32LE(12)
           };
           const msgBody = msg.subarray(16);
@@ -282,6 +284,58 @@ describe('new Connection()', function () {
 
         it('calls the operation description callback with the document', function () {
           expect(callbackSpy).to.be.calledOnceWith(undefined, document);
+        });
+      });
+
+      context('when more than one operation description is in the queue', function () {
+        let spyOne;
+        let spyTwo;
+        const document = { ok: 1 };
+
+        beforeEach(function () {
+          spyOne = sinon.spy();
+          spyTwo = sinon.spy();
+
+          // @ts-expect-error: driverSocket does not fully satisfy the stream type, but that's okay
+          connection = sinon.spy(new Connection(driverSocket, connectionOptionsDefaults));
+          connection.isMonitoringConnection = true;
+          const queueSymbol = getSymbolFrom(connection, 'queue');
+          queue = connection[queueSymbol];
+
+          // Create the operation descriptions.
+          const descriptionOne: OperationDescription = {
+            requestId: 1,
+            cb: spyOne
+          };
+          const descriptionTwo: OperationDescription = {
+            requestId: 2,
+            cb: spyTwo
+          };
+
+          // Stick an operation description in the queue.
+          queue.set(2, descriptionOne);
+          queue.set(3, descriptionTwo);
+          // Emit a message that matches the existing operation description.
+          const msg = generateOpMsgBuffer(document);
+          const msgHeader: MessageHeader = {
+            length: msg.readInt32LE(0),
+            requestId: 2,
+            responseTo: 1,
+            opCode: msg.readInt32LE(12)
+          };
+          const msgBody = msg.subarray(16);
+
+          const message = new BinMsg(msg, msgHeader, msgBody);
+          connection.onMessage(message);
+        });
+
+        it('calls all operation description callbacks with an error', function () {
+          expect(spyOne).to.be.calledOnce;
+          expect(spyTwo).to.be.calledOnce;
+          const errorOne = spyOne.firstCall.args[0];
+          const errorTwo = spyTwo.firstCall.args[0];
+          expect(errorOne).to.be.instanceof(MongoRuntimeError);
+          expect(errorTwo).to.be.instanceof(MongoRuntimeError);
         });
       });
     });

--- a/test/unit/cmap/message_stream.test.js
+++ b/test/unit/cmap/message_stream.test.js
@@ -6,19 +6,7 @@ const { MessageStream } = require('../../../src/cmap/message_stream');
 const { Msg } = require('../../../src/cmap/commands');
 const expect = require('chai').expect;
 const { LEGACY_HELLO_COMMAND } = require('../../../src/constants');
-const { generateOpMsgBuffer } = require('../../tools/utils');
-
-function bufferToStream(buffer) {
-  const stream = new Readable();
-  if (Array.isArray(buffer)) {
-    buffer.forEach(b => stream.push(b));
-  } else {
-    stream.push(buffer);
-  }
-
-  stream.push(null);
-  return stream;
-}
+const { bufferToStream, generateOpMsgBuffer } = require('../../tools/utils');
 
 describe('MessageStream', function () {
   context('when the stream is for a monitoring connection', function () {


### PR DESCRIPTION
### Description

In the case where streaming hello responses are skipped in the driver, the last hello that is processed will get ignored by the connection's `onMessage` handler because the `responseTo` field of the hello does not match the original `requestId`

#### What is changing?

This was the least invasive change I could think of doing without reworking the monitoring connection to not depend on its internal queue. That is the basis of not just matching the request and responses but all the callback execution and error handling also is closely coupled to the queue.

This change basically knows that when an operation description is not found in the queue for the `responseTo` field and it is a monitoring connection, that hellos have been skipped and there will be one operation description in the queue for the original hello that was sent. We remove this one from the queue and the `onMessage` handler will auto-correct and put a new operation description back in the queue with the correct key.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-4783 / SERVER-45775

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
