### PR TITLE
test(NODE-5033): fix handshake error message check

### DIFF
--- a/test/integration/client-side-encryption/client_side_encryption.prose.test.js
+++ b/test/integration/client-side-encryption/client_side_encryption.prose.test.js
@@ -1422,7 +1422,7 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
           expect.fail('it must fail with no tls');
         } catch (e) {
           //Expect an error indicating TLS handshake failed.
-          expect(e.originalError.message).to.include('before secure TLS connection');
+          expect(e.originalError.message).to.match(/before secure TLS connection|handshake/);
         }
       });
 


### PR DESCRIPTION
### Description

Fix the CSFLE handshake error test.

#### What is changing?

- Check for both the old and new handshake error messages in the prose test.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-5033

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
