### PR TITLE
fix(NODE-5027): revert "ensure that MessageStream is destroyed when connections are destroyed"

### DIFF
--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -52,7 +52,7 @@ else
   source "$DRIVERS_TOOLS"/.evergreen/csfle/set-temp-creds.sh
 fi
 
-npm install mongodb-client-encryption@"2.4.0-alpha.2"
+npm install mongodb-client-encryption@"2.4.0"
 npm install @mongodb-js/zstd
 npm install snappy
 

--- a/src/cmap/connect.ts
+++ b/src/cmap/connect.ts
@@ -96,7 +96,7 @@ function performInitialHandshake(
 ) {
   const callback: Callback<Document> = function (err, ret) {
     if (err && conn) {
-      conn.destroy({ force: false });
+      conn.destroy();
     }
     _callback(err, ret);
   };

--- a/src/cmap/connection.ts
+++ b/src/cmap/connection.ts
@@ -133,7 +133,7 @@ export interface ConnectionOptions
 /** @public */
 export interface DestroyOptions {
   /** Force the destruction. */
-  force: boolean;
+  force?: boolean;
 }
 
 /** @public */
@@ -154,8 +154,8 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
   address: string;
   socketTimeoutMS: number;
   monitorCommands: boolean;
-  /** Indicates that the connection (including underlying TCP socket) has been closed. */
   closed: boolean;
+  destroyed: boolean;
   lastHelloMS?: number;
   serverApi?: ServerApi;
   helloOk?: boolean;
@@ -204,6 +204,7 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
     this.monitorCommands = options.monitorCommands;
     this.serverApi = options.serverApi;
     this.closed = false;
+    this.destroyed = false;
     this[kHello] = null;
     this[kClusterTime] = null;
 
@@ -296,7 +297,10 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
     if (this.closed) {
       return;
     }
-    this.destroy({ force: false });
+
+    this[kStream].destroy(error);
+
+    this.closed = true;
 
     for (const op of this[kQueue].values()) {
       op.cb(error);
@@ -310,7 +314,8 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
     if (this.closed) {
       return;
     }
-    this.destroy({ force: false });
+
+    this.closed = true;
 
     const message = `connection ${this.id} to ${this.address} closed`;
     for (const op of this[kQueue].values()) {
@@ -327,7 +332,9 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
     }
 
     this[kDelayedTimeoutId] = setTimeout(() => {
-      this.destroy({ force: false });
+      this[kStream].destroy();
+
+      this.closed = true;
 
       const message = `connection ${this.id} to ${this.address} timed out`;
       const beforeHandshake = this.hello == null;
@@ -436,27 +443,41 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
     callback(undefined, message.documents[0]);
   }
 
-  destroy(options: DestroyOptions, callback?: Callback): void {
+  destroy(options?: DestroyOptions, callback?: Callback): void {
+    if (typeof options === 'function') {
+      callback = options;
+      options = { force: false };
+    }
+
     this.removeAllListeners(Connection.PINNED);
     this.removeAllListeners(Connection.UNPINNED);
 
-    this[kMessageStream].destroy();
-    this.closed = true;
+    options = Object.assign({ force: false }, options);
+    if (this[kStream] == null || this.destroyed) {
+      this.destroyed = true;
+      if (typeof callback === 'function') {
+        callback();
+      }
+
+      return;
+    }
 
     if (options.force) {
       this[kStream].destroy();
-      if (callback) {
-        return process.nextTick(callback);
+      this.destroyed = true;
+      if (typeof callback === 'function') {
+        callback();
       }
+
+      return;
     }
 
-    if (!this[kStream].writableEnded) {
-      this[kStream].end(callback);
-    } else {
-      if (callback) {
-        return process.nextTick(callback);
+    this[kStream].end(() => {
+      this.destroyed = true;
+      if (typeof callback === 'function') {
+        callback();
       }
-    }
+    });
   }
 
   command(

--- a/src/cmap/connection.ts
+++ b/src/cmap/connection.ts
@@ -130,7 +130,7 @@ export interface ConnectionOptions
   metadata: ClientMetadata;
 }
 
-/** @public */
+/** @internal */
 export interface DestroyOptions {
   /** Force the destruction. */
   force?: boolean;

--- a/src/cmap/connection_pool.ts
+++ b/src/cmap/connection_pool.ts
@@ -510,7 +510,7 @@ export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
           ConnectionPool.CONNECTION_CLOSED,
           new ConnectionClosedEvent(this, conn, 'poolClosed')
         );
-        conn.destroy({ force: !!options.force }, cb);
+        conn.destroy(options, cb);
       },
       err => {
         this[kConnections].clear();
@@ -586,7 +586,7 @@ export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
       new ConnectionClosedEvent(this, connection, reason)
     );
     // destroy the connection
-    process.nextTick(() => connection.destroy({ force: false }));
+    process.nextTick(() => connection.destroy());
   }
 
   private connectionIsStale(connection: Connection) {

--- a/src/sdam/server.ts
+++ b/src/sdam/server.ts
@@ -241,10 +241,7 @@ export class Server extends TypedEventEmitter<ServerEvents> {
 
   /** Destroy the server connection */
   destroy(options?: DestroyOptions, callback?: Callback): void {
-    if (typeof options === 'function') {
-      callback = options;
-      options = { force: false };
-    }
+    if (typeof options === 'function') (callback = options), (options = {});
     options = Object.assign({}, { force: false }, options);
 
     if (this.s.state === STATE_CLOSED) {

--- a/src/sdam/topology.ts
+++ b/src/sdam/topology.ts
@@ -466,17 +466,26 @@ export class Topology extends TypedEventEmitter<TopologyEvents> {
   }
 
   /** Close this topology */
+  close(callback: Callback): void;
   close(options: CloseOptions): void;
   close(options: CloseOptions, callback: Callback): void;
-  close(options?: CloseOptions, callback?: Callback): void {
-    options = options ?? { force: false };
+  close(options?: CloseOptions | Callback, callback?: Callback): void {
+    if (typeof options === 'function') {
+      callback = options;
+      options = {};
+    }
+
+    if (typeof options === 'boolean') {
+      options = { force: options };
+    }
+    options = options ?? {};
 
     if (this.s.state === STATE_CLOSED || this.s.state === STATE_CLOSING) {
       return callback?.();
     }
 
     const destroyedServers = Array.from(this.s.servers.values(), server => {
-      return promisify(destroyServer)(server, this, { force: !!options?.force });
+      return promisify(destroyServer)(server, this, options as CloseOptions);
     });
 
     Promise.all(destroyedServers)
@@ -731,7 +740,7 @@ function destroyServer(
   options?: DestroyOptions,
   callback?: Callback
 ) {
-  options = options ?? { force: false };
+  options = options ?? {};
   for (const event of LOCAL_SERVER_EVENTS) {
     server.removeAllListeners(event);
   }

--- a/test/integration/crud/misc_cursors.test.js
+++ b/test/integration/crud/misc_cursors.test.js
@@ -13,7 +13,6 @@ const { ReadPreference } = require('../../mongodb');
 const { ServerType } = require('../../mongodb');
 const { formatSort } = require('../../mongodb');
 const { getSymbolFrom } = require('../../tools/utils');
-const { MongoExpiredSessionError } = require('../../mongodb');
 
 describe('Cursor', function () {
   before(function () {
@@ -1868,31 +1867,61 @@ describe('Cursor', function () {
     }
   });
 
-  it('closes cursors when client is closed even if it has not been exhausted', async function () {
-    await client
-      .db()
-      .dropCollection('test_cleanup_tailable')
-      .catch(() => null);
+  it('should close dead tailable cursors', {
+    metadata: {
+      os: '!win32' // NODE-2943: timeout on windows
+    },
 
-    const collection = await client
-      .db()
-      .createCollection('test_cleanup_tailable', { capped: true, size: 1000, max: 3 });
+    test: function (done) {
+      // http://www.mongodb.org/display/DOCS/Tailable+Cursors
 
-    // insert only 2 docs in capped coll of 3
-    await collection.insertMany([{ a: 1 }, { a: 1 }]);
+      const configuration = this.configuration;
+      client.connect((err, client) => {
+        expect(err).to.not.exist;
+        this.defer(() => client.close());
 
-    const cursor = collection.find({}, { tailable: true, awaitData: true, maxAwaitTimeMS: 2000 });
+        const db = client.db(configuration.db);
+        const options = { capped: true, size: 10000000 };
+        db.createCollection(
+          'test_if_dead_tailable_cursors_close',
+          options,
+          function (err, collection) {
+            expect(err).to.not.exist;
 
-    await cursor.next();
-    await cursor.next();
-    // will block for maxAwaitTimeMS (except we are closing the client)
-    const rejectedEarlyBecauseClientClosed = cursor.next().catch(error => error);
+            let closeCount = 0;
+            const docs = Array.from({ length: 100 }).map(() => ({ a: 1 }));
+            collection.insertMany(docs, { w: 'majority', wtimeoutMS: 5000 }, err => {
+              expect(err).to.not.exist;
 
-    await client.close();
-    expect(cursor).to.have.property('killed', true);
+              const cursor = collection.find({}, { tailable: true, awaitData: true });
+              const stream = cursor.stream();
 
-    const error = await rejectedEarlyBecauseClientClosed;
-    expect(error).to.be.instanceOf(MongoExpiredSessionError);
+              stream.resume();
+
+              var validator = () => {
+                closeCount++;
+                if (closeCount === 2) {
+                  done();
+                }
+              };
+
+              // we validate that the stream "ends" either cleanly or with an error
+              stream.on('end', validator);
+              stream.on('error', validator);
+
+              cursor.on('close', validator);
+
+              const docs = Array.from({ length: 100 }).map(() => ({ a: 1 }));
+              collection.insertMany(docs, err => {
+                expect(err).to.not.exist;
+
+                setTimeout(() => client.close());
+              });
+            });
+          }
+        );
+      });
+    }
   });
 
   it('shouldAwaitData', {

--- a/test/integration/node-specific/topology.test.js
+++ b/test/integration/node-specific/topology.test.js
@@ -10,20 +10,12 @@ describe('Topology', function () {
       const states = [];
       topology.on('stateChanged', (_, newState) => states.push(newState));
       topology.connect(err => {
-        try {
+        expect(err).to.not.exist;
+        topology.close(err => {
           expect(err).to.not.exist;
-        } catch (error) {
-          done(error);
-        }
-        topology.close({}, err => {
-          try {
-            expect(err).to.not.exist;
-            expect(topology.isDestroyed()).to.be.true;
-            expect(states).to.eql(['connecting', 'connected', 'closing', 'closed']);
-            done();
-          } catch (error) {
-            done(error);
-          }
+          expect(topology.isDestroyed()).to.be.true;
+          expect(states).to.eql(['connecting', 'connected', 'closing', 'closed']);
+          done();
         });
       });
     }

--- a/test/unit/assorted/polling_srv_records_for_mongos_discovery.prose.test.ts
+++ b/test/unit/assorted/polling_srv_records_for_mongos_discovery.prose.test.ts
@@ -103,7 +103,7 @@ describe('Polling Srv Records for Mongos Discovery', () => {
 
     afterEach(function (done) {
       if (context.topology) {
-        context.topology.close({}, done);
+        context.topology.close(done);
       } else {
         done();
       }

--- a/test/unit/assorted/server_selection_spec_helper.js
+++ b/test/unit/assorted/server_selection_spec_helper.js
@@ -109,7 +109,7 @@ function executeServerSelectionTest(testDefinition, testDone) {
     });
 
   function done(err) {
-    topology.close({}, e => testDone(e || err));
+    topology.close(e => testDone(e || err));
   }
 
   topology.connect(err => {

--- a/test/unit/error.test.ts
+++ b/test/unit/error.test.ts
@@ -381,7 +381,7 @@ describe('MongoErrors', () => {
 
       makeAndConnectReplSet((err, topology) => {
         // cleanup the server before calling done
-        const cleanup = err => topology.close({}, err2 => done(err || err2));
+        const cleanup = err => topology.close(err2 => done(err || err2));
 
         if (err) {
           return cleanup(err);

--- a/test/unit/sdam/monitor.test.ts
+++ b/test/unit/sdam/monitor.test.ts
@@ -56,7 +56,7 @@ describe('monitoring', function () {
         const serverDescription = Array.from(topology.description.servers.values())[0];
         expect(serverDescription).property('roundTripTime').to.be.greaterThan(0);
 
-        topology.close({}, done as any);
+        topology.close(done as any);
       }, 500);
     });
   }).skipReason = 'TODO(NODE-3819): Unskip flaky tests';
@@ -96,7 +96,7 @@ describe('monitoring', function () {
       const serverDescription = Array.from(topology.description.servers.values())[0];
       expect(serverDescription).property('roundTripTime').to.be.greaterThan(0);
 
-      topology.close({}, done);
+      topology.close(done);
     });
   }).skipReason = 'TODO(NODE-3600): Unskip flaky tests';
 

--- a/test/unit/sdam/topology.test.js
+++ b/test/unit/sdam/topology.test.js
@@ -26,7 +26,7 @@ describe('Topology (unit)', function () {
     }
 
     if (topology) {
-      topology.close({});
+      topology.close();
     }
   });
 
@@ -107,7 +107,7 @@ describe('Topology (unit)', function () {
 
       topology.connect(() => {
         expect(topology.shouldCheckForSessionSupport()).to.be.true;
-        topology.close({}, done);
+        topology.close(done);
       });
     });
 
@@ -127,7 +127,7 @@ describe('Topology (unit)', function () {
 
       topology.connect(() => {
         expect(topology.shouldCheckForSessionSupport()).to.be.false;
-        topology.close({}, done);
+        topology.close(done);
       });
     });
 
@@ -147,7 +147,7 @@ describe('Topology (unit)', function () {
 
       topology.connect(() => {
         expect(topology.shouldCheckForSessionSupport()).to.be.false;
-        topology.close({}, done);
+        topology.close(done);
       });
     });
   });
@@ -182,7 +182,7 @@ describe('Topology (unit)', function () {
             expect(err).to.exist;
             expect(err).to.match(/timed out/);
 
-            topology.close({}, done);
+            topology.close(done);
           });
         });
       });
@@ -325,7 +325,7 @@ describe('Topology (unit)', function () {
             expect(err).to.exist;
             expect(err).to.eql(serverDescription.error);
             expect(poolCleared).to.be.false;
-            topology.close({}, done);
+            topology.close(done);
           });
         });
       });
@@ -467,7 +467,7 @@ describe('Topology (unit)', function () {
 
         it('should clean up listeners on close', function (done) {
           topology.s.state = 'connected'; // fake state to test clean up logic
-          topology.close({}, e => {
+          topology.close(e => {
             const srvPollerListeners = topology.s.srvPoller.listeners(
               SrvPoller.SRV_RECORD_DISCOVERY
             );
@@ -547,7 +547,7 @@ describe('Topology (unit)', function () {
           // occurs `requestCheck` will be called for an immediate check.
           expect(requestCheck).property('callCount').to.equal(1);
 
-          topology.close({}, done);
+          topology.close(done);
         });
       });
     });
@@ -559,7 +559,7 @@ describe('Topology (unit)', function () {
         this.emit('connect');
       });
 
-      topology.close({}, () => {
+      topology.close(() => {
         topology.selectServer(ReadPreference.primary, { serverSelectionTimeoutMS: 2000 }, err => {
           expect(err).to.exist;
           expect(err).to.match(/Topology is closed/);


### PR DESCRIPTION
This reverts commit 8338bae933c777dee4e7e49dbcf52c4fd7047528.

### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
