### PR TITLE
feat(NODE-4898)!: aws credential providers now optional peerDependency

### DIFF
--- a/etc/notes/CHANGES_5.0.0.md
+++ b/etc/notes/CHANGES_5.0.0.md
@@ -25,6 +25,15 @@ This means `npm` will let you know if the version of snappy you have installed i
 npm install --save snappy@7
 ```
 
+### @aws-sdk/credential-providers v3.186.0 or later and optional peerDependency
+
+`@aws-sdk/credential-providers` has been added to the package.json as a peerDependency that is **optional**.
+This means `npm` will let you know if the version of the sdk you have installed is incompatible with the driver.
+
+```sh
+npm install --save @aws-sdk/credential-providers@3.186.0
+```
+
 ### Minimum supported Node version
 
 The new minimum supported Node.js version is now 14.20.1.

--- a/etc/notes/CHANGES_5.0.0.md
+++ b/etc/notes/CHANGES_5.0.0.md
@@ -25,7 +25,7 @@ This means `npm` will let you know if the version of snappy you have installed i
 npm install --save snappy@7
 ```
 
-### @aws-sdk/credential-providers v3.186.0 or later and optional peerDependency
+### @aws-sdk/credential-providers v3.201.0 or later and optional peerDependency
 
 `@aws-sdk/credential-providers` has been added to the package.json as a peerDependency that is **optional**.
 This means `npm` will let you know if the version of the sdk you have installed is incompatible with the driver.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "socks": "^2.7.1"
       },
       "devDependencies": {
-        "@aws-sdk/credential-providers": "^3.186.0",
+        "@aws-sdk/credential-providers": "^3.201.0",
         "@iarna/toml": "^2.2.5",
         "@istanbuljs/nyc-config-typescript": "^1.0.2",
         "@microsoft/api-extractor": "^7.33.3",
@@ -70,7 +70,7 @@
         "saslprep": "^1.0.3"
       },
       "peerDependencies": {
-        "@aws-sdk/credential-providers": "^3.186.0",
+        "@aws-sdk/credential-providers": "^3.201.0",
         "snappy": "7.x.x"
       },
       "peerDependenciesMeta": {
@@ -182,694 +182,776 @@
       "dev": true
     },
     "node_modules/@aws-sdk/abort-controller": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.190.0.tgz",
-      "integrity": "sha512-M6qo2exTzEfHT5RuW7K090OgesUojhb2JyWiV4ulu7ngY4DWBUBMKUqac696sHRUZvGE5CDzSi0606DMboM+kA==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.226.0.tgz",
+      "integrity": "sha512-cJVzr1xxPBd08voknXvR0RLgtZKGKt6WyDpH/BaPCu3rfSqWCDZKzwqe940eqosjmKrxC6pUZNKASIqHOQ8xxQ==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity": {
-      "version": "3.192.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.192.0.tgz",
-      "integrity": "sha512-nIRmiv5JY8wWGUadhG7yLx8o8aVETj5CAgO8e8UJIwwqfue/Yv9bHi2mvkUphO1pj0TeBatAtvu79neJQtsR5g==",
+      "version": "3.235.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.235.0.tgz",
+      "integrity": "sha512-Qjvo10SYkfswYT0D2Xn5AxVP07eH4p+NPhtGnXXVoSI0GJyRlPz8MfyoHYWEPKZ929TzYXyvrz4MaTqOjLqenA==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.192.0",
-        "@aws-sdk/config-resolver": "3.190.0",
-        "@aws-sdk/credential-provider-node": "3.190.0",
-        "@aws-sdk/fetch-http-handler": "3.190.0",
-        "@aws-sdk/hash-node": "3.190.0",
-        "@aws-sdk/invalid-dependency": "3.190.0",
-        "@aws-sdk/middleware-content-length": "3.190.0",
-        "@aws-sdk/middleware-host-header": "3.190.0",
-        "@aws-sdk/middleware-logger": "3.190.0",
-        "@aws-sdk/middleware-recursion-detection": "3.190.0",
-        "@aws-sdk/middleware-retry": "3.190.0",
-        "@aws-sdk/middleware-serde": "3.190.0",
-        "@aws-sdk/middleware-signing": "3.192.0",
-        "@aws-sdk/middleware-stack": "3.190.0",
-        "@aws-sdk/middleware-user-agent": "3.190.0",
-        "@aws-sdk/node-config-provider": "3.190.0",
-        "@aws-sdk/node-http-handler": "3.190.0",
-        "@aws-sdk/protocol-http": "3.190.0",
-        "@aws-sdk/smithy-client": "3.190.0",
-        "@aws-sdk/types": "3.190.0",
-        "@aws-sdk/url-parser": "3.190.0",
-        "@aws-sdk/util-base64-browser": "3.188.0",
-        "@aws-sdk/util-base64-node": "3.188.0",
+        "@aws-sdk/client-sts": "3.235.0",
+        "@aws-sdk/config-resolver": "3.234.0",
+        "@aws-sdk/credential-provider-node": "3.235.0",
+        "@aws-sdk/fetch-http-handler": "3.226.0",
+        "@aws-sdk/hash-node": "3.226.0",
+        "@aws-sdk/invalid-dependency": "3.226.0",
+        "@aws-sdk/middleware-content-length": "3.226.0",
+        "@aws-sdk/middleware-endpoint": "3.226.0",
+        "@aws-sdk/middleware-host-header": "3.226.0",
+        "@aws-sdk/middleware-logger": "3.226.0",
+        "@aws-sdk/middleware-recursion-detection": "3.226.0",
+        "@aws-sdk/middleware-retry": "3.235.0",
+        "@aws-sdk/middleware-serde": "3.226.0",
+        "@aws-sdk/middleware-signing": "3.226.0",
+        "@aws-sdk/middleware-stack": "3.226.0",
+        "@aws-sdk/middleware-user-agent": "3.226.0",
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/node-http-handler": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/smithy-client": "3.234.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/url-parser": "3.226.0",
+        "@aws-sdk/util-base64": "3.208.0",
         "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.188.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.190.0",
-        "@aws-sdk/util-defaults-mode-node": "3.190.0",
-        "@aws-sdk/util-user-agent-browser": "3.190.0",
-        "@aws-sdk/util-user-agent-node": "3.190.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.234.0",
+        "@aws-sdk/util-defaults-mode-node": "3.234.0",
+        "@aws-sdk/util-endpoints": "3.226.0",
+        "@aws-sdk/util-retry": "3.229.0",
+        "@aws-sdk/util-user-agent-browser": "3.226.0",
+        "@aws-sdk/util-user-agent-node": "3.226.0",
         "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.190.0.tgz",
-      "integrity": "sha512-joEKRjJEzgvXnEih/x2UDDCPlvXWCO3MAHmqi44yJ36Ph4YsFS299mOjPdVLuzUtpQ+cST1nRO7hXNFrulW2jQ==",
+      "version": "3.235.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.235.0.tgz",
+      "integrity": "sha512-CdZ2EnDuB6V41u6brk/Nt19EZneLorsNkNWr4J7zkR/2gKiqdUN6PUs6jxDtK9M7V/r81jaE0ViLwLVmYhL/bQ==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.190.0",
-        "@aws-sdk/fetch-http-handler": "3.190.0",
-        "@aws-sdk/hash-node": "3.190.0",
-        "@aws-sdk/invalid-dependency": "3.190.0",
-        "@aws-sdk/middleware-content-length": "3.190.0",
-        "@aws-sdk/middleware-host-header": "3.190.0",
-        "@aws-sdk/middleware-logger": "3.190.0",
-        "@aws-sdk/middleware-recursion-detection": "3.190.0",
-        "@aws-sdk/middleware-retry": "3.190.0",
-        "@aws-sdk/middleware-serde": "3.190.0",
-        "@aws-sdk/middleware-stack": "3.190.0",
-        "@aws-sdk/middleware-user-agent": "3.190.0",
-        "@aws-sdk/node-config-provider": "3.190.0",
-        "@aws-sdk/node-http-handler": "3.190.0",
-        "@aws-sdk/protocol-http": "3.190.0",
-        "@aws-sdk/smithy-client": "3.190.0",
-        "@aws-sdk/types": "3.190.0",
-        "@aws-sdk/url-parser": "3.190.0",
-        "@aws-sdk/util-base64-browser": "3.188.0",
-        "@aws-sdk/util-base64-node": "3.188.0",
+        "@aws-sdk/config-resolver": "3.234.0",
+        "@aws-sdk/fetch-http-handler": "3.226.0",
+        "@aws-sdk/hash-node": "3.226.0",
+        "@aws-sdk/invalid-dependency": "3.226.0",
+        "@aws-sdk/middleware-content-length": "3.226.0",
+        "@aws-sdk/middleware-endpoint": "3.226.0",
+        "@aws-sdk/middleware-host-header": "3.226.0",
+        "@aws-sdk/middleware-logger": "3.226.0",
+        "@aws-sdk/middleware-recursion-detection": "3.226.0",
+        "@aws-sdk/middleware-retry": "3.235.0",
+        "@aws-sdk/middleware-serde": "3.226.0",
+        "@aws-sdk/middleware-stack": "3.226.0",
+        "@aws-sdk/middleware-user-agent": "3.226.0",
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/node-http-handler": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/smithy-client": "3.234.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/url-parser": "3.226.0",
+        "@aws-sdk/util-base64": "3.208.0",
         "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.188.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.190.0",
-        "@aws-sdk/util-defaults-mode-node": "3.190.0",
-        "@aws-sdk/util-user-agent-browser": "3.190.0",
-        "@aws-sdk/util-user-agent-node": "3.190.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.234.0",
+        "@aws-sdk/util-defaults-mode-node": "3.234.0",
+        "@aws-sdk/util-endpoints": "3.226.0",
+        "@aws-sdk/util-retry": "3.229.0",
+        "@aws-sdk/util-user-agent-browser": "3.226.0",
+        "@aws-sdk/util-user-agent-node": "3.226.0",
         "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-sts": {
-      "version": "3.192.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.192.0.tgz",
-      "integrity": "sha512-iv72dmRxbZ1cN5jGn4KIVzzu11eduS2fXHbNgd7JsFd5hLBV5TvJaugQzUdXNmy2gN4HiRJr+qa9WkD5b39lsA==",
+    "node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.235.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.235.0.tgz",
+      "integrity": "sha512-oSF0lSPmE5jaaigxc5TZyDjqfgTiDsromEdvv5s5a/qAOZBNtsVaS4+8cn9kIt43Ceo7dxHXk7cwvXMNPwVnWw==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.190.0",
-        "@aws-sdk/credential-provider-node": "3.190.0",
-        "@aws-sdk/fetch-http-handler": "3.190.0",
-        "@aws-sdk/hash-node": "3.190.0",
-        "@aws-sdk/invalid-dependency": "3.190.0",
-        "@aws-sdk/middleware-content-length": "3.190.0",
-        "@aws-sdk/middleware-host-header": "3.190.0",
-        "@aws-sdk/middleware-logger": "3.190.0",
-        "@aws-sdk/middleware-recursion-detection": "3.190.0",
-        "@aws-sdk/middleware-retry": "3.190.0",
-        "@aws-sdk/middleware-sdk-sts": "3.192.0",
-        "@aws-sdk/middleware-serde": "3.190.0",
-        "@aws-sdk/middleware-signing": "3.192.0",
-        "@aws-sdk/middleware-stack": "3.190.0",
-        "@aws-sdk/middleware-user-agent": "3.190.0",
-        "@aws-sdk/node-config-provider": "3.190.0",
-        "@aws-sdk/node-http-handler": "3.190.0",
-        "@aws-sdk/protocol-http": "3.190.0",
-        "@aws-sdk/smithy-client": "3.190.0",
-        "@aws-sdk/types": "3.190.0",
-        "@aws-sdk/url-parser": "3.190.0",
-        "@aws-sdk/util-base64-browser": "3.188.0",
-        "@aws-sdk/util-base64-node": "3.188.0",
+        "@aws-sdk/config-resolver": "3.234.0",
+        "@aws-sdk/fetch-http-handler": "3.226.0",
+        "@aws-sdk/hash-node": "3.226.0",
+        "@aws-sdk/invalid-dependency": "3.226.0",
+        "@aws-sdk/middleware-content-length": "3.226.0",
+        "@aws-sdk/middleware-endpoint": "3.226.0",
+        "@aws-sdk/middleware-host-header": "3.226.0",
+        "@aws-sdk/middleware-logger": "3.226.0",
+        "@aws-sdk/middleware-recursion-detection": "3.226.0",
+        "@aws-sdk/middleware-retry": "3.235.0",
+        "@aws-sdk/middleware-serde": "3.226.0",
+        "@aws-sdk/middleware-stack": "3.226.0",
+        "@aws-sdk/middleware-user-agent": "3.226.0",
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/node-http-handler": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/smithy-client": "3.234.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/url-parser": "3.226.0",
+        "@aws-sdk/util-base64": "3.208.0",
         "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.188.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.190.0",
-        "@aws-sdk/util-defaults-mode-node": "3.190.0",
-        "@aws-sdk/util-user-agent-browser": "3.190.0",
-        "@aws-sdk/util-user-agent-node": "3.190.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.234.0",
+        "@aws-sdk/util-defaults-mode-node": "3.234.0",
+        "@aws-sdk/util-endpoints": "3.226.0",
+        "@aws-sdk/util-retry": "3.229.0",
+        "@aws-sdk/util-user-agent-browser": "3.226.0",
+        "@aws-sdk/util-user-agent-node": "3.226.0",
         "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts": {
+      "version": "3.235.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.235.0.tgz",
+      "integrity": "sha512-P1pqvg7brdBUGrTlyMc+LCe6rnWrWufdd7bpzuC9lcVzkoOHJw8j8wDItwoCsvy1O3SeK7vtmOTLxV2yuTEO3Q==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.234.0",
+        "@aws-sdk/credential-provider-node": "3.235.0",
+        "@aws-sdk/fetch-http-handler": "3.226.0",
+        "@aws-sdk/hash-node": "3.226.0",
+        "@aws-sdk/invalid-dependency": "3.226.0",
+        "@aws-sdk/middleware-content-length": "3.226.0",
+        "@aws-sdk/middleware-endpoint": "3.226.0",
+        "@aws-sdk/middleware-host-header": "3.226.0",
+        "@aws-sdk/middleware-logger": "3.226.0",
+        "@aws-sdk/middleware-recursion-detection": "3.226.0",
+        "@aws-sdk/middleware-retry": "3.235.0",
+        "@aws-sdk/middleware-sdk-sts": "3.226.0",
+        "@aws-sdk/middleware-serde": "3.226.0",
+        "@aws-sdk/middleware-signing": "3.226.0",
+        "@aws-sdk/middleware-stack": "3.226.0",
+        "@aws-sdk/middleware-user-agent": "3.226.0",
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/node-http-handler": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/smithy-client": "3.234.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/url-parser": "3.226.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.234.0",
+        "@aws-sdk/util-defaults-mode-node": "3.234.0",
+        "@aws-sdk/util-endpoints": "3.226.0",
+        "@aws-sdk/util-retry": "3.229.0",
+        "@aws-sdk/util-user-agent-browser": "3.226.0",
+        "@aws-sdk/util-user-agent-node": "3.226.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
         "fast-xml-parser": "4.0.11",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/config-resolver": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.190.0.tgz",
-      "integrity": "sha512-K+VnDtjTgjpf7yHEdDB0qgGbHToF0pIL0pQMSnmk2yc8BoB3LGG/gg1T0Ki+wRlrFnDCJ6L+8zUdawY2qDsbyw==",
+      "version": "3.234.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.234.0.tgz",
+      "integrity": "sha512-uZxy4wzllfvgCQxVc+Iqhde0NGAnfmV2hWR6ejadJaAFTuYNvQiRg9IqJy3pkyDPqXySiJ8Bom5PoJfgn55J/A==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/signature-v4": "3.190.0",
-        "@aws-sdk/types": "3.190.0",
-        "@aws-sdk/util-config-provider": "3.188.0",
-        "@aws-sdk/util-middleware": "3.190.0",
+        "@aws-sdk/signature-v4": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.226.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-cognito-identity": {
-      "version": "3.192.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.192.0.tgz",
-      "integrity": "sha512-CWo+KyHCGyYtvjlmDIGtnwBEkdiondergZADiStbFFvie8pPI7IsdTXNVssQQ1VxKIBGGHVebgZGSklHBqthwA==",
+      "version": "3.235.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.235.0.tgz",
+      "integrity": "sha512-OlnqSYJtaGlAMG+8bLjVIkK53eNd22VN5Rk2WwKNKd3qShMSvTz9RDnTv3RHBsYiaZOU7P409ph583pBluOsFA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.192.0",
-        "@aws-sdk/property-provider": "3.190.0",
-        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/client-cognito-identity": "3.235.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.190.0.tgz",
-      "integrity": "sha512-GTY7l3SJhTmRGFpWddbdJOihSqoMN8JMo3CsCtIjk4/h3xirBi02T4GSvbrMyP7FP3Fdl4NAdT+mHJ4q2Bvzxw==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.226.0.tgz",
+      "integrity": "sha512-sd8uK1ojbXxaZXlthzw/VXZwCPUtU3PjObOfr3Evj7MPIM2IH8h29foOlggx939MdLQGboJf9gKvLlvKDWtJRA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.190.0",
-        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-imds": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.190.0.tgz",
-      "integrity": "sha512-gI5pfBqGYCKdmx8igPvq+jLzyE2kuNn9Q5u73pdM/JZxiq7GeWYpE/MqqCubHxPtPcTFgAwxCxCFoXlUTBh/2g==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.226.0.tgz",
+      "integrity": "sha512-//z/COQm2AjYFI1Lb0wKHTQSrvLFTyuKLFQGPJsKS7DPoxGOCKB7hmYerlbl01IDoCxTdyL//TyyPxbZEOQD5Q==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.190.0",
-        "@aws-sdk/property-provider": "3.190.0",
-        "@aws-sdk/types": "3.190.0",
-        "@aws-sdk/url-parser": "3.190.0",
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/url-parser": "3.226.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.190.0.tgz",
-      "integrity": "sha512-Z7NN/evXJk59hBQlfOSWDfHntwmxwryu6uclgv7ECI6SEVtKt1EKIlPuCLUYgQ4lxb9bomyO5lQAl/1WutNT5w==",
+      "version": "3.235.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.235.0.tgz",
+      "integrity": "sha512-i3efxJw+9hN/opmjlRqT0lv/gKjOHmgGBUbFCdbCmSUTc8QH3sbkIY6FLX2q0PSu4q4CpCwWZ587lkThtFerJA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.190.0",
-        "@aws-sdk/credential-provider-imds": "3.190.0",
-        "@aws-sdk/credential-provider-sso": "3.190.0",
-        "@aws-sdk/credential-provider-web-identity": "3.190.0",
-        "@aws-sdk/property-provider": "3.190.0",
-        "@aws-sdk/shared-ini-file-loader": "3.190.0",
-        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/credential-provider-env": "3.226.0",
+        "@aws-sdk/credential-provider-imds": "3.226.0",
+        "@aws-sdk/credential-provider-process": "3.226.0",
+        "@aws-sdk/credential-provider-sso": "3.235.0",
+        "@aws-sdk/credential-provider-web-identity": "3.226.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/shared-ini-file-loader": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.190.0.tgz",
-      "integrity": "sha512-ctCG5+TsIK2gVgvvFiFjinPjc5nGpSypU3nQKCaihtPh83wDN6gCx4D0p9M8+fUrlPa5y+o/Y7yHo94ATepM8w==",
+      "version": "3.235.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.235.0.tgz",
+      "integrity": "sha512-xJSAntEBlbXbngSzpyMnlZzOldxV0sNOQ7ggDUmIQNVWbu3XwP6MiA8CjAHnH10vs6+pcyHtpfUj3evdQZ4JlQ==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.190.0",
-        "@aws-sdk/credential-provider-imds": "3.190.0",
-        "@aws-sdk/credential-provider-ini": "3.190.0",
-        "@aws-sdk/credential-provider-process": "3.190.0",
-        "@aws-sdk/credential-provider-sso": "3.190.0",
-        "@aws-sdk/credential-provider-web-identity": "3.190.0",
-        "@aws-sdk/property-provider": "3.190.0",
-        "@aws-sdk/shared-ini-file-loader": "3.190.0",
-        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/credential-provider-env": "3.226.0",
+        "@aws-sdk/credential-provider-imds": "3.226.0",
+        "@aws-sdk/credential-provider-ini": "3.235.0",
+        "@aws-sdk/credential-provider-process": "3.226.0",
+        "@aws-sdk/credential-provider-sso": "3.235.0",
+        "@aws-sdk/credential-provider-web-identity": "3.226.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/shared-ini-file-loader": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.190.0.tgz",
-      "integrity": "sha512-sIJhICR80n5XY1kW/EFHTh5ZzBHb5X+744QCH3StcbKYI44mOZvNKfFdeRL2fQ7yLgV7npte2HJRZzQPWpZUrw==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.226.0.tgz",
+      "integrity": "sha512-iUDMdnrTvbvaCFhWwqyXrhvQ9+ojPqPqXhwZtY1X/Qaz+73S9gXBPJHZaZb2Ke0yKE1Ql3bJbKvmmxC/qLQMng==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.190.0",
-        "@aws-sdk/shared-ini-file-loader": "3.190.0",
-        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/shared-ini-file-loader": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.190.0.tgz",
-      "integrity": "sha512-uarU9vk471MHHT+GJj3KWFSmaaqLNL5n1KcMer2CCAZfjs+mStAi8+IjZuuKXB4vqVs5DxdH8cy5aLaJcBlXwQ==",
+      "version": "3.235.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.235.0.tgz",
+      "integrity": "sha512-+7UORB7Wo/d0mEz7J16/hsRumIhtdl4KekJfrXH5OrLiXXIsn68wmQkrvwD2CibbtgOY0P69G12qbcBHkg3qng==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/client-sso": "3.190.0",
-        "@aws-sdk/property-provider": "3.190.0",
-        "@aws-sdk/shared-ini-file-loader": "3.190.0",
-        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/client-sso": "3.235.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/shared-ini-file-loader": "3.226.0",
+        "@aws-sdk/token-providers": "3.235.0",
+        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.190.0.tgz",
-      "integrity": "sha512-nlIBeK9hGHKWC874h+ITAfPZ9Eaok+x/ydZQVKsLHiQ9PH3tuQ8AaGqhuCwBSH0hEAHZ/BiKeEx5VyWAE8/x+Q==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.226.0.tgz",
+      "integrity": "sha512-CCpv847rLB0SFOHz2igvUMFAzeT2fD3YnY4C8jltuJoEkn0ITn1Hlgt13nTJ5BUuvyti2mvyXZHmNzhMIMrIlw==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.190.0",
-        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-providers": {
-      "version": "3.192.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.192.0.tgz",
-      "integrity": "sha512-iBTrEPkfOHlfgQyk7EeUCmZnhUKXsGcc/hhxBbc6Z/Xc7Y8LqRVLbEmHq9lruXraFuvs26xV9oZi1s1UMXneQA==",
+      "version": "3.235.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.235.0.tgz",
+      "integrity": "sha512-HCrXbXAnd4dywv1WW3/P8bJp3FEJuG+Gul0pC+b5wh90Ppy50ay/01KcLpvqS1SgKdk7toucWnpExgEJZHUcOQ==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.192.0",
-        "@aws-sdk/client-sso": "3.190.0",
-        "@aws-sdk/client-sts": "3.192.0",
-        "@aws-sdk/credential-provider-cognito-identity": "3.192.0",
-        "@aws-sdk/credential-provider-env": "3.190.0",
-        "@aws-sdk/credential-provider-imds": "3.190.0",
-        "@aws-sdk/credential-provider-ini": "3.190.0",
-        "@aws-sdk/credential-provider-node": "3.190.0",
-        "@aws-sdk/credential-provider-process": "3.190.0",
-        "@aws-sdk/credential-provider-sso": "3.190.0",
-        "@aws-sdk/credential-provider-web-identity": "3.190.0",
-        "@aws-sdk/property-provider": "3.190.0",
-        "@aws-sdk/shared-ini-file-loader": "3.190.0",
-        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/client-cognito-identity": "3.235.0",
+        "@aws-sdk/client-sso": "3.235.0",
+        "@aws-sdk/client-sts": "3.235.0",
+        "@aws-sdk/credential-provider-cognito-identity": "3.235.0",
+        "@aws-sdk/credential-provider-env": "3.226.0",
+        "@aws-sdk/credential-provider-imds": "3.226.0",
+        "@aws-sdk/credential-provider-ini": "3.235.0",
+        "@aws-sdk/credential-provider-node": "3.235.0",
+        "@aws-sdk/credential-provider-process": "3.226.0",
+        "@aws-sdk/credential-provider-sso": "3.235.0",
+        "@aws-sdk/credential-provider-web-identity": "3.226.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/shared-ini-file-loader": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/fetch-http-handler": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.190.0.tgz",
-      "integrity": "sha512-5riRpKydARXAPLesTZm6eP6QKJ4HJGQ3k0Tepi3nvxHVx3UddkRNoX0pLS3rvbajkykWPNC2qdfRGApWlwOYsA==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.226.0.tgz",
+      "integrity": "sha512-JewZPMNEBXfi1xVnRa7pVtK/zgZD8/lQ/YnD8pq79WuMa2cwyhDtr8oqCoqsPW+WJT5ScXoMtuHxN78l8eKWgg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.190.0",
-        "@aws-sdk/querystring-builder": "3.190.0",
-        "@aws-sdk/types": "3.190.0",
-        "@aws-sdk/util-base64-browser": "3.188.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/querystring-builder": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-base64": "3.208.0",
         "tslib": "^2.3.1"
       }
     },
     "node_modules/@aws-sdk/hash-node": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.190.0.tgz",
-      "integrity": "sha512-DNwVT3O8zc9Jk/bXiXcN0WsD98r+JJWryw9F1/ZZbuzbf6rx2qhI8ZK+nh5X6WMtYPU84luQMcF702fJt/1bzg==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.226.0.tgz",
+      "integrity": "sha512-MdlJhJ9/Espwd0+gUXdZRsHuostB2WxEVAszWxobP0FTT9PnicqnfK7ExmW+DUAc0ywxtEbR3e0UND65rlSTVw==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.190.0",
-        "@aws-sdk/util-buffer-from": "3.188.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-buffer-from": "3.208.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/invalid-dependency": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.190.0.tgz",
-      "integrity": "sha512-crCh63e8d/Uw9y3dQlVTPja7+IZiXpNXyH6oSuAadTDQwMq6KK87Av1/SDzVf6bAo2KgAOo41MyO2joaCEk0dQ==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.226.0.tgz",
+      "integrity": "sha512-QXOYFmap8g9QzRjumcRCIo2GEZkdCwd7ePQW0OABWPhKHzlJ74vvBxywjU3s39EEBEluWXtZ7Iufg6GxZM4ifw==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       }
     },
     "node_modules/@aws-sdk/is-array-buffer": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.188.0.tgz",
