### PR TITLE
chore(NODE-4993): update fle hash to pull in promise tests

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2132,7 +2132,7 @@ tasks:
       - func: bootstrap kms servers
       - func: run custom csfle tests
         vars:
-          CSFLE_GIT_REF: ff9e095eaf72f9e442761f69080dae159a395d94
+          CSFLE_GIT_REF: e8e0c0b07db62b0e8ee0e5f3b669a180a94df1e8
   - name: run-custom-csfle-tests-5.0-master
     tags:
       - run-custom-dependency-tests
@@ -2162,7 +2162,7 @@ tasks:
       - func: bootstrap kms servers
       - func: run custom csfle tests
         vars:
-          CSFLE_GIT_REF: ff9e095eaf72f9e442761f69080dae159a395d94
+          CSFLE_GIT_REF: e8e0c0b07db62b0e8ee0e5f3b669a180a94df1e8
   - name: run-custom-csfle-tests-rapid-master
     tags:
       - run-custom-dependency-tests
@@ -2192,7 +2192,7 @@ tasks:
       - func: bootstrap kms servers
       - func: run custom csfle tests
         vars:
-          CSFLE_GIT_REF: ff9e095eaf72f9e442761f69080dae159a395d94
+          CSFLE_GIT_REF: e8e0c0b07db62b0e8ee0e5f3b669a180a94df1e8
   - name: run-custom-csfle-tests-latest-master
     tags:
       - run-custom-dependency-tests

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -579,7 +579,7 @@ BUILD_VARIANTS.push({
 const oneOffFuncAsTasks = []
 
 for (const version of ['5.0', 'rapid', 'latest']) {
-  for (const ref of ['ff9e095eaf72f9e442761f69080dae159a395d94', 'master']) {
+  for (const ref of ['e8e0c0b07db62b0e8ee0e5f3b669a180a94df1e8', 'master']) {
     oneOffFuncAsTasks.push({
       name: `run-custom-csfle-tests-${version}-${ref === 'master' ? ref : 'pinned-commit'}`,
       tags: ['run-custom-dependency-tests'],


### PR DESCRIPTION
### Description

#### What is changing?

Bumps pinned commit for FLE

#### What is the motivation for this change?

Need promise style tests

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
