### PR TITLE
test(NODE-4498): ts tests for OptionalId wrapping schemas with _id

### DIFF
--- a/test/types/schema_helpers.test-d.ts
+++ b/test/types/schema_helpers.test-d.ts
@@ -90,6 +90,48 @@ expectAssignable<SchemaWithIdInterface | null>(
   (await interfaceTestCollection.findOneAndUpdate({ a: 1 }, { a: 5 })).value
 );
 
+// OptionalId assignability when wrapping a schema with _id: number
+type SchemaWithIdNumberType = {
+  _id: number;
+  a: number;
+};
+interface SchemaWithIdNumberInterface {
+  _id: number;
+  a: number;
+}
+const typeNumberTestCollection = new Collection<OptionalId<SchemaWithIdNumberType>>(
+  {} as Db,
+  'test'
+);
+const interfaceNumberTestCollection = new Collection<OptionalId<SchemaWithIdNumberInterface>>(
+  {} as Db,
+  'test'
+);
+expectAssignable<SchemaWithIdNumberType | null>(await typeNumberTestCollection.findOne());
+expectAssignable<SchemaWithIdNumberInterface | null>(await interfaceNumberTestCollection.findOne());
+expectAssignable<SchemaWithIdNumberType>((await typeNumberTestCollection.find().toArray())[0]);
+expectAssignable<SchemaWithIdNumberInterface>(
+  (await interfaceNumberTestCollection.find().toArray())[0]
+);
+expectAssignable<SchemaWithIdNumberType | null>(
+  (await typeNumberTestCollection.findOneAndDelete({ a: 1 })).value
+);
+expectAssignable<SchemaWithIdNumberInterface | null>(
+  (await interfaceNumberTestCollection.findOneAndDelete({ a: 1 })).value
+);
+expectAssignable<SchemaWithIdNumberType | null>(
+  (await typeNumberTestCollection.findOneAndReplace({ a: 1 }, { a: 5 })).value
+);
+expectAssignable<SchemaWithIdNumberInterface | null>(
+  (await interfaceNumberTestCollection.findOneAndReplace({ a: 1 }, { a: 5 })).value
+);
+expectAssignable<SchemaWithIdNumberType | null>(
+  (await typeNumberTestCollection.findOneAndUpdate({ a: 1 }, { a: 5 })).value
+);
+expectAssignable<SchemaWithIdNumberInterface | null>(
+  (await interfaceNumberTestCollection.findOneAndUpdate({ a: 1 }, { a: 5 })).value
+);
+
 /** ----------------------------------------------------------------------
  * OptionalUnlessRequiredId
  */

--- a/test/types/schema_helpers.test-d.ts
+++ b/test/types/schema_helpers.test-d.ts
@@ -10,7 +10,10 @@ import type {
   WithoutId
 } from '../../src/mongo_types';
 
-// InferIdType
+/** ----------------------------------------------------------------------
+ * InferIdType
+ */
+
 expectType<InferIdType<Document>>(new ObjectId());
 expectType<InferIdType<{ _id: number }>>(1 + 1);
 expectType<InferIdType<{ a: number } | { b: string }>>(new ObjectId());
@@ -22,12 +25,19 @@ expectError<InferIdType<{ _id: Record<string, any> }>>({});
 expectAssignable<InferIdType<{ _id: number } | { b: string }>>(new ObjectId());
 expectAssignable<InferIdType<{ _id: number } | { b: string }>>(1 + 1);
 
-// WithId
+/** ----------------------------------------------------------------------
+ * WithId
+ */
+
 expectAssignable<WithId<Document>>({ _id: new ObjectId() });
 expectAssignable<WithId<{ a: number }>>({ _id: new ObjectId(), a: 3 });
 expectAssignable<WithId<{ _id: ObjectId }>>({ _id: new ObjectId() });
 expectAssignable<WithId<{ _id: number }>>({ _id: 5 });
 expectNotType<WithId<Document>>({ _id: 3 });
+
+/** ----------------------------------------------------------------------
+ * OptionalId
+ */
 
 // Changing _id to a type other than ObjectId makes it required:
 expectNotType<OptionalId<{ _id: number; a: number }>>({ a: 3 });
@@ -44,20 +54,33 @@ class MyId {}
 expectNotType<OptionalId<{ _id: MyId; a: number }>>({ a: 3 });
 expectNotType<OptionalId<{ _id: MyId; a: number }>>({ _id: new ObjectId(), a: 3 });
 
+/** ----------------------------------------------------------------------
+ * OptionalUnlessRequiredId
+ */
+
 declare function functionReturningOptionalId(): OptionalId<{
   _id?: ObjectId | undefined;
   a: number;
 }>;
-// OptionalUnlessRequiredId
 expectType<OptionalUnlessRequiredId<{ _id: ObjectId; a: number }>>({ a: 3, _id: new ObjectId() });
 expectType<OptionalUnlessRequiredId<{ _id?: ObjectId; a: number }>>(functionReturningOptionalId());
 
-// WithoutId removes _id whether defined in the schema or not
+/** ----------------------------------------------------------------------
+ * WithoutId
+ *
+ * WithoutId removes _id whether defined in the schema or not
+ */
+
 expectType<WithoutId<{ _id: number; a: number }>>({ a: 2 });
 expectNotType<WithoutId<{ _id: number; a: number }>>({ _id: 3, a: 2 });
 expectNotType<WithoutId<{ a: number }>>({ _id: 3, a: 2 });
 
