### PR TITLE
test(NODE-5022): skip socks5-csfle tests on windows

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1306,7 +1306,8 @@ tasks:
       - func: bootstrap kms servers
       - func: run socks5 tests
   - name: test-socks5-csfle
-    tags: []
+    tags:
+      - socks5-csfle
     commands:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
@@ -2856,7 +2857,6 @@ buildvariants:
       - test-latest-server-v1-api
       - test-atlas-data-lake
       - test-socks5
-      - test-socks5-csfle
       - test-socks5-tls
       - test-zstd-compression
       - test-snappy-compression
@@ -2899,7 +2899,6 @@ buildvariants:
       - test-latest-server-v1-api
       - test-atlas-data-lake
       - test-socks5
-      - test-socks5-csfle
       - test-socks5-tls
       - test-tls-support-latest
       - test-tls-support-6.0
@@ -2940,7 +2939,6 @@ buildvariants:
       - test-latest-server-v1-api
       - test-atlas-data-lake
       - test-socks5
-      - test-socks5-csfle
       - test-socks5-tls
       - test-tls-support-latest
       - test-tls-support-6.0

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -39,7 +39,7 @@ const OPERATING_SYSTEMS = [
 }));
 
 // TODO: NODE-3060: enable skipped tests on windows
-const WINDOWS_SKIP_TAGS = new Set(['atlas-connect', 'auth', 'load_balancer']);
+const WINDOWS_SKIP_TAGS = new Set(['atlas-connect', 'auth', 'load_balancer', 'socks5-csfle']);
 
 const TASKS = [];
 const SINGLETON_TASKS = [];
@@ -206,7 +206,7 @@ TASKS.push(
     },
     {
       name: 'test-socks5-csfle',
-      tags: [],
+      tags: ['socks5-csfle'],
       commands: [
         { func: 'install dependencies' },
         {

--- a/.evergreen/run-kms-servers.sh
+++ b/.evergreen/run-kms-servers.sh
@@ -1,6 +1,7 @@
 cd ${DRIVERS_TOOLS}/.evergreen/csfle
 . ./activate-kmstlsvenv.sh
 # by default it always runs on port 5698
+ls -la ./kmstlsvenv/bin/
 ./kmstlsvenv/bin/python3 -u kms_kmip_server.py &
 ./kmstlsvenv/bin/python3 -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/expired.pem --port 8000  &
 ./kmstlsvenv/bin/python3 -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/wrong-host.pem --port 8001  &

--- a/.evergreen/run-kms-servers.sh
+++ b/.evergreen/run-kms-servers.sh
@@ -1,8 +1,7 @@
 cd ${DRIVERS_TOOLS}/.evergreen/csfle
 . ./activate-kmstlsvenv.sh
 # by default it always runs on port 5698
-ls -la ./kmstlsvenv/bin/
-./kmstlsvenv/bin/python3 -u kms_kmip_server.py &
-./kmstlsvenv/bin/python3 -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/expired.pem --port 8000  &
-./kmstlsvenv/bin/python3 -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/wrong-host.pem --port 8001  &
-./kmstlsvenv/bin/python3 -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/server.pem --port 8002 --require_client_cert &
+python -u kms_kmip_server.py &
+python -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/expired.pem --port 8000  &
+python -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/wrong-host.pem --port 8001  &
+python -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/server.pem --port 8002 --require_client_cert &


### PR DESCRIPTION
### Description

Just use the python in the path once the env is set.

#### What is changing?

Calls to python are just the main runtime name.

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
