### PR TITLE
test(NODE-4919): import mongodb-legacy in tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "js-yaml": "^4.1.0",
         "mocha": "^9.2.2",
         "mocha-sinon": "^2.1.2",
+        "mongodb-legacy": "^4.0.0",
         "nyc": "^15.1.0",
         "prettier": "^2.7.1",
         "rimraf": "^3.0.2",
@@ -6827,6 +6828,24 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/mongodb": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.13.0.tgz",
+      "integrity": "sha512-+taZ/bV8d1pYuHL4U+gSwkhmDrwkWbH1l4aah4YpmpscMwgFBkufIKxgP/G7m87/NUuQzc2Z75ZTI7ZOyqZLbw==",
+      "dev": true,
+      "dependencies": {
+        "bson": "^4.7.0",
+        "mongodb-connection-string-url": "^2.5.4",
+        "socks": "^2.7.1"
+      },
+      "engines": {
+        "node": ">=12.9.0"
+      },
+      "optionalDependencies": {
+        "@aws-sdk/credential-providers": "^3.186.0",
+        "saslprep": "^1.0.3"
+      }
+    },
     "node_modules/mongodb-connection-string-url": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
@@ -6843,6 +6862,18 @@
       "dependencies": {
         "@types/node": "*",
         "@types/webidl-conversions": "*"
+      }
+    },
+    "node_modules/mongodb-legacy": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mongodb-legacy/-/mongodb-legacy-4.0.0.tgz",
+      "integrity": "sha512-bO7di48oL4NNAPbDL4cFU+1movNoncxVTIX52m5At7lYB40apV8VD9cSO79FEZ0wYvQ3YL2q8+rpjVAEEKfegg==",
+      "dev": true,
+      "dependencies": {
+        "mongodb": "^4.10.0"
+      },
+      "engines": {
+        "node": ">=12.9.0"
       }
     },
     "node_modules/ms": {
@@ -14701,6 +14732,19 @@
       "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
       "dev": true
     },
+    "mongodb": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.13.0.tgz",
+      "integrity": "sha512-+taZ/bV8d1pYuHL4U+gSwkhmDrwkWbH1l4aah4YpmpscMwgFBkufIKxgP/G7m87/NUuQzc2Z75ZTI7ZOyqZLbw==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/credential-providers": "^3.186.0",
+        "bson": "^4.7.0",
+        "mongodb-connection-string-url": "^2.5.4",
+        "saslprep": "^1.0.3",
+        "socks": "^2.7.1"
+      }
+    },
     "mongodb-connection-string-url": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
@@ -14719,6 +14763,15 @@
             "@types/webidl-conversions": "*"
           }
         }
