### PR TITLE
feat(NODE-4034)!: make internal bulk result private

### DIFF
--- a/etc/notes/CHANGES_5.0.0.md
+++ b/etc/notes/CHANGES_5.0.0.md
@@ -191,3 +191,21 @@ await collection.insertMany([{ name: 'fido' }, { name: 'luna' }])
 
 The `keepGoing` option was a legacy name for setting `ordered` to `false` for bulk inserts.
 It was only supported by the legacy `collection.insert()` method which is now removed as noted above.
+
+### `BulkWriteResult` no longer contains a publicly enumerable `result` property.
+
+To access the raw result, please use `bulkWriteResult.getRawResponse()`. 
+
+### `BulkWriteResult` now contains individual ressult properties.
+
+These can be accessed via:
+
+```ts
+  bulkWriteResult.insertedCount;
+  bulkWriteResult.matchedCount;
+  bulkWriteResult.modifiedCount;
+  bulkWriteResult.deletedCount;
+  bulkWriteResult.upsertedCount;
+  bulkWriteResult.upsertedIds;
+  bulkWriteResult.insertedIds;
+```

--- a/src/bulk/common.ts
+++ b/src/bulk/common.ts
@@ -123,11 +123,7 @@ export type AnyBulkWriteOperation<TSchema extends Document = Document> =
   | { deleteOne: DeleteOneModel<TSchema> }
   | { deleteMany: DeleteManyModel<TSchema> };
 