-      "integrity": "sha512-n69N4zJZCNd87Rf4NzufPzhactUeM877Y0Tp/F3KiHqGeTnVjYUa4Lv1vLBjqtfjYb2HWT3NKlYn5yzrhaEwiQ==",
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-content-length": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.190.0.tgz",
-      "integrity": "sha512-sSU347SuC6I8kWum1jlJlpAqeV23KP7enG+ToWcEcgFrJhm3AvuqB//NJxDbkKb2DNroRvJjBckBvrwNAjQnBQ==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.226.0.tgz",
+      "integrity": "sha512-ksUzlHJN2JMuyavjA46a4sctvnrnITqt2tbGGWWrAuXY1mel2j+VbgnmJUiwHKUO6bTFBBeft5Vd1TSOb4JmiA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.190.0",
-        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.226.0.tgz",
+      "integrity": "sha512-EvLFafjtUxTT0AC9p3aBQu1/fjhWdIeK58jIXaNFONfZ3F8QbEYUPuF/SqZvJM6cWfOO9qwYKkRDbCSTYhprIg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/middleware-serde": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/signature-v4": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/url-parser": "3.226.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.190.0.tgz",
-      "integrity": "sha512-cL7Vo/QSpGx/DDmFxjeV0Qlyi1atvHQDPn3MLBBmi1icu+3GKZkCMAJwzsrV3U4+WoVoDYT9FJ9yMQf2HaIjeQ==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.226.0.tgz",
+      "integrity": "sha512-haVkWVh6BUPwKgWwkL6sDvTkcZWvJjv8AgC8jiQuSl8GLZdzHTB8Qhi3IsfFta9HAuoLjxheWBE5Z/L0UrfhLA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.190.0",
-        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.190.0.tgz",
-      "integrity": "sha512-rrfLGYSZCBtiXNrIa8pJ2uwUoUMyj6Q82E8zmduTvqKWviCr6ZKes0lttGIkWhjvhql2m4CbjG5MPBnY7RXL4A==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.226.0.tgz",
+      "integrity": "sha512-m9gtLrrYnpN6yckcQ09rV7ExWOLMuq8mMPF/K3DbL/YL0TuILu9i2T1W+JuxSX+K9FMG2HrLAKivE/kMLr55xA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.190.0.tgz",
-      "integrity": "sha512-5tc1AIIZe5jDNdyuJW+7vIFmQOxz3q031ZVrEtUEIF7cz2ySho2lkOWziz+v+UGSLhjHGKMz3V26+aN1FLZNxQ==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.226.0.tgz",
+      "integrity": "sha512-mwRbdKEUeuNH5TEkyZ5FWxp6bL2UC1WbY+LDv6YjHxmSMKpAoOueEdtU34PqDOLrpXXxIGHDFmjeGeMfktyEcA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.190.0",
-        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-retry": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.190.0.tgz",
-      "integrity": "sha512-h1bPopkncf2ue/erJdhqvgR2AEh0bIvkNsIHhx93DckWKotZd/GAVDq0gpKj7/f/7B+teHH8Fg5GDOwOOGyKcg==",
+      "version": "3.235.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.235.0.tgz",
+      "integrity": "sha512-50WHbJGpD3SNp9763MAlHqIhXil++JdQbKejNpHg7HsJne/ao3ub+fDOfx//mMBjpzBV25BGd5UlfL6blrClSg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.190.0",
-        "@aws-sdk/service-error-classification": "3.190.0",
-        "@aws-sdk/types": "3.190.0",
-        "@aws-sdk/util-middleware": "3.190.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/service-error-classification": "3.229.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-middleware": "3.226.0",
+        "@aws-sdk/util-retry": "3.229.0",
         "tslib": "^2.3.1",
         "uuid": "^8.3.2"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-sts": {
