### PR TITLE
chore(no-story): allow clones that use https in docs pre-generation check

### DIFF
--- a/etc/check-remote.sh
+++ b/etc/check-remote.sh
@@ -1,21 +1,6 @@
 #! /bin/bash
 
-echo "full list of remotes"
-git remote -v
-
-printf "\n\n"
-
-echo "push origin remote"
-git remote get-url --push origin
-
-printf "\n\n"
-
-echo "looking for 'github.com:mongodb' in uri"
-git remote get-url --push origin | grep -v "github.com:mongodb"
-
-printf "\n\n"
-
-if git remote get-url --push origin | grep -qv "github.com:mongodb"; then
+if git remote get-url --push origin | grep -qv "github.com:mongodb\|github.com/mongodb"; then
     echo "git remote does not match node-mongodb-native.  are you working off of a fork?"
     exit 1
 fi

--- a/etc/docs/build.ts
+++ b/etc/docs/build.ts
@@ -76,7 +76,6 @@ async function main() {
   try {
     await exec('bash ./etc/check-remote.sh');
   } catch (error) {
-    console.error(error.stderr);
     console.error(error.stdout);
     process.exit(1);
   }


### PR DESCRIPTION
### Description

#### What is changing?

Adds support for remotes that were cloned with https instead of ssh in our pre-docs generation check.

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
