### PR TITLE
feat(NODE-4767): Change abstract cursor return type

### DIFF
--- a/etc/notes/CHANGES_5.0.0.md
+++ b/etc/notes/CHANGES_5.0.0.md
@@ -192,7 +192,10 @@ The new minimum supported Node.js version is now 14.20.1.
 The MongoClient option `promiseLibrary` along with the `Promise.set` export that allows specifying a custom promise library has been removed.
 This allows the driver to adopt async/await syntax which has [performance benefits](https://v8.dev/blog/fast-async) over manual promise construction.
 
+### Cursors now implement `AsyncGenerator` interface instead of `AsyncIterator`
+
 All cursor types have been changed to implement `AsyncGenerator` instead of `AsyncIterator`.
+This was done to make our typing more accurate.
 
 ### Cursor closes on exit of for await of loops
 

--- a/etc/notes/CHANGES_5.0.0.md
+++ b/etc/notes/CHANGES_5.0.0.md
@@ -192,7 +192,7 @@ The new minimum supported Node.js version is now 14.20.1.
 The MongoClient option `promiseLibrary` along with the `Promise.set` export that allows specifying a custom promise library has been removed.
 This allows the driver to adopt async/await syntax which has [performance benefits](https://v8.dev/blog/fast-async) over manual promise construction.
 
-The cursor type has been changed to implement `AsyncGenerator` instead of `AsyncIterator`.
+All cursor types have been changed to implement `AsyncGenerator` instead of `AsyncIterator`.
 
 ### Cursor closes on exit of for await of loops
 

--- a/etc/notes/CHANGES_5.0.0.md
+++ b/etc/notes/CHANGES_5.0.0.md
@@ -192,6 +192,8 @@ The new minimum supported Node.js version is now 14.20.1.
 The MongoClient option `promiseLibrary` along with the `Promise.set` export that allows specifying a custom promise library has been removed.
 This allows the driver to adopt async/await syntax which has [performance benefits](https://v8.dev/blog/fast-async) over manual promise construction.
 
+The cursor type has been changed to implement `AsyncGenerator` instead of `AsyncIterator`.
+
 ### Cursor closes on exit of for await of loops
 
 Cursors will now automatically close when exiting a for await of loop on the cursor itself.

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -288,7 +288,7 @@ export abstract class AbstractCursor<
     return bufferedDocs;
   }
 
-  async *[Symbol.asyncIterator](): AsyncIterator<TSchema, void> {
+  async *[Symbol.asyncIterator](): AsyncGenerator<TSchema, void, void> {
     if (this.closed) {
       return;
     }


### PR DESCRIPTION
### Description

Change the return type of the `AbstractCursor`'s `asyncIterator` implementation to `AsyncGenerator`

##### Is there new documentation needed for these changes?

Yes. Added note in upgrade guide to mention type change.

#### What is the motivation for this change?

Narrowing the Typescript types for better developer experience.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
