### PR TITLE
feat(NODE-2014)!: return the result of provided callback in withTransaction and withSession

### DIFF
--- a/etc/notes/CHANGES_5.0.0.md
+++ b/etc/notes/CHANGES_5.0.0.md
@@ -191,3 +191,17 @@ await collection.insertMany([{ name: 'fido' }, { name: 'luna' }])
 
 The `keepGoing` option was a legacy name for setting `ordered` to `false` for bulk inserts.
 It was only supported by the legacy `collection.insert()` method which is now removed as noted above.
+
+### `withSession` and `withTransaction` now return the result of the provided callback.
+
+These two methods previously returned `Promise<void>` but now users can control what the return value
+in the promise is:
+
+```ts
+const value = await client.withSession(async (session) => {
+  return session.withTransaction(async () => {
+    await collection.insertOne({ a: 1 });
+    return true;
+  });
+}); // value is the boolean true;
+```

--- a/test/integration/transactions/transactions.test.ts
+++ b/test/integration/transactions/transactions.test.ts
@@ -90,19 +90,19 @@ describe('Transactions', function () {
           expect(withTransactionResult).to.be.undefined;
         });
 
-        it('should return raw command when transaction is successfully committed', async () => {
+        it('should return callback return value when transaction is successfully committed', async () => {
           const session = client.startSession();
 
           const withTransactionResult = await session
             .withTransaction(async session => {
               await collection.insertOne({ a: 1 }, { session });
-              await collection.findOne({ a: 1 }, { session });
+              return await collection.findOne({ a: 1 }, { session });
             })
             .finally(async () => await session.endSession());
 
           expect(withTransactionResult).to.exist;
           expect(withTransactionResult).to.be.an('object');
-          expect(withTransactionResult).to.have.property('ok', 1);
+          expect(withTransactionResult).to.have.property('a', 1);
         });
 
         it('should throw when transaction is aborted due to an error', async () => {

--- a/test/unit/mongo_client.test.js
+++ b/test/unit/mongo_client.test.js
@@ -873,3 +873,25 @@ describe('MongoOptions', function () {
     });
   });
 });
+
+describe('MongoClient', function () {
+  describe('#withSession', function () {
+    const client = new MongoClient('mongodb://localhost:27017');
+
+    context('when the callback returns a value', function () {
+      it('returns the value in the promise', async function () {
+        const value = await client.withSession(async () => {
+          return 'test';
+        });
+        expect(value).to.equal('test');
+      });
+    });
+
+    context('when the callback does not return a value', function () {
+      it('does not return a value in the promise', async function () {
+        const value = await client.withSession(async () => {});
+        expect(value).to.equal(undefined);
+      });
+    });
+  });
+});

--- a/test/unit/sessions.test.js
+++ b/test/unit/sessions.test.js
@@ -32,6 +32,24 @@ describe('Sessions - unit', function () {
       });
     });
 
+    describe('#withTransaction', function () {
+      context('when the callback returns a value', function () {
+        it('returns the value in the promise', async function () {
+          const value = await session.withTransaction(async () => {
+            return 'test';
+          });
+          expect(value).to.equal('test');
+        });
+      });
+
+      context('when the callback does not return a value', function () {
+        it('does not return a value in the promise', async function () {
+          const value = await session.withTransaction(async () => {});
+          expect(value).to.equal(undefined);
+        });
+      });
+    });
+
     describe('advanceClusterTime()', () => {
       it('should throw an error if the input cluster time is not an object', function () {
         const invalidInputs = [undefined, null, 3, 'a'];


### PR DESCRIPTION
### Description

Updates `withTransaction` and `withSession` helpers to return the return value of the user provided callback.

#### What is changing?

- `session.withTransaction()` now properly returns the return value of the callback.
- `client.withSession()` updates its signature to return `Promise<any>` instead of `Promise<void` and returns the return value of the provided callback.
- Updates migration guide.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-2014

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
