### PR TITLE
test(NODE-4800): update build env scripts

### DIFF
--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -527,10 +527,11 @@ functions:
       type: test
       params:
         working_dir: "src"
+        shell: bash
         script: |
           ${PREPARE_SHELL}
           cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
-          . ./activate_venv.sh
+          . ./activate-authawsvenv.sh
           cd -
 
   "run aws auth test with regular aws credentials":
@@ -538,10 +539,11 @@ functions:
       type: test
       params:
         working_dir: "src"
+        shell: bash
         script: |
           ${PREPARE_SHELL}
           cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
-          . ./activate_venv.sh
+          . ./activate-authawsvenv.sh
           ${MONGODB_BINARIES}/mongo aws_e2e_regular_aws.js
     - command: shell.exec
       type: test
@@ -568,10 +570,11 @@ functions:
       type: test
       params:
         working_dir: "src"
+        shell: bash
         script: |
           ${PREPARE_SHELL}
           cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
-          . ./activate_venv.sh
+          . ./activate-authawsvenv.sh
           ${MONGODB_BINARIES}/mongo aws_e2e_assume_role.js
     - command: shell.exec
       type: test
@@ -602,13 +605,14 @@ functions:
       type: test
       params:
         working_dir: "src"
+        shell: bash
         script: |
           ${PREPARE_SHELL}
           # Write an empty prepare_mongodb_aws so no auth environment variables
           # are set.
           echo "" > "${PROJECT_DIRECTORY}/prepare_mongodb_aws.sh"
           cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
-          . ./activate_venv.sh
+          . ./activate-authawsvenv.sh
           ${MONGODB_BINARIES}/mongo aws_e2e_ec2.js
     - command: shell.exec
       type: test
@@ -671,6 +675,7 @@ functions:
       type: test
       params:
         working_dir: src
+        shell: bash
         script: |
           ${PREPARE_SHELL}
           AUTH_AWS_DIR=${DRIVERS_TOOLS}/.evergreen/auth_aws
@@ -691,7 +696,7 @@ functions:
           EOF
 
           cat setup.js
-          . ./activate_venv.sh
+          . ./activate-authawsvenv.sh
           ${MONGODB_BINARIES}/mongo --nodb setup.js aws_e2e_ecs.js
 
   "run-ocsp-test":

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -490,20 +490,22 @@ functions:
       type: test
       params:
         working_dir: src
+        shell: bash
         script: |
           ${PREPARE_SHELL}
           cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
-          . ./activate_venv.sh
+          . ./activate-authawsvenv.sh
           cd -
   run aws auth test with regular aws credentials:
     - command: shell.exec
       type: test
       params:
         working_dir: src
+        shell: bash
         script: |
           ${PREPARE_SHELL}
           cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
-          . ./activate_venv.sh
+          . ./activate-authawsvenv.sh
           ${MONGODB_BINARIES}/mongo aws_e2e_regular_aws.js
     - command: shell.exec
       type: test
@@ -529,10 +531,11 @@ functions:
       type: test
       params:
         working_dir: src
+        shell: bash
         script: |
           ${PREPARE_SHELL}
           cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
-          . ./activate_venv.sh
+          . ./activate-authawsvenv.sh
           ${MONGODB_BINARIES}/mongo aws_e2e_assume_role.js
     - command: shell.exec
       type: test
@@ -562,13 +565,14 @@ functions:
       type: test
       params:
         working_dir: src
+        shell: bash
         script: |
           ${PREPARE_SHELL}
           # Write an empty prepare_mongodb_aws so no auth environment variables
           # are set.
           echo "" > "${PROJECT_DIRECTORY}/prepare_mongodb_aws.sh"
           cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
-          . ./activate_venv.sh
+          . ./activate-authawsvenv.sh
           ${MONGODB_BINARIES}/mongo aws_e2e_ec2.js
     - command: shell.exec
       type: test
@@ -628,6 +632,7 @@ functions:
       type: test
       params:
         working_dir: src
+        shell: bash
         script: |
           ${PREPARE_SHELL}
           AUTH_AWS_DIR=${DRIVERS_TOOLS}/.evergreen/auth_aws
@@ -648,7 +653,7 @@ functions:
           EOF
 
           cat setup.js
