### PR TITLE
feat(NODE-4992): Deprecate methods and options that reference legacy logger

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -774,7 +774,8 @@ export class Db {
     return new ChangeStream<TSchema, TChange>(this, pipeline, resolveOptions(this, options));
   }
 
-  /** Return the db logger
+  /**
+   * Return the db logger
    * @deprecated The Legacy Logger is deprecated and will be removed in the next major version.
    */
   getLogger(): Logger {

--- a/src/db.ts
+++ b/src/db.ts
@@ -775,12 +775,12 @@ export class Db {
   }
 
   /** Return the db logger
-   * @deprecated The Legacy Logger is deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
+   * @deprecated The Legacy Logger is deprecated and will be removed in the next major version.*/
   getLogger(): Logger {
     return this.s.logger;
   }
 
-  /** @deprecated The Legacy Logger is deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
+  /** @deprecated The Legacy Logger is deprecated and will be removed in the next major version.*/
   get logger(): Logger {
     return this.s.logger;
   }

--- a/src/db.ts
+++ b/src/db.ts
@@ -775,12 +775,13 @@ export class Db {
   }
 
   /** Return the db logger
-   * @deprecated The Legacy Logger is deprecated and will be removed in the next major version.*/
+   * @deprecated The Legacy Logger is deprecated and will be removed in the next major version.
+   */
   getLogger(): Logger {
     return this.s.logger;
   }
 
-  /** @deprecated The Legacy Logger is deprecated and will be removed in the next major version.*/
+  /** @deprecated The Legacy Logger is deprecated and will be removed in the next major version. */
   get logger(): Logger {
     return this.s.logger;
   }

--- a/src/db.ts
+++ b/src/db.ts
@@ -80,7 +80,6 @@ const DB_OPTIONS_ALLOW_LIST = [
 export interface DbPrivate {
   client: MongoClient;
   options?: DbOptions;
-  /** @deprecated The Legacy Logger is deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   logger: Logger;
   readPreference?: ReadPreference;
   pkFactory: PkFactory;

--- a/src/db.ts
+++ b/src/db.ts
@@ -80,6 +80,7 @@ const DB_OPTIONS_ALLOW_LIST = [
 export interface DbPrivate {
   client: MongoClient;
   options?: DbOptions;
+  /** @deprecated The Legacy Logger is deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   logger: Logger;
   readPreference?: ReadPreference;
   pkFactory: PkFactory;
@@ -774,11 +775,13 @@ export class Db {
     return new ChangeStream<TSchema, TChange>(this, pipeline, resolveOptions(this, options));
   }
 
-  /** Return the db logger */
+  /** Return the db logger
+   * @deprecated The Legacy Logger is deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   getLogger(): Logger {
     return this.s.logger;
   }
 
+  /** @deprecated The Legacy Logger is deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   get logger(): Logger {
     return this.s.logger;
   }

--- a/src/gridfs/download.ts
+++ b/src/gridfs/download.ts
@@ -184,8 +184,9 @@ export class GridFSBucketReadStream extends Readable implements NodeJS.ReadableS
    * the 'close' event once the cursor is successfully killed.
    *
    * @param callback - called when the cursor is successfully closed or an error occurred.
-   *
-   * @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance
+   */
+  abort(): Promise<void>;
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance
    */
   abort(callback: Callback<void>): void;
   abort(callback?: Callback<void>): Promise<void> | void {

--- a/src/gridfs/download.ts
+++ b/src/gridfs/download.ts
@@ -185,7 +185,7 @@ export class GridFSBucketReadStream extends Readable implements NodeJS.ReadableS
    *
    * @param callback - called when the cursor is successfully closed or an error occurred.
    *
-   * @deprecated GridFSBucketReadStream.abort is deprecated
+   * @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance
    */
   abort(callback?: Callback<void>): void {
     this.push(null);

--- a/src/gridfs/download.ts
+++ b/src/gridfs/download.ts
@@ -12,7 +12,7 @@ import {
 import type { FindOptions } from '../operations/find';
 import type { ReadPreference } from '../read_preference';
 import type { Sort } from '../sort';
-import type { Callback } from '../utils';
+import { Callback, maybeCallback } from '../utils';
 import type { GridFSChunk } from './upload';
 
 /** @public */
@@ -187,22 +187,24 @@ export class GridFSBucketReadStream extends Readable implements NodeJS.ReadableS
    *
    * @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance
    */
-  abort(callback?: Callback<void>): void {
-    this.push(null);
-    this.destroyed = true;
-    if (this.s.cursor) {
-      this.s.cursor.close(error => {
-        this.emit(GridFSBucketReadStream.CLOSE);
-        callback && callback(error);
-      });
-    } else {
-      if (!this.s.init) {
-        // If not initialized, fire close event because we will never
-        // get a cursor
-        this.emit(GridFSBucketReadStream.CLOSE);
+  abort(callback: Callback<void>): void;
+  abort(callback?: Callback<void>): Promise<void> | void {
+    return maybeCallback(async () => {
+      this.push(null);
+      this.destroyed = true;
+      if (this.s.cursor) {
+        await this.s.cursor.close().catch(error => {
+          this.emit(GridFSBucketReadStream.CLOSE);
+          throw error;
+        });
+      } else {
+        if (!this.s.init) {
+          // If not initialized, fire close event because we will never
+          // get a cursor
+          this.emit(GridFSBucketReadStream.CLOSE);
+        }
       }
-      callback && callback();
-    }
+    }, callback);
   }
 }
 

--- a/src/gridfs/download.ts
+++ b/src/gridfs/download.ts
@@ -186,8 +186,7 @@ export class GridFSBucketReadStream extends Readable implements NodeJS.ReadableS
    * @param callback - called when the cursor is successfully closed or an error occurred.
    */
   abort(): Promise<void>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance
-   */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   abort(callback: Callback<void>): void;
   abort(callback?: Callback<void>): Promise<void> | void {
     return maybeCallback(async () => {

--- a/src/gridfs/download.ts
+++ b/src/gridfs/download.ts
@@ -184,6 +184,8 @@ export class GridFSBucketReadStream extends Readable implements NodeJS.ReadableS
    * the 'close' event once the cursor is successfully killed.
    *
    * @param callback - called when the cursor is successfully closed or an error occurred.
+   *
+   * @deprecated GridFSBucketReadStream.abort is deprecated
    */
   abort(callback?: Callback<void>): void {
     this.push(null);

--- a/src/gridfs/index.ts
+++ b/src/gridfs/index.ts
@@ -227,7 +227,7 @@ export class GridFSBucket extends TypedEventEmitter<GridFSBucketEvents> {
   }
 
   /** Get the Db scoped logger.
-   * @deprecated Legacy Logger is deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance
+   * @deprecated Legacy Logger is deprecated and will be removed in the next major version.
    */
   getLogger(): Logger {
     return this.s.db.s.logger;

--- a/src/gridfs/index.ts
+++ b/src/gridfs/index.ts
@@ -226,7 +226,9 @@ export class GridFSBucket extends TypedEventEmitter<GridFSBucketEvents> {
     }, callback);
   }
 
-  /** Get the Db scoped logger. */
+  /** Get the Db scoped logger.
+   * @deprecated Legacy Logger is deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance
+   */
   getLogger(): Logger {
     return this.s.db.s.logger;
   }

--- a/src/gridfs/index.ts
+++ b/src/gridfs/index.ts
@@ -226,7 +226,9 @@ export class GridFSBucket extends TypedEventEmitter<GridFSBucketEvents> {
     }, callback);
   }
 
-  /** Get the Db scoped logger.
+  /**
+   * Get the Db scoped logger.
+   *
    * @deprecated Legacy Logger is deprecated and will be removed in the next major version.
    */
   getLogger(): Logger {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -29,15 +29,18 @@ export const LoggerLevel = Object.freeze({
 } as const);
 
 /** @public
- * @deprecated The Legacy Logger is deprecated and will be removed in the next major version.*/
+ *  @deprecated The Legacy Logger is deprecated and will be removed in the next major version.
+ */
 export type LoggerLevel = typeof LoggerLevel[keyof typeof LoggerLevel];
 
 /** @public
- * @deprecated The Legacy Logger is deprecated and will be removed in the next major version.*/
+ *  @deprecated The Legacy Logger is deprecated and will be removed in the next major version.
+ */
 export type LoggerFunction = (message?: any, ...optionalParams: any[]) => void;
 
 /** @public
- * @deprecated The Legacy Logger is deprecated and will be removed in the next major version.*/
+ *  @deprecated The Legacy Logger is deprecated and will be removed in the next major version.
+ */
 export interface LoggerOptions {
   logger?: LoggerFunction;
   loggerLevel?: LoggerLevel;

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -15,7 +15,8 @@ const pid = process.pid;
 // eslint-disable-next-line no-console
 let currentLogger: LoggerFunction = console.warn;
 
-/** @public
+/**
+ * @public
  * @deprecated The Legacy Logger is deprecated and will be removed in the next major version.*/
 export const LoggerLevel = Object.freeze({
   ERROR: 'error',
@@ -28,18 +29,21 @@ export const LoggerLevel = Object.freeze({
   debug: 'debug'
 } as const);
 
-/** @public
- *  @deprecated The Legacy Logger is deprecated and will be removed in the next major version.
+/**
+ * @public
+ * @deprecated The Legacy Logger is deprecated and will be removed in the next major version.
  */
 export type LoggerLevel = typeof LoggerLevel[keyof typeof LoggerLevel];
 
-/** @public
- *  @deprecated The Legacy Logger is deprecated and will be removed in the next major version.
+/**
+ * @public
+ * @deprecated The Legacy Logger is deprecated and will be removed in the next major version.
  */
 export type LoggerFunction = (message?: any, ...optionalParams: any[]) => void;
 
-/** @public
- *  @deprecated The Legacy Logger is deprecated and will be removed in the next major version.
+/**
+ * @public
+ * @deprecated The Legacy Logger is deprecated and will be removed in the next major version.
  */
 export interface LoggerOptions {
   logger?: LoggerFunction;

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -17,7 +17,8 @@ let currentLogger: LoggerFunction = console.warn;
 
 /**
  * @public
- * @deprecated The Legacy Logger is deprecated and will be removed in the next major version.*/
+ * @deprecated The Legacy Logger is deprecated and will be removed in the next major version.
+ */
 export const LoggerLevel = Object.freeze({
   ERROR: 'error',
   WARN: 'warn',

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -15,7 +15,8 @@ const pid = process.pid;
 // eslint-disable-next-line no-console
 let currentLogger: LoggerFunction = console.warn;
 
-/** @public */
+/** @public
+ * @deprecated The Legacy Logger is deprecated and will be removed in the next major version.*/
 export const LoggerLevel = Object.freeze({
   ERROR: 'error',
   WARN: 'warn',
@@ -27,13 +28,16 @@ export const LoggerLevel = Object.freeze({
   debug: 'debug'
 } as const);
 
-/** @public */
+/** @public
+ * @deprecated The Legacy Logger is deprecated and will be removed in the next major version.*/
 export type LoggerLevel = typeof LoggerLevel[keyof typeof LoggerLevel];
 
-/** @public */
+/** @public
+ * @deprecated The Legacy Logger is deprecated and will be removed in the next major version.*/
 export type LoggerFunction = (message?: any, ...optionalParams: any[]) => void;
 
-/** @public */
+/** @public
+ * @deprecated The Legacy Logger is deprecated and will be removed in the next major version.*/
 export interface LoggerOptions {
   logger?: LoggerFunction;
   loggerLevel?: LoggerLevel;

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -717,7 +717,7 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> {
   }
 
   /** Return the mongo client logger
-   * @deprecated The Legacy Logger is deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance*/
+   * @deprecated The Legacy Logger is deprecated and will be removed in the next major version.*/
   getLogger(): LegacyLogger {
     return this.s.logger;
   }

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -233,9 +233,13 @@ export interface MongoClientOptions extends BSONSerializeOptions, SupportedNodeC
    * @deprecated Setting a custom promise library is deprecated the next major version will use the global Promise constructor only.
    */
   promiseLibrary?: any;
-  /** The logging level */
+  /** The logging level
+   * @deprecated The Legacy Logger is deprecated and will be removed in the next major version
+   * */
   loggerLevel?: LegacyLoggerLevel;
-  /** Custom logger object */
+  /** Custom logger object
+   * @deprecated The Legacy Logger is deprecated and will be removed in the next major version
+   */
   logger?: LegacyLogger;
   /** Enable command monitoring for this client */
   monitorCommands?: boolean;
@@ -421,6 +425,7 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> {
     return this.s.bsonOptions;
   }
 
+  /** @deprecated The Legacy Logger is deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   get logger(): LegacyLogger {
     return this.s.logger;
   }
@@ -711,7 +716,8 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> {
     return new ChangeStream<TSchema, TChange>(this, pipeline, resolveOptions(this, options));
   }
 
-  /** Return the mongo client logger */
+  /** Return the mongo client logger
+   * @deprecated The Legacy Logger is deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance*/
   getLogger(): LegacyLogger {
     return this.s.logger;
   }

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -233,11 +233,13 @@ export interface MongoClientOptions extends BSONSerializeOptions, SupportedNodeC
    * @deprecated Setting a custom promise library is deprecated the next major version will use the global Promise constructor only.
    */
   promiseLibrary?: any;
-  /** The logging level
+  /**
+   * The logging level
    * @deprecated The Legacy Logger is deprecated and will be removed in the next major version.
-   * */
+   */
   loggerLevel?: LegacyLoggerLevel;
-  /** Custom logger object
+  /**
+   * Custom logger object
    * @deprecated The Legacy Logger is deprecated and will be removed in the next major version.
    */
   logger?: LegacyLogger;
@@ -425,7 +427,7 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> {
     return this.s.bsonOptions;
   }
 
-  /** @deprecated The Legacy Logger is deprecated and will be removed in the next major version.*/
+  /** @deprecated The Legacy Logger is deprecated and will be removed in the next major version. */
   get logger(): LegacyLogger {
     return this.s.logger;
   }
@@ -716,8 +718,10 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> {
     return new ChangeStream<TSchema, TChange>(this, pipeline, resolveOptions(this, options));
   }
 
-  /** Return the mongo client logger
-   * @deprecated The Legacy Logger is deprecated and will be removed in the next major version.*/
+  /** 
+   * Return the mongo client logger
+   * @deprecated The Legacy Logger is deprecated and will be removed in the next major version.
+   */
   getLogger(): LegacyLogger {
     return this.s.logger;
   }

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -718,7 +718,7 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> {
     return new ChangeStream<TSchema, TChange>(this, pipeline, resolveOptions(this, options));
   }
 
-  /** 
+  /**
    * Return the mongo client logger
    * @deprecated The Legacy Logger is deprecated and will be removed in the next major version.
    */

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -234,11 +234,11 @@ export interface MongoClientOptions extends BSONSerializeOptions, SupportedNodeC
    */
   promiseLibrary?: any;
   /** The logging level
-   * @deprecated The Legacy Logger is deprecated and will be removed in the next major version
+   * @deprecated The Legacy Logger is deprecated and will be removed in the next major version.
    * */
   loggerLevel?: LegacyLoggerLevel;
   /** Custom logger object
-   * @deprecated The Legacy Logger is deprecated and will be removed in the next major version
+   * @deprecated The Legacy Logger is deprecated and will be removed in the next major version.
    */
   logger?: LegacyLogger;
   /** Enable command monitoring for this client */
@@ -425,7 +425,7 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> {
     return this.s.bsonOptions;
   }
 
-  /** @deprecated The Legacy Logger is deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
+  /** @deprecated The Legacy Logger is deprecated and will be removed in the next major version.*/
   get logger(): LegacyLogger {
     return this.s.logger;
   }
@@ -436,7 +436,7 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> {
    * @see docs.mongodb.org/manual/reference/connection-string/
    */
   connect(): Promise<this>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version.*/
   connect(callback: Callback<this>): void;
   connect(callback?: Callback<this>): Promise<this> | void {
     if (callback && typeof callback !== 'function') {

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -436,7 +436,7 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> {
    * @see docs.mongodb.org/manual/reference/connection-string/
    */
   connect(): Promise<this>;
-  /** @deprecated Callbacks are deprecated and will be removed in the next major version.*/
+  /** @deprecated Callbacks are deprecated and will be removed in the next major version. See [mongodb-legacy](https://github.com/mongodb-js/nodejs-mongodb-legacy) for migration assistance */
   connect(callback: Callback<this>): void;
   connect(callback?: Callback<this>): Promise<this> | void {
     if (callback && typeof callback !== 'function') {


### PR DESCRIPTION
### Description

Deprecating methods and options that are being removed in the driver v5.

#### What is changing?

Deprecating the following methods

- [x] MongoClient.getLogger()
- [x] MongoClient.logger()
- [x] Db.getLogger()
- [x] Db.logger()
- [x] GridFSBucket.getLogger()
- [x] GridFSBucketReadStream.abort()

Deprecating the following options

- [x] MongoClient.logger
- [x] MongoClient.loggerLevel

##### Is there new documentation needed for these changes?

No, documentation is in the tsdoc comments

#### What is the motivation for this change?

Getting rid of old logger cleanly to make way for spec-compliant logger.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] New TODOs have a related JIRA ticket
