### PR TITLE
fix(NODE-4998): use ipv4 in socks5 tests for node 18

### DIFF
--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -434,6 +434,7 @@ functions:
           export DRIVERS_TOOLS="${DRIVERS_TOOLS}"
           export NODE_LTS_NAME='${NODE_LTS_NAME}'
           export MONGODB_URI="${MONGODB_URI}"
+          export TEST_SOCKS5_CSFLE="${TEST_SOCKS5_CSFLE}"
           export SSL="${SSL}"
 
           # Disable xtrace (just in case it was accidentally set).

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -398,6 +398,8 @@ functions:
 
           export MONGODB_URI="${MONGODB_URI}"
 
+          export TEST_SOCKS5_CSFLE="${TEST_SOCKS5_CSFLE}"
+
           export SSL="${SSL}"
 
 
@@ -1303,6 +1305,18 @@ tasks:
           TOPOLOGY: replica_set
       - func: bootstrap kms servers
       - func: run socks5 tests
+  - name: test-socks5-csfle
+    tags: []
+    commands:
+      - func: install dependencies
+      - func: bootstrap mongo-orchestration
+        vars:
+          VERSION: latest
+          TOPOLOGY: replica_set
+      - func: bootstrap kms servers
+      - func: run socks5 tests
+        vars:
+          TEST_SOCKS5_CSFLE: 'true'
   - name: test-socks5-tls
     tags: []
     commands:
@@ -2661,6 +2675,7 @@ buildvariants:
       - test-auth-kerberos
       - test-auth-ldap
       - test-socks5
+      - test-socks5-csfle
       - test-socks5-tls
       - test-zstd-compression
       - test-snappy-compression
@@ -2709,6 +2724,7 @@ buildvariants:
       - test-auth-kerberos
       - test-auth-ldap
       - test-socks5
+      - test-socks5-csfle
       - test-socks5-tls
       - test-tls-support-latest
       - test-tls-support-6.0
@@ -2754,6 +2770,7 @@ buildvariants:
       - test-latest-load-balanced
       - test-auth-ldap
       - test-socks5
+      - test-socks5-csfle
       - test-socks5-tls
       - test-tls-support-latest
       - test-tls-support-6.0
@@ -2798,6 +2815,7 @@ buildvariants:
       - test-6.0-load-balanced
       - test-latest-load-balanced
       - test-auth-ldap
+      - test-socks5-csfle
       - test-socks5-tls
       - test-tls-support-latest
       - test-tls-support-6.0
@@ -2838,6 +2856,7 @@ buildvariants:
       - test-latest-server-v1-api
       - test-atlas-data-lake
       - test-socks5
+      - test-socks5-csfle
       - test-socks5-tls
       - test-zstd-compression
       - test-snappy-compression
@@ -2880,6 +2899,7 @@ buildvariants:
       - test-latest-server-v1-api
       - test-atlas-data-lake
       - test-socks5
+      - test-socks5-csfle
       - test-socks5-tls
       - test-tls-support-latest
       - test-tls-support-6.0
@@ -2920,6 +2940,7 @@ buildvariants:
       - test-latest-server-v1-api
       - test-atlas-data-lake
       - test-socks5
