### PR TITLE
feat(NODE-4436)!: update minimum supported node version

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2063,7 +2063,7 @@ tasks:
     commands:
       - func: install dependencies
         vars:
-          NODE_LTS_NAME: erbium
+          NODE_LTS_NAME: fermium
       - func: run unit tests
   - name: run-lint-checks
     tags:
@@ -2071,7 +2071,7 @@ tasks:
     commands:
       - func: install dependencies
         vars:
-          NODE_LTS_NAME: erbium
+          NODE_LTS_NAME: fermium
       - func: run lint checks
   - name: check-types-typescript-next
     tags:
@@ -2079,7 +2079,7 @@ tasks:
     commands:
       - func: install dependencies
         vars:
-          NODE_LTS_NAME: erbium
+          NODE_LTS_NAME: fermium
       - func: check types
         vars:
           TS_VERSION: next
@@ -2089,7 +2089,7 @@ tasks:
     commands:
       - func: install dependencies
         vars:
-          NODE_LTS_NAME: erbium
+          NODE_LTS_NAME: fermium
       - func: compile driver
         vars:
           TS_VERSION: current
@@ -2099,7 +2099,7 @@ tasks:
     commands:
       - func: install dependencies
         vars:
-          NODE_LTS_NAME: erbium
+          NODE_LTS_NAME: fermium
       - func: check types
         vars:
           TS_VERSION: current
@@ -2109,7 +2109,7 @@ tasks:
     commands:
       - func: install dependencies
         vars:
-          NODE_LTS_NAME: erbium
+          NODE_LTS_NAME: fermium
       - func: check types
         vars:
           TS_VERSION: 4.1.6
@@ -2137,7 +2137,7 @@ tasks:
     commands:
       - func: install dependencies
         vars:
-          NODE_LTS_NAME: erbium
+          NODE_LTS_NAME: fermium
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '5.0'
@@ -2146,7 +2146,7 @@ tasks:
       - name: run-bson-ext-integration
         func: run bson-ext test
         vars:
-          NODE_LTS_NAME: erbium
+          NODE_LTS_NAME: fermium
           TEST_NPM_SCRIPT: check:test
   - name: run-bson-ext-unit
     tags:
@@ -2154,7 +2154,7 @@ tasks:
     commands:
       - func: install dependencies
         vars:
-          NODE_LTS_NAME: erbium
+          NODE_LTS_NAME: fermium
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '5.0'
@@ -2163,7 +2163,7 @@ tasks:
       - name: run-bson-ext-unit
         func: run bson-ext test
         vars:
-          NODE_LTS_NAME: erbium
+          NODE_LTS_NAME: fermium
           TEST_NPM_SCRIPT: check:unit
   - name: run-custom-csfle-tests-5.0-pinned-commit
     tags:
@@ -2171,7 +2171,7 @@ tasks:
     commands:
       - func: install dependencies
         vars:
-          NODE_LTS_NAME: erbium
+          NODE_LTS_NAME: fermium
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '5.0'
@@ -2186,7 +2186,7 @@ tasks:
     commands:
       - func: install dependencies
         vars:
-          NODE_LTS_NAME: erbium
+          NODE_LTS_NAME: fermium
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '5.0'
@@ -2201,7 +2201,7 @@ tasks:
     commands:
       - func: install dependencies
         vars:
-          NODE_LTS_NAME: erbium
+          NODE_LTS_NAME: fermium
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: rapid
@@ -2216,7 +2216,7 @@ tasks:
     commands:
       - func: install dependencies
         vars:
-          NODE_LTS_NAME: erbium
+          NODE_LTS_NAME: fermium
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: rapid
@@ -2231,7 +2231,7 @@ tasks:
     commands:
       - func: install dependencies
         vars:
-          NODE_LTS_NAME: erbium
+          NODE_LTS_NAME: fermium
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: latest
@@ -2246,7 +2246,7 @@ tasks:
     commands:
       - func: install dependencies
         vars:
-          NODE_LTS_NAME: erbium
+          NODE_LTS_NAME: fermium
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: latest
@@ -2668,54 +2668,6 @@ buildvariants:
     run_on: rhel80-large
     tasks:
       - run-spec-benchmark-tests
