### PR TITLE
test(NODE-4894): re-enable kerberos tests on 18

### DIFF
--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -452,6 +452,7 @@ functions:
         script: |
           export PROJECT_DIRECTORY="$(pwd)"
           export KRB5_KEYTAB='${gssapi_auth_keytab_base64}'
+          export KRB5_NEW_KEYTAB='${gssapi_auth_new_keytab_base64}'
           export KRB5_PRINCIPAL='${gssapi_auth_principal}'
           export MONGODB_URI='${gssapi_auth_mongodb_uri}'
           export NODE_LTS_NAME='${NODE_LTS_NAME}'

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2816,7 +2816,6 @@ buildvariants:
       - test-5.0-load-balanced
       - test-6.0-load-balanced
       - test-latest-load-balanced
-      - test-auth-kerberos
       - test-auth-ldap
       - test-socks5-csfle
       - test-socks5-tls

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2124,13 +2124,6 @@ tasks:
         vars:
           NODE_LTS_NAME: gallium
       - func: run mongosh integration tests
-  - name: test-auth-kerberos-ubuntu
-    tags:
-      - auth
-      - kerberos
-    commands:
-      - func: install dependencies
-      - func: run kerberos tests
   - name: download-and-merge-coverage
     tags: []
     commands:
@@ -2985,11 +2978,6 @@ buildvariants:
     run_on: ubuntu1804-large
     tasks:
       - run-mongosh-integration-tests
-  - name: run_kerberos_tests_ubuntu
-    display_name: kerberos tests ubuntu
-    run_on: ubuntu1804-large
-    tasks:
-      - test-auth-kerberos-ubuntu
   - name: ubuntu1804-test-mongodb-aws
     display_name: MONGODB-AWS Auth test
     run_on: ubuntu1804-large

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -421,6 +421,7 @@ functions:
         script: |
           export PROJECT_DIRECTORY="$(pwd)"
           export KRB5_KEYTAB='${gssapi_auth_keytab_base64}'
+          export KRB5_NEW_KEYTAB='${gssapi_auth_new_keytab_base64}'
           export KRB5_PRINCIPAL='${gssapi_auth_principal}'
           export MONGODB_URI='${gssapi_auth_mongodb_uri}'
           export NODE_LTS_NAME='${NODE_LTS_NAME}'

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2768,6 +2768,7 @@ buildvariants:
       - test-5.0-load-balanced
       - test-6.0-load-balanced
       - test-latest-load-balanced
+      - test-auth-kerberos
       - test-auth-ldap
       - test-socks5
       - test-socks5-csfle
@@ -2814,6 +2815,7 @@ buildvariants:
       - test-5.0-load-balanced
       - test-6.0-load-balanced
       - test-latest-load-balanced
+      - test-auth-kerberos
       - test-auth-ldap
       - test-socks5-csfle
       - test-socks5-tls

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2123,6 +2123,13 @@ tasks:
         vars:
           NODE_LTS_NAME: gallium
       - func: run mongosh integration tests
+  - name: test-auth-kerberos-ubuntu
+    tags:
+      - auth
+      - kerberos
+    commands:
+      - func: install dependencies
+      - func: run kerberos tests
   - name: download-and-merge-coverage
     tags: []
     commands:
@@ -2977,6 +2984,11 @@ buildvariants:
     run_on: ubuntu1804-large
     tasks:
       - run-mongosh-integration-tests
+  - name: run_kerberos_tests_ubuntu
+    display_name: kerberos tests ubuntu
+    run_on: ubuntu1804-large
+    tasks:
+      - test-auth-kerberos-ubuntu
   - name: ubuntu1804-test-mongodb-aws
     display_name: MONGODB-AWS Auth test
     run_on: ubuntu1804-large

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -688,6 +688,15 @@ for (const variant of BUILD_VARIANTS.filter(
   );
 }
 
