### PR TITLE
refactor(NODE-4904): change internal gridfs logic to use promises

### DIFF
--- a/test/integration/gridfs/gridfs.spec.test.js
+++ b/test/integration/gridfs/gridfs.spec.test.js
@@ -5,7 +5,7 @@ const { setupDatabase } = require('./../shared');
 const { expect } = require('chai');
 const { GridFSBucket } = require('../../../src');
 
-describe('GridFS', function () {
+describe('GridFS spec', function () {
   before(function () {
     return setupDatabase(this.configuration);
   });

--- a/test/integration/gridfs/gridfs.test.ts
+++ b/test/integration/gridfs/gridfs.test.ts
@@ -1,0 +1,112 @@
+import { expect } from 'chai';
+
+import { type Db, type MongoClient, CommandStartedEvent, GridFSBucket } from '../../../src';
+import { sleep } from '../../tools/utils';
+
+describe('GridFS', () => {
+  let client: MongoClient;
+  let db: Db;
+  let bucket: GridFSBucket;
+  let commandStartedEvents: CommandStartedEvent[];
+
+  beforeEach(async function () {
+    client = this.configuration.newClient({ monitorCommands: true });
+    db = client.db('gridfsTest');
+    await db.dropDatabase().catch(() => null);
+
+    commandStartedEvents = [];
+    client.on('commandStarted', e => commandStartedEvents.push(e));
+    bucket = new GridFSBucket(db);
+  });
+
+  afterEach(async function () {
+    commandStartedEvents = [];
+    await client.close();
+  });
+
+  describe('class GridFSBucket', () => {
+    const assertIndexesExist = () => {
+      const listIndexes = commandStartedEvents.filter(e => e.commandName === 'listIndexes');
+      expect(listIndexes).to.have.lengthOf(2);
+
+      const createIndexes = commandStartedEvents.filter(e => e.commandName === 'createIndexes');
+      expect(createIndexes).to.have.lengthOf(2);
+      expect(createIndexes[0]).to.have.deep.nested.property('command.createIndexes', 'fs.files');
+      expect(createIndexes[0]).to.have.deep.nested.property(
+        'command.indexes[0].key',
+        new Map([
+          ['filename', 1],
+          ['uploadDate', 1]
+        ])
+      );
+      expect(createIndexes[1]).to.have.deep.nested.property('command.createIndexes', 'fs.chunks');
+      expect(createIndexes[1]).to.have.deep.nested.property(
+        'command.indexes[0].key',
+        new Map([
+          ['files_id', 1],
+          ['n', 1]
+        ])
+      );
+    };
+
+    it('ensures chunks and files collection have required indexes when namespace does not exist', async () => {
+      // Ensure the namespace does not exist; beforeEach should drop the Db, keeping this true
+      expect(
+        (await db.collections()).filter(({ namespace }) => namespace.startsWith('fs'))
+      ).to.have.lengthOf(0);
+
+      const upload = bucket.openUploadStream('test.txt');
+      await upload.abort();
+
+      await sleep(100);
+      assertIndexesExist();
+    });
+
+    it('ensures chunks and files collection have required indexes when namespace does', async () => {
+      // Ensure the namespace does exist
+      await db.createCollection('fs.files');
+      await db.createCollection('fs.chunks');
+
+      const upload = bucket.openUploadStream('test.txt');
+      await upload.abort();
+
+      await sleep(100);
+      assertIndexesExist();
+    });
+
+    it('skips creating required indexes if they already exist', async () => {
+      const files = await db.createCollection('fs.files');
+      const chunks = await db.createCollection('fs.chunks');
+
+      await files.createIndex(
+        new Map([
+          ['filename', 1],
+          ['uploadDate', 1]
+        ])
+      );
+
+      await chunks.createIndex(
+        new Map([
+          ['files_id', 1],
+          ['n', 1]
+        ])
+      );
+
+      // reset events array
+      commandStartedEvents = [];
+
+      const upload = bucket.openUploadStream('test.txt');
+      await upload.abort();
+
+      await sleep(100);
+
+      // Still listed indexes
+      const listIndexes = commandStartedEvents.filter(e => e.commandName === 'listIndexes');
+      expect(listIndexes).to.have.lengthOf(2);
+
+      // But since it found them, we didn't attempt creation
+      const createIndexes = commandStartedEvents.filter(e => e.commandName === 'createIndexes');
+      expect(createIndexes).to.have.lengthOf(0);
+    });
+  });
+});


### PR DESCRIPTION
### Description

#### What is changing?

Refactor GridFS internals to use promises

#### What is the motivation for this change?

Isolate the changes needed for callback removals.

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
