### PR TITLE
feat(NODE-4751)!: drop support for client encryption < 2.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,13 +34,17 @@
   },
   "peerDependencies": {
     "@aws-sdk/credential-providers": "^3.201.0",
-    "snappy": "7.x.x"
+    "snappy": "7.x.x",
+    "mongodb-client-encryption": "2.x.x"
   },
   "peerDependenciesMeta": {
     "@aws-sdk/credential-providers": {
       "optional": true
     },
     "snappy": {
+      "optional": true
+    },
+    "mongodb-client-encryption": {
       "optional": true
     }
   },

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "peerDependencies": {
     "@aws-sdk/credential-providers": "^3.201.0",
     "snappy": "7.x.x",
-    "mongodb-client-encryption": "2.x.x"
+    "mongodb-client-encryption": "^2.3.0"
   },
   "peerDependenciesMeta": {
     "@aws-sdk/credential-providers": {

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -86,7 +86,6 @@ import {
   Callback,
   checkCollectionName,
   DEFAULT_PK_FACTORY,
-  emitWarningOnce,
   MongoDBNamespace,
   normalizeHintField,
   resolveOptions

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -283,12 +283,6 @@ export class Collection<TSchema extends Document = Document> {
       options = {};
     }
 
-    // versions of mongodb-client-encryption before v1.2.6 pass in hardcoded { w: 'majority' }
-    // specifically to an insertOne call in createDataKey, so we want to support this only here
-    if (options && Reflect.get(options, 'w')) {
-      options.writeConcern = WriteConcern.fromOptions(Reflect.get(options, 'w'));
-    }
-
     return executeOperation(
       this.s.db.s.client,
       new InsertOneOperation(

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-import type { deserialize, Document, serialize } from './bson';
+import type { Document } from './bson';
 import type { AWSCredentials } from './cmap/auth/mongodb_aws';
 import type { ProxyOptions } from './cmap/connection';
 import { MongoMissingDependencyError } from './error';

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -214,8 +214,6 @@ export interface AutoEncryptionTlsOptions {
 
 /** @public */
 export interface AutoEncryptionOptions {
-  /** @internal */
-  bson?: { serialize: typeof serialize; deserialize: typeof deserialize };
   /** @internal client for metadata lookups */
   metadataClient?: MongoClient;
   /** A `MongoClient` used to fetch keys from a key vault */

--- a/src/encrypter.ts
+++ b/src/encrypter.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 
-import { deserialize, serialize } from './bson';
 import { MONGO_CLIENT_EVENTS } from './constants';
 import type { AutoEncrypter, AutoEncryptionOptions } from './deps';
 import { MongoInvalidArgumentError, MongoMissingDependencyError } from './error';

--- a/src/encrypter.ts
+++ b/src/encrypter.ts
@@ -58,12 +58,6 @@ export class Encrypter {
       };
     }
 
-    options.autoEncryption.bson = Object.create(null);
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    options.autoEncryption.bson!.serialize = serialize;
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    options.autoEncryption.bson!.deserialize = deserialize;
-
     this.autoEncrypter = new AutoEncrypterClass(client, options.autoEncryption);
   }
 

--- a/src/sdam/topology.ts
+++ b/src/sdam/topology.ts
@@ -2,7 +2,6 @@ import { clearTimeout, setTimeout } from 'timers';
 import { promisify } from 'util';
 
 import type { BSONSerializeOptions, Document } from '../bson';
-import { deserialize, serialize } from '../bson';
 import type { MongoCredentials } from '../cmap/auth/mongo_credentials';
 import type { ConnectionEvents, DestroyOptions } from '../cmap/connection';
 import type { CloseOptions, ConnectionPoolEvents } from '../cmap/connection_pool';

--- a/src/sdam/topology.ts
+++ b/src/sdam/topology.ts
@@ -222,16 +222,6 @@ export class Topology extends TypedEventEmitter<TopologyEvents> {
   /** @event */
   static readonly TIMEOUT = TIMEOUT;
 
-  /**
-   * @internal
-   *
-   * @privateRemarks
-   * mongodb-client-encryption's class ClientEncryption falls back to finding the bson lib
-   * defined on client.topology.bson, in order to maintain compatibility with any version
-   * of mongodb-client-encryption we keep a reference to serialize and deserialize here.
-   */
-  bson: { serialize: typeof serialize; deserialize: typeof deserialize };
-
   selectServerAsync: (
     selector: string | ReadPreference | ServerSelector,
     options: SelectServerOptions
@@ -250,12 +240,6 @@ export class Topology extends TypedEventEmitter<TopologyEvents> {
         callback: (e: Error, r: Server) => void
       ) => this.selectServer(selector, options, callback as any)
     );
-
-    // Saving a reference to these BSON functions
-    // supports v2.2.0 and older versions of mongodb-client-encryption
-    this.bson = Object.create(null);
-    this.bson.serialize = serialize;
-    this.bson.deserialize = deserialize;
 
     // Options should only be undefined in tests, MongoClient will always have defined options
     options = options ?? {

--- a/test/action/dependency.test.ts
+++ b/test/action/dependency.test.ts
@@ -7,7 +7,11 @@ import { expect } from 'chai';
 import { dependencies, peerDependencies, peerDependenciesMeta } from '../../package.json';
 
 const EXPECTED_DEPENDENCIES = ['bson', 'mongodb-connection-string-url', 'socks'];
-const EXPECTED_PEER_DEPENDENCIES = ['@aws-sdk/credential-providers', 'snappy'];
+const EXPECTED_PEER_DEPENDENCIES = [
+  '@aws-sdk/credential-providers',
+  'snappy',
+  'mongodb-client-encryption'
+];
 
 describe('package.json', function () {
   describe('dependencies', function () {


### PR DESCRIPTION
### Description

#### What is changing?

mongodb-client-encryption is now an optional peer dependency with a support version range of `^2.3.0`.

##### Is there new documentation needed for these changes?

Yes, we need to document our support matrix.  

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
