### PR TITLE
ci(NODE-5032): fix windows node 18.14.0 npm version issue

### DIFF
--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -375,7 +375,7 @@ functions:
         working_dir: "src"
         script: |
           ${PREPARE_SHELL}
-          NODE_LTS_NAME=${NODE_LTS_NAME} MSVS_VERSION=${MSVS_VERSION} NPM_OPTIONS=${NPM_OPTIONS}\
+          NODE_LTS_NAME=${NODE_LTS_NAME} NPM_OPTIONS=${NPM_OPTIONS}\
             bash ${PROJECT_DIRECTORY}/.evergreen/install-dependencies.sh
     - command: expansions.update
       params:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -334,7 +334,7 @@ functions:
         working_dir: src
         script: |
           ${PREPARE_SHELL}
-          NODE_LTS_NAME=${NODE_LTS_NAME} MSVS_VERSION=${MSVS_VERSION} NPM_OPTIONS=${NPM_OPTIONS}\
+          NODE_LTS_NAME=${NODE_LTS_NAME} NPM_OPTIONS=${NPM_OPTIONS}\
             bash ${PROJECT_DIRECTORY}/.evergreen/install-dependencies.sh
     - command: expansions.update
       params:
@@ -2828,7 +2828,6 @@ buildvariants:
     run_on: windows-64-vs2019-large
     expansions:
       NODE_LTS_NAME: fermium
-      MSVS_VERSION: 2019
     tasks:
       - test-latest-server
       - test-latest-replica_set
@@ -2870,7 +2869,6 @@ buildvariants:
     run_on: windows-64-vs2019-large
     expansions:
       NODE_LTS_NAME: gallium
-      MSVS_VERSION: 2019
     tasks:
       - test-latest-server
       - test-latest-replica_set
@@ -2910,7 +2908,6 @@ buildvariants:
     run_on: windows-64-vs2019-large
     expansions:
       NODE_LTS_NAME: hydrogen
-      MSVS_VERSION: 2019
     tasks:
       - test-latest-server
       - test-latest-replica_set

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -28,7 +28,6 @@ const OPERATING_SYSTEMS = [
     name: 'windows-64-vs2019',
     display_name: 'Windows (VS2019)',
     run_on: 'windows-64-vs2019-large',
-    msvsVersion: 2019,
     clientEncryption: false // TODO(NODE-3401): Unskip when Windows no longer fails to launch mongocryptd occasionally
   }
 ].map(osConfig => ({
@@ -395,7 +394,6 @@ for (const
     run_on,
     nodeVersions = NODE_VERSIONS,
     clientEncryption,
-    msvsVersion
   } of OPERATING_SYSTEMS) {
   const testedNodeVersions = NODE_VERSIONS.filter(version => nodeVersions.includes(version));
   const os = osName.split('-')[0];
@@ -417,9 +415,6 @@ for (const
 
     if (clientEncryption) {
       expansions.CLIENT_ENCRYPTION = true;
-    }
-    if (msvsVersion) {
-      expansions.MSVS_VERSION = msvsVersion;
     }
 
     BUILD_VARIANTS.push({ name, display_name, run_on, expansions, tasks: taskNames });

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -99,22 +99,12 @@ EOT
   which node || echo "node not found, PATH=$PATH"
   which npm || echo "npm not found, PATH=$PATH"
   npm cache clear --force # Fixes: Cannot read properties of null (reading 'pickAlgorithm') error on windows
-  npm config set msvs_version ${MSVS_VERSION}
-  npm config set scripts-prepend-node-path true
 
 # install Node.js on Linux/MacOS
 else
   curl -o- $NVM_URL | bash
   [ -s "${NVM_DIR}/nvm.sh" ] && source "${NVM_DIR}/nvm.sh"
   nvm install --no-progress "$NODE_VERSION"
-
-  # setup npm cache in a local directory
-  cat <<EOT > .npmrc
-devdir=${NPM_CACHE_DIR}/.node-gyp
-init-module=${NPM_CACHE_DIR}/.npm-init.js
-cache=${NPM_CACHE_DIR}
-tmp=${NPM_TMP_DIR}
-EOT
 fi
 
 npm install ${NPM_OPTIONS}

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -5,19 +5,14 @@ NVM_WINDOWS_URL="https://github.com/coreybutler/nvm-windows/releases/download/1.
 NVM_URL="https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh"
 
 NODE_LTS_NAME=${NODE_LTS_NAME:-fermium}
-MSVS_VERSION=${MSVS_VERSION:-2019}
 NODE_ARTIFACTS_PATH="${PROJECT_DIRECTORY}/node-artifacts"
-NPM_CACHE_DIR="${NODE_ARTIFACTS_PATH}/npm"
-NPM_TMP_DIR="${NODE_ARTIFACTS_PATH}/tmp"
 
 # this needs to be explicitly exported for the nvm install below
 export NVM_DIR="${NODE_ARTIFACTS_PATH}/nvm"
 export XDG_CONFIG_HOME=${NODE_ARTIFACTS_PATH}
 
 # create node artifacts path if needed
-mkdir -p ${NODE_ARTIFACTS_PATH}
-mkdir -p ${NPM_CACHE_DIR}
-mkdir -p "${NPM_TMP_DIR}"
+mkdir -p "${NODE_ARTIFACTS_PATH}"
 
 function node_lts_to_version() {
   case $1 in


### PR DESCRIPTION
### Description

#### What is changing?

Remove from npm settings that are no longer supported (and unused)

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
