### PR TITLE
chore(NODE-4983): bump BSON to v5.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.0.0-alpha.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "bson": "^5.0.0-alpha.3",
+        "bson": "^5.0.0",
         "mongodb-connection-string-url": "^2.6.0",
         "socks": "^2.7.1"
       },
@@ -3134,9 +3134,9 @@
       }
     },
     "node_modules/bson": {
-      "version": "5.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-5.0.0-alpha.3.tgz",
-      "integrity": "sha512-bxrSDfyd4NRL38sD72SRsQp00U2oW2fDuN+GiZfsXzZYzSMABWId2U/scSrLAjrMEmBno60BDAdzO/O1q+5rfg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-5.0.0.tgz",
+      "integrity": "sha512-EL2KpZdyhshyyptj6pnQfnFKPoncD9KwZYvgmj/FXQiOUU1HWTHWmBOP4TZXU3YzStcI5qgpIl68YnMo16s26A==",
       "engines": {
         "node": ">=14.20.1"
       }
@@ -11977,9 +11977,9 @@
       }
     },
     "bson": {
-      "version": "5.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-5.0.0-alpha.3.tgz",
-      "integrity": "sha512-bxrSDfyd4NRL38sD72SRsQp00U2oW2fDuN+GiZfsXzZYzSMABWId2U/scSrLAjrMEmBno60BDAdzO/O1q+5rfg=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-5.0.0.tgz",
+      "integrity": "sha512-EL2KpZdyhshyyptj6pnQfnFKPoncD9KwZYvgmj/FXQiOUU1HWTHWmBOP4TZXU3YzStcI5qgpIl68YnMo16s26A=="
     },
     "buffer": {
       "version": "5.7.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "email": "dbx-node@mongodb.com"
   },
   "dependencies": {
-    "bson": "^5.0.0-alpha.3",
+    "bson": "^5.0.0",
     "mongodb-connection-string-url": "^2.6.0",
     "socks": "^2.7.1"
   },


### PR DESCRIPTION
### Description

#### What is changing?

Update BSON to v5.0.0

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