-          . ./activate_venv.sh
+          . ./activate-authawsvenv.sh
           ${MONGODB_BINARIES}/mongo --nodb setup.js aws_e2e_ecs.js
   run-ocsp-test:
     - command: shell.exec

--- a/.evergreen/run-kms-servers.sh
+++ b/.evergreen/run-kms-servers.sh
@@ -1,5 +1,5 @@
 cd ${DRIVERS_TOOLS}/.evergreen/csfle
-. ./activate_venv.sh
+. ./activate-kmstlsvenv.sh
 # by default it always runs on port 5698
 ./kmstlsvenv/bin/python3 -u kms_kmip_server.py &
 ./kmstlsvenv/bin/python3 -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/expired.pem --port 8000 &

--- a/test/readme.md
+++ b/test/readme.md
@@ -422,7 +422,7 @@ The following steps will walk you through how to run the tests for CSFLE.
 #### KMIP FLE support tests
 
 1. Install virtualenv: `pip install virtualenv`
-2. Source the ./activate_venv.sh script in driver evergreen tools `.evergreen/csfle/activate_venv.sh`
+2. Source the ./activate-kmstlsvenv.sh script in driver evergreen tools `.evergreen/csfle/activate-kmstlsvenv.sh`
     1. This will install all the dependencies needed to run a python kms_kmip simulated server
 3. In 4 separate terminals launch the following:
     - `./kmstlsvenv/bin/python3 -u kms_kmip_server.py` # by default it always runs on port 5698

--- a/test/spec/client-side-encryption/tests/README.rst
+++ b/test/spec/client-side-encryption/tests/README.rst
@@ -1193,14 +1193,14 @@ KMS TLS Tests
 The following tests that connections to KMS servers with TLS verify peer certificates.
 
 The two tests below make use of mock KMS servers which can be run on Evergreen using `the mock KMS server script <https://github.com/mongodb-labs/drivers-evergreen-tools/blob/master/.evergreen/csfle/kms_http_server.py>`_.
-Drivers can set up their local Python enviroment for the mock KMS server by running `the virtualenv activation script <https://github.com/mongodb-labs/drivers-evergreen-tools/blob/master/.evergreen/csfle/activate_venv.sh>`_.
+Drivers can set up their local Python enviroment for the mock KMS server by running `the virtualenv activation script <https://github.com/mongodb-labs/drivers-evergreen-tools/blob/master/.evergreen/csfle/activate-kmstlsvenv.sh>`_.
 
 To start two mock KMS servers, one on port 9000 with `ca.pem`_ as a CA file and `expired.pem`_ as a cert file, and one on port 9001 with `ca.pem`_ as a CA file and `wrong-host.pem`_ as a cert file,
 run the following commands from the ``.evergreen/csfle`` directory:
 
 .. code::
 
-   . ./activate_venv.sh
+   . ./activate-kmstlsvenv.sh
    python -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/expired.pem --port 9000 &
    python -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/wrong-host.pem --port 9001 &
 


### PR DESCRIPTION
### Description

Update to latest drivers evergreen tools scripts.

Test failures on latest related to: https://jira.mongodb.org/browse/DRIVERS-2490

#### What is changing?

- Replaces usages of [csfle/activate_venv.sh](https://github.com/mongodb-labs/drivers-evergreen-tools/blob/a3a17f1185643135a6b24f318bf0ce1e58fdea94/.evergreen/csfle/activate_venv.sh) with [csfle/activate-kmstlsvenv.sh](https://github.com/mongodb-labs/drivers-evergreen-tools/blob/a3a17f1185643135a6b24f318bf0ce1e58fdea94/.evergreen/csfle/activate-kmstlsvenv.sh).
- Replaces usages of [auth_aws/activate_venv.sh](https://github.com/mongodb-labs/drivers-evergreen-tools/blob/a3a17f1185643135a6b24f318bf0ce1e58fdea94/.evergreen/auth_aws/activate_venv.sh) with [auth_aws/activate-authawsvenv.sh](https://github.com/mongodb-labs/drivers-evergreen-tools/blob/a3a17f1185643135a6b24f318bf0ce1e58fdea94/.evergreen/auth_aws/activate-authawsvenv.sh).
- Ensure new scripts are run in a bash shell.
- No usages of the utils script or OCSP in this repo.
- No usages of any of the scripts in our other managed repos. Changes only needed here.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-4800

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