-      "version": "3.192.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.192.0.tgz",
-      "integrity": "sha512-xzTV7MyG5ipWYTvekWX1tQc5ExsUvCYsDTBCD3LR5hBrP8assUDPo52zGSe+QMcjgnQv7BcYIzeikTkLEG0dUw==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.226.0.tgz",
+      "integrity": "sha512-NN9T/qoSD1kZvAT+VLny3NnlqgylYQcsgV3rvi/8lYzw/G/2s8VS6sm/VTWGGZhx08wZRv20MWzYu3bftcyqUg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/middleware-signing": "3.192.0",
-        "@aws-sdk/property-provider": "3.190.0",
-        "@aws-sdk/protocol-http": "3.190.0",
-        "@aws-sdk/signature-v4": "3.190.0",
-        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/middleware-signing": "3.226.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/signature-v4": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-serde": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.190.0.tgz",
-      "integrity": "sha512-S132hEOK4jwbtZ1bGAgSuQ0DMFG4TiD4ulAwbQRBYooC7tiWZbRiR0Pkt2hV8d7WhOHgUpg7rvqlA7/HXXBAsA==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.226.0.tgz",
+      "integrity": "sha512-nPuOOAkSfx9TxzdKFx0X2bDlinOxGrqD7iof926K/AEflxGD1DBdcaDdjlYlPDW2CVE8LV/rAgbYuLxh/E/1VA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.192.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.192.0.tgz",
-      "integrity": "sha512-qTRIU/TL/dvtTrNj+AkZkgYeTIFslib3Y3XnQNNM6RCm4cMxIgs2K/lnhaUmLdbzHrpOQb4cISkY8yiHo+pNsw==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.226.0.tgz",
+      "integrity": "sha512-E6HmtPcl+IjYDDzi1xI2HpCbBq2avNWcjvCriMZWuTAtRVpnA6XDDGW5GY85IfS3A8G8vuWqEVPr8JcYUcjfew==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.190.0",
-        "@aws-sdk/protocol-http": "3.190.0",
-        "@aws-sdk/signature-v4": "3.190.0",
-        "@aws-sdk/types": "3.190.0",
-        "@aws-sdk/util-middleware": "3.190.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/signature-v4": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-middleware": "3.226.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-stack": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.190.0.tgz",
-      "integrity": "sha512-h1mqiWNJdi1OTSEY8QovpiHgDQEeRG818v8yShpqSYXJKEqdn54MA3Z1D2fg/Wv/8ZJsFrBCiI7waT1JUYOmCg==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.226.0.tgz",
+      "integrity": "sha512-85wF29LvPvpoed60fZGDYLwv1Zpd/cM0C22WSSFPw1SSJeqO4gtFYyCg2squfT3KI6kF43IIkOCJ+L7GtryPug==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.190.0.tgz",
-      "integrity": "sha512-y/2cTE1iYHKR0nkb3DvR3G8vt12lcTP95r/iHp8ZO+Uzpc25jM/AyMHWr2ZjqQiHKNlzh8uRw1CmQtgg4sBxXQ==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.226.0.tgz",
+      "integrity": "sha512-N1WnfzCW1Y5yWhVAphf8OPGTe8Df3vmV7/LdsoQfmpkCZgLZeK2o0xITkUQhRj1mbw7yp8tVFLFV3R2lMurdAQ==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.190.0",
-        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/node-config-provider": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.190.0.tgz",
-      "integrity": "sha512-TJPUchyeK5KeEXWrwb6oW5/OkY3STCSGR1QIlbPcaTGkbo4kXAVyQmmZsY4KtRPuDM6/HlfUQV17bD716K65rQ==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.226.0.tgz",
+      "integrity": "sha512-B8lQDqiRk7X5izFEUMXmi8CZLOKCTWQJU9HQf3ako+sF0gexo4nHN3jhoRWyLtcgC5S3on/2jxpAcqtm7kuY3w==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.190.0",
-        "@aws-sdk/shared-ini-file-loader": "3.190.0",
-        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/shared-ini-file-loader": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/node-http-handler": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.190.0.tgz",
-      "integrity": "sha512-3Klkr73TpZkCzcnSP+gmFF0Baluzk3r7BaWclJHqt2LcFUWfIJzYlnbBQNZ4t3EEq7ZlBJX85rIDHBRlS+rUyA==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.226.0.tgz",
+      "integrity": "sha512-xQCddnZNMiPmjr3W7HYM+f5ir4VfxgJh37eqZwX6EZmyItFpNNeVzKUgA920ka1VPz/ZUYB+2OFGiX3LCLkkaA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/abort-controller": "3.190.0",
-        "@aws-sdk/protocol-http": "3.190.0",
-        "@aws-sdk/querystring-builder": "3.190.0",
-        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/abort-controller": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/querystring-builder": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/property-provider": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.190.0.tgz",
-      "integrity": "sha512-uzdKjHE2blbuceTC5zeBgZ0+Uo/hf9pH20CHpJeVNtrrtF3GALtu4Y1Gu5QQVIQBz8gjHnqANx0XhfYzorv69Q==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.226.0.tgz",
+      "integrity": "sha512-TsljjG+Sg0LmdgfiAlWohluWKnxB/k8xenjeozZfzOr5bHmNHtdbWv6BtNvD/R83hw7SFXxbJHlD5H4u9p2NFg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/protocol-http": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.190.0.tgz",
-      "integrity": "sha512-s5MVfeONpfZYRzCSbqQ+wJ3GxKED+aSS7+CQoeaYoD6HDTDxaMGNv9aiPxVCzW02sgG7py7f29Q6Vw+5taZXZA==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
+      "integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/querystring-builder": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.190.0.tgz",
-      "integrity": "sha512-w9mTKkCsaLIBC8EA4RAHrqethNGbf60CbpPzN/QM7yCV3ZZJAXkppFfjTVVOMbPaI8GUEOptJtzgqV68CRB7ow==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.226.0.tgz",
+      "integrity": "sha512-LVurypuNeotO4lmirKXRC4NYrZRAyMJXuwO0f2a5ZAUJCjauwYrifKue6yCfU7bls7gut7nfcR6B99WBYpHs3g==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.190.0",
-        "@aws-sdk/util-uri-escape": "3.188.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/querystring-parser": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.190.0.tgz",
-      "integrity": "sha512-vCKP0s33VtS47LSYzEWRRr2aTbi3qNkUuQyIrc5LMqBfS5hsy79P1HL4Q7lCVqZB5fe61N8fKzOxDxWRCF0sXg==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.226.0.tgz",
+      "integrity": "sha512-FzB+VrQ47KAFxiPt2YXrKZ8AOLZQqGTLCKHzx4bjxGmwgsjV8yIbtJiJhZLMcUQV4LtGeIY9ixIqQhGvnZHE4A==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/service-error-classification": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.190.0.tgz",
-      "integrity": "sha512-g+s6xtaMa5fCMA2zJQC4BiFGMP7FN5/L1V/UwxCnKy8skCwaN0K5A1tFffBjjbYiPI7Gu7LVorWD2A0Y4xl01Q==",
+      "version": "3.229.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.229.0.tgz",
+      "integrity": "sha512-dnzWWQ0/NoWMUZ5C0DW3dPm0wC1O76Y/SpKbuJzWPkx1EYy6r8p32Ly4D9vUzrKDbRGf48YHIF2kOkBmu21CLg==",
       "dev": true,
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/shared-ini-file-loader": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.190.0.tgz",
-      "integrity": "sha512-CZC/xsGReUEl5w+JgfancrxfkaCbEisyIFy6HALUYrioWQe80WMqLAdUMZSXHWjIaNK9mH0J/qvcSV2MuIoMzQ==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.226.0.tgz",
+      "integrity": "sha512-661VQefsARxVyyV2FX9V61V+nNgImk7aN2hYlFKla6BCwZfMng+dEtD0xVGyg1PfRw0qvEv5LQyxMVgHcUSevA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/signature-v4": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.190.0.tgz",
-      "integrity": "sha512-L/R/1X2T+/Kg2k/sjoYyDFulVUGrVcRfyEKKVFIUNg0NwUtw5UKa1/gS7geTKcg4q8M2pd/v+OCBrge2X7phUw==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.226.0.tgz",
+      "integrity": "sha512-/R5q5agdPd7HJB68XMzpxrNPk158EHUvkFkuRu5Qf3kkkHebEzWEBlWoVpUe6ss4rP9Tqcue6xPuaftEmhjpYw==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.188.0",
-        "@aws-sdk/types": "3.190.0",
-        "@aws-sdk/util-hex-encoding": "3.188.0",
-        "@aws-sdk/util-middleware": "3.190.0",
-        "@aws-sdk/util-uri-escape": "3.188.0",
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-hex-encoding": "3.201.0",
+        "@aws-sdk/util-middleware": "3.226.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/smithy-client": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.190.0.tgz",
-      "integrity": "sha512-f5EoCwjBLXMyuN491u1NmEutbolL0cJegaJbtgK9OJw2BLuRHiBknjDF4OEVuK/WqK0kz2JLMGi9xwVPl4BKCA==",
+      "version": "3.234.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.234.0.tgz",
+      "integrity": "sha512-8AtR/k4vsFvjXeQbIzq/Wy7Nbk48Ou0wUEeVYPHWHPSU8QamFWORkOwmKtKMfHAyZvmqiAPeQqHFkq+UJhWyyQ==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/middleware-stack": "3.190.0",
-        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/middleware-stack": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.235.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.235.0.tgz",
+      "integrity": "sha512-TdUbQ0wWVTO7azF/8ojtd4MNFjEfQKhGoGib0g/W5pa/FJryOkiIP8U4POC/I+0ATMkLK3vAC07kNHtey0ooZg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/client-sso-oidc": "3.235.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/shared-ini-file-loader": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.190.0.tgz",
-      "integrity": "sha512-mkeZ+vJZzElP6OdRXvuLKWHSlDQxZP9u8BjQB9N0Rw0pCXTzYS0vzIhN1pL0uddWp5fMrIE68snto9xNR6BQuA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/url-parser": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.190.0.tgz",
-      "integrity": "sha512-FKFDtxA9pvHmpfWmNVK5BAVRpDgkWMz3u4Sg9UzB+WAFN6UexRypXXUZCFAo8S04FbPKfYOR3O0uVlw7kzmj9g==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
+      "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/querystring-parser": "3.190.0",
-        "@aws-sdk/types": "3.190.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/util-base64-browser": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.188.0.tgz",
-      "integrity": "sha512-qlH+5NZBLiyKziL335BEPedYxX6j+p7KFRWXvDQox9S+s+gLCayednpK+fteOhBenCcR9fUZOVuAPScy1I8qCg==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/util-base64-node": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.188.0.tgz",
-      "integrity": "sha512-r1dccRsRjKq+OhVRUfqFiW3sGgZBjHbMeHLbrAs9jrOjU2PTQ8PSzAXLvX/9lmp7YjmX17Qvlsg0NCr1tbB9OA==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.188.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/url-parser": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.226.0.tgz",
+      "integrity": "sha512-p5RLE0QWyP0OcTOLmFcLdVgUcUEzmEfmdrnOxyNzomcYb0p3vUagA5zfa1HVK2azsQJFBv28GfvMnba9bGhObg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/querystring-parser": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-base64": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.208.0.tgz",
+      "integrity": "sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-body-length-browser": {
@@ -882,50 +964,50 @@
       }
     },
     "node_modules/@aws-sdk/util-body-length-node": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.188.0.tgz",
-      "integrity": "sha512-XwqP3vxk60MKp4YDdvDeCD6BPOiG2e+/Ou4AofZOy5/toB6NKz2pFNibQIUg2+jc7mPMnGnvOW3MQEgSJ+gu/Q==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
+      "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-buffer-from": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.188.0.tgz",
-      "integrity": "sha512-NX1WXZ8TH20IZb4jPFT2CnLKSqZWddGxtfiWxD9M47YOtq/SSQeR82fhqqVjJn4P8w2F5E28f+Du4ntg/sGcxA==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
+      "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.188.0",
+        "@aws-sdk/is-array-buffer": "3.201.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-config-provider": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.188.0.tgz",
-      "integrity": "sha512-LBA7tLbi7v4uvbOJhSnjJrxbcRifKK/1ZVK94JTV2MNSCCyNkFotyEI5UWDl10YKriTIUyf7o5cakpiDZ3O4xg==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
+      "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.190.0.tgz",
-      "integrity": "sha512-FKxTU4tIbFk2pdUbBNneStF++j+/pB4NYJ1HRSEAb/g4D2+kxikR/WKIv3p0JTVvAkwcuX/ausILYEPUyDZ4HQ==",
+      "version": "3.234.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.234.0.tgz",
+      "integrity": "sha512-IHMKXjTbOD8XMz5+2oCOsVP94BYb9YyjXdns0aAXr2NAo7k2+RCzXQ2DebJXppGda1F6opFutoKwyVSN0cmbMw==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.190.0",
-        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
         "bowser": "^2.11.0",
         "tslib": "^2.3.1"
       },
@@ -934,93 +1016,119 @@
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-node": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.190.0.tgz",
-      "integrity": "sha512-qBiIMjNynqAP7p6urG1+ZattYkFaylhyinofVcLEiDvM9a6zGt6GZsxru2Loq0kRAXXGew9E9BWGt45HcDc20g==",
+      "version": "3.234.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.234.0.tgz",
+      "integrity": "sha512-UGjQ+OjBYYhxFVtUY+jtr0ZZgzZh6OHtYwRhFt8IHewJXFCfZTyfsbX20szBj5y1S4HRIUJ7cwBLIytTqMbI5w==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/config-resolver": "3.190.0",
-        "@aws-sdk/credential-provider-imds": "3.190.0",
-        "@aws-sdk/node-config-provider": "3.190.0",
-        "@aws-sdk/property-provider": "3.190.0",
-        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/config-resolver": "3.234.0",
+        "@aws-sdk/credential-provider-imds": "3.226.0",
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.226.0.tgz",
+      "integrity": "sha512-iqOkac/zLmyPBUJd7SLN0PeZMkOmlGgD5PHmmekTClOkce2eUjK9SNX1PzL73aXPoPTyhg9QGLH8uEZEQ8YUzg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@aws-sdk/util-hex-encoding": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.188.0.tgz",
-      "integrity": "sha512-QyWovTtjQ2RYxqVM+STPh65owSqzuXURnfoof778spyX4iQ4z46wOge1YV2ZtwS8w5LWd9eeVvDrLu5POPYOnA==",
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
+      "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-locate-window": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.188.0.tgz",
-      "integrity": "sha512-SxobBVLZkkLSawTCfeQnhVX3Azm9O+C2dngZVe1+BqtF8+retUbVTs7OfYeWBlawVkULKF2e781lTzEHBBjCzw==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.208.0.tgz",
+      "integrity": "sha512-iua1A2+P7JJEDHVgvXrRJSvsnzG7stYSGQnBVphIUlemwl6nN5D+QrgbjECtrbxRz8asYFHSzhdhECqN+tFiBg==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-middleware": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.190.0.tgz",
-      "integrity": "sha512-qzTJ/qhFDzHZS+iXdHydQ/0sWAuNIB5feeLm55Io/I8Utv3l3TKYOhbgGwTsXY+jDk7oD+YnAi7hLN5oEBCwpg==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.226.0.tgz",
+      "integrity": "sha512-B96CQnwX4gRvQdaQkdUtqvDPkrptV5+va6FVeJOocU/DbSYMAScLxtR3peMS8cnlOT6nL1Eoa42OI9AfZz1VwQ==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-retry": {
+      "version": "3.229.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.229.0.tgz",
+      "integrity": "sha512-0zKTqi0P1inD0LzIMuXRIYYQ/8c1lWMg/cfiqUcIAF1TpatlpZuN7umU0ierpBFud7S+zDgg0oemh+Nj8xliJw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/service-error-classification": "3.229.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-uri-escape": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.188.0.tgz",
-      "integrity": "sha512-4Y6AYZMT483Tiuq8dxz5WHIiPNdSFPGrl6tRTo2Oi2FcwypwmFhqgEGcqxeXDUJktvaCBxeA08DLr/AemVhPCg==",
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
+      "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.190.0.tgz",
-      "integrity": "sha512-c074wjsD+/u9vT7DVrBLkwVhn28I+OEHuHaqpTVCvAIjpueZ3oms0e99YJLfpdpEgdLavOroAsNFtAuRrrTZZw==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.226.0.tgz",
+      "integrity": "sha512-PhBIu2h6sPJPcv2I7ELfFizdl5pNiL4LfxrasMCYXQkJvVnoXztHA1x+CQbXIdtZOIlpjC+6BjDcE0uhnpvfcA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/types": "3.226.0",
         "bowser": "^2.11.0",
         "tslib": "^2.3.1"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.190.0.tgz",
-      "integrity": "sha512-R36BMvvPX8frqFhU4lAsrOJ/2PJEHH/Jz1WZzO3GWmVSEAQQdHmo8tVPE3KOM7mZWe5Hj1dZudFAIxWHHFYKJA==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.226.0.tgz",
+      "integrity": "sha512-othPc5Dz/pkYkxH+nZPhc1Al0HndQT8zHD4e9h+EZ+8lkd8n+IsnLfTS/mSJWrfiC6UlNRVw55cItstmJyMe/A==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.190.0",
-        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
         "aws-crt": ">=1.0.0"
@@ -1041,16 +1149,16 @@
       }
     },
     "node_modules/@aws-sdk/util-utf8-node": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.188.0.tgz",
-      "integrity": "sha512-hCgP4+C0Lekjpjt2zFJ2R/iHes5sBGljXa5bScOFAEkRUc0Qw0VNgTv7LpEbIOAwGmqyxBoCwBW0YHPW1DfmYQ==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
+      "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.188.0",
+        "@aws-sdk/util-buffer-from": "3.208.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -8886,9 +8994,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
       "dev": true
     },
     "node_modules/tsutils": {
@@ -9558,579 +9666,652 @@
       }
     },
     "@aws-sdk/abort-controller": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.190.0.tgz",
