### PR TITLE
chore(NODE-4959): use caret notation for snappy peer dependency

### DIFF
--- a/etc/notes/CHANGES_5.0.0.md
+++ b/etc/notes/CHANGES_5.0.0.md
@@ -111,13 +111,13 @@ no longer normalizes the values. There is no new method or property to replace t
 When calling `close()` on a `Cursor`, no more options can be provided. This removes support for the
 `skipKillCursors` option that was unused.
 
-### Snappy v7.x.x or later and optional peerDependency
+### Snappy v7.2.2 or later and optional peerDependency
 
 `snappy` compression has been added to the package.json as a peerDependency that is **optional**.
 This means `npm` will let you know if the version of snappy you have installed is incompatible with the driver.
 
 ```sh
-npm install --save snappy@7
+npm install --save "snappy@^7.2.2"
 ```
 
 ### `.unref()` removed from `Db`

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,10 +70,14 @@
       },
       "peerDependencies": {
         "@aws-sdk/credential-providers": "^3.201.0",
+        "mongodb-client-encryption": "^2.3.0",
         "snappy": "^7.2.2"
       },
       "peerDependenciesMeta": {
         "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
           "optional": true
         },
         "snappy": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,7 @@
       },
       "peerDependencies": {
         "@aws-sdk/credential-providers": "^3.201.0",
-        "snappy": "7.x.x"
+        "snappy": "^7.2.2"
       },
       "peerDependenciesMeta": {
         "@aws-sdk/credential-providers": {

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
   },
   "peerDependencies": {
     "@aws-sdk/credential-providers": "^3.201.0",
-    "snappy": "^7.2.2",
-    "mongodb-client-encryption": "^2.3.0"
+    "mongodb-client-encryption": "^2.3.0",
+    "snappy": "^7.2.2"
   },
   "peerDependenciesMeta": {
     "@aws-sdk/credential-providers": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "peerDependencies": {
     "@aws-sdk/credential-providers": "^3.201.0",
-    "snappy": "7.x.x",
+    "snappy": "^7.2.2",
     "mongodb-client-encryption": "^2.3.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
### Description

[NODE-4959](https://jira.mongodb.org/browse/NODE-4959)

#### What is changing?

We decided to use the caret notation instead of .x.x notation in the non-required deps spike

#### What is the motivation for this change?

Consistency

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
