### PR TITLE
fix(NODE-4831): check map value is not undefined

### DIFF
--- a/src/cmap/connection.ts
+++ b/src/cmap/connection.ts
@@ -384,8 +384,7 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
       } else {
         // Get the first orphaned operation description.
         const entry = this[kQueue].entries().next();
-        /* eslint no-restricted-syntax: 0 */
-        if (entry.value !== undefined) {
+        if (entry.value != null) {
           const [requestId, orphaned]: [number, OperationDescription] = entry.value;
           // If the orphaned operation description exists then set it.
           operationDescription = orphaned;

--- a/src/cmap/connection.ts
+++ b/src/cmap/connection.ts
@@ -384,7 +384,8 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
       } else {
         // Get the first orphaned operation description.
         const entry = this[kQueue].entries().next();
-        if (entry) {
+        /* eslint no-restricted-syntax: 0 */
+        if (entry.value !== undefined) {
           const [requestId, orphaned]: [number, OperationDescription] = entry.value;
           // If the orphaned operation description exists then set it.
           operationDescription = orphaned;

--- a/test/unit/cmap/connection.test.ts
+++ b/test/unit/cmap/connection.test.ts
@@ -311,7 +311,7 @@ describe('new Connection()', function () {
           const message = new BinMsg(msg, msgHeader, msgBody);
           expect(() => {
             connection.onMessage(message);
-          }).to.not.throw(/undefined is not iterable/);
+          }).to.not.throw();
         });
       });
 

--- a/test/unit/cmap/connection.test.ts
+++ b/test/unit/cmap/connection.test.ts
@@ -287,6 +287,34 @@ describe('new Connection()', function () {
         });
       });
 
+      context('when no operation description is in the queue', function () {
+        const document = { ok: 1 };
+
+        beforeEach(function () {
+          // @ts-expect-error: driverSocket does not fully satisfy the stream type, but that's okay
+          connection = sinon.spy(new Connection(driverSocket, connectionOptionsDefaults));
+          connection.isMonitoringConnection = true;
+          const queueSymbol = getSymbolFrom(connection, 'queue');
+          queue = connection[queueSymbol];
+        });
+
+        it('does not error', function () {
+          const msg = generateOpMsgBuffer(document);
+          const msgHeader: MessageHeader = {
+            length: msg.readInt32LE(0),
+            requestId: 2,
+            responseTo: 1,
+            opCode: msg.readInt32LE(12)
+          };
+          const msgBody = msg.subarray(16);
+
+          const message = new BinMsg(msg, msgHeader, msgBody);
+          expect(() => {
+            connection.onMessage(message);
+          }).to.not.throw(/undefined is not iterable/);
+        });
+      });
+
       context('when more than one operation description is in the queue', function () {
         let spyOne;
         let spyTwo;


### PR DESCRIPTION
### Description

When no operation description is in the monitoring connection's queue map and a message comes in the application would error _"TypeError: undefined is not iterable (cannot read property Symbol(Symbol.iterator))"._

#### What is changing?

The iterator `next()` call when nothing is in the map will return `{ value: undefined, done: true }` - so we change the existence check to look at the actual value.

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

NODE-4831

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