+// TODO(NODE-4894): fix kerberos tests on Node18
+for (const variant of BUILD_VARIANTS.filter(
+  variant => variant.expansions && ['latest'].includes(variant.expansions.NODE_LTS_NAME)
+)) {
+  variant.tasks = variant.tasks.filter(
+    name => !['test-auth-kerberos'].includes(name)
+  );
+}
+
 // TODO(NODE-4897): Debug socks5 tests on node latest
 for (const variant of BUILD_VARIANTS.filter(
   variant => variant.expansions && ['latest'].includes(variant.expansions.NODE_LTS_NAME)

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -579,24 +579,11 @@ SINGLETON_TASKS.push({
   ]
 });
 
-SINGLETON_TASKS.push({
-  name: 'test-auth-kerberos-ubuntu',
-  tags: ['auth', 'kerberos'],
-  commands: [{ func: 'install dependencies' }, { func: 'run kerberos tests' }]
-});
-
 BUILD_VARIANTS.push({
   name: 'mongosh_integration_tests',
   display_name: 'mongosh integration tests',
   run_on: 'ubuntu1804-large',
   tasks: ['run-mongosh-integration-tests']
-});
-
-BUILD_VARIANTS.push({
-  name: 'run_kerberos_tests_ubuntu',
-  display_name: 'kerberos tests ubuntu',
-  run_on: 'ubuntu1804-large',
-  tasks: ['test-auth-kerberos-ubuntu']
 });
 
 // special case for MONGODB-AWS authentication

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -688,7 +688,7 @@ for (const variant of BUILD_VARIANTS.filter(
   );
 }
 
-// TODO(NODE-4894): fix kerberos tests on Node18
+// TODO(NODE-5021): Drop support for Kerberos 1.x on in 6.0.0
 for (const variant of BUILD_VARIANTS.filter(
   variant => variant.expansions && ['latest'].includes(variant.expansions.NODE_LTS_NAME)
 )) {

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -688,15 +688,6 @@ for (const variant of BUILD_VARIANTS.filter(
   );
 }
 
-// TODO(NODE-4894): fix kerberos tests on Node18
-for (const variant of BUILD_VARIANTS.filter(
-  variant => variant.expansions && ['hydrogen', 'latest'].includes(variant.expansions.NODE_LTS_NAME)
-)) {
-  variant.tasks = variant.tasks.filter(
-    name => !['test-auth-kerberos'].includes(name)
-  );
-}
-
 // TODO(NODE-4897): Debug socks5 tests on node latest
 for (const variant of BUILD_VARIANTS.filter(
   variant => variant.expansions && ['latest'].includes(variant.expansions.NODE_LTS_NAME)

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -579,11 +579,24 @@ SINGLETON_TASKS.push({
   ]
 });
 
+SINGLETON_TASKS.push({
+  name: 'test-auth-kerberos-ubuntu',
+  tags: ['auth', 'kerberos'],
+  commands: [{ func: 'install dependencies' }, { func: 'run kerberos tests' }]
+});
+
 BUILD_VARIANTS.push({
   name: 'mongosh_integration_tests',
   display_name: 'mongosh integration tests',
   run_on: 'ubuntu1804-large',
   tasks: ['run-mongosh-integration-tests']
+});
+
+BUILD_VARIANTS.push({
+  name: 'run_kerberos_tests_ubuntu',
+  display_name: 'kerberos tests ubuntu',
+  run_on: 'ubuntu1804-large',
+  tasks: ['test-auth-kerberos-ubuntu']
 });
 
 // special case for MONGODB-AWS authentication

--- a/.evergreen/krb5.conf
+++ b/.evergreen/krb5.conf
@@ -1,3 +1,0 @@
-default_tkt_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96
-default_tgs_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96
-permitted_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96

--- a/.evergreen/krb5.conf
+++ b/.evergreen/krb5.conf
@@ -1,0 +1,3 @@
+default_tkt_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 rc4-hmac
+default_tgs_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 rc4-hmac
+permitted_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 rc4-hmac

--- a/.evergreen/krb5.conf
+++ b/.evergreen/krb5.conf
@@ -1,3 +1,3 @@
-default_tkt_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 rc4-hmac
-default_tgs_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 rc4-hmac
-permitted_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 rc4-hmac
+default_tkt_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96
+default_tgs_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96
+permitted_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96

--- a/.evergreen/run-kerberos-tests.sh
+++ b/.evergreen/run-kerberos-tests.sh
@@ -6,8 +6,7 @@ source "${PROJECT_DIRECTORY}/.evergreen/init-nvm.sh"
 
 # set up keytab
 mkdir -p "$(pwd)/.evergreen"
-touch "$(pwd)/.evergreen/krb5.conf.empty"
-export KRB5_CONFIG="$(pwd)/.evergreen/krb5.conf.empty"
+export KRB5_CONFIG="$(pwd)/.evergreen/krb5.conf"
 export KRB5_TRACE="/dev/stderr"
 echo "Writing keytab"
 # DON'T PRINT KEYTAB TO STDOUT
@@ -19,6 +18,8 @@ else
 fi
 echo "Running kinit"
 kinit -k -t "$(pwd)/.evergreen/drivers.keytab" -p ${KRB5_PRINCIPAL}
+klist -ef
+kvno -S ldap domain | echo "finished kvno"
 
 set -o xtrace
 npm install kerberos@">=2.0.0-beta.0"

--- a/.evergreen/run-kerberos-tests.sh
+++ b/.evergreen/run-kerberos-tests.sh
@@ -12,10 +12,12 @@ echo "Writing keytab"
 # DON'T PRINT KEYTAB TO STDOUT
 set +o verbose
 if [[ "$OSTYPE" == "darwin"* ]]; then
-    echo ${KRB5_KEYTAB} | base64 -D > "$(pwd)/.evergreen/drivers.keytab"
+    echo ${KRB5_NEW_KEYTAB} | base64 -D > "$(pwd)/.evergreen/drivers.keytab"
 else
-    echo ${KRB5_KEYTAB} | base64 -d > "$(pwd)/.evergreen/drivers.keytab"
+    echo ${KRB5_NEW_KEYTAB} | base64 -d > "$(pwd)/.evergreen/drivers.keytab"
 fi
+echo "Running kdestroy"
+kdestroy -A
 echo "Running kinit"
 kinit -k -t "$(pwd)/.evergreen/drivers.keytab" -p ${KRB5_PRINCIPAL}
 klist -ef

--- a/.evergreen/run-kerberos-tests.sh
+++ b/.evergreen/run-kerberos-tests.sh
@@ -6,7 +6,6 @@ source "${PROJECT_DIRECTORY}/.evergreen/init-nvm.sh"
 
 # set up keytab
 mkdir -p "$(pwd)/.evergreen"
-export KRB5_TRACE="/dev/stderr"
 export KRB5_CONFIG="$(pwd)/.evergreen/krb5.conf.empty"
 echo "Writing keytab"
 echo "${KRB5_NEW_KEYTAB}"
@@ -21,8 +20,6 @@ echo "Running kdestroy"
 kdestroy -A
 echo "Running kinit"
 kinit -k -t "$(pwd)/.evergreen/drivers.keytab" -p ${KRB5_PRINCIPAL}
-klist -ef
-kvno -S ldap domain | echo "finished kvno"
 
 set -o xtrace
 npm install kerberos@">=2.0.0-beta.0"

--- a/.evergreen/run-kerberos-tests.sh
+++ b/.evergreen/run-kerberos-tests.sh
@@ -9,6 +9,7 @@ mkdir -p "$(pwd)/.evergreen"
 export KRB5_CONFIG="$(pwd)/.evergreen/krb5.conf"
 export KRB5_TRACE="/dev/stderr"
 echo "Writing keytab"
+echo "${KRB5_NEW_KEYTAB}"
 # DON'T PRINT KEYTAB TO STDOUT
 set +o verbose
 if [[ "$OSTYPE" == "darwin"* ]]; then

--- a/.evergreen/run-kerberos-tests.sh
+++ b/.evergreen/run-kerberos-tests.sh
@@ -8,7 +8,6 @@ source "${PROJECT_DIRECTORY}/.evergreen/init-nvm.sh"
 mkdir -p "$(pwd)/.evergreen"
 export KRB5_CONFIG="$(pwd)/.evergreen/krb5.conf.empty"
 echo "Writing keytab"
-echo "${KRB5_NEW_KEYTAB}"
 # DON'T PRINT KEYTAB TO STDOUT
 set +o verbose
 if [[ "$OSTYPE" == "darwin"* ]]; then

--- a/.evergreen/run-kerberos-tests.sh
+++ b/.evergreen/run-kerberos-tests.sh
@@ -6,8 +6,8 @@ source "${PROJECT_DIRECTORY}/.evergreen/init-nvm.sh"
 
 # set up keytab
 mkdir -p "$(pwd)/.evergreen"
-export KRB5_CONFIG="$(pwd)/.evergreen/krb5.conf"
 export KRB5_TRACE="/dev/stderr"
+export KRB5_CONFIG="$(pwd)/.evergreen/krb5.conf.empty"
 echo "Writing keytab"
 echo "${KRB5_NEW_KEYTAB}"
 # DON'T PRINT KEYTAB TO STDOUT

--- a/.evergreen/run-kerberos-tests.sh
+++ b/.evergreen/run-kerberos-tests.sh
@@ -8,6 +8,7 @@ source "${PROJECT_DIRECTORY}/.evergreen/init-nvm.sh"
 mkdir -p "$(pwd)/.evergreen"
 touch "$(pwd)/.evergreen/krb5.conf.empty"
 export KRB5_CONFIG="$(pwd)/.evergreen/krb5.conf.empty"
+export KRB5_TRACE="/dev/stderr"
 echo "Writing keytab"
 # DON'T PRINT KEYTAB TO STDOUT
 set +o verbose


### PR DESCRIPTION
### Description

Re-enables the Kerberos auth tests on Node 18 and latest.

#### What is changing?

RHEL 8.0 forces a cipher suite for libkrb5 of rc4-hmac which is both legacy and deprecated, and Node 18 dropped support for it. We've generated a new drivers keytab that forces aes256-cts and aes128-cts and use it specifically in all tests now.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
