### PR TITLE
feat(NODE-4757): deprecate unused PipeOptions

### DIFF
--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -78,7 +78,10 @@ export type ResumeToken = unknown;
  */
 export type OperationTime = Timestamp;
 
-/** @public */
+/**
+ * @public
+ * @deprecated This interface is unused and will be removed in the next major version of the driver.
+ */
 export interface PipeOptions {
   end?: boolean;
 }


### PR DESCRIPTION
### Description
NODE-4757

#### What is changing?
Deprecating the unused PipeOptions public export

##### Is there new documentation needed for these changes?
No

#### What is the motivation for this change?
Clean up public API

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