-  - name: rhel80-large-erbium
-    display_name: rhel8 Node12
-    run_on: rhel80-large
-    expansions:
-      NODE_LTS_NAME: erbium
-      CLIENT_ENCRYPTION: true
-    tasks:
-      - test-latest-server
-      - test-latest-replica_set
-      - test-latest-sharded_cluster
-      - test-rapid-server
-      - test-rapid-replica_set
-      - test-rapid-sharded_cluster
-      - test-6.0-server
-      - test-6.0-replica_set
-      - test-6.0-sharded_cluster
-      - test-5.0-server
-      - test-5.0-replica_set
-      - test-5.0-sharded_cluster
-      - test-4.4-server
-      - test-4.4-replica_set
-      - test-4.4-sharded_cluster
-      - test-4.2-server
-      - test-4.2-replica_set
-      - test-4.2-sharded_cluster
-      - test-4.0-server
-      - test-4.0-replica_set
-      - test-4.0-sharded_cluster
-      - test-3.6-server
-      - test-3.6-replica_set
-      - test-3.6-sharded_cluster
-      - test-latest-server-v1-api
-      - test-atlas-connectivity
-      - test-atlas-data-lake
-      - test-5.0-load-balanced
-      - test-6.0-load-balanced
-      - test-latest-load-balanced
-      - test-auth-kerberos
-      - test-auth-ldap
-      - test-socks5
-      - test-socks5-tls
-      - test-zstd-compression
-      - test-snappy-compression
-      - test-tls-support-latest
-      - test-tls-support-6.0
-      - test-tls-support-5.0
-      - test-tls-support-4.4
-      - test-tls-support-4.2
   - name: rhel80-large-fermium
     display_name: rhel8 Node14
     run_on: rhel80-large
@@ -2899,48 +2851,6 @@ buildvariants:
       - test-tls-support-5.0
       - test-tls-support-4.4
       - test-tls-support-4.2
-  - name: windows-64-vs2019-erbium
-    display_name: Windows (VS2019) Node12
-    run_on: windows-64-vs2019-large
-    expansions:
-      NODE_LTS_NAME: erbium
-      MSVS_VERSION: 2019
-    tasks:
-      - test-latest-server
-      - test-latest-replica_set
-      - test-latest-sharded_cluster
-      - test-rapid-server
-      - test-rapid-replica_set
-      - test-rapid-sharded_cluster
-      - test-6.0-server
-      - test-6.0-replica_set
-      - test-6.0-sharded_cluster
-      - test-5.0-server
-      - test-5.0-replica_set
-      - test-5.0-sharded_cluster
-      - test-4.4-server
-      - test-4.4-replica_set
-      - test-4.4-sharded_cluster
-      - test-4.2-server
-      - test-4.2-replica_set
-      - test-4.2-sharded_cluster
-      - test-4.0-server
-      - test-4.0-replica_set
-      - test-4.0-sharded_cluster
-      - test-3.6-server
-      - test-3.6-replica_set
-      - test-3.6-sharded_cluster
-      - test-latest-server-v1-api
-      - test-atlas-data-lake
-      - test-socks5
-      - test-socks5-tls
-      - test-zstd-compression
-      - test-snappy-compression
-      - test-tls-support-latest
-      - test-tls-support-6.0
-      - test-tls-support-5.0
-      - test-tls-support-4.4
-      - test-tls-support-4.2
   - name: windows-64-vs2019-fermium
     display_name: Windows (VS2019) Node14
     run_on: windows-64-vs2019-large
@@ -3095,7 +3005,7 @@ buildvariants:
     display_name: MONGODB-AWS Auth test
     run_on: ubuntu1804-large
     expansions:
-      NODE_LTS_NAME: erbium
+      NODE_LTS_NAME: fermium
     tasks:
       - aws-latest-auth-test-run-aws-auth-test-with-regular-aws-credentials
       - aws-latest-auth-test-run-aws-auth-test-with-assume-role-credentials
@@ -3162,7 +3072,7 @@ buildvariants:
     display_name: Serverless Test
     run_on: rhel80-large
     expansions:
-      NODE_LTS_NAME: erbium
+      NODE_LTS_NAME: fermium
     tasks:
       - serverless_task_group
   - name: rhel8-no-auth-tests

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -3,7 +3,6 @@ const yaml = require('js-yaml');
 
 const MONGODB_VERSIONS = ['latest', 'rapid', '6.0', '5.0', '4.4', '4.2', '4.0', '3.6'];
 const versions = [
-  { codeName: 'erbium', versionNumber: 12 },
   { codeName: 'fermium', versionNumber: 14 },
   { codeName: 'gallium', versionNumber: 16 },
   { codeName: 'hydrogen', versionNumber: 18 }

--- a/etc/notes/CHANGES_5.0.0.md
+++ b/etc/notes/CHANGES_5.0.0.md
@@ -24,3 +24,7 @@ This means `npm` will let you know if the version of snappy you have installed i
 ```sh
 npm install --save snappy@7
 ```
+
+### Minimum supported Node version
+
+The new minimum supported Node.js version is now 14.20.1.

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "yargs": "^17.6.0"
       },
       "engines": {
-        "node": ">=12.9.0"
+        "node": ">=14.20.1"
       },
       "optionalDependencies": {
         "@aws-sdk/credential-providers": "^3.186.0",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=12.9.0"
+    "node": ">=14.20.1"
   },
   "bugs": {
     "url": "https://jira.mongodb.org/projects/NODE/issues/"


### PR DESCRIPTION
### Description

Updates the minimum supported Node version to 14.20.1.

#### What is changing?

- Removes Node 12 from CI
- Updates the engine requirement to >=14.20.1
- Updates the migration guide.

##### Is there new documentation needed for these changes?

Compatibility matrix needs to be updated.

#### What is the motivation for this change?

NODE-4436

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