-/**
- * @public
- *
- * @deprecated Will be made internal in 5.0
- */
+/** @internal */
 export interface BulkResult {
   ok: number;
   writeErrors: WriteError[];
@@ -172,8 +168,7 @@ export class Batch<T = Document> {
  * The result of a bulk write.
  */
 export class BulkWriteResult {
-  /** @deprecated Will be removed in 5.0 */
-  result: BulkResult;
+  private result: BulkResult;
 
   /**
    * Create a new BulkWriteResult instance
@@ -181,6 +176,7 @@ export class BulkWriteResult {
    */
   constructor(bulkResult: BulkResult) {
     this.result = bulkResult;
+    Object.defineProperty(this, 'result', { value: this.result, enumerable: false });
   }
 
   /** Number of documents inserted. */
@@ -314,13 +310,8 @@ export class BulkWriteResult {
     }
   }
 
-  /* @deprecated Will be removed in 5.0 release */
-  toJSON(): BulkResult {
-    return this.result;
-  }
-
   toString(): string {
-    return `BulkWriteResult(${this.toJSON()})`;
+    return `BulkWriteResult(${this.result})`;
   }
 
   isOk(): boolean {

--- a/src/bulk/common.ts
+++ b/src/bulk/common.ts
@@ -530,8 +530,8 @@ function executeCommands(
     }
 
     // Merge the results together
-    const writeResult = new BulkWriteResult(bulkOperation.s.bulkResult);
     const mergeResult = mergeBatchResults(batch, bulkOperation.s.bulkResult, err, result);
+    const writeResult = new BulkWriteResult(bulkOperation.s.bulkResult);
     if (mergeResult != null) {
       return callback(undefined, writeResult);
     }
@@ -1226,7 +1226,6 @@ export abstract class BulkOperationBase {
       this.s.executed = true;
       const finalOptions = { ...this.s.options, ...options };
       const operation = new BulkWriteShimOperation(this, finalOptions);
-
       return executeOperation(this.s.collection.s.db.s.client, operation);
     }, callback);
   }

--- a/test/integration/retryable-writes/retryable_writes.spec.test.ts
+++ b/test/integration/retryable-writes/retryable_writes.spec.test.ts
@@ -15,7 +15,7 @@ interface RetryableWriteTestContext {
 }
 
 const ALLOWED_BULK_PROPERTIES = [
-  'ackknowledged',
+  'acknowledged',
   'insertedCount',
   'matchedCount',
   'modifiedCount',

--- a/test/integration/retryable-writes/retryable_writes.spec.test.ts
+++ b/test/integration/retryable-writes/retryable_writes.spec.test.ts
@@ -14,6 +14,17 @@ interface RetryableWriteTestContext {
   failPointName?: any;
 }
 
+const ALLOWED_BULK_PROPERTIES = [
+  'ackknowledged',
+  'insertedCount',
+  'matchedCount',
+  'modifiedCount',
+  'deletedCount',
+  'upsertedCount',
+  'upsertedIds',
+  'insertedIds'
+];
+
 describe('Legacy Retryable Writes Specs', function () {
   let ctx: RetryableWriteTestContext = {};
 
@@ -155,6 +166,11 @@ async function executeScenarioTest(test, ctx: RetryableWriteTestContext) {
     // not part of the test expectations.
     for (const property in expected) {
       expect(actual).to.have.deep.property(property, expected[property]);
+    }
+
+    // Check we don't have any extra properties on the bulk write result.
+    for (const property in actual) {
+      expect(ALLOWED_BULK_PROPERTIES).to.include(property);
     }
   }
 

--- a/test/integration/retryable-writes/retryable_writes.spec.test.ts
+++ b/test/integration/retryable-writes/retryable_writes.spec.test.ts
@@ -14,17 +14,6 @@ interface RetryableWriteTestContext {
   failPointName?: any;
 }
 
-const ALLOWED_BULK_PROPERTIES = [
-  'acknowledged',
-  'insertedCount',
-  'matchedCount',
-  'modifiedCount',
-  'deletedCount',
-  'upsertedCount',
-  'upsertedIds',
-  'insertedIds'
-];
-
 describe('Legacy Retryable Writes Specs', function () {
   let ctx: RetryableWriteTestContext = {};
 
@@ -166,11 +155,6 @@ async function executeScenarioTest(test, ctx: RetryableWriteTestContext) {
     // not part of the test expectations.
     for (const property in expected) {
       expect(actual).to.have.deep.property(property, expected[property]);
-    }
-
-    // Check we don't have any extra properties on the bulk write result.
-    for (const property in actual) {
-      expect(ALLOWED_BULK_PROPERTIES).to.include(property);
     }
   }
 

--- a/test/integration/retryable-writes/retryable_writes.spec.test.ts
+++ b/test/integration/retryable-writes/retryable_writes.spec.test.ts
@@ -150,8 +150,12 @@ async function executeScenarioTest(test, ctx: RetryableWriteTestContext) {
     const result = resultOrError;
     const expected = test.outcome.result;
 
-    // TODO(NODE-4034): Make CRUD results spec compliant
-    expect(result.value ?? result).to.deep.include(expected);
+    const actual = result.value ?? result;
+    // Some of our result classes contain the optional 'acknowledged' property which is
+    // not part of the test expectations.
+    for (const property in expected) {
+      expect(actual).to.have.deep.property(property, expected[property]);
+    }
   }
 
   if (test.outcome.collection) {

--- a/test/spec/client-side-encryption/tests/unified/rewrapManyDataKey.json
+++ b/test/spec/client-side-encryption/tests/unified/rewrapManyDataKey.json
@@ -321,7 +321,10 @@
               "modifiedCount": 4,
               "deletedCount": 0,
               "upsertedCount": 0,
-              "upsertedIds": {}
+              "upsertedIds": {},
+              "insertedIds": {
+                "$$unsetOrMatches": {}
+              }
             }
           }
         }
@@ -503,7 +506,10 @@
               "modifiedCount": 4,
               "deletedCount": 0,
               "upsertedCount": 0,
-              "upsertedIds": {}
+              "upsertedIds": {},
+              "insertedIds": {
+                "$$unsetOrMatches": {}
+              }
             }
           }
         }
@@ -687,7 +693,10 @@
               "modifiedCount": 4,
               "deletedCount": 0,
               "upsertedCount": 0,
-              "upsertedIds": {}
+              "upsertedIds": {},
+              "insertedIds": {
+                "$$unsetOrMatches": {}
+              }
             }
           }
         }