+      }
+    },
+    "mongodb-legacy": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mongodb-legacy/-/mongodb-legacy-4.0.0.tgz",
+      "integrity": "sha512-bO7di48oL4NNAPbDL4cFU+1movNoncxVTIX52m5At7lYB40apV8VD9cSO79FEZ0wYvQ3YL2q8+rpjVAEEKfegg==",
+      "dev": true,
+      "requires": {
+        "mongodb": "^4.10.0"
       }
     },
     "ms": {

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "js-yaml": "^4.1.0",
     "mocha": "^9.2.2",
     "mocha-sinon": "^2.1.2",
+    "mongodb-legacy": "^4.0.0",
     "nyc": "^15.1.0",
     "prettier": "^2.7.1",
     "rimraf": "^3.0.2",

--- a/test/mongodb.ts
+++ b/test/mongodb.ts
@@ -197,7 +197,15 @@ export * from '../src/write_concern';
 // Must be last for precedence
 export * from '../src/index';
 
-if (process.env.DISABLE_MONGODB_LEGACY !== 'true') {
+/**
+ * TODO(NODE-4979): ENABLE_MONGODB_LEGACY is 'true' by default for now
+ */
+const ENABLE_MONGODB_LEGACY =
+  typeof process.env.ENABLE_MONGODB_LEGACY === 'string' && process.env.ENABLE_MONGODB_LEGACY !== ''
+    ? process.env.ENABLE_MONGODB_LEGACY
+    : 'true';
+
+if (ENABLE_MONGODB_LEGACY === 'true') {
   // Override our own exports with the legacy patched ones
   importMongoDBLegacy(module.exports);
 }

--- a/test/mongodb.ts
+++ b/test/mongodb.ts
@@ -34,7 +34,7 @@ function printExports() {
  *
  * @param exportsToOverride - An object that is an import of the MongoDB driver to be modified by this function
  */
-function importMongoDBLegacy(exportsToOverride) {
+function importMongoDBLegacy(exportsToOverride: Record<string, unknown>) {
   const mongodbLegacyEntryPoint = require.resolve('mongodb-legacy');
   const mongodbLegacyLocation = path.dirname(mongodbLegacyEntryPoint);
   const mongodbLegacyIndex = fs.readFileSync(mongodbLegacyEntryPoint, {

--- a/test/mongodb.ts
+++ b/test/mongodb.ts
@@ -26,8 +26,8 @@ function printExports() {
 }
 
 /**
- * Using node's require resolution logic this function will locate the entrypoint for the `'mongodb-legacy'` module.
- * Then execute the `mongodb-legacy` module in a `vm` context that replaces the global require function with a custom
+ * Using node's require resolution logic this function will locate the entrypoint for the `'mongodb-legacy'` module,
+ * then execute the `mongodb-legacy` module in a `vm` context that replaces the global require function with a custom
  * implementation. The custom version of `require` will return the local instance of the driver import (magically compiled by ts-node) when
  * the module specifier is 'mongodb' and otherwise defer to the normal require behavior to import relative files and stdlib modules.
  * Each of the legacy module's patched classes are placed on the input object.

--- a/test/unit/assorted/client.test.js
+++ b/test/unit/assorted/client.test.js
@@ -7,6 +7,7 @@ const { isHello } = require('../../mongodb');
 
 describe('Client (unit)', function () {
   let server, client;
+  const isLegacyMongoClient = MongoClient.name === 'LegacyMongoClient';
 
   afterEach(async () => {
     await client.close();
@@ -41,9 +42,9 @@ describe('Client (unit)', function () {
       expect(handshake)
         .nested.property('client.driver.name')
         // TODO(NODE-4979): Currently the tests import the LegacyMongoClient which overrides the client metadata
-        // We still are confirming here that a third party wrapper can set the metadata, but when the tests
-        // no longer need LegacyMongoClient, this string should be reverted to 'nodejs|mongoose'
-        .to.equal('nodejs|mongodb-legacy|mongoose');
+        // We still are confirming here that a third party wrapper can set the metadata but it will change depending on the
+        // MongoClient constructor that is imported
+        .to.equal(isLegacyMongoClient ? 'nodejs|mongodb-legacy|mongoose' : 'nodejs|mongoose');
       expect(handshake)
         .nested.property('client.driver.version')
         .to.match(/|5.7.10/);

--- a/test/unit/assorted/client.test.js
+++ b/test/unit/assorted/client.test.js
@@ -40,7 +40,9 @@ describe('Client (unit)', function () {
       expect(handshake).to.have.nested.property('client.driver');
       expect(handshake)
         .nested.property('client.driver.name')
-        // TODO(NODE-4979): Our tests depend on mongodb-legacy
+        // TODO(NODE-4979): Currently the tests import the LegacyMongoClient which overrides the client metadata
+        // We still are confirming here that a third party wrapper can set the metadata, but when the tests
+        // no longer need LegacyMongoClient, this string should be reverted to 'nodejs|mongoose'
         .to.equal('nodejs|mongodb-legacy|mongoose');
       expect(handshake)
         .nested.property('client.driver.version')

--- a/test/unit/assorted/client.test.js
+++ b/test/unit/assorted/client.test.js
@@ -41,7 +41,7 @@ describe('Client (unit)', function () {
       expect(handshake).to.have.nested.property('client.driver');
       expect(handshake)
         .nested.property('client.driver.name')
-        // TODO(NODE-4979): Currently the tests import the LegacyMongoClient which overrides the client metadata
+        // Currently the tests import either MongoClient or LegacyMongoClient, the latter of which overrides the client metadata
         // We still are confirming here that a third party wrapper can set the metadata but it will change depending on the
         // MongoClient constructor that is imported
         .to.equal(isLegacyMongoClient ? 'nodejs|mongodb-legacy|mongoose' : 'nodejs|mongoose');

--- a/test/unit/assorted/client.test.js
+++ b/test/unit/assorted/client.test.js
@@ -38,7 +38,10 @@ describe('Client (unit)', function () {
 
     return client.connect().then(() => {
       expect(handshake).to.have.nested.property('client.driver');
-      expect(handshake).nested.property('client.driver.name').to.equal('nodejs|mongoose');
+      expect(handshake)
+        .nested.property('client.driver.name')
+        // TODO(NODE-4979): Our tests depend on mongodb-legacy
+        .to.equal('nodejs|mongodb-legacy|mongoose');
       expect(handshake)
         .nested.property('client.driver.version')
         .to.match(/|5.7.10/);

--- a/test/unit/cursor/abstract_cursor.test.ts
+++ b/test/unit/cursor/abstract_cursor.test.ts
@@ -11,7 +11,7 @@ import {
   Server
 } from '../../mongodb';
 
-/** Minimal do nothing cursor to focus on testing the base cusor behavior */
+/** Minimal do nothing cursor to focus on testing the base cursor behavior */
 class ConcreteCursor extends AbstractCursor {
   constructor(client: MongoClient, options: AbstractCursorOptions = {}) {
     super(client, ns('test.test'), options);

--- a/test/unit/mongodb-legacy.test.ts
+++ b/test/unit/mongodb-legacy.test.ts
@@ -1,0 +1,9 @@
+import { expect } from 'chai';
+
+import { Db } from '../mongodb';
+
+describe('mongodb-legacy', () => {
+  it('imports a Db with the legacy symbol', () => {
+    expect(Db.prototype).to.have.property(Symbol.for('@@mdb.callbacks.toLegacy'));
+  });
+});

--- a/test/unit/mongodb-legacy.test.ts
+++ b/test/unit/mongodb-legacy.test.ts
@@ -1,9 +1,0 @@
-import { expect } from 'chai';
-
-import { Db } from '../mongodb';
-
-describe('mongodb-legacy', () => {
-  it('imports a Db with the legacy symbol', () => {
-    expect(Db.prototype).to.have.property(Symbol.for('@@mdb.callbacks.toLegacy'));
-  });
-});

--- a/test/unit/tools/mongodb-legacy.test.ts
+++ b/test/unit/tools/mongodb-legacy.test.ts
@@ -1,0 +1,49 @@
+import { expect } from 'chai';
+
+import {
+  Admin,
+  AggregationCursor,
+  ChangeStream,
+  ClientSession,
+  Collection,
+  Db,
+  FindCursor,
+  GridFSBucket,
+  GridFSBucketWriteStream,
+  ListCollectionsCursor,
+  ListIndexesCursor,
+  MongoClient,
+  OrderedBulkOperation,
+  UnorderedBulkOperation
+} from '../../mongodb';
+
+const classesWithAsyncAPIs = new Map<string, any>([
+  ['Admin', Admin],
+  ['FindCursor', FindCursor],
+  ['ListCollectionsCursor', ListCollectionsCursor],
+  ['ListIndexesCursor', ListIndexesCursor],
+  ['AggregationCursor', AggregationCursor],
+  ['ChangeStream', ChangeStream],
+  ['Collection', Collection],
+  ['Db', Db],
+  ['GridFSBucket', GridFSBucket],
+  ['ClientSession', ClientSession],
+  ['GridFSBucketWriteStream', GridFSBucketWriteStream],
+  ['OrderedBulkOperation', OrderedBulkOperation],
+  ['UnorderedBulkOperation', UnorderedBulkOperation]
+]);
+
+describe('mongodb-legacy', () => {
+  for (const [className, ctor] of classesWithAsyncAPIs) {
+    it(`test suite imports a ${className} with the legacy symbol`, () => {
+      // Just confirming that the mongodb-legacy import is correctly overriding the local copies
+      // of these classes from "src". See test/mongodb.ts for more.
+      expect(ctor.prototype).to.have.property(Symbol.for('@@mdb.callbacks.toLegacy'));
+    });
+  }
+  it('test suite imports a LegacyMongoClient as MongoClient', () => {
+    // Just confirming that the mongodb-legacy import is correctly overriding the local copy
+    // of MongoClient from "src". See test/mongodb.ts for more.
+    expect(MongoClient).to.have.property('name', 'LegacyMongoClient');
+  });
+});


### PR DESCRIPTION
### Description

#### What is changing?

We use the mongodb-legacy package to continue supporting callback style tests

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