-      "integrity": "sha512-M6qo2exTzEfHT5RuW7K090OgesUojhb2JyWiV4ulu7ngY4DWBUBMKUqac696sHRUZvGE5CDzSi0606DMboM+kA==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.226.0.tgz",
+      "integrity": "sha512-cJVzr1xxPBd08voknXvR0RLgtZKGKt6WyDpH/BaPCu3rfSqWCDZKzwqe940eqosjmKrxC6pUZNKASIqHOQ8xxQ==",
       "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/client-cognito-identity": {
-      "version": "3.192.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.192.0.tgz",
-      "integrity": "sha512-nIRmiv5JY8wWGUadhG7yLx8o8aVETj5CAgO8e8UJIwwqfue/Yv9bHi2mvkUphO1pj0TeBatAtvu79neJQtsR5g==",
+      "version": "3.235.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.235.0.tgz",
+      "integrity": "sha512-Qjvo10SYkfswYT0D2Xn5AxVP07eH4p+NPhtGnXXVoSI0GJyRlPz8MfyoHYWEPKZ929TzYXyvrz4MaTqOjLqenA==",
       "dev": true,
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.192.0",
-        "@aws-sdk/config-resolver": "3.190.0",
-        "@aws-sdk/credential-provider-node": "3.190.0",
-        "@aws-sdk/fetch-http-handler": "3.190.0",
-        "@aws-sdk/hash-node": "3.190.0",
-        "@aws-sdk/invalid-dependency": "3.190.0",
-        "@aws-sdk/middleware-content-length": "3.190.0",
-        "@aws-sdk/middleware-host-header": "3.190.0",
-        "@aws-sdk/middleware-logger": "3.190.0",
-        "@aws-sdk/middleware-recursion-detection": "3.190.0",
-        "@aws-sdk/middleware-retry": "3.190.0",
-        "@aws-sdk/middleware-serde": "3.190.0",
-        "@aws-sdk/middleware-signing": "3.192.0",
-        "@aws-sdk/middleware-stack": "3.190.0",
-        "@aws-sdk/middleware-user-agent": "3.190.0",
-        "@aws-sdk/node-config-provider": "3.190.0",
-        "@aws-sdk/node-http-handler": "3.190.0",
-        "@aws-sdk/protocol-http": "3.190.0",
-        "@aws-sdk/smithy-client": "3.190.0",
-        "@aws-sdk/types": "3.190.0",
-        "@aws-sdk/url-parser": "3.190.0",
-        "@aws-sdk/util-base64-browser": "3.188.0",
-        "@aws-sdk/util-base64-node": "3.188.0",
+        "@aws-sdk/client-sts": "3.235.0",
+        "@aws-sdk/config-resolver": "3.234.0",
+        "@aws-sdk/credential-provider-node": "3.235.0",
+        "@aws-sdk/fetch-http-handler": "3.226.0",
+        "@aws-sdk/hash-node": "3.226.0",
+        "@aws-sdk/invalid-dependency": "3.226.0",
+        "@aws-sdk/middleware-content-length": "3.226.0",
+        "@aws-sdk/middleware-endpoint": "3.226.0",
+        "@aws-sdk/middleware-host-header": "3.226.0",
+        "@aws-sdk/middleware-logger": "3.226.0",
+        "@aws-sdk/middleware-recursion-detection": "3.226.0",
+        "@aws-sdk/middleware-retry": "3.235.0",
+        "@aws-sdk/middleware-serde": "3.226.0",
+        "@aws-sdk/middleware-signing": "3.226.0",
+        "@aws-sdk/middleware-stack": "3.226.0",
+        "@aws-sdk/middleware-user-agent": "3.226.0",
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/node-http-handler": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/smithy-client": "3.234.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/url-parser": "3.226.0",
+        "@aws-sdk/util-base64": "3.208.0",
         "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.188.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.190.0",
-        "@aws-sdk/util-defaults-mode-node": "3.190.0",
-        "@aws-sdk/util-user-agent-browser": "3.190.0",
-        "@aws-sdk/util-user-agent-node": "3.190.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.234.0",
+        "@aws-sdk/util-defaults-mode-node": "3.234.0",
+        "@aws-sdk/util-endpoints": "3.226.0",
+        "@aws-sdk/util-retry": "3.229.0",
+        "@aws-sdk/util-user-agent-browser": "3.226.0",
+        "@aws-sdk/util-user-agent-node": "3.226.0",
         "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/client-sso": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.190.0.tgz",
-      "integrity": "sha512-joEKRjJEzgvXnEih/x2UDDCPlvXWCO3MAHmqi44yJ36Ph4YsFS299mOjPdVLuzUtpQ+cST1nRO7hXNFrulW2jQ==",
+      "version": "3.235.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.235.0.tgz",
+      "integrity": "sha512-CdZ2EnDuB6V41u6brk/Nt19EZneLorsNkNWr4J7zkR/2gKiqdUN6PUs6jxDtK9M7V/r81jaE0ViLwLVmYhL/bQ==",
       "dev": true,
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.190.0",
-        "@aws-sdk/fetch-http-handler": "3.190.0",
-        "@aws-sdk/hash-node": "3.190.0",
-        "@aws-sdk/invalid-dependency": "3.190.0",
-        "@aws-sdk/middleware-content-length": "3.190.0",
-        "@aws-sdk/middleware-host-header": "3.190.0",
-        "@aws-sdk/middleware-logger": "3.190.0",
-        "@aws-sdk/middleware-recursion-detection": "3.190.0",
-        "@aws-sdk/middleware-retry": "3.190.0",
-        "@aws-sdk/middleware-serde": "3.190.0",
-        "@aws-sdk/middleware-stack": "3.190.0",
-        "@aws-sdk/middleware-user-agent": "3.190.0",
-        "@aws-sdk/node-config-provider": "3.190.0",
-        "@aws-sdk/node-http-handler": "3.190.0",
-        "@aws-sdk/protocol-http": "3.190.0",
-        "@aws-sdk/smithy-client": "3.190.0",
-        "@aws-sdk/types": "3.190.0",
-        "@aws-sdk/url-parser": "3.190.0",
-        "@aws-sdk/util-base64-browser": "3.188.0",
-        "@aws-sdk/util-base64-node": "3.188.0",
+        "@aws-sdk/config-resolver": "3.234.0",
+        "@aws-sdk/fetch-http-handler": "3.226.0",
+        "@aws-sdk/hash-node": "3.226.0",
+        "@aws-sdk/invalid-dependency": "3.226.0",
+        "@aws-sdk/middleware-content-length": "3.226.0",
+        "@aws-sdk/middleware-endpoint": "3.226.0",
+        "@aws-sdk/middleware-host-header": "3.226.0",
+        "@aws-sdk/middleware-logger": "3.226.0",
+        "@aws-sdk/middleware-recursion-detection": "3.226.0",
+        "@aws-sdk/middleware-retry": "3.235.0",
+        "@aws-sdk/middleware-serde": "3.226.0",
+        "@aws-sdk/middleware-stack": "3.226.0",
+        "@aws-sdk/middleware-user-agent": "3.226.0",
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/node-http-handler": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/smithy-client": "3.234.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/url-parser": "3.226.0",
+        "@aws-sdk/util-base64": "3.208.0",
         "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.188.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.190.0",
-        "@aws-sdk/util-defaults-mode-node": "3.190.0",
-        "@aws-sdk/util-user-agent-browser": "3.190.0",
-        "@aws-sdk/util-user-agent-node": "3.190.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.234.0",
+        "@aws-sdk/util-defaults-mode-node": "3.234.0",
+        "@aws-sdk/util-endpoints": "3.226.0",
+        "@aws-sdk/util-retry": "3.229.0",
+        "@aws-sdk/util-user-agent-browser": "3.226.0",
+        "@aws-sdk/util-user-agent-node": "3.226.0",
         "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/client-sso-oidc": {
+      "version": "3.235.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.235.0.tgz",
+      "integrity": "sha512-oSF0lSPmE5jaaigxc5TZyDjqfgTiDsromEdvv5s5a/qAOZBNtsVaS4+8cn9kIt43Ceo7dxHXk7cwvXMNPwVnWw==",
+      "dev": true,
+      "requires": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.234.0",
+        "@aws-sdk/fetch-http-handler": "3.226.0",
+        "@aws-sdk/hash-node": "3.226.0",
+        "@aws-sdk/invalid-dependency": "3.226.0",
+        "@aws-sdk/middleware-content-length": "3.226.0",
+        "@aws-sdk/middleware-endpoint": "3.226.0",
+        "@aws-sdk/middleware-host-header": "3.226.0",
+        "@aws-sdk/middleware-logger": "3.226.0",
+        "@aws-sdk/middleware-recursion-detection": "3.226.0",
+        "@aws-sdk/middleware-retry": "3.235.0",
+        "@aws-sdk/middleware-serde": "3.226.0",
+        "@aws-sdk/middleware-stack": "3.226.0",
+        "@aws-sdk/middleware-user-agent": "3.226.0",
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/node-http-handler": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/smithy-client": "3.234.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/url-parser": "3.226.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.234.0",
+        "@aws-sdk/util-defaults-mode-node": "3.234.0",
+        "@aws-sdk/util-endpoints": "3.226.0",
+        "@aws-sdk/util-retry": "3.229.0",
+        "@aws-sdk/util-user-agent-browser": "3.226.0",
+        "@aws-sdk/util-user-agent-node": "3.226.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/client-sts": {
-      "version": "3.192.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.192.0.tgz",
-      "integrity": "sha512-iv72dmRxbZ1cN5jGn4KIVzzu11eduS2fXHbNgd7JsFd5hLBV5TvJaugQzUdXNmy2gN4HiRJr+qa9WkD5b39lsA==",
+      "version": "3.235.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.235.0.tgz",
+      "integrity": "sha512-P1pqvg7brdBUGrTlyMc+LCe6rnWrWufdd7bpzuC9lcVzkoOHJw8j8wDItwoCsvy1O3SeK7vtmOTLxV2yuTEO3Q==",
       "dev": true,
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.190.0",
-        "@aws-sdk/credential-provider-node": "3.190.0",
-        "@aws-sdk/fetch-http-handler": "3.190.0",
-        "@aws-sdk/hash-node": "3.190.0",
-        "@aws-sdk/invalid-dependency": "3.190.0",
-        "@aws-sdk/middleware-content-length": "3.190.0",
-        "@aws-sdk/middleware-host-header": "3.190.0",
-        "@aws-sdk/middleware-logger": "3.190.0",
-        "@aws-sdk/middleware-recursion-detection": "3.190.0",
-        "@aws-sdk/middleware-retry": "3.190.0",
-        "@aws-sdk/middleware-sdk-sts": "3.192.0",
-        "@aws-sdk/middleware-serde": "3.190.0",
-        "@aws-sdk/middleware-signing": "3.192.0",
-        "@aws-sdk/middleware-stack": "3.190.0",
-        "@aws-sdk/middleware-user-agent": "3.190.0",
-        "@aws-sdk/node-config-provider": "3.190.0",
-        "@aws-sdk/node-http-handler": "3.190.0",
-        "@aws-sdk/protocol-http": "3.190.0",
-        "@aws-sdk/smithy-client": "3.190.0",
-        "@aws-sdk/types": "3.190.0",
-        "@aws-sdk/url-parser": "3.190.0",
-        "@aws-sdk/util-base64-browser": "3.188.0",
-        "@aws-sdk/util-base64-node": "3.188.0",
+        "@aws-sdk/config-resolver": "3.234.0",
+        "@aws-sdk/credential-provider-node": "3.235.0",
+        "@aws-sdk/fetch-http-handler": "3.226.0",
+        "@aws-sdk/hash-node": "3.226.0",
+        "@aws-sdk/invalid-dependency": "3.226.0",
+        "@aws-sdk/middleware-content-length": "3.226.0",
+        "@aws-sdk/middleware-endpoint": "3.226.0",
+        "@aws-sdk/middleware-host-header": "3.226.0",
+        "@aws-sdk/middleware-logger": "3.226.0",
+        "@aws-sdk/middleware-recursion-detection": "3.226.0",
+        "@aws-sdk/middleware-retry": "3.235.0",
+        "@aws-sdk/middleware-sdk-sts": "3.226.0",
+        "@aws-sdk/middleware-serde": "3.226.0",
+        "@aws-sdk/middleware-signing": "3.226.0",
+        "@aws-sdk/middleware-stack": "3.226.0",
+        "@aws-sdk/middleware-user-agent": "3.226.0",
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/node-http-handler": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/smithy-client": "3.234.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/url-parser": "3.226.0",
+        "@aws-sdk/util-base64": "3.208.0",
         "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.188.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.190.0",
-        "@aws-sdk/util-defaults-mode-node": "3.190.0",
-        "@aws-sdk/util-user-agent-browser": "3.190.0",
-        "@aws-sdk/util-user-agent-node": "3.190.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.234.0",
+        "@aws-sdk/util-defaults-mode-node": "3.234.0",
+        "@aws-sdk/util-endpoints": "3.226.0",
+        "@aws-sdk/util-retry": "3.229.0",
+        "@aws-sdk/util-user-agent-browser": "3.226.0",
+        "@aws-sdk/util-user-agent-node": "3.226.0",
         "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
         "fast-xml-parser": "4.0.11",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/config-resolver": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.190.0.tgz",
-      "integrity": "sha512-K+VnDtjTgjpf7yHEdDB0qgGbHToF0pIL0pQMSnmk2yc8BoB3LGG/gg1T0Ki+wRlrFnDCJ6L+8zUdawY2qDsbyw==",
+      "version": "3.234.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.234.0.tgz",
+      "integrity": "sha512-uZxy4wzllfvgCQxVc+Iqhde0NGAnfmV2hWR6ejadJaAFTuYNvQiRg9IqJy3pkyDPqXySiJ8Bom5PoJfgn55J/A==",
       "dev": true,
       "requires": {
-        "@aws-sdk/signature-v4": "3.190.0",
-        "@aws-sdk/types": "3.190.0",
-        "@aws-sdk/util-config-provider": "3.188.0",
-        "@aws-sdk/util-middleware": "3.190.0",
+        "@aws-sdk/signature-v4": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.226.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-cognito-identity": {
-      "version": "3.192.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.192.0.tgz",
-      "integrity": "sha512-CWo+KyHCGyYtvjlmDIGtnwBEkdiondergZADiStbFFvie8pPI7IsdTXNVssQQ1VxKIBGGHVebgZGSklHBqthwA==",
+      "version": "3.235.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.235.0.tgz",
+      "integrity": "sha512-OlnqSYJtaGlAMG+8bLjVIkK53eNd22VN5Rk2WwKNKd3qShMSvTz9RDnTv3RHBsYiaZOU7P409ph583pBluOsFA==",
       "dev": true,
       "requires": {
-        "@aws-sdk/client-cognito-identity": "3.192.0",
-        "@aws-sdk/property-provider": "3.190.0",
-        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/client-cognito-identity": "3.235.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-env": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.190.0.tgz",
-      "integrity": "sha512-GTY7l3SJhTmRGFpWddbdJOihSqoMN8JMo3CsCtIjk4/h3xirBi02T4GSvbrMyP7FP3Fdl4NAdT+mHJ4q2Bvzxw==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.226.0.tgz",
+      "integrity": "sha512-sd8uK1ojbXxaZXlthzw/VXZwCPUtU3PjObOfr3Evj7MPIM2IH8h29foOlggx939MdLQGboJf9gKvLlvKDWtJRA==",
       "dev": true,
       "requires": {
-        "@aws-sdk/property-provider": "3.190.0",
-        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-imds": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.190.0.tgz",
-      "integrity": "sha512-gI5pfBqGYCKdmx8igPvq+jLzyE2kuNn9Q5u73pdM/JZxiq7GeWYpE/MqqCubHxPtPcTFgAwxCxCFoXlUTBh/2g==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.226.0.tgz",
+      "integrity": "sha512-//z/COQm2AjYFI1Lb0wKHTQSrvLFTyuKLFQGPJsKS7DPoxGOCKB7hmYerlbl01IDoCxTdyL//TyyPxbZEOQD5Q==",
       "dev": true,
       "requires": {
-        "@aws-sdk/node-config-provider": "3.190.0",
-        "@aws-sdk/property-provider": "3.190.0",
-        "@aws-sdk/types": "3.190.0",
-        "@aws-sdk/url-parser": "3.190.0",
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/url-parser": "3.226.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-ini": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.190.0.tgz",
-      "integrity": "sha512-Z7NN/evXJk59hBQlfOSWDfHntwmxwryu6uclgv7ECI6SEVtKt1EKIlPuCLUYgQ4lxb9bomyO5lQAl/1WutNT5w==",
+      "version": "3.235.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.235.0.tgz",
+      "integrity": "sha512-i3efxJw+9hN/opmjlRqT0lv/gKjOHmgGBUbFCdbCmSUTc8QH3sbkIY6FLX2q0PSu4q4CpCwWZ587lkThtFerJA==",
       "dev": true,
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.190.0",
-        "@aws-sdk/credential-provider-imds": "3.190.0",
-        "@aws-sdk/credential-provider-sso": "3.190.0",
-        "@aws-sdk/credential-provider-web-identity": "3.190.0",
-        "@aws-sdk/property-provider": "3.190.0",
-        "@aws-sdk/shared-ini-file-loader": "3.190.0",
-        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/credential-provider-env": "3.226.0",
+        "@aws-sdk/credential-provider-imds": "3.226.0",
+        "@aws-sdk/credential-provider-process": "3.226.0",
+        "@aws-sdk/credential-provider-sso": "3.235.0",
+        "@aws-sdk/credential-provider-web-identity": "3.226.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/shared-ini-file-loader": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-node": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.190.0.tgz",
-      "integrity": "sha512-ctCG5+TsIK2gVgvvFiFjinPjc5nGpSypU3nQKCaihtPh83wDN6gCx4D0p9M8+fUrlPa5y+o/Y7yHo94ATepM8w==",
+      "version": "3.235.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.235.0.tgz",
+      "integrity": "sha512-xJSAntEBlbXbngSzpyMnlZzOldxV0sNOQ7ggDUmIQNVWbu3XwP6MiA8CjAHnH10vs6+pcyHtpfUj3evdQZ4JlQ==",
       "dev": true,
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.190.0",
-        "@aws-sdk/credential-provider-imds": "3.190.0",
-        "@aws-sdk/credential-provider-ini": "3.190.0",
-        "@aws-sdk/credential-provider-process": "3.190.0",
-        "@aws-sdk/credential-provider-sso": "3.190.0",
-        "@aws-sdk/credential-provider-web-identity": "3.190.0",
-        "@aws-sdk/property-provider": "3.190.0",
-        "@aws-sdk/shared-ini-file-loader": "3.190.0",
-        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/credential-provider-env": "3.226.0",
+        "@aws-sdk/credential-provider-imds": "3.226.0",
+        "@aws-sdk/credential-provider-ini": "3.235.0",
+        "@aws-sdk/credential-provider-process": "3.226.0",
+        "@aws-sdk/credential-provider-sso": "3.235.0",
+        "@aws-sdk/credential-provider-web-identity": "3.226.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/shared-ini-file-loader": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-process": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.190.0.tgz",
-      "integrity": "sha512-sIJhICR80n5XY1kW/EFHTh5ZzBHb5X+744QCH3StcbKYI44mOZvNKfFdeRL2fQ7yLgV7npte2HJRZzQPWpZUrw==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.226.0.tgz",
+      "integrity": "sha512-iUDMdnrTvbvaCFhWwqyXrhvQ9+ojPqPqXhwZtY1X/Qaz+73S9gXBPJHZaZb2Ke0yKE1Ql3bJbKvmmxC/qLQMng==",
       "dev": true,
       "requires": {
-        "@aws-sdk/property-provider": "3.190.0",
-        "@aws-sdk/shared-ini-file-loader": "3.190.0",
-        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/shared-ini-file-loader": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-sso": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.190.0.tgz",
-      "integrity": "sha512-uarU9vk471MHHT+GJj3KWFSmaaqLNL5n1KcMer2CCAZfjs+mStAi8+IjZuuKXB4vqVs5DxdH8cy5aLaJcBlXwQ==",
+      "version": "3.235.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.235.0.tgz",
+      "integrity": "sha512-+7UORB7Wo/d0mEz7J16/hsRumIhtdl4KekJfrXH5OrLiXXIsn68wmQkrvwD2CibbtgOY0P69G12qbcBHkg3qng==",
       "dev": true,
       "requires": {
-        "@aws-sdk/client-sso": "3.190.0",
-        "@aws-sdk/property-provider": "3.190.0",
-        "@aws-sdk/shared-ini-file-loader": "3.190.0",
-        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/client-sso": "3.235.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/shared-ini-file-loader": "3.226.0",
+        "@aws-sdk/token-providers": "3.235.0",
+        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-web-identity": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.190.0.tgz",
-      "integrity": "sha512-nlIBeK9hGHKWC874h+ITAfPZ9Eaok+x/ydZQVKsLHiQ9PH3tuQ8AaGqhuCwBSH0hEAHZ/BiKeEx5VyWAE8/x+Q==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.226.0.tgz",
+      "integrity": "sha512-CCpv847rLB0SFOHz2igvUMFAzeT2fD3YnY4C8jltuJoEkn0ITn1Hlgt13nTJ5BUuvyti2mvyXZHmNzhMIMrIlw==",
       "dev": true,
       "requires": {
-        "@aws-sdk/property-provider": "3.190.0",
-        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-providers": {
-      "version": "3.192.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.192.0.tgz",
-      "integrity": "sha512-iBTrEPkfOHlfgQyk7EeUCmZnhUKXsGcc/hhxBbc6Z/Xc7Y8LqRVLbEmHq9lruXraFuvs26xV9oZi1s1UMXneQA==",
+      "version": "3.235.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.235.0.tgz",
+      "integrity": "sha512-HCrXbXAnd4dywv1WW3/P8bJp3FEJuG+Gul0pC+b5wh90Ppy50ay/01KcLpvqS1SgKdk7toucWnpExgEJZHUcOQ==",
       "dev": true,
       "requires": {
-        "@aws-sdk/client-cognito-identity": "3.192.0",
-        "@aws-sdk/client-sso": "3.190.0",
-        "@aws-sdk/client-sts": "3.192.0",
-        "@aws-sdk/credential-provider-cognito-identity": "3.192.0",
-        "@aws-sdk/credential-provider-env": "3.190.0",
-        "@aws-sdk/credential-provider-imds": "3.190.0",
-        "@aws-sdk/credential-provider-ini": "3.190.0",
-        "@aws-sdk/credential-provider-node": "3.190.0",
-        "@aws-sdk/credential-provider-process": "3.190.0",
-        "@aws-sdk/credential-provider-sso": "3.190.0",
-        "@aws-sdk/credential-provider-web-identity": "3.190.0",
-        "@aws-sdk/property-provider": "3.190.0",
-        "@aws-sdk/shared-ini-file-loader": "3.190.0",
-        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/client-cognito-identity": "3.235.0",
+        "@aws-sdk/client-sso": "3.235.0",
+        "@aws-sdk/client-sts": "3.235.0",
+        "@aws-sdk/credential-provider-cognito-identity": "3.235.0",
+        "@aws-sdk/credential-provider-env": "3.226.0",
+        "@aws-sdk/credential-provider-imds": "3.226.0",
+        "@aws-sdk/credential-provider-ini": "3.235.0",
+        "@aws-sdk/credential-provider-node": "3.235.0",
+        "@aws-sdk/credential-provider-process": "3.226.0",
+        "@aws-sdk/credential-provider-sso": "3.235.0",
+        "@aws-sdk/credential-provider-web-identity": "3.226.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/shared-ini-file-loader": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/fetch-http-handler": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.190.0.tgz",
-      "integrity": "sha512-5riRpKydARXAPLesTZm6eP6QKJ4HJGQ3k0Tepi3nvxHVx3UddkRNoX0pLS3rvbajkykWPNC2qdfRGApWlwOYsA==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.226.0.tgz",
+      "integrity": "sha512-JewZPMNEBXfi1xVnRa7pVtK/zgZD8/lQ/YnD8pq79WuMa2cwyhDtr8oqCoqsPW+WJT5ScXoMtuHxN78l8eKWgg==",
       "dev": true,
       "requires": {
-        "@aws-sdk/protocol-http": "3.190.0",
-        "@aws-sdk/querystring-builder": "3.190.0",
-        "@aws-sdk/types": "3.190.0",
-        "@aws-sdk/util-base64-browser": "3.188.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/querystring-builder": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-base64": "3.208.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/hash-node": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.190.0.tgz",
-      "integrity": "sha512-DNwVT3O8zc9Jk/bXiXcN0WsD98r+JJWryw9F1/ZZbuzbf6rx2qhI8ZK+nh5X6WMtYPU84luQMcF702fJt/1bzg==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.226.0.tgz",
+      "integrity": "sha512-MdlJhJ9/Espwd0+gUXdZRsHuostB2WxEVAszWxobP0FTT9PnicqnfK7ExmW+DUAc0ywxtEbR3e0UND65rlSTVw==",
       "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.190.0",
-        "@aws-sdk/util-buffer-from": "3.188.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-buffer-from": "3.208.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/invalid-dependency": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.190.0.tgz",
-      "integrity": "sha512-crCh63e8d/Uw9y3dQlVTPja7+IZiXpNXyH6oSuAadTDQwMq6KK87Av1/SDzVf6bAo2KgAOo41MyO2joaCEk0dQ==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.226.0.tgz",
+      "integrity": "sha512-QXOYFmap8g9QzRjumcRCIo2GEZkdCwd7ePQW0OABWPhKHzlJ74vvBxywjU3s39EEBEluWXtZ7Iufg6GxZM4ifw==",
       "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/is-array-buffer": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.188.0.tgz",
-      "integrity": "sha512-n69N4zJZCNd87Rf4NzufPzhactUeM877Y0Tp/F3KiHqGeTnVjYUa4Lv1vLBjqtfjYb2HWT3NKlYn5yzrhaEwiQ==",
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
       "dev": true,
       "requires": {
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-content-length": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.190.0.tgz",
-      "integrity": "sha512-sSU347SuC6I8kWum1jlJlpAqeV23KP7enG+ToWcEcgFrJhm3AvuqB//NJxDbkKb2DNroRvJjBckBvrwNAjQnBQ==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.226.0.tgz",
+      "integrity": "sha512-ksUzlHJN2JMuyavjA46a4sctvnrnITqt2tbGGWWrAuXY1mel2j+VbgnmJUiwHKUO6bTFBBeft5Vd1TSOb4JmiA==",
       "dev": true,
       "requires": {
-        "@aws-sdk/protocol-http": "3.190.0",
-        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-endpoint": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.226.0.tgz",
+      "integrity": "sha512-EvLFafjtUxTT0AC9p3aBQu1/fjhWdIeK58jIXaNFONfZ3F8QbEYUPuF/SqZvJM6cWfOO9qwYKkRDbCSTYhprIg==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/middleware-serde": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/signature-v4": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/url-parser": "3.226.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.226.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-host-header": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.190.0.tgz",
-      "integrity": "sha512-cL7Vo/QSpGx/DDmFxjeV0Qlyi1atvHQDPn3MLBBmi1icu+3GKZkCMAJwzsrV3U4+WoVoDYT9FJ9yMQf2HaIjeQ==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.226.0.tgz",
+      "integrity": "sha512-haVkWVh6BUPwKgWwkL6sDvTkcZWvJjv8AgC8jiQuSl8GLZdzHTB8Qhi3IsfFta9HAuoLjxheWBE5Z/L0UrfhLA==",
       "dev": true,
       "requires": {
-        "@aws-sdk/protocol-http": "3.190.0",
-        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-logger": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.190.0.tgz",
-      "integrity": "sha512-rrfLGYSZCBtiXNrIa8pJ2uwUoUMyj6Q82E8zmduTvqKWviCr6ZKes0lttGIkWhjvhql2m4CbjG5MPBnY7RXL4A==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.226.0.tgz",
+      "integrity": "sha512-m9gtLrrYnpN6yckcQ09rV7ExWOLMuq8mMPF/K3DbL/YL0TuILu9i2T1W+JuxSX+K9FMG2HrLAKivE/kMLr55xA==",
       "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-recursion-detection": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.190.0.tgz",
-      "integrity": "sha512-5tc1AIIZe5jDNdyuJW+7vIFmQOxz3q031ZVrEtUEIF7cz2ySho2lkOWziz+v+UGSLhjHGKMz3V26+aN1FLZNxQ==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.226.0.tgz",
+      "integrity": "sha512-mwRbdKEUeuNH5TEkyZ5FWxp6bL2UC1WbY+LDv6YjHxmSMKpAoOueEdtU34PqDOLrpXXxIGHDFmjeGeMfktyEcA==",
       "dev": true,
       "requires": {
-        "@aws-sdk/protocol-http": "3.190.0",
-        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-retry": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.190.0.tgz",
-      "integrity": "sha512-h1bPopkncf2ue/erJdhqvgR2AEh0bIvkNsIHhx93DckWKotZd/GAVDq0gpKj7/f/7B+teHH8Fg5GDOwOOGyKcg==",
+      "version": "3.235.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.235.0.tgz",
+      "integrity": "sha512-50WHbJGpD3SNp9763MAlHqIhXil++JdQbKejNpHg7HsJne/ao3ub+fDOfx//mMBjpzBV25BGd5UlfL6blrClSg==",
       "dev": true,
       "requires": {
-        "@aws-sdk/protocol-http": "3.190.0",
-        "@aws-sdk/service-error-classification": "3.190.0",
-        "@aws-sdk/types": "3.190.0",
-        "@aws-sdk/util-middleware": "3.190.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/service-error-classification": "3.229.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-middleware": "3.226.0",
+        "@aws-sdk/util-retry": "3.229.0",
         "tslib": "^2.3.1",
         "uuid": "^8.3.2"
       }
     },
     "@aws-sdk/middleware-sdk-sts": {
-      "version": "3.192.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.192.0.tgz",
-      "integrity": "sha512-xzTV7MyG5ipWYTvekWX1tQc5ExsUvCYsDTBCD3LR5hBrP8assUDPo52zGSe+QMcjgnQv7BcYIzeikTkLEG0dUw==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.226.0.tgz",
+      "integrity": "sha512-NN9T/qoSD1kZvAT+VLny3NnlqgylYQcsgV3rvi/8lYzw/G/2s8VS6sm/VTWGGZhx08wZRv20MWzYu3bftcyqUg==",
       "dev": true,
       "requires": {
-        "@aws-sdk/middleware-signing": "3.192.0",
-        "@aws-sdk/property-provider": "3.190.0",
-        "@aws-sdk/protocol-http": "3.190.0",
-        "@aws-sdk/signature-v4": "3.190.0",
-        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/middleware-signing": "3.226.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/signature-v4": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-serde": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.190.0.tgz",
-      "integrity": "sha512-S132hEOK4jwbtZ1bGAgSuQ0DMFG4TiD4ulAwbQRBYooC7tiWZbRiR0Pkt2hV8d7WhOHgUpg7rvqlA7/HXXBAsA==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.226.0.tgz",
+      "integrity": "sha512-nPuOOAkSfx9TxzdKFx0X2bDlinOxGrqD7iof926K/AEflxGD1DBdcaDdjlYlPDW2CVE8LV/rAgbYuLxh/E/1VA==",
       "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-signing": {
-      "version": "3.192.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.192.0.tgz",
-      "integrity": "sha512-qTRIU/TL/dvtTrNj+AkZkgYeTIFslib3Y3XnQNNM6RCm4cMxIgs2K/lnhaUmLdbzHrpOQb4cISkY8yiHo+pNsw==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.226.0.tgz",
+      "integrity": "sha512-E6HmtPcl+IjYDDzi1xI2HpCbBq2avNWcjvCriMZWuTAtRVpnA6XDDGW5GY85IfS3A8G8vuWqEVPr8JcYUcjfew==",
       "dev": true,
       "requires": {
-        "@aws-sdk/property-provider": "3.190.0",
-        "@aws-sdk/protocol-http": "3.190.0",
-        "@aws-sdk/signature-v4": "3.190.0",
-        "@aws-sdk/types": "3.190.0",
-        "@aws-sdk/util-middleware": "3.190.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/signature-v4": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-middleware": "3.226.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-stack": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.190.0.tgz",
-      "integrity": "sha512-h1mqiWNJdi1OTSEY8QovpiHgDQEeRG818v8yShpqSYXJKEqdn54MA3Z1D2fg/Wv/8ZJsFrBCiI7waT1JUYOmCg==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.226.0.tgz",
+      "integrity": "sha512-85wF29LvPvpoed60fZGDYLwv1Zpd/cM0C22WSSFPw1SSJeqO4gtFYyCg2squfT3KI6kF43IIkOCJ+L7GtryPug==",
       "dev": true,
       "requires": {
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-user-agent": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.190.0.tgz",
-      "integrity": "sha512-y/2cTE1iYHKR0nkb3DvR3G8vt12lcTP95r/iHp8ZO+Uzpc25jM/AyMHWr2ZjqQiHKNlzh8uRw1CmQtgg4sBxXQ==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.226.0.tgz",
+      "integrity": "sha512-N1WnfzCW1Y5yWhVAphf8OPGTe8Df3vmV7/LdsoQfmpkCZgLZeK2o0xITkUQhRj1mbw7yp8tVFLFV3R2lMurdAQ==",
       "dev": true,
       "requires": {
-        "@aws-sdk/protocol-http": "3.190.0",
-        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/node-config-provider": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.190.0.tgz",
-      "integrity": "sha512-TJPUchyeK5KeEXWrwb6oW5/OkY3STCSGR1QIlbPcaTGkbo4kXAVyQmmZsY4KtRPuDM6/HlfUQV17bD716K65rQ==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.226.0.tgz",
+      "integrity": "sha512-B8lQDqiRk7X5izFEUMXmi8CZLOKCTWQJU9HQf3ako+sF0gexo4nHN3jhoRWyLtcgC5S3on/2jxpAcqtm7kuY3w==",
       "dev": true,
       "requires": {
-        "@aws-sdk/property-provider": "3.190.0",
-        "@aws-sdk/shared-ini-file-loader": "3.190.0",
-        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/shared-ini-file-loader": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/node-http-handler": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.190.0.tgz",
-      "integrity": "sha512-3Klkr73TpZkCzcnSP+gmFF0Baluzk3r7BaWclJHqt2LcFUWfIJzYlnbBQNZ4t3EEq7ZlBJX85rIDHBRlS+rUyA==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.226.0.tgz",
+      "integrity": "sha512-xQCddnZNMiPmjr3W7HYM+f5ir4VfxgJh37eqZwX6EZmyItFpNNeVzKUgA920ka1VPz/ZUYB+2OFGiX3LCLkkaA==",
       "dev": true,
       "requires": {
-        "@aws-sdk/abort-controller": "3.190.0",
-        "@aws-sdk/protocol-http": "3.190.0",
-        "@aws-sdk/querystring-builder": "3.190.0",
-        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/abort-controller": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/querystring-builder": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/property-provider": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.190.0.tgz",
-      "integrity": "sha512-uzdKjHE2blbuceTC5zeBgZ0+Uo/hf9pH20CHpJeVNtrrtF3GALtu4Y1Gu5QQVIQBz8gjHnqANx0XhfYzorv69Q==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.226.0.tgz",
+      "integrity": "sha512-TsljjG+Sg0LmdgfiAlWohluWKnxB/k8xenjeozZfzOr5bHmNHtdbWv6BtNvD/R83hw7SFXxbJHlD5H4u9p2NFg==",
       "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/protocol-http": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.190.0.tgz",
-      "integrity": "sha512-s5MVfeONpfZYRzCSbqQ+wJ3GxKED+aSS7+CQoeaYoD6HDTDxaMGNv9aiPxVCzW02sgG7py7f29Q6Vw+5taZXZA==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
+      "integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
       "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/querystring-builder": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.190.0.tgz",
-      "integrity": "sha512-w9mTKkCsaLIBC8EA4RAHrqethNGbf60CbpPzN/QM7yCV3ZZJAXkppFfjTVVOMbPaI8GUEOptJtzgqV68CRB7ow==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.226.0.tgz",
+      "integrity": "sha512-LVurypuNeotO4lmirKXRC4NYrZRAyMJXuwO0f2a5ZAUJCjauwYrifKue6yCfU7bls7gut7nfcR6B99WBYpHs3g==",
       "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.190.0",
-        "@aws-sdk/util-uri-escape": "3.188.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/querystring-parser": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.190.0.tgz",
-      "integrity": "sha512-vCKP0s33VtS47LSYzEWRRr2aTbi3qNkUuQyIrc5LMqBfS5hsy79P1HL4Q7lCVqZB5fe61N8fKzOxDxWRCF0sXg==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.226.0.tgz",
+      "integrity": "sha512-FzB+VrQ47KAFxiPt2YXrKZ8AOLZQqGTLCKHzx4bjxGmwgsjV8yIbtJiJhZLMcUQV4LtGeIY9ixIqQhGvnZHE4A==",
       "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/service-error-classification": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.190.0.tgz",
-      "integrity": "sha512-g+s6xtaMa5fCMA2zJQC4BiFGMP7FN5/L1V/UwxCnKy8skCwaN0K5A1tFffBjjbYiPI7Gu7LVorWD2A0Y4xl01Q==",
+      "version": "3.229.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.229.0.tgz",
+      "integrity": "sha512-dnzWWQ0/NoWMUZ5C0DW3dPm0wC1O76Y/SpKbuJzWPkx1EYy6r8p32Ly4D9vUzrKDbRGf48YHIF2kOkBmu21CLg==",
       "dev": true
     },
     "@aws-sdk/shared-ini-file-loader": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.190.0.tgz",
-      "integrity": "sha512-CZC/xsGReUEl5w+JgfancrxfkaCbEisyIFy6HALUYrioWQe80WMqLAdUMZSXHWjIaNK9mH0J/qvcSV2MuIoMzQ==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.226.0.tgz",
+      "integrity": "sha512-661VQefsARxVyyV2FX9V61V+nNgImk7aN2hYlFKla6BCwZfMng+dEtD0xVGyg1PfRw0qvEv5LQyxMVgHcUSevA==",
       "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/signature-v4": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.190.0.tgz",
-      "integrity": "sha512-L/R/1X2T+/Kg2k/sjoYyDFulVUGrVcRfyEKKVFIUNg0NwUtw5UKa1/gS7geTKcg4q8M2pd/v+OCBrge2X7phUw==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.226.0.tgz",
+      "integrity": "sha512-/R5q5agdPd7HJB68XMzpxrNPk158EHUvkFkuRu5Qf3kkkHebEzWEBlWoVpUe6ss4rP9Tqcue6xPuaftEmhjpYw==",
       "dev": true,
       "requires": {
-        "@aws-sdk/is-array-buffer": "3.188.0",
-        "@aws-sdk/types": "3.190.0",
-        "@aws-sdk/util-hex-encoding": "3.188.0",
-        "@aws-sdk/util-middleware": "3.190.0",
-        "@aws-sdk/util-uri-escape": "3.188.0",
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-hex-encoding": "3.201.0",
+        "@aws-sdk/util-middleware": "3.226.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/smithy-client": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.190.0.tgz",
-      "integrity": "sha512-f5EoCwjBLXMyuN491u1NmEutbolL0cJegaJbtgK9OJw2BLuRHiBknjDF4OEVuK/WqK0kz2JLMGi9xwVPl4BKCA==",
+      "version": "3.234.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.234.0.tgz",
+      "integrity": "sha512-8AtR/k4vsFvjXeQbIzq/Wy7Nbk48Ou0wUEeVYPHWHPSU8QamFWORkOwmKtKMfHAyZvmqiAPeQqHFkq+UJhWyyQ==",
       "dev": true,
       "requires": {
-        "@aws-sdk/middleware-stack": "3.190.0",
-        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/middleware-stack": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/token-providers": {
+      "version": "3.235.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.235.0.tgz",
+      "integrity": "sha512-TdUbQ0wWVTO7azF/8ojtd4MNFjEfQKhGoGib0g/W5pa/FJryOkiIP8U4POC/I+0ATMkLK3vAC07kNHtey0ooZg==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/client-sso-oidc": "3.235.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/shared-ini-file-loader": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/types": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.190.0.tgz",
-      "integrity": "sha512-mkeZ+vJZzElP6OdRXvuLKWHSlDQxZP9u8BjQB9N0Rw0pCXTzYS0vzIhN1pL0uddWp5fMrIE68snto9xNR6BQuA==",
-      "dev": true
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
+      "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
     },
     "@aws-sdk/url-parser": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.190.0.tgz",
-      "integrity": "sha512-FKFDtxA9pvHmpfWmNVK5BAVRpDgkWMz3u4Sg9UzB+WAFN6UexRypXXUZCFAo8S04FbPKfYOR3O0uVlw7kzmj9g==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.226.0.tgz",
+      "integrity": "sha512-p5RLE0QWyP0OcTOLmFcLdVgUcUEzmEfmdrnOxyNzomcYb0p3vUagA5zfa1HVK2azsQJFBv28GfvMnba9bGhObg==",
       "dev": true,
       "requires": {
-        "@aws-sdk/querystring-parser": "3.190.0",
-        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/querystring-parser": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       }
     },
-    "@aws-sdk/util-base64-browser": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.188.0.tgz",
-      "integrity": "sha512-qlH+5NZBLiyKziL335BEPedYxX6j+p7KFRWXvDQox9S+s+gLCayednpK+fteOhBenCcR9fUZOVuAPScy1I8qCg==",
+    "@aws-sdk/util-base64": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.208.0.tgz",
+      "integrity": "sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==",
       "dev": true,
       "requires": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-base64-node": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.188.0.tgz",
-      "integrity": "sha512-r1dccRsRjKq+OhVRUfqFiW3sGgZBjHbMeHLbrAs9jrOjU2PTQ8PSzAXLvX/9lmp7YjmX17Qvlsg0NCr1tbB9OA==",
-      "dev": true,
-      "requires": {
-        "@aws-sdk/util-buffer-from": "3.188.0",
+        "@aws-sdk/util-buffer-from": "3.208.0",
         "tslib": "^2.3.1"
       }
     },
@@ -10144,114 +10325,134 @@
       }
     },
     "@aws-sdk/util-body-length-node": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.188.0.tgz",
-      "integrity": "sha512-XwqP3vxk60MKp4YDdvDeCD6BPOiG2e+/Ou4AofZOy5/toB6NKz2pFNibQIUg2+jc7mPMnGnvOW3MQEgSJ+gu/Q==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
+      "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
       "dev": true,
       "requires": {
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-buffer-from": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.188.0.tgz",
-      "integrity": "sha512-NX1WXZ8TH20IZb4jPFT2CnLKSqZWddGxtfiWxD9M47YOtq/SSQeR82fhqqVjJn4P8w2F5E28f+Du4ntg/sGcxA==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
+      "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
       "dev": true,
       "requires": {
-        "@aws-sdk/is-array-buffer": "3.188.0",
+        "@aws-sdk/is-array-buffer": "3.201.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-config-provider": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.188.0.tgz",
-      "integrity": "sha512-LBA7tLbi7v4uvbOJhSnjJrxbcRifKK/1ZVK94JTV2MNSCCyNkFotyEI5UWDl10YKriTIUyf7o5cakpiDZ3O4xg==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
+      "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
       "dev": true,
       "requires": {
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.190.0.tgz",
-      "integrity": "sha512-FKxTU4tIbFk2pdUbBNneStF++j+/pB4NYJ1HRSEAb/g4D2+kxikR/WKIv3p0JTVvAkwcuX/ausILYEPUyDZ4HQ==",
+      "version": "3.234.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.234.0.tgz",
+      "integrity": "sha512-IHMKXjTbOD8XMz5+2oCOsVP94BYb9YyjXdns0aAXr2NAo7k2+RCzXQ2DebJXppGda1F6opFutoKwyVSN0cmbMw==",
       "dev": true,
       "requires": {
-        "@aws-sdk/property-provider": "3.190.0",
-        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
         "bowser": "^2.11.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-defaults-mode-node": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.190.0.tgz",
-      "integrity": "sha512-qBiIMjNynqAP7p6urG1+ZattYkFaylhyinofVcLEiDvM9a6zGt6GZsxru2Loq0kRAXXGew9E9BWGt45HcDc20g==",
+      "version": "3.234.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.234.0.tgz",
+      "integrity": "sha512-UGjQ+OjBYYhxFVtUY+jtr0ZZgzZh6OHtYwRhFt8IHewJXFCfZTyfsbX20szBj5y1S4HRIUJ7cwBLIytTqMbI5w==",
       "dev": true,
       "requires": {
-        "@aws-sdk/config-resolver": "3.190.0",
-        "@aws-sdk/credential-provider-imds": "3.190.0",
-        "@aws-sdk/node-config-provider": "3.190.0",
-        "@aws-sdk/property-provider": "3.190.0",
-        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/config-resolver": "3.234.0",
+        "@aws-sdk/credential-provider-imds": "3.226.0",
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-endpoints": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.226.0.tgz",
+      "integrity": "sha512-iqOkac/zLmyPBUJd7SLN0PeZMkOmlGgD5PHmmekTClOkce2eUjK9SNX1PzL73aXPoPTyhg9QGLH8uEZEQ8YUzg==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-hex-encoding": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.188.0.tgz",
-      "integrity": "sha512-QyWovTtjQ2RYxqVM+STPh65owSqzuXURnfoof778spyX4iQ4z46wOge1YV2ZtwS8w5LWd9eeVvDrLu5POPYOnA==",
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
+      "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
       "dev": true,
       "requires": {
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-locate-window": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.188.0.tgz",
-      "integrity": "sha512-SxobBVLZkkLSawTCfeQnhVX3Azm9O+C2dngZVe1+BqtF8+retUbVTs7OfYeWBlawVkULKF2e781lTzEHBBjCzw==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.208.0.tgz",
+      "integrity": "sha512-iua1A2+P7JJEDHVgvXrRJSvsnzG7stYSGQnBVphIUlemwl6nN5D+QrgbjECtrbxRz8asYFHSzhdhECqN+tFiBg==",
       "dev": true,
       "requires": {
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-middleware": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.190.0.tgz",
-      "integrity": "sha512-qzTJ/qhFDzHZS+iXdHydQ/0sWAuNIB5feeLm55Io/I8Utv3l3TKYOhbgGwTsXY+jDk7oD+YnAi7hLN5oEBCwpg==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.226.0.tgz",
+      "integrity": "sha512-B96CQnwX4gRvQdaQkdUtqvDPkrptV5+va6FVeJOocU/DbSYMAScLxtR3peMS8cnlOT6nL1Eoa42OI9AfZz1VwQ==",
       "dev": true,
       "requires": {
         "tslib": "^2.3.1"
       }
     },
+    "@aws-sdk/util-retry": {
+      "version": "3.229.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.229.0.tgz",
+      "integrity": "sha512-0zKTqi0P1inD0LzIMuXRIYYQ/8c1lWMg/cfiqUcIAF1TpatlpZuN7umU0ierpBFud7S+zDgg0oemh+Nj8xliJw==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/service-error-classification": "3.229.0",
+        "tslib": "^2.3.1"
+      }
+    },
     "@aws-sdk/util-uri-escape": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.188.0.tgz",
-      "integrity": "sha512-4Y6AYZMT483Tiuq8dxz5WHIiPNdSFPGrl6tRTo2Oi2FcwypwmFhqgEGcqxeXDUJktvaCBxeA08DLr/AemVhPCg==",
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
+      "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
       "dev": true,
       "requires": {
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-user-agent-browser": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.190.0.tgz",
-      "integrity": "sha512-c074wjsD+/u9vT7DVrBLkwVhn28I+OEHuHaqpTVCvAIjpueZ3oms0e99YJLfpdpEgdLavOroAsNFtAuRrrTZZw==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.226.0.tgz",
+      "integrity": "sha512-PhBIu2h6sPJPcv2I7ELfFizdl5pNiL4LfxrasMCYXQkJvVnoXztHA1x+CQbXIdtZOIlpjC+6BjDcE0uhnpvfcA==",
       "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/types": "3.226.0",
         "bowser": "^2.11.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-user-agent-node": {
-      "version": "3.190.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.190.0.tgz",
-      "integrity": "sha512-R36BMvvPX8frqFhU4lAsrOJ/2PJEHH/Jz1WZzO3GWmVSEAQQdHmo8tVPE3KOM7mZWe5Hj1dZudFAIxWHHFYKJA==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.226.0.tgz",
+      "integrity": "sha512-othPc5Dz/pkYkxH+nZPhc1Al0HndQT8zHD4e9h+EZ+8lkd8n+IsnLfTS/mSJWrfiC6UlNRVw55cItstmJyMe/A==",
       "dev": true,
       "requires": {
-        "@aws-sdk/node-config-provider": "3.190.0",
-        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       }
     },
@@ -10265,12 +10466,12 @@
       }
     },
     "@aws-sdk/util-utf8-node": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.188.0.tgz",
-      "integrity": "sha512-hCgP4+C0Lekjpjt2zFJ2R/iHes5sBGljXa5bScOFAEkRUc0Qw0VNgTv7LpEbIOAwGmqyxBoCwBW0YHPW1DfmYQ==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
+      "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
       "dev": true,
       "requires": {
-        "@aws-sdk/util-buffer-from": "3.188.0",
+        "@aws-sdk/util-buffer-from": "3.208.0",
         "tslib": "^2.3.1"
       }
     },
@@ -16143,9 +16344,9 @@
       }
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
       "dev": true
     },
     "tsutils": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "socks": "^2.7.1"
       },
       "devDependencies": {
+        "@aws-sdk/credential-providers": "^3.186.0",
         "@iarna/toml": "^2.2.5",
         "@istanbuljs/nyc-config-typescript": "^1.0.2",
         "@microsoft/api-extractor": "^7.33.3",
@@ -66,13 +67,16 @@
         "node": ">=14.20.1"
       },
       "optionalDependencies": {
-        "@aws-sdk/credential-providers": "^3.186.0",
         "saslprep": "^1.0.3"
       },
       "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.186.0",
         "snappy": "7.x.x"
       },
       "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
         "snappy": {
           "optional": true
         }
@@ -95,7 +99,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.2.tgz",
       "integrity": "sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "tslib": "^1.11.1"
       }
@@ -104,13 +108,13 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "optional": true
+      "dev": true
     },
     "node_modules/@aws-crypto/sha256-browser": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
       "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "@aws-crypto/ie11-detection": "^2.0.0",
         "@aws-crypto/sha256-js": "^2.0.0",
@@ -126,13 +130,13 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "optional": true
+      "dev": true
     },
     "node_modules/@aws-crypto/sha256-js": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
       "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "@aws-crypto/util": "^2.0.0",
         "@aws-sdk/types": "^3.1.0",
@@ -143,13 +147,13 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "optional": true
+      "dev": true
     },
     "node_modules/@aws-crypto/supports-web-crypto": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.2.tgz",
       "integrity": "sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "tslib": "^1.11.1"
       }
@@ -158,13 +162,13 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "optional": true
+      "dev": true
     },
     "node_modules/@aws-crypto/util": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.2.tgz",
       "integrity": "sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "^3.110.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
@@ -175,13 +179,13 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "optional": true
+      "dev": true
     },
     "node_modules/@aws-sdk/abort-controller": {
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.190.0.tgz",
       "integrity": "sha512-M6qo2exTzEfHT5RuW7K090OgesUojhb2JyWiV4ulu7ngY4DWBUBMKUqac696sHRUZvGE5CDzSi0606DMboM+kA==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.190.0",
         "tslib": "^2.3.1"
@@ -194,7 +198,7 @@
       "version": "3.192.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.192.0.tgz",
       "integrity": "sha512-nIRmiv5JY8wWGUadhG7yLx8o8aVETj5CAgO8e8UJIwwqfue/Yv9bHi2mvkUphO1pj0TeBatAtvu79neJQtsR5g==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
@@ -239,7 +243,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.190.0.tgz",
       "integrity": "sha512-joEKRjJEzgvXnEih/x2UDDCPlvXWCO3MAHmqi44yJ36Ph4YsFS299mOjPdVLuzUtpQ+cST1nRO7hXNFrulW2jQ==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
@@ -281,7 +285,7 @@
       "version": "3.192.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.192.0.tgz",
       "integrity": "sha512-iv72dmRxbZ1cN5jGn4KIVzzu11eduS2fXHbNgd7JsFd5hLBV5TvJaugQzUdXNmy2gN4HiRJr+qa9WkD5b39lsA==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
@@ -327,7 +331,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.190.0.tgz",
       "integrity": "sha512-K+VnDtjTgjpf7yHEdDB0qgGbHToF0pIL0pQMSnmk2yc8BoB3LGG/gg1T0Ki+wRlrFnDCJ6L+8zUdawY2qDsbyw==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "@aws-sdk/signature-v4": "3.190.0",
         "@aws-sdk/types": "3.190.0",
@@ -343,7 +347,7 @@
       "version": "3.192.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.192.0.tgz",
       "integrity": "sha512-CWo+KyHCGyYtvjlmDIGtnwBEkdiondergZADiStbFFvie8pPI7IsdTXNVssQQ1VxKIBGGHVebgZGSklHBqthwA==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "@aws-sdk/client-cognito-identity": "3.192.0",
         "@aws-sdk/property-provider": "3.190.0",
@@ -358,7 +362,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.190.0.tgz",
       "integrity": "sha512-GTY7l3SJhTmRGFpWddbdJOihSqoMN8JMo3CsCtIjk4/h3xirBi02T4GSvbrMyP7FP3Fdl4NAdT+mHJ4q2Bvzxw==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "@aws-sdk/property-provider": "3.190.0",
         "@aws-sdk/types": "3.190.0",
@@ -372,7 +376,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.190.0.tgz",
       "integrity": "sha512-gI5pfBqGYCKdmx8igPvq+jLzyE2kuNn9Q5u73pdM/JZxiq7GeWYpE/MqqCubHxPtPcTFgAwxCxCFoXlUTBh/2g==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "@aws-sdk/node-config-provider": "3.190.0",
         "@aws-sdk/property-provider": "3.190.0",
@@ -388,7 +392,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.190.0.tgz",
       "integrity": "sha512-Z7NN/evXJk59hBQlfOSWDfHntwmxwryu6uclgv7ECI6SEVtKt1EKIlPuCLUYgQ4lxb9bomyO5lQAl/1WutNT5w==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.190.0",
         "@aws-sdk/credential-provider-imds": "3.190.0",
@@ -407,7 +411,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.190.0.tgz",
       "integrity": "sha512-ctCG5+TsIK2gVgvvFiFjinPjc5nGpSypU3nQKCaihtPh83wDN6gCx4D0p9M8+fUrlPa5y+o/Y7yHo94ATepM8w==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.190.0",
         "@aws-sdk/credential-provider-imds": "3.190.0",
@@ -428,7 +432,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.190.0.tgz",
       "integrity": "sha512-sIJhICR80n5XY1kW/EFHTh5ZzBHb5X+744QCH3StcbKYI44mOZvNKfFdeRL2fQ7yLgV7npte2HJRZzQPWpZUrw==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "@aws-sdk/property-provider": "3.190.0",
         "@aws-sdk/shared-ini-file-loader": "3.190.0",
@@ -443,7 +447,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.190.0.tgz",
       "integrity": "sha512-uarU9vk471MHHT+GJj3KWFSmaaqLNL5n1KcMer2CCAZfjs+mStAi8+IjZuuKXB4vqVs5DxdH8cy5aLaJcBlXwQ==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "@aws-sdk/client-sso": "3.190.0",
         "@aws-sdk/property-provider": "3.190.0",
@@ -459,7 +463,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.190.0.tgz",
       "integrity": "sha512-nlIBeK9hGHKWC874h+ITAfPZ9Eaok+x/ydZQVKsLHiQ9PH3tuQ8AaGqhuCwBSH0hEAHZ/BiKeEx5VyWAE8/x+Q==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "@aws-sdk/property-provider": "3.190.0",
         "@aws-sdk/types": "3.190.0",
@@ -473,7 +477,7 @@
       "version": "3.192.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.192.0.tgz",
       "integrity": "sha512-iBTrEPkfOHlfgQyk7EeUCmZnhUKXsGcc/hhxBbc6Z/Xc7Y8LqRVLbEmHq9lruXraFuvs26xV9oZi1s1UMXneQA==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "@aws-sdk/client-cognito-identity": "3.192.0",
         "@aws-sdk/client-sso": "3.190.0",
@@ -499,7 +503,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.190.0.tgz",
       "integrity": "sha512-5riRpKydARXAPLesTZm6eP6QKJ4HJGQ3k0Tepi3nvxHVx3UddkRNoX0pLS3rvbajkykWPNC2qdfRGApWlwOYsA==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "@aws-sdk/protocol-http": "3.190.0",
         "@aws-sdk/querystring-builder": "3.190.0",
@@ -512,7 +516,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.190.0.tgz",
       "integrity": "sha512-DNwVT3O8zc9Jk/bXiXcN0WsD98r+JJWryw9F1/ZZbuzbf6rx2qhI8ZK+nh5X6WMtYPU84luQMcF702fJt/1bzg==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.190.0",
         "@aws-sdk/util-buffer-from": "3.188.0",
@@ -526,7 +530,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.190.0.tgz",
       "integrity": "sha512-crCh63e8d/Uw9y3dQlVTPja7+IZiXpNXyH6oSuAadTDQwMq6KK87Av1/SDzVf6bAo2KgAOo41MyO2joaCEk0dQ==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.190.0",
         "tslib": "^2.3.1"
@@ -536,7 +540,7 @@
       "version": "3.188.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.188.0.tgz",
       "integrity": "sha512-n69N4zJZCNd87Rf4NzufPzhactUeM877Y0Tp/F3KiHqGeTnVjYUa4Lv1vLBjqtfjYb2HWT3NKlYn5yzrhaEwiQ==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -548,7 +552,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.190.0.tgz",
       "integrity": "sha512-sSU347SuC6I8kWum1jlJlpAqeV23KP7enG+ToWcEcgFrJhm3AvuqB//NJxDbkKb2DNroRvJjBckBvrwNAjQnBQ==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "@aws-sdk/protocol-http": "3.190.0",
         "@aws-sdk/types": "3.190.0",
@@ -562,7 +566,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.190.0.tgz",
       "integrity": "sha512-cL7Vo/QSpGx/DDmFxjeV0Qlyi1atvHQDPn3MLBBmi1icu+3GKZkCMAJwzsrV3U4+WoVoDYT9FJ9yMQf2HaIjeQ==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "@aws-sdk/protocol-http": "3.190.0",
         "@aws-sdk/types": "3.190.0",
@@ -576,7 +580,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.190.0.tgz",
       "integrity": "sha512-rrfLGYSZCBtiXNrIa8pJ2uwUoUMyj6Q82E8zmduTvqKWviCr6ZKes0lttGIkWhjvhql2m4CbjG5MPBnY7RXL4A==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.190.0",
         "tslib": "^2.3.1"
@@ -589,7 +593,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.190.0.tgz",
       "integrity": "sha512-5tc1AIIZe5jDNdyuJW+7vIFmQOxz3q031ZVrEtUEIF7cz2ySho2lkOWziz+v+UGSLhjHGKMz3V26+aN1FLZNxQ==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "@aws-sdk/protocol-http": "3.190.0",
         "@aws-sdk/types": "3.190.0",
@@ -603,7 +607,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.190.0.tgz",
       "integrity": "sha512-h1bPopkncf2ue/erJdhqvgR2AEh0bIvkNsIHhx93DckWKotZd/GAVDq0gpKj7/f/7B+teHH8Fg5GDOwOOGyKcg==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "@aws-sdk/protocol-http": "3.190.0",
         "@aws-sdk/service-error-classification": "3.190.0",
@@ -620,7 +624,7 @@
       "version": "3.192.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.192.0.tgz",
       "integrity": "sha512-xzTV7MyG5ipWYTvekWX1tQc5ExsUvCYsDTBCD3LR5hBrP8assUDPo52zGSe+QMcjgnQv7BcYIzeikTkLEG0dUw==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "@aws-sdk/middleware-signing": "3.192.0",
         "@aws-sdk/property-provider": "3.190.0",
@@ -637,7 +641,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.190.0.tgz",
       "integrity": "sha512-S132hEOK4jwbtZ1bGAgSuQ0DMFG4TiD4ulAwbQRBYooC7tiWZbRiR0Pkt2hV8d7WhOHgUpg7rvqlA7/HXXBAsA==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.190.0",
         "tslib": "^2.3.1"
@@ -650,7 +654,7 @@
       "version": "3.192.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.192.0.tgz",
       "integrity": "sha512-qTRIU/TL/dvtTrNj+AkZkgYeTIFslib3Y3XnQNNM6RCm4cMxIgs2K/lnhaUmLdbzHrpOQb4cISkY8yiHo+pNsw==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "@aws-sdk/property-provider": "3.190.0",
         "@aws-sdk/protocol-http": "3.190.0",
@@ -667,7 +671,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.190.0.tgz",
       "integrity": "sha512-h1mqiWNJdi1OTSEY8QovpiHgDQEeRG818v8yShpqSYXJKEqdn54MA3Z1D2fg/Wv/8ZJsFrBCiI7waT1JUYOmCg==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -679,7 +683,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.190.0.tgz",
       "integrity": "sha512-y/2cTE1iYHKR0nkb3DvR3G8vt12lcTP95r/iHp8ZO+Uzpc25jM/AyMHWr2ZjqQiHKNlzh8uRw1CmQtgg4sBxXQ==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "@aws-sdk/protocol-http": "3.190.0",
         "@aws-sdk/types": "3.190.0",
@@ -693,7 +697,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.190.0.tgz",
       "integrity": "sha512-TJPUchyeK5KeEXWrwb6oW5/OkY3STCSGR1QIlbPcaTGkbo4kXAVyQmmZsY4KtRPuDM6/HlfUQV17bD716K65rQ==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "@aws-sdk/property-provider": "3.190.0",
         "@aws-sdk/shared-ini-file-loader": "3.190.0",
@@ -708,7 +712,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.190.0.tgz",
       "integrity": "sha512-3Klkr73TpZkCzcnSP+gmFF0Baluzk3r7BaWclJHqt2LcFUWfIJzYlnbBQNZ4t3EEq7ZlBJX85rIDHBRlS+rUyA==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "@aws-sdk/abort-controller": "3.190.0",
         "@aws-sdk/protocol-http": "3.190.0",
@@ -724,7 +728,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.190.0.tgz",
       "integrity": "sha512-uzdKjHE2blbuceTC5zeBgZ0+Uo/hf9pH20CHpJeVNtrrtF3GALtu4Y1Gu5QQVIQBz8gjHnqANx0XhfYzorv69Q==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.190.0",
         "tslib": "^2.3.1"
@@ -737,7 +741,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.190.0.tgz",
       "integrity": "sha512-s5MVfeONpfZYRzCSbqQ+wJ3GxKED+aSS7+CQoeaYoD6HDTDxaMGNv9aiPxVCzW02sgG7py7f29Q6Vw+5taZXZA==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.190.0",
         "tslib": "^2.3.1"
@@ -750,7 +754,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.190.0.tgz",
       "integrity": "sha512-w9mTKkCsaLIBC8EA4RAHrqethNGbf60CbpPzN/QM7yCV3ZZJAXkppFfjTVVOMbPaI8GUEOptJtzgqV68CRB7ow==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.190.0",
         "@aws-sdk/util-uri-escape": "3.188.0",
@@ -764,7 +768,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.190.0.tgz",
       "integrity": "sha512-vCKP0s33VtS47LSYzEWRRr2aTbi3qNkUuQyIrc5LMqBfS5hsy79P1HL4Q7lCVqZB5fe61N8fKzOxDxWRCF0sXg==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.190.0",
         "tslib": "^2.3.1"
@@ -777,7 +781,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.190.0.tgz",
       "integrity": "sha512-g+s6xtaMa5fCMA2zJQC4BiFGMP7FN5/L1V/UwxCnKy8skCwaN0K5A1tFffBjjbYiPI7Gu7LVorWD2A0Y4xl01Q==",
-      "optional": true,
+      "dev": true,
       "engines": {
         "node": ">= 12.0.0"
       }
@@ -786,7 +790,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.190.0.tgz",
       "integrity": "sha512-CZC/xsGReUEl5w+JgfancrxfkaCbEisyIFy6HALUYrioWQe80WMqLAdUMZSXHWjIaNK9mH0J/qvcSV2MuIoMzQ==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.190.0",
         "tslib": "^2.3.1"
@@ -799,7 +803,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.190.0.tgz",
       "integrity": "sha512-L/R/1X2T+/Kg2k/sjoYyDFulVUGrVcRfyEKKVFIUNg0NwUtw5UKa1/gS7geTKcg4q8M2pd/v+OCBrge2X7phUw==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "@aws-sdk/is-array-buffer": "3.188.0",
         "@aws-sdk/types": "3.190.0",
@@ -816,7 +820,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.190.0.tgz",
       "integrity": "sha512-f5EoCwjBLXMyuN491u1NmEutbolL0cJegaJbtgK9OJw2BLuRHiBknjDF4OEVuK/WqK0kz2JLMGi9xwVPl4BKCA==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "@aws-sdk/middleware-stack": "3.190.0",
         "@aws-sdk/types": "3.190.0",
@@ -830,7 +834,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.190.0.tgz",
       "integrity": "sha512-mkeZ+vJZzElP6OdRXvuLKWHSlDQxZP9u8BjQB9N0Rw0pCXTzYS0vzIhN1pL0uddWp5fMrIE68snto9xNR6BQuA==",
-      "optional": true,
+      "dev": true,
       "engines": {
         "node": ">= 12.0.0"
       }
@@ -839,7 +843,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.190.0.tgz",
       "integrity": "sha512-FKFDtxA9pvHmpfWmNVK5BAVRpDgkWMz3u4Sg9UzB+WAFN6UexRypXXUZCFAo8S04FbPKfYOR3O0uVlw7kzmj9g==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "@aws-sdk/querystring-parser": "3.190.0",
         "@aws-sdk/types": "3.190.0",
@@ -850,7 +854,7 @@
       "version": "3.188.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.188.0.tgz",
       "integrity": "sha512-qlH+5NZBLiyKziL335BEPedYxX6j+p7KFRWXvDQox9S+s+gLCayednpK+fteOhBenCcR9fUZOVuAPScy1I8qCg==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
       }
@@ -859,7 +863,7 @@
       "version": "3.188.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.188.0.tgz",
       "integrity": "sha512-r1dccRsRjKq+OhVRUfqFiW3sGgZBjHbMeHLbrAs9jrOjU2PTQ8PSzAXLvX/9lmp7YjmX17Qvlsg0NCr1tbB9OA==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "@aws-sdk/util-buffer-from": "3.188.0",
         "tslib": "^2.3.1"
@@ -872,7 +876,7 @@
       "version": "3.188.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
       "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
       }
@@ -881,7 +885,7 @@
       "version": "3.188.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.188.0.tgz",
       "integrity": "sha512-XwqP3vxk60MKp4YDdvDeCD6BPOiG2e+/Ou4AofZOy5/toB6NKz2pFNibQIUg2+jc7mPMnGnvOW3MQEgSJ+gu/Q==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -893,7 +897,7 @@
       "version": "3.188.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.188.0.tgz",
       "integrity": "sha512-NX1WXZ8TH20IZb4jPFT2CnLKSqZWddGxtfiWxD9M47YOtq/SSQeR82fhqqVjJn4P8w2F5E28f+Du4ntg/sGcxA==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "@aws-sdk/is-array-buffer": "3.188.0",
         "tslib": "^2.3.1"
@@ -906,7 +910,7 @@
       "version": "3.188.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.188.0.tgz",
       "integrity": "sha512-LBA7tLbi7v4uvbOJhSnjJrxbcRifKK/1ZVK94JTV2MNSCCyNkFotyEI5UWDl10YKriTIUyf7o5cakpiDZ3O4xg==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -918,7 +922,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.190.0.tgz",
       "integrity": "sha512-FKxTU4tIbFk2pdUbBNneStF++j+/pB4NYJ1HRSEAb/g4D2+kxikR/WKIv3p0JTVvAkwcuX/ausILYEPUyDZ4HQ==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "@aws-sdk/property-provider": "3.190.0",
         "@aws-sdk/types": "3.190.0",
@@ -933,7 +937,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.190.0.tgz",
       "integrity": "sha512-qBiIMjNynqAP7p6urG1+ZattYkFaylhyinofVcLEiDvM9a6zGt6GZsxru2Loq0kRAXXGew9E9BWGt45HcDc20g==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "@aws-sdk/config-resolver": "3.190.0",
         "@aws-sdk/credential-provider-imds": "3.190.0",
@@ -950,7 +954,7 @@
       "version": "3.188.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.188.0.tgz",
       "integrity": "sha512-QyWovTtjQ2RYxqVM+STPh65owSqzuXURnfoof778spyX4iQ4z46wOge1YV2ZtwS8w5LWd9eeVvDrLu5POPYOnA==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -962,7 +966,7 @@
       "version": "3.188.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.188.0.tgz",
       "integrity": "sha512-SxobBVLZkkLSawTCfeQnhVX3Azm9O+C2dngZVe1+BqtF8+retUbVTs7OfYeWBlawVkULKF2e781lTzEHBBjCzw==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -974,7 +978,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.190.0.tgz",
       "integrity": "sha512-qzTJ/qhFDzHZS+iXdHydQ/0sWAuNIB5feeLm55Io/I8Utv3l3TKYOhbgGwTsXY+jDk7oD+YnAi7hLN5oEBCwpg==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -986,7 +990,7 @@
       "version": "3.188.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.188.0.tgz",
       "integrity": "sha512-4Y6AYZMT483Tiuq8dxz5WHIiPNdSFPGrl6tRTo2Oi2FcwypwmFhqgEGcqxeXDUJktvaCBxeA08DLr/AemVhPCg==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -998,7 +1002,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.190.0.tgz",
       "integrity": "sha512-c074wjsD+/u9vT7DVrBLkwVhn28I+OEHuHaqpTVCvAIjpueZ3oms0e99YJLfpdpEgdLavOroAsNFtAuRrrTZZw==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.190.0",
         "bowser": "^2.11.0",
@@ -1009,7 +1013,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.190.0.tgz",
       "integrity": "sha512-R36BMvvPX8frqFhU4lAsrOJ/2PJEHH/Jz1WZzO3GWmVSEAQQdHmo8tVPE3KOM7mZWe5Hj1dZudFAIxWHHFYKJA==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "@aws-sdk/node-config-provider": "3.190.0",
         "@aws-sdk/types": "3.190.0",
@@ -1031,7 +1035,7 @@
       "version": "3.188.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
       "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
       }
@@ -1040,7 +1044,7 @@
       "version": "3.188.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.188.0.tgz",
       "integrity": "sha512-hCgP4+C0Lekjpjt2zFJ2R/iHes5sBGljXa5bScOFAEkRUc0Qw0VNgTv7LpEbIOAwGmqyxBoCwBW0YHPW1DfmYQ==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "@aws-sdk/util-buffer-from": "3.188.0",
         "tslib": "^2.3.1"
@@ -2956,7 +2960,7 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
       "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
-      "optional": true
+      "dev": true
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -4617,7 +4621,7 @@
       "version": "4.0.11",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
       "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "strnum": "^1.0.5"
       },
@@ -8458,7 +8462,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
       "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
-      "optional": true
+      "dev": true
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -8885,7 +8889,7 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-      "optional": true
+      "dev": true
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -9122,7 +9126,7 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "devOptional": true,
+      "dev": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -9461,7 +9465,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.2.tgz",
       "integrity": "sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "tslib": "^1.11.1"
       },
@@ -9470,7 +9474,7 @@
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
           "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -9478,7 +9482,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
       "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "@aws-crypto/ie11-detection": "^2.0.0",
         "@aws-crypto/sha256-js": "^2.0.0",
@@ -9494,7 +9498,7 @@
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
           "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -9502,7 +9506,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
       "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "@aws-crypto/util": "^2.0.0",
         "@aws-sdk/types": "^3.1.0",
@@ -9513,7 +9517,7 @@
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
           "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -9521,7 +9525,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.2.tgz",
       "integrity": "sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "tslib": "^1.11.1"
       },
@@ -9530,7 +9534,7 @@
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
           "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -9538,7 +9542,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.2.tgz",
       "integrity": "sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "@aws-sdk/types": "^3.110.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
@@ -9549,7 +9553,7 @@
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
           "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -9557,7 +9561,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.190.0.tgz",
       "integrity": "sha512-M6qo2exTzEfHT5RuW7K090OgesUojhb2JyWiV4ulu7ngY4DWBUBMKUqac696sHRUZvGE5CDzSi0606DMboM+kA==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.190.0",
         "tslib": "^2.3.1"
@@ -9567,7 +9571,7 @@
       "version": "3.192.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.192.0.tgz",
       "integrity": "sha512-nIRmiv5JY8wWGUadhG7yLx8o8aVETj5CAgO8e8UJIwwqfue/Yv9bHi2mvkUphO1pj0TeBatAtvu79neJQtsR5g==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
@@ -9609,7 +9613,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.190.0.tgz",
       "integrity": "sha512-joEKRjJEzgvXnEih/x2UDDCPlvXWCO3MAHmqi44yJ36Ph4YsFS299mOjPdVLuzUtpQ+cST1nRO7hXNFrulW2jQ==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
@@ -9648,7 +9652,7 @@
       "version": "3.192.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.192.0.tgz",
       "integrity": "sha512-iv72dmRxbZ1cN5jGn4KIVzzu11eduS2fXHbNgd7JsFd5hLBV5TvJaugQzUdXNmy2gN4HiRJr+qa9WkD5b39lsA==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
@@ -9691,7 +9695,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.190.0.tgz",
       "integrity": "sha512-K+VnDtjTgjpf7yHEdDB0qgGbHToF0pIL0pQMSnmk2yc8BoB3LGG/gg1T0Ki+wRlrFnDCJ6L+8zUdawY2qDsbyw==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "@aws-sdk/signature-v4": "3.190.0",
         "@aws-sdk/types": "3.190.0",
@@ -9704,7 +9708,7 @@
       "version": "3.192.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.192.0.tgz",
       "integrity": "sha512-CWo+KyHCGyYtvjlmDIGtnwBEkdiondergZADiStbFFvie8pPI7IsdTXNVssQQ1VxKIBGGHVebgZGSklHBqthwA==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "@aws-sdk/client-cognito-identity": "3.192.0",
         "@aws-sdk/property-provider": "3.190.0",
@@ -9716,7 +9720,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.190.0.tgz",
       "integrity": "sha512-GTY7l3SJhTmRGFpWddbdJOihSqoMN8JMo3CsCtIjk4/h3xirBi02T4GSvbrMyP7FP3Fdl4NAdT+mHJ4q2Bvzxw==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "@aws-sdk/property-provider": "3.190.0",
         "@aws-sdk/types": "3.190.0",
@@ -9727,7 +9731,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.190.0.tgz",
       "integrity": "sha512-gI5pfBqGYCKdmx8igPvq+jLzyE2kuNn9Q5u73pdM/JZxiq7GeWYpE/MqqCubHxPtPcTFgAwxCxCFoXlUTBh/2g==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "@aws-sdk/node-config-provider": "3.190.0",
         "@aws-sdk/property-provider": "3.190.0",
@@ -9740,7 +9744,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.190.0.tgz",
       "integrity": "sha512-Z7NN/evXJk59hBQlfOSWDfHntwmxwryu6uclgv7ECI6SEVtKt1EKIlPuCLUYgQ4lxb9bomyO5lQAl/1WutNT5w==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "@aws-sdk/credential-provider-env": "3.190.0",
         "@aws-sdk/credential-provider-imds": "3.190.0",
@@ -9756,7 +9760,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.190.0.tgz",
       "integrity": "sha512-ctCG5+TsIK2gVgvvFiFjinPjc5nGpSypU3nQKCaihtPh83wDN6gCx4D0p9M8+fUrlPa5y+o/Y7yHo94ATepM8w==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "@aws-sdk/credential-provider-env": "3.190.0",
         "@aws-sdk/credential-provider-imds": "3.190.0",
@@ -9774,7 +9778,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.190.0.tgz",
       "integrity": "sha512-sIJhICR80n5XY1kW/EFHTh5ZzBHb5X+744QCH3StcbKYI44mOZvNKfFdeRL2fQ7yLgV7npte2HJRZzQPWpZUrw==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "@aws-sdk/property-provider": "3.190.0",
         "@aws-sdk/shared-ini-file-loader": "3.190.0",
@@ -9786,7 +9790,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.190.0.tgz",
       "integrity": "sha512-uarU9vk471MHHT+GJj3KWFSmaaqLNL5n1KcMer2CCAZfjs+mStAi8+IjZuuKXB4vqVs5DxdH8cy5aLaJcBlXwQ==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "@aws-sdk/client-sso": "3.190.0",
         "@aws-sdk/property-provider": "3.190.0",
@@ -9799,7 +9803,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.190.0.tgz",
       "integrity": "sha512-nlIBeK9hGHKWC874h+ITAfPZ9Eaok+x/ydZQVKsLHiQ9PH3tuQ8AaGqhuCwBSH0hEAHZ/BiKeEx5VyWAE8/x+Q==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "@aws-sdk/property-provider": "3.190.0",
         "@aws-sdk/types": "3.190.0",
@@ -9810,7 +9814,7 @@
       "version": "3.192.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.192.0.tgz",
       "integrity": "sha512-iBTrEPkfOHlfgQyk7EeUCmZnhUKXsGcc/hhxBbc6Z/Xc7Y8LqRVLbEmHq9lruXraFuvs26xV9oZi1s1UMXneQA==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "@aws-sdk/client-cognito-identity": "3.192.0",
         "@aws-sdk/client-sso": "3.190.0",
@@ -9833,7 +9837,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.190.0.tgz",
       "integrity": "sha512-5riRpKydARXAPLesTZm6eP6QKJ4HJGQ3k0Tepi3nvxHVx3UddkRNoX0pLS3rvbajkykWPNC2qdfRGApWlwOYsA==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "@aws-sdk/protocol-http": "3.190.0",
         "@aws-sdk/querystring-builder": "3.190.0",
@@ -9846,7 +9850,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.190.0.tgz",
       "integrity": "sha512-DNwVT3O8zc9Jk/bXiXcN0WsD98r+JJWryw9F1/ZZbuzbf6rx2qhI8ZK+nh5X6WMtYPU84luQMcF702fJt/1bzg==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.190.0",
         "@aws-sdk/util-buffer-from": "3.188.0",
@@ -9857,7 +9861,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.190.0.tgz",
       "integrity": "sha512-crCh63e8d/Uw9y3dQlVTPja7+IZiXpNXyH6oSuAadTDQwMq6KK87Av1/SDzVf6bAo2KgAOo41MyO2joaCEk0dQ==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.190.0",
         "tslib": "^2.3.1"
@@ -9867,7 +9871,7 @@
       "version": "3.188.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.188.0.tgz",
       "integrity": "sha512-n69N4zJZCNd87Rf4NzufPzhactUeM877Y0Tp/F3KiHqGeTnVjYUa4Lv1vLBjqtfjYb2HWT3NKlYn5yzrhaEwiQ==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -9876,7 +9880,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.190.0.tgz",
       "integrity": "sha512-sSU347SuC6I8kWum1jlJlpAqeV23KP7enG+ToWcEcgFrJhm3AvuqB//NJxDbkKb2DNroRvJjBckBvrwNAjQnBQ==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "@aws-sdk/protocol-http": "3.190.0",
         "@aws-sdk/types": "3.190.0",
@@ -9887,7 +9891,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.190.0.tgz",
       "integrity": "sha512-cL7Vo/QSpGx/DDmFxjeV0Qlyi1atvHQDPn3MLBBmi1icu+3GKZkCMAJwzsrV3U4+WoVoDYT9FJ9yMQf2HaIjeQ==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "@aws-sdk/protocol-http": "3.190.0",
         "@aws-sdk/types": "3.190.0",
@@ -9898,7 +9902,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.190.0.tgz",
       "integrity": "sha512-rrfLGYSZCBtiXNrIa8pJ2uwUoUMyj6Q82E8zmduTvqKWviCr6ZKes0lttGIkWhjvhql2m4CbjG5MPBnY7RXL4A==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.190.0",
         "tslib": "^2.3.1"
@@ -9908,7 +9912,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.190.0.tgz",
       "integrity": "sha512-5tc1AIIZe5jDNdyuJW+7vIFmQOxz3q031ZVrEtUEIF7cz2ySho2lkOWziz+v+UGSLhjHGKMz3V26+aN1FLZNxQ==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "@aws-sdk/protocol-http": "3.190.0",
         "@aws-sdk/types": "3.190.0",
@@ -9919,7 +9923,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.190.0.tgz",
       "integrity": "sha512-h1bPopkncf2ue/erJdhqvgR2AEh0bIvkNsIHhx93DckWKotZd/GAVDq0gpKj7/f/7B+teHH8Fg5GDOwOOGyKcg==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "@aws-sdk/protocol-http": "3.190.0",
         "@aws-sdk/service-error-classification": "3.190.0",
@@ -9933,7 +9937,7 @@
       "version": "3.192.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.192.0.tgz",
       "integrity": "sha512-xzTV7MyG5ipWYTvekWX1tQc5ExsUvCYsDTBCD3LR5hBrP8assUDPo52zGSe+QMcjgnQv7BcYIzeikTkLEG0dUw==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "@aws-sdk/middleware-signing": "3.192.0",
         "@aws-sdk/property-provider": "3.190.0",
@@ -9947,7 +9951,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.190.0.tgz",
       "integrity": "sha512-S132hEOK4jwbtZ1bGAgSuQ0DMFG4TiD4ulAwbQRBYooC7tiWZbRiR0Pkt2hV8d7WhOHgUpg7rvqlA7/HXXBAsA==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.190.0",
         "tslib": "^2.3.1"
@@ -9957,7 +9961,7 @@
       "version": "3.192.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.192.0.tgz",
       "integrity": "sha512-qTRIU/TL/dvtTrNj+AkZkgYeTIFslib3Y3XnQNNM6RCm4cMxIgs2K/lnhaUmLdbzHrpOQb4cISkY8yiHo+pNsw==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "@aws-sdk/property-provider": "3.190.0",
         "@aws-sdk/protocol-http": "3.190.0",
@@ -9971,7 +9975,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.190.0.tgz",
       "integrity": "sha512-h1mqiWNJdi1OTSEY8QovpiHgDQEeRG818v8yShpqSYXJKEqdn54MA3Z1D2fg/Wv/8ZJsFrBCiI7waT1JUYOmCg==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -9980,7 +9984,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.190.0.tgz",
       "integrity": "sha512-y/2cTE1iYHKR0nkb3DvR3G8vt12lcTP95r/iHp8ZO+Uzpc25jM/AyMHWr2ZjqQiHKNlzh8uRw1CmQtgg4sBxXQ==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "@aws-sdk/protocol-http": "3.190.0",
         "@aws-sdk/types": "3.190.0",
@@ -9991,7 +9995,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.190.0.tgz",
       "integrity": "sha512-TJPUchyeK5KeEXWrwb6oW5/OkY3STCSGR1QIlbPcaTGkbo4kXAVyQmmZsY4KtRPuDM6/HlfUQV17bD716K65rQ==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "@aws-sdk/property-provider": "3.190.0",
         "@aws-sdk/shared-ini-file-loader": "3.190.0",
@@ -10003,7 +10007,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.190.0.tgz",
       "integrity": "sha512-3Klkr73TpZkCzcnSP+gmFF0Baluzk3r7BaWclJHqt2LcFUWfIJzYlnbBQNZ4t3EEq7ZlBJX85rIDHBRlS+rUyA==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "@aws-sdk/abort-controller": "3.190.0",
         "@aws-sdk/protocol-http": "3.190.0",
@@ -10016,7 +10020,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.190.0.tgz",
       "integrity": "sha512-uzdKjHE2blbuceTC5zeBgZ0+Uo/hf9pH20CHpJeVNtrrtF3GALtu4Y1Gu5QQVIQBz8gjHnqANx0XhfYzorv69Q==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.190.0",
         "tslib": "^2.3.1"
@@ -10026,7 +10030,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.190.0.tgz",
       "integrity": "sha512-s5MVfeONpfZYRzCSbqQ+wJ3GxKED+aSS7+CQoeaYoD6HDTDxaMGNv9aiPxVCzW02sgG7py7f29Q6Vw+5taZXZA==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.190.0",
         "tslib": "^2.3.1"
@@ -10036,7 +10040,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.190.0.tgz",
       "integrity": "sha512-w9mTKkCsaLIBC8EA4RAHrqethNGbf60CbpPzN/QM7yCV3ZZJAXkppFfjTVVOMbPaI8GUEOptJtzgqV68CRB7ow==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.190.0",
         "@aws-sdk/util-uri-escape": "3.188.0",
@@ -10047,7 +10051,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.190.0.tgz",
       "integrity": "sha512-vCKP0s33VtS47LSYzEWRRr2aTbi3qNkUuQyIrc5LMqBfS5hsy79P1HL4Q7lCVqZB5fe61N8fKzOxDxWRCF0sXg==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.190.0",
         "tslib": "^2.3.1"
@@ -10057,13 +10061,13 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.190.0.tgz",
       "integrity": "sha512-g+s6xtaMa5fCMA2zJQC4BiFGMP7FN5/L1V/UwxCnKy8skCwaN0K5A1tFffBjjbYiPI7Gu7LVorWD2A0Y4xl01Q==",
-      "optional": true
+      "dev": true
     },
     "@aws-sdk/shared-ini-file-loader": {
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.190.0.tgz",
       "integrity": "sha512-CZC/xsGReUEl5w+JgfancrxfkaCbEisyIFy6HALUYrioWQe80WMqLAdUMZSXHWjIaNK9mH0J/qvcSV2MuIoMzQ==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.190.0",
         "tslib": "^2.3.1"
@@ -10073,7 +10077,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.190.0.tgz",
       "integrity": "sha512-L/R/1X2T+/Kg2k/sjoYyDFulVUGrVcRfyEKKVFIUNg0NwUtw5UKa1/gS7geTKcg4q8M2pd/v+OCBrge2X7phUw==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "@aws-sdk/is-array-buffer": "3.188.0",
         "@aws-sdk/types": "3.190.0",
@@ -10087,7 +10091,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.190.0.tgz",
       "integrity": "sha512-f5EoCwjBLXMyuN491u1NmEutbolL0cJegaJbtgK9OJw2BLuRHiBknjDF4OEVuK/WqK0kz2JLMGi9xwVPl4BKCA==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "@aws-sdk/middleware-stack": "3.190.0",
         "@aws-sdk/types": "3.190.0",
@@ -10098,13 +10102,13 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.190.0.tgz",
       "integrity": "sha512-mkeZ+vJZzElP6OdRXvuLKWHSlDQxZP9u8BjQB9N0Rw0pCXTzYS0vzIhN1pL0uddWp5fMrIE68snto9xNR6BQuA==",
-      "optional": true
+      "dev": true
     },
     "@aws-sdk/url-parser": {
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.190.0.tgz",
       "integrity": "sha512-FKFDtxA9pvHmpfWmNVK5BAVRpDgkWMz3u4Sg9UzB+WAFN6UexRypXXUZCFAo8S04FbPKfYOR3O0uVlw7kzmj9g==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "@aws-sdk/querystring-parser": "3.190.0",
         "@aws-sdk/types": "3.190.0",
@@ -10115,7 +10119,7 @@
       "version": "3.188.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.188.0.tgz",
       "integrity": "sha512-qlH+5NZBLiyKziL335BEPedYxX6j+p7KFRWXvDQox9S+s+gLCayednpK+fteOhBenCcR9fUZOVuAPScy1I8qCg==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -10124,7 +10128,7 @@
       "version": "3.188.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.188.0.tgz",
       "integrity": "sha512-r1dccRsRjKq+OhVRUfqFiW3sGgZBjHbMeHLbrAs9jrOjU2PTQ8PSzAXLvX/9lmp7YjmX17Qvlsg0NCr1tbB9OA==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "@aws-sdk/util-buffer-from": "3.188.0",
         "tslib": "^2.3.1"
@@ -10134,7 +10138,7 @@
       "version": "3.188.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
       "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -10143,7 +10147,7 @@
       "version": "3.188.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.188.0.tgz",
       "integrity": "sha512-XwqP3vxk60MKp4YDdvDeCD6BPOiG2e+/Ou4AofZOy5/toB6NKz2pFNibQIUg2+jc7mPMnGnvOW3MQEgSJ+gu/Q==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -10152,7 +10156,7 @@
       "version": "3.188.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.188.0.tgz",
       "integrity": "sha512-NX1WXZ8TH20IZb4jPFT2CnLKSqZWddGxtfiWxD9M47YOtq/SSQeR82fhqqVjJn4P8w2F5E28f+Du4ntg/sGcxA==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "@aws-sdk/is-array-buffer": "3.188.0",
         "tslib": "^2.3.1"
@@ -10162,7 +10166,7 @@
       "version": "3.188.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.188.0.tgz",
       "integrity": "sha512-LBA7tLbi7v4uvbOJhSnjJrxbcRifKK/1ZVK94JTV2MNSCCyNkFotyEI5UWDl10YKriTIUyf7o5cakpiDZ3O4xg==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -10171,7 +10175,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.190.0.tgz",
       "integrity": "sha512-FKxTU4tIbFk2pdUbBNneStF++j+/pB4NYJ1HRSEAb/g4D2+kxikR/WKIv3p0JTVvAkwcuX/ausILYEPUyDZ4HQ==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "@aws-sdk/property-provider": "3.190.0",
         "@aws-sdk/types": "3.190.0",
@@ -10183,7 +10187,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.190.0.tgz",
       "integrity": "sha512-qBiIMjNynqAP7p6urG1+ZattYkFaylhyinofVcLEiDvM9a6zGt6GZsxru2Loq0kRAXXGew9E9BWGt45HcDc20g==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "@aws-sdk/config-resolver": "3.190.0",
         "@aws-sdk/credential-provider-imds": "3.190.0",
@@ -10197,7 +10201,7 @@
       "version": "3.188.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.188.0.tgz",
       "integrity": "sha512-QyWovTtjQ2RYxqVM+STPh65owSqzuXURnfoof778spyX4iQ4z46wOge1YV2ZtwS8w5LWd9eeVvDrLu5POPYOnA==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -10206,7 +10210,7 @@
       "version": "3.188.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.188.0.tgz",
       "integrity": "sha512-SxobBVLZkkLSawTCfeQnhVX3Azm9O+C2dngZVe1+BqtF8+retUbVTs7OfYeWBlawVkULKF2e781lTzEHBBjCzw==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -10215,7 +10219,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.190.0.tgz",
       "integrity": "sha512-qzTJ/qhFDzHZS+iXdHydQ/0sWAuNIB5feeLm55Io/I8Utv3l3TKYOhbgGwTsXY+jDk7oD+YnAi7hLN5oEBCwpg==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -10224,7 +10228,7 @@
       "version": "3.188.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.188.0.tgz",
       "integrity": "sha512-4Y6AYZMT483Tiuq8dxz5WHIiPNdSFPGrl6tRTo2Oi2FcwypwmFhqgEGcqxeXDUJktvaCBxeA08DLr/AemVhPCg==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -10233,7 +10237,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.190.0.tgz",
       "integrity": "sha512-c074wjsD+/u9vT7DVrBLkwVhn28I+OEHuHaqpTVCvAIjpueZ3oms0e99YJLfpdpEgdLavOroAsNFtAuRrrTZZw==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.190.0",
         "bowser": "^2.11.0",
@@ -10244,7 +10248,7 @@
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.190.0.tgz",
       "integrity": "sha512-R36BMvvPX8frqFhU4lAsrOJ/2PJEHH/Jz1WZzO3GWmVSEAQQdHmo8tVPE3KOM7mZWe5Hj1dZudFAIxWHHFYKJA==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "@aws-sdk/node-config-provider": "3.190.0",
         "@aws-sdk/types": "3.190.0",
@@ -10255,7 +10259,7 @@
       "version": "3.188.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
       "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -10264,7 +10268,7 @@
       "version": "3.188.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.188.0.tgz",
       "integrity": "sha512-hCgP4+C0Lekjpjt2zFJ2R/iHes5sBGljXa5bScOFAEkRUc0Qw0VNgTv7LpEbIOAwGmqyxBoCwBW0YHPW1DfmYQ==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "@aws-sdk/util-buffer-from": "3.188.0",
         "tslib": "^2.3.1"
@@ -11673,7 +11677,7 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
       "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
-      "optional": true
+      "dev": true
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -12941,7 +12945,7 @@
       "version": "4.0.11",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
       "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "strnum": "^1.0.5"
       }
@@ -15826,7 +15830,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
       "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
-      "optional": true
+      "dev": true
     },
     "supports-color": {
       "version": "7.2.0",
@@ -16142,7 +16146,7 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-      "optional": true
+      "dev": true
     },
     "tsutils": {
       "version": "3.21.0",
@@ -16315,7 +16319,7 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "devOptional": true
+      "dev": true
     },
     "v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "saslprep": "^1.0.3"
   },
   "peerDependencies": {
-    "@aws-sdk/credential-providers": "^3.186.0",
+    "@aws-sdk/credential-providers": "^3.201.0",
     "snappy": "7.x.x"
   },
   "peerDependenciesMeta": {
@@ -45,7 +45,7 @@
     }
   },
   "devDependencies": {
-    "@aws-sdk/credential-providers": "^3.186.0",
+    "@aws-sdk/credential-providers": "^3.201.0",
     "@iarna/toml": "^2.2.5",
     "@istanbuljs/nyc-config-typescript": "^1.0.2",
     "@microsoft/api-extractor": "^7.33.3",

--- a/package.json
+++ b/package.json
@@ -30,18 +30,22 @@
     "socks": "^2.7.1"
   },
   "optionalDependencies": {
-    "@aws-sdk/credential-providers": "^3.186.0",
     "saslprep": "^1.0.3"
   },
   "peerDependencies": {
+    "@aws-sdk/credential-providers": "^3.186.0",
     "snappy": "7.x.x"
   },
   "peerDependenciesMeta": {
+    "@aws-sdk/credential-providers": {
+      "optional": true
+    },
     "snappy": {
       "optional": true
     }
   },
   "devDependencies": {
+    "@aws-sdk/credential-providers": "^3.186.0",
     "@iarna/toml": "^2.2.5",
     "@istanbuljs/nyc-config-typescript": "^1.0.2",
     "@microsoft/api-extractor": "^7.33.3",

--- a/test/action/dependency.test.ts
+++ b/test/action/dependency.test.ts
@@ -7,7 +7,7 @@ import { expect } from 'chai';
 import { dependencies, peerDependencies, peerDependenciesMeta } from '../../package.json';
 
 const EXPECTED_DEPENDENCIES = ['bson', 'mongodb-connection-string-url', 'socks'];
-const EXPECTED_PEER_DEPENDENCIES = ['snappy'];
+const EXPECTED_PEER_DEPENDENCIES = ['@aws-sdk/credential-providers', 'snappy'];
 
 describe('package.json', function () {
   describe('dependencies', function () {


### PR DESCRIPTION
### Description

Makes `@aws-sdk/credentials-provider` an optional peer dependency.

#### What is changing?
- Makes `@aws-sdk/credentials-provider` a peer dependency with optional metadata.
- Adds the sdk as a dev dependency
- Updates the dependency check Github action.

##### Is there new documentation needed for these changes?

Updates to migration doc.

#### What is the motivation for this change?

NODE-4898

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