@@ -873,7 +882,10 @@
               "modifiedCount": 4,
               "deletedCount": 0,
               "upsertedCount": 0,
-              "upsertedIds": {}
+              "upsertedIds": {},
+              "insertedIds": {
+                "$$unsetOrMatches": {}
+              }
             }
           }
         }
@@ -1055,7 +1067,10 @@
               "modifiedCount": 4,
               "deletedCount": 0,
               "upsertedCount": 0,
-              "upsertedIds": {}
+              "upsertedIds": {},
+              "insertedIds": {
+                "$$unsetOrMatches": {}
+              }
             }
           }
         }
@@ -1218,7 +1233,10 @@
               "modifiedCount": 5,
               "deletedCount": 0,
               "upsertedCount": 0,
-              "upsertedIds": {}
+              "upsertedIds": {},
+              "insertedIds": {
+                "$$unsetOrMatches": {}
+              }
             }
           }
         },

--- a/test/spec/client-side-encryption/tests/unified/rewrapManyDataKey.yml
+++ b/test/spec/client-side-encryption/tests/unified/rewrapManyDataKey.yml
@@ -130,6 +130,7 @@ tests:
             deletedCount: 0
             upsertedCount: 0
             upsertedIds: {}
+            insertedIds: { $$unsetOrMatches: {} }
     expectEvents:
       - client: *client0
         events:
@@ -182,6 +183,7 @@ tests:
             deletedCount: 0
             upsertedCount: 0
             upsertedIds: {}
+            insertedIds: { $$unsetOrMatches: {} }
     expectEvents:
       - client: *client0
         events:
@@ -236,6 +238,7 @@ tests:
             deletedCount: 0
             upsertedCount: 0
             upsertedIds: {}
+            insertedIds: { $$unsetOrMatches: {} }
     expectEvents:
       - client: *client0
         events:
@@ -285,6 +288,7 @@ tests:
             deletedCount: 0
             upsertedCount: 0
             upsertedIds: {}
+            insertedIds: { $$unsetOrMatches: {} }
     expectEvents:
       - client: *client0
         events:
@@ -334,6 +338,7 @@ tests:
             deletedCount: 0
             upsertedCount: 0
             upsertedIds: {}
+            insertedIds: { $$unsetOrMatches: {} }
     expectEvents:
       - client: *client0
         events:
@@ -381,6 +386,7 @@ tests:
             deletedCount: 0
             upsertedCount: 0
             upsertedIds: {}
+            insertedIds: { $$unsetOrMatches: {} }
       - name: find
         object: *collection0
         arguments:

