### PR TITLE
feat(NODE-5016)!: compile ts with target es2020

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,7 +2,7 @@
   "root": true,
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
-    "ecmaVersion": 2019
+    "ecmaVersion": 2020
   },
   "plugins": [
     "simple-import-sort",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,11 +4,13 @@
     "checkJs": false,
     "strict": true,
     "alwaysStrict": true,
-    "target": "ES2019",
+    "target": "ES2020",
     "module": "commonJS",
     "moduleResolution": "node",
     "skipLibCheck": true,
-    "lib": ["es2020"],
+    "lib": [
+      "es2020"
+    ],
     // We don't make use of tslib helpers, all syntax used is supported by target engine
     "importHelpers": false,
     "noEmitHelpers": true,
@@ -25,7 +27,9 @@
     // we include sources in the release
     "inlineSources": false,
     // Prevents web types from being suggested by vscode.
-    "types": ["node"],
+    "types": [
+      "node"
+    ],
     "forceConsistentCasingInFileNames": true,
     "noImplicitOverride": true,
     "noImplicitReturns": true,
@@ -36,5 +40,7 @@
     "transpileOnly": true,
     "compiler": "typescript-cached-transpile"
   },
-  "include": ["src/**/*"]
+  "include": [
+    "src/**/*"
+  ]
 }


### PR DESCRIPTION
### Description

#### What is changing?

- tsconfig "target" set to es2020
- eslintrc ecmaVersion set to es2020

#### What is the motivation for this change?

Align output syntax with ts syntax.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
