### PR TITLE
feat(NODE-3489)!: remove cursor close options

### DIFF
--- a/etc/notes/CHANGES_5.0.0.md
+++ b/etc/notes/CHANGES_5.0.0.md
@@ -16,6 +16,11 @@ The following is a detailed collection of the changes in the major v5 release of
 
 ## Changes
 
+### `CursorCloseOptions` removed
+
+When calling `close()` on a `Cursor`, no more options can be provided. This removes support for the
+`skipKillCursors` option that was unused.
+
 ### Snappy v7.x.x or later and optional peerDependency
 
 `snappy` compression has been added to the package.json as a peerDependency that is **optional**.

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -58,14 +58,6 @@ export const CURSOR_FLAGS = [
   'partial'
 ] as const;
 
-/** @public
- * @deprecated This interface is deprecated */
-export interface CursorCloseOptions {
-  /** Bypass calling killCursors when closing the cursor. */
-  /** @deprecated  the skipKillCursors option is deprecated */
-  skipKillCursors?: boolean;
-}
-
 /** @public */
 export interface CursorStreamOptions {
   /** A transformation method applied to each document emitted by the stream */
@@ -447,18 +439,7 @@ export abstract class AbstractCursor<
   close(): Promise<void>;
   /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   close(callback: Callback): void;
-  /**
-   * @deprecated options argument is deprecated
-   */
-  close(options: CursorCloseOptions): Promise<void>;
-  /**
-   * @deprecated options argument is deprecated. Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance
-   */
-  close(options: CursorCloseOptions, callback: Callback): void;
-  close(options?: CursorCloseOptions | Callback, callback?: Callback): Promise<void> | void {
-    if (typeof options === 'function') (callback = options), (options = {});
-    options = options ?? {};
-
+  close(callback?: Callback): Promise<void> | void {
     const needsToEmitClosed = !this[kClosed];
     this[kClosed] = true;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -257,7 +257,6 @@ export type { MONGO_CLIENT_EVENTS } from './constants';
 export type {
   AbstractCursorEvents,
   AbstractCursorOptions,
-  CursorCloseOptions,
   CursorFlag,
   CursorStreamOptions
 } from './cursor/abstract_cursor';


### PR DESCRIPTION
### Description

Removes `CursorCloseOptions`.

#### What is changing?
- Removes the `CursorCloseOptions` and updates the `close()` method to no longer take options.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-3489
<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
