### PR TITLE
test(NODE-4985): update csfle build scripts

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2132,7 +2132,7 @@ tasks:
       - func: bootstrap kms servers
       - func: run custom csfle tests
         vars:
-          CSFLE_GIT_REF: ddb19ae22dc4a5f8b9208096f69fc23e19bae6c9
+          CSFLE_GIT_REF: ff9e095eaf72f9e442761f69080dae159a395d94
   - name: run-custom-csfle-tests-5.0-master
     tags:
       - run-custom-dependency-tests
@@ -2162,7 +2162,7 @@ tasks:
       - func: bootstrap kms servers
       - func: run custom csfle tests
         vars:
-          CSFLE_GIT_REF: ddb19ae22dc4a5f8b9208096f69fc23e19bae6c9
+          CSFLE_GIT_REF: ff9e095eaf72f9e442761f69080dae159a395d94
   - name: run-custom-csfle-tests-rapid-master
     tags:
       - run-custom-dependency-tests
@@ -2192,7 +2192,7 @@ tasks:
       - func: bootstrap kms servers
       - func: run custom csfle tests
         vars:
-          CSFLE_GIT_REF: ddb19ae22dc4a5f8b9208096f69fc23e19bae6c9
+          CSFLE_GIT_REF: ff9e095eaf72f9e442761f69080dae159a395d94
   - name: run-custom-csfle-tests-latest-master
     tags:
       - run-custom-dependency-tests

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -579,7 +579,7 @@ BUILD_VARIANTS.push({
 const oneOffFuncAsTasks = []
 
 for (const version of ['5.0', 'rapid', 'latest']) {
-  for (const ref of ['ddb19ae22dc4a5f8b9208096f69fc23e19bae6c9', 'master']) {
+  for (const ref of ['ff9e095eaf72f9e442761f69080dae159a395d94', 'master']) {
     oneOffFuncAsTasks.push({
       name: `run-custom-csfle-tests-${version}-${ref === 'master' ? ref : 'pinned-commit'}`,
       tags: ['run-custom-dependency-tests'],

--- a/.evergreen/run-custom-csfle-tests.sh
+++ b/.evergreen/run-custom-csfle-tests.sh
@@ -53,7 +53,6 @@ popd # mongo-c-driver
 pushd libmongocrypt/bindings/node
 
 npm install --production --ignore-scripts
-source ./.evergreen/find_cmake.sh
 bash ./etc/build-static.sh
 
 popd # libmongocrypt/bindings/node


### PR DESCRIPTION
### Description

Removes usage of `find_cmake` script and updates to latest fle sha1.

#### What is changing?

This fixes the CSFLE custom CI tasks.

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

NODE-4985

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