-// EnhancedOmit fixes a problem with Typescript's built in Omit that breaks discriminated unions
+/** ----------------------------------------------------------------------
+ * EnhancedOmit
+ *
+ * EnhancedOmit fixes a problem with Typescript's built in Omit that breaks discriminated unions
+ */
+
 // NODE-3287
 // expectNotAssignable<EnhancedOmit<{ a: 'one' } | { b: 'two' }, 'a'>>({
 //   a: 'one' as const

--- a/test/types/schema_helpers.test-d.ts
+++ b/test/types/schema_helpers.test-d.ts
@@ -1,6 +1,7 @@
 import { Document, ObjectId } from 'bson';
 import { expectAssignable, expectError, expectNotType, expectType } from 'tsd';
 
+import { Collection, Db } from '../../src';
 import type {
   EnhancedOmit,
   InferIdType,
@@ -53,6 +54,41 @@ expectNotType<OptionalId<{ _id: number; [x: string]: number }>>({ a: 3 });
 class MyId {}
 expectNotType<OptionalId<{ _id: MyId; a: number }>>({ a: 3 });
 expectNotType<OptionalId<{ _id: MyId; a: number }>>({ _id: new ObjectId(), a: 3 });
+
+// OptionalId assignability when wrapping a schema with _id: ObjectId
+type SchemaWithIdType = {
+  _id: ObjectId;
+  a: number;
+};
+interface SchemaWithIdInterface {
+  _id: ObjectId;
+  a: number;
+}
+
+const typeTestCollection = new Collection<OptionalId<SchemaWithIdType>>({} as Db, 'test');
+const interfaceTestCollection = new Collection<OptionalId<SchemaWithIdInterface>>({} as Db, 'test');
+expectAssignable<SchemaWithIdType | null>(await typeTestCollection.findOne());
+expectAssignable<SchemaWithIdInterface | null>(await interfaceTestCollection.findOne());
+expectAssignable<SchemaWithIdType>((await typeTestCollection.find().toArray())[0]);
+expectAssignable<SchemaWithIdInterface>((await interfaceTestCollection.find().toArray())[0]);
+expectAssignable<SchemaWithIdType | null>(
+  (await typeTestCollection.findOneAndDelete({ a: 1 })).value
+);
+expectAssignable<SchemaWithIdInterface | null>(
+  (await interfaceTestCollection.findOneAndDelete({ a: 1 })).value
+);
+expectAssignable<SchemaWithIdType | null>(
+  (await typeTestCollection.findOneAndReplace({ a: 1 }, { a: 5 })).value
+);
+expectAssignable<SchemaWithIdInterface | null>(
+  (await interfaceTestCollection.findOneAndReplace({ a: 1 }, { a: 5 })).value
+);
+expectAssignable<SchemaWithIdType | null>(
+  (await typeTestCollection.findOneAndUpdate({ a: 1 }, { a: 5 })).value
+);
+expectAssignable<SchemaWithIdInterface | null>(
+  (await interfaceTestCollection.findOneAndUpdate({ a: 1 }, { a: 5 })).value
+);
 
 /** ----------------------------------------------------------------------
  * OptionalUnlessRequiredId

--- a/test/types/schema_helpers.test-d.ts
+++ b/test/types/schema_helpers.test-d.ts
@@ -1,7 +1,7 @@
 import { Document, ObjectId } from 'bson';
 import { expectAssignable, expectError, expectNotType, expectType } from 'tsd';
 
-import { Collection, Db } from '../../src';
+import type { Collection } from '../../src';
 import type {
   EnhancedOmit,
   InferIdType,
@@ -64,9 +64,9 @@ interface SchemaWithIdInterface {
   _id: ObjectId;
   a: number;
 }
+declare const typeTestCollection: Collection<OptionalId<SchemaWithIdType>>;
+declare const interfaceTestCollection: Collection<OptionalId<SchemaWithIdInterface>>;
 
-const typeTestCollection = new Collection<OptionalId<SchemaWithIdType>>({} as Db, 'test');
-const interfaceTestCollection = new Collection<OptionalId<SchemaWithIdInterface>>({} as Db, 'test');
 expectAssignable<SchemaWithIdType | null>(await typeTestCollection.findOne());
 expectAssignable<SchemaWithIdInterface | null>(await interfaceTestCollection.findOne());
 expectAssignable<SchemaWithIdType>((await typeTestCollection.find().toArray())[0]);
@@ -99,14 +99,9 @@ interface SchemaWithIdNumberInterface {
   _id: number;
   a: number;
 }
-const typeNumberTestCollection = new Collection<OptionalId<SchemaWithIdNumberType>>(
-  {} as Db,
-  'test'
-);
-const interfaceNumberTestCollection = new Collection<OptionalId<SchemaWithIdNumberInterface>>(
-  {} as Db,
-  'test'
-);
+declare const typeNumberTestCollection: Collection<OptionalId<SchemaWithIdNumberType>>;
+declare const interfaceNumberTestCollection: Collection<OptionalId<SchemaWithIdNumberInterface>>;
+
 expectAssignable<SchemaWithIdNumberType | null>(await typeNumberTestCollection.findOne());
 expectAssignable<SchemaWithIdNumberInterface | null>(await interfaceNumberTestCollection.findOne());
 expectAssignable<SchemaWithIdNumberType>((await typeNumberTestCollection.find().toArray())[0]);


### PR DESCRIPTION
### Description
NODE-4498
#### What is changing?

Adding tests to make sure document types returned from methods on a collection using an `OptionalId`-wrapped schema with a defined `_id` are still assignable to the original schema.

##### Is there new documentation needed for these changes?
No

#### What is the motivation for this change?
Ensure user types continue to work as expected when using the `OptionalId` helper wrapper

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