+      - test-socks5-csfle
       - test-socks5-tls
       - test-tls-support-latest
       - test-tls-support-6.0

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -205,6 +205,27 @@ TASKS.push(
       ]
     },
     {
+      name: 'test-socks5-csfle',
+      tags: [],
+      commands: [
+        { func: 'install dependencies' },
+        {
+          func: 'bootstrap mongo-orchestration',
+          vars: {
+            VERSION: 'latest',
+            TOPOLOGY: 'replica_set'
+          }
+        },
+        { func: 'bootstrap kms servers' },
+        {
+          func: 'run socks5 tests',
+          vars: {
+            TEST_SOCKS5_CSFLE: 'true'
+          }
+        }
+      ]
+    },
+    {
       name: 'test-socks5-tls',
       tags: [],
       commands: [

--- a/.evergreen/run-socks5-tests.sh
+++ b/.evergreen/run-socks5-tests.sh
@@ -30,21 +30,27 @@ fi
 
 # First, test with Socks5 + authentication required
 "$PYTHON_BINARY" "$SOCKS5_SERVER_SCRIPT" --port 1080 --auth username:p4ssw0rd --map "127.0.0.1:12345 to $FIRST_HOST" &
-PID=$!
-env SOCKS5_CONFIG='["127.0.0.1",1080,"username","p4ssw0rd"]' npm run check:socks5
-[[ $TEST_SOCKS5_CSFLE == "true" ]] && [ "$SSL" == "nossl" ] && [[ "$OSTYPE" == "linux-gnu"* ]] && \
+SOCKS5_PROXY_PID=$!
+if [[ $TEST_SOCKS5_CSFLE == "true" ]]; then
+  [ "$SSL" == "nossl" ] && [[ "$OSTYPE" == "linux-gnu"* ]] && \
   env MONGODB_URI='mongodb://127.0.0.1:12345/?proxyHost=127.0.0.1&proxyUsername=username&proxyPassword=p4ssw0rd' \
   bash "${PROJECT_DIRECTORY}/.evergreen/run-custom-csfle-tests.sh"
-kill $PID
+else
+  env SOCKS5_CONFIG='["127.0.0.1",1080,"username","p4ssw0rd"]' npm run check:socks5
+fi
+kill $SOCKS5_PROXY_PID
 
 # Second, test with Socks5 + no authentication
 "$PYTHON_BINARY" "$SOCKS5_SERVER_SCRIPT" --port 1081 --map "127.0.0.1:12345 to $FIRST_HOST" &
-PID=$!
-env SOCKS5_CONFIG='["127.0.0.1",1081]' npm run check:socks5
-[[ $TEST_SOCKS5_CSFLE == "true" ]] && [ "$SSL" == "nossl" ] && [[ "$OSTYPE" == "linux-gnu"* ]] && \
-  env MONGODB_URI='mongodb://127.0.0.1:12345/?proxyHost=127.0.0.1&proxyPort=1081' \
-  bash "${PROJECT_DIRECTORY}/.evergreen/run-custom-csfle-tests.sh"
-kill $PID
+SOCKS5_PROXY_PID=$!
+if [[ $TEST_SOCKS5_CSFLE == "true" ]]; then
+  [ "$SSL" == "nossl" ] && [[ "$OSTYPE" == "linux-gnu"* ]] && \
+    env MONGODB_URI='mongodb://127.0.0.1:12345/?proxyHost=127.0.0.1&proxyPort=1081' \
+    bash "${PROJECT_DIRECTORY}/.evergreen/run-custom-csfle-tests.sh"
+else
+  env SOCKS5_CONFIG='["127.0.0.1",1081]' npm run check:socks5
+fi
+kill $SOCKS5_PROXY_PID
 
 # TODO: It might be worth using something more robust to control
 # the Socks5 proxy server script's lifetime

--- a/.evergreen/run-socks5-tests.sh
+++ b/.evergreen/run-socks5-tests.sh
@@ -32,7 +32,7 @@ fi
 "$PYTHON_BINARY" "$SOCKS5_SERVER_SCRIPT" --port 1080 --auth username:p4ssw0rd --map "127.0.0.1:12345 to $FIRST_HOST" &
 PID=$!
 env SOCKS5_CONFIG='["127.0.0.1",1080,"username","p4ssw0rd"]' npm run check:socks5
-[ "$SSL" == "nossl" ] && [[ "$OSTYPE" == "linux-gnu"* ]] && \
+[[ $TEST_SOCKS5_CSFLE == "true" ]] && [ "$SSL" == "nossl" ] && [[ "$OSTYPE" == "linux-gnu"* ]] && \
   env MONGODB_URI='mongodb://127.0.0.1:12345/?proxyHost=127.0.0.1&proxyUsername=username&proxyPassword=p4ssw0rd' \
   bash "${PROJECT_DIRECTORY}/.evergreen/run-custom-csfle-tests.sh"
 kill $PID
@@ -41,7 +41,7 @@ kill $PID
 "$PYTHON_BINARY" "$SOCKS5_SERVER_SCRIPT" --port 1081 --map "127.0.0.1:12345 to $FIRST_HOST" &
 PID=$!
 env SOCKS5_CONFIG='["127.0.0.1",1081]' npm run check:socks5
-[ "$SSL" == "nossl" ] && [[ "$OSTYPE" == "linux-gnu"* ]] && \
+[[ $TEST_SOCKS5_CSFLE == "true" ]] && [ "$SSL" == "nossl" ] && [[ "$OSTYPE" == "linux-gnu"* ]] && \
   env MONGODB_URI='mongodb://127.0.0.1:12345/?proxyHost=127.0.0.1&proxyPort=1081' \
   bash "${PROJECT_DIRECTORY}/.evergreen/run-custom-csfle-tests.sh"
 kill $PID

--- a/.evergreen/run-socks5-tests.sh
+++ b/.evergreen/run-socks5-tests.sh
@@ -18,9 +18,9 @@ fi
 
 # Grab a connection string that only refers to *one* of the hosts in MONGODB_URI
 FIRST_HOST=$(node -p 'new (require("mongodb-connection-string-url").default)(process.env.MONGODB_URI).hosts[0]')
-# Use localhost:12345 as the URL for the single host that we connect to,
+# Use 127.0.0.1:12345 as the URL for the single host that we connect to,
 # we configure the Socks5 proxy server script to redirect from this to FIRST_HOST
-export MONGODB_URI_SINGLEHOST="mongodb://localhost:12345/"
+export MONGODB_URI_SINGLEHOST="mongodb://127.0.0.1:12345/"
 
 # Compute path to socks5 fake server script in a way that works on Windows
 SOCKS5_SERVER_SCRIPT="$DRIVERS_TOOLS/.evergreen/socks5srv.py"
@@ -29,20 +29,20 @@ if [ "Windows_NT" = "$OS" ]; then
 fi
 
 # First, test with Socks5 + authentication required
-"$PYTHON_BINARY" "$SOCKS5_SERVER_SCRIPT" --port 1080 --auth username:p4ssw0rd --map "localhost:12345 to $FIRST_HOST" &
+"$PYTHON_BINARY" "$SOCKS5_SERVER_SCRIPT" --port 1080 --auth username:p4ssw0rd --map "127.0.0.1:12345 to $FIRST_HOST" &
 PID=$!
-env SOCKS5_CONFIG='["localhost",1080,"username","p4ssw0rd"]' npm run check:socks5
+env SOCKS5_CONFIG='["127.0.0.1",1080,"username","p4ssw0rd"]' npm run check:socks5
 [ "$SSL" == "nossl" ] && [[ "$OSTYPE" == "linux-gnu"* ]] && \
-  env MONGODB_URI='mongodb://localhost:12345/?proxyHost=localhost&proxyUsername=username&proxyPassword=p4ssw0rd' \
+  env MONGODB_URI='mongodb://127.0.0.1:12345/?proxyHost=127.0.0.1&proxyUsername=username&proxyPassword=p4ssw0rd' \
   bash "${PROJECT_DIRECTORY}/.evergreen/run-custom-csfle-tests.sh"
 kill $PID
 
 # Second, test with Socks5 + no authentication
-"$PYTHON_BINARY" "$SOCKS5_SERVER_SCRIPT" --port 1081 --map "localhost:12345 to $FIRST_HOST" &
+"$PYTHON_BINARY" "$SOCKS5_SERVER_SCRIPT" --port 1081 --map "127.0.0.1:12345 to $FIRST_HOST" &
 PID=$!
-env SOCKS5_CONFIG='["localhost",1081]' npm run check:socks5
+env SOCKS5_CONFIG='["127.0.0.1",1081]' npm run check:socks5
 [ "$SSL" == "nossl" ] && [[ "$OSTYPE" == "linux-gnu"* ]] && \
-  env MONGODB_URI='mongodb://localhost:12345/?proxyHost=localhost&proxyPort=1081' \
+  env MONGODB_URI='mongodb://127.0.0.1:12345/?proxyHost=127.0.0.1&proxyPort=1081' \
   bash "${PROJECT_DIRECTORY}/.evergreen/run-custom-csfle-tests.sh"
 kill $PID
 


### PR DESCRIPTION
### Description

#### What is changing?

* Changes the proxy host addresses to be IPv4 to avoid node 18 dns issue
* Splits socks5 driver only run from socks5 csfle run

#### What is the motivation for this change?

Green ci

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
