### PR TITLE
test(NODE-4580): use primary preferred in socks test

### DIFF
--- a/test/manual/socks5.test.ts
+++ b/test/manual/socks5.test.ts
@@ -34,6 +34,7 @@ describe('Socks5 Connectivity', function () {
   }
   rsConnectionString.searchParams.set('serverSelectionTimeoutMS', '2000');
   singleConnectionString.searchParams.set('serverSelectionTimeoutMS', '2000');
+  singleConnectionString.searchParams.set('readPreference', 'primaryPreferred');
 
   installNodeDNSWorkaroundHooks();
 


### PR DESCRIPTION
### Description

Fix Socks5 flaky tests

#### What is changing?
- Updates the single connection URI to use read preference primary preferred to avoid the "not primary and secondaryOk=false" errors.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-4580

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
