### PR TITLE
fix(NODE-4830): lazily import aws module

### DIFF
--- a/src/cmap/auth/mongodb_aws.ts
+++ b/src/cmap/auth/mongodb_aws.ts
@@ -4,7 +4,7 @@ import * as url from 'url';
 
 import type { Binary, BSONSerializeOptions } from '../../bson';
 import * as BSON from '../../bson';
-import { aws4, credentialProvider } from '../../deps';
+import { aws4, getAwsCredentialProvider } from '../../deps';
 import {
   MongoAWSError,
   MongoCompatibilityError,
@@ -197,6 +197,8 @@ function makeTempCredentials(credentials: MongoCredentials, callback: Callback<M
       })
     );
   }
+
+  const credentialProvider = getAwsCredentialProvider();
 
   // Check if the AWS credential provider from the SDK is present. If not,
   // use the old method.

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -72,18 +72,22 @@ type CredentialProvider = {
   fromNodeProviderChain(this: void): () => Promise<AWSCredentials>;
 };
 
-export let credentialProvider: CredentialProvider | { kModuleError: MongoMissingDependencyError } =
-  makeErrorModule(
-    new MongoMissingDependencyError(
-      'Optional module `@aws-sdk/credential-providers` not found.' +
-        ' Please install it to enable getting aws credentials via the official sdk.'
-    )
-  );
-
-try {
-  // Ensure you always wrap an optional require in the try block NODE-3199
-  credentialProvider = require('@aws-sdk/credential-providers');
-} catch {} // eslint-disable-line
+export function getAwsCredentialProvider():
+  | CredentialProvider
+  | { kModuleError: MongoMissingDependencyError } {
+  try {
+    // Ensure you always wrap an optional require in the try block NODE-3199
+    const credentialProvider = require('@aws-sdk/credential-providers');
+    return credentialProvider;
+  } catch {
+    return makeErrorModule(
+      new MongoMissingDependencyError(
+        'Optional module `@aws-sdk/credential-providers` not found.' +
+          ' Please install it to enable getting aws credentials via the official sdk.'
+      )
+    );
+  }
+}
 
 type SnappyLib = {
   [PKG_VERSION]: { major: number; minor: number; patch: number };


### PR DESCRIPTION
### Description

#### What is changing?

This PR refactors the import for the aws module to be imported lazily, on demand.

##### Is there new documentation needed for these changes?

No.

#### What is the motivation for this change?

We don't want to import aws code when aws is not configured by the user.

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