--- a/test/tools/unified-spec-runner/operations.ts
+++ b/test/tools/unified-spec-runner/operations.ts
@@ -659,21 +659,7 @@ operations.set('rewrapManyDataKey', async ({ entities, operation }) => {
   const clientEncryption = entities.getEntity('clientEncryption', operation.object);
   const { filter, opts } = operation.arguments!;
 
-  const rewrapManyDataKeyResult = await clientEncryption.rewrapManyDataKey(filter, opts);
-  if (rewrapManyDataKeyResult.bulkWriteResult != null) {
-    // TODO: Can be removed with DRIVERS-2523
-    //
-    // The unified spec runner match function will assert that documents have no extra
-    // keys.  For `rewrapManyDataKey` operations, our unifed tests will fail because
-    // our BulkWriteResult class has an insertedIds property, which is correct by the
-    // spec but not defined in the spec tests.
-    const { bulkWriteResult } = rewrapManyDataKeyResult;
-    Object.defineProperty(bulkWriteResult, 'insertedIds', {
-      value: bulkWriteResult.insertedIds,
-      enumerable: false
-    });
-  }
-  return rewrapManyDataKeyResult;
+  return await clientEncryption.rewrapManyDataKey(filter, opts);
 });
 
 operations.set('deleteKey', async ({ entities, operation }) => {

--- a/test/tools/unified-spec-runner/operations.ts
+++ b/test/tools/unified-spec-runner/operations.ts
@@ -659,7 +659,21 @@ operations.set('rewrapManyDataKey', async ({ entities, operation }) => {
   const clientEncryption = entities.getEntity('clientEncryption', operation.object);
   const { filter, opts } = operation.arguments!;
 
-  return await clientEncryption.rewrapManyDataKey(filter, opts);
+  const rewrapManyDataKeyResult = await clientEncryption.rewrapManyDataKey(filter, opts);
+  if (rewrapManyDataKeyResult.bulkWriteResult != null) {
+    // TODO: Create DRIVERS ticket.
+    //
+    // The unified spec runner match function will assert that documents have no extra
+    // keys.  For `rewrapManyDataKey` operations, our unifed tests will fail because
+    // our BulkWriteResult class has an insertedIds property, which is correct by the
+    // spec but not defined in the spec tests.
+    const { bulkWriteResult } = rewrapManyDataKeyResult;
+    Object.defineProperty(bulkWriteResult, 'insertedIds', {
+      value: bulkWriteResult.insertedIds,
+      enumerable: false
+    });
+  }
+  return rewrapManyDataKeyResult;
 });
 
 operations.set('deleteKey', async ({ entities, operation }) => {

--- a/test/tools/unified-spec-runner/operations.ts
+++ b/test/tools/unified-spec-runner/operations.ts
@@ -659,22 +659,7 @@ operations.set('rewrapManyDataKey', async ({ entities, operation }) => {
   const clientEncryption = entities.getEntity('clientEncryption', operation.object);
   const { filter, opts } = operation.arguments!;
 
-  const rewrapManyDataKeyResult = await clientEncryption.rewrapManyDataKey(filter, opts);
-
-  if (rewrapManyDataKeyResult.bulkWriteResult != null) {
-    // TODO(NODE-4393): refactor BulkWriteResult to not have a 'result' property
-    //
-    // The unified spec runner match function will assert that documents have no extra
-    // keys.  For `rewrapManyDataKey` operations, our unifed tests will fail because
-    // our BulkWriteResult class has an extra property - "result".  We explicitly make it
-    // non-enumerable for the purposes of testing so that the tests can pass.
-    const { bulkWriteResult } = rewrapManyDataKeyResult;
-    Object.defineProperty(bulkWriteResult, 'result', {
-      value: bulkWriteResult.result,
-      enumerable: false
-    });
-  }
-  return rewrapManyDataKeyResult;
+  return await clientEncryption.rewrapManyDataKey(filter, opts);
 });
 
 operations.set('deleteKey', async ({ entities, operation }) => {

--- a/test/tools/unified-spec-runner/operations.ts
+++ b/test/tools/unified-spec-runner/operations.ts
@@ -661,7 +661,7 @@ operations.set('rewrapManyDataKey', async ({ entities, operation }) => {
 
   const rewrapManyDataKeyResult = await clientEncryption.rewrapManyDataKey(filter, opts);
   if (rewrapManyDataKeyResult.bulkWriteResult != null) {
-    // TODO: Create DRIVERS ticket.
+    // TODO: Can be removed with DRIVERS-2523
     //
     // The unified spec runner match function will assert that documents have no extra
     // keys.  For `rewrapManyDataKey` operations, our unifed tests will fail because


### PR DESCRIPTION
### Description

Makes the internal `BulkResult` on the `BulkWriteResult` private.

#### What is changing?
- Marks the `BulkResult` interface as internal.
- Makes the `result` property of the `BulkWriteResult` private and non-enumerable.
- Makes all properties of the `BulkWriteResult` per the crud spec definition actual properties instead of getters.
- Removes `toJSON()`.
- DRYs up the generation of the inserted/upserted id maps.
- Eliminates `insertedIds` from the result enumerable in unified tests.

mongosh CI failures fix in this PR: https://github.com/mongodb-js/mongosh/pull/1386

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-4034/NODE-4393/NODE-4973

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
