### PR TITLE
fix(NODE-5064): consolidate connection cleanup logic and ensure socket is always closed

### DIFF
--- a/src/cmap/connection.ts
+++ b/src/cmap/connection.ts
@@ -154,8 +154,8 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
   address: string;
   socketTimeoutMS: number;
   monitorCommands: boolean;
+  /** Indicates that the connection (including underlying TCP socket) has been closed. */
   closed: boolean;
-  destroyed: boolean;
   lastHelloMS?: number;
   serverApi?: ServerApi;
   helloOk?: boolean;
@@ -204,7 +204,6 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
     this.monitorCommands = options.monitorCommands;
     this.serverApi = options.serverApi;
     this.closed = false;
-    this.destroyed = false;
     this[kHello] = null;
     this[kClusterTime] = null;
 
@@ -297,10 +296,7 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
     if (this.closed) {
       return;
     }
-
-    this[kStream].destroy(error);
-
-    this.closed = true;
+    this.destroy({ force: false });
 
     for (const op of this[kQueue].values()) {
       op.cb(error);
@@ -314,8 +310,7 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
     if (this.closed) {
       return;
     }
-
-    this.closed = true;
+    this.destroy({ force: false });
 
     const message = `connection ${this.id} to ${this.address} closed`;
     for (const op of this[kQueue].values()) {
@@ -332,9 +327,7 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
     }
 
     this[kDelayedTimeoutId] = setTimeout(() => {
-      this[kStream].destroy();
-
-      this.closed = true;
+      this.destroy({ force: false });
 
       const message = `connection ${this.id} to ${this.address} timed out`;
       const beforeHandshake = this.hello == null;
@@ -447,31 +440,23 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
     this.removeAllListeners(Connection.PINNED);
     this.removeAllListeners(Connection.UNPINNED);
 
-    if (this[kStream] == null || this.destroyed) {
-      this.destroyed = true;
-      if (typeof callback === 'function') {
-        callback();
-      }
-
-      return;
-    }
+    this[kMessageStream].destroy();
+    this.closed = true;
 
     if (options.force) {
       this[kStream].destroy();
-      this.destroyed = true;
-      if (typeof callback === 'function') {
-        callback();
+      if (callback) {
+        return process.nextTick(callback);
       }
-
-      return;
     }
 
-    this[kStream].end(() => {
-      this.destroyed = true;
-      if (typeof callback === 'function') {
-        callback();
+    if (!this[kStream].writableEnded) {
+      this[kStream].end(callback);
+    } else {
+      if (callback) {
+        return process.nextTick(callback);
       }
-    });
+    }
   }
 
   command(

--- a/src/cmap/connection.ts
+++ b/src/cmap/connection.ts
@@ -293,26 +293,19 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
   }
 
   onError(error: Error) {
-    if (this.closed) {
-      return;
-    }
-    this.cleanup(false, error);
+    this.cleanup(true, error);
   }
 
   onClose() {
     const message = `connection ${this.id} to ${this.address} closed`;
-    this.cleanup(false, new MongoNetworkError(message));
+    this.cleanup(true, new MongoNetworkError(message));
   }
 
   onTimeout() {
-    if (this.closed) {
-      return;
-    }
-
     this[kDelayedTimeoutId] = setTimeout(() => {
       const message = `connection ${this.id} to ${this.address} timed out`;
       const beforeHandshake = this.hello == null;
-      this.cleanup(false, new MongoNetworkTimeoutError(message, { beforeHandshake }));
+      this.cleanup(true, new MongoNetworkTimeoutError(message, { beforeHandshake }));
     }, 1).unref(); // No need for this timer to hold the event loop open
   }
 

--- a/src/cmap/connection.ts
+++ b/src/cmap/connection.ts
@@ -449,8 +449,18 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
       this.emit(Connection.CLOSE);
     };
 
-    this.removeAllListeners(Connection.PINNED);
-    this.removeAllListeners(Connection.UNPINNED);
+    for (const event of [
+      Connection.MESSAGE,
+      Connection.PINNED,
+      Connection.UNPINNED,
+      Connection.COMMAND_STARTED,
+      Connection.COMMAND_FAILED,
+      Connection.COMMAND_SUCCEEDED,
+      Connection.CLUSTER_TIME_RECEIVED
+    ]) {
+      this.removeAllListeners(event);
+    }
+
     this[kStream].removeAllListeners();
     this[kMessageStream].removeAllListeners();
 

--- a/test/integration/crud/misc_cursors.test.js
+++ b/test/integration/crud/misc_cursors.test.js
@@ -14,7 +14,6 @@ const { ReadPreference, MongoExpiredSessionError } = require('../../mongodb');
 const { ServerType } = require('../../mongodb');
 const { formatSort } = require('../../mongodb');
 const { getSymbolFrom } = require('../../tools/utils');
-const { MongoExpiredSessionError } = require('../../../src/error');
 
 describe('Cursor', function () {
   before(function () {

--- a/test/integration/crud/misc_cursors.test.js
+++ b/test/integration/crud/misc_cursors.test.js
@@ -14,6 +14,7 @@ const { ReadPreference, MongoExpiredSessionError } = require('../../mongodb');
 const { ServerType } = require('../../mongodb');
 const { formatSort } = require('../../mongodb');
 const { getSymbolFrom } = require('../../tools/utils');
+const { MongoExpiredSessionError } = require('../../../src/error');
 
 describe('Cursor', function () {
   before(function () {

--- a/test/unit/cmap/connection.test.ts
+++ b/test/unit/cmap/connection.test.ts
@@ -433,8 +433,12 @@ describe('new Connection()', function () {
       connection.on('close', () => {
         closeCount++;
       });
-      connection.once(Connection.PINNED, () => {});
-      connection.once(Connection.UNPINNED, () => {});
+      connection.once(Connection.PINNED, () => {
+        /* no-op */
+      });
+      connection.once(Connection.UNPINNED, () => {
+        /* no-op */
+      });
 
       // Stick an operation description in the queue.
       const queueSymbol = getSymbolFrom(connection, 'queue');
@@ -579,8 +583,12 @@ describe('new Connection()', function () {
         closeCount++;
       });
 
-      connection.once(Connection.PINNED, () => {});
-      connection.once(Connection.UNPINNED, () => {});
+      connection.once(Connection.PINNED, () => {
+        /* no-op */
+      });
+      connection.once(Connection.UNPINNED, () => {
+        /* no-op */
+      });
 
       // Stick an operation description in the queue.
       const queueSymbol = getSymbolFrom(connection, 'queue');
@@ -664,8 +672,12 @@ describe('new Connection()', function () {
         closeCount++;
       });
 
-      connection.once(Connection.PINNED, () => {});
-      connection.once(Connection.UNPINNED, () => {});
+      connection.once(Connection.PINNED, () => {
+        /* no-op */
+      });
+      connection.once(Connection.UNPINNED, () => {
+        /* no-op */
+      });
 
       // Stick an operation description in the queue.
       const queueSymbol = getSymbolFrom(connection, 'queue');
@@ -797,13 +809,17 @@ describe('new Connection()', function () {
     });
 
     it('removes all Connection.PINNED listeners', () => {
-      connection.once(Connection.PINNED, () => {});
+      connection.once(Connection.PINNED, () => {
+        /* no-op */
+      });
       connection.destroy({ force: true });
       expect(connection.listenerCount(Connection.PINNED)).to.equal(0);
     });
 
     it('removes all Connection.UNPINNED listeners', () => {
-      connection.once(Connection.UNPINNED, () => {});
+      connection.once(Connection.UNPINNED, () => {
+        /* no-op */
+      });
       connection.destroy({ force: true });
       expect(connection.listenerCount(Connection.UNPINNED)).to.equal(0);
     });

--- a/test/unit/cmap/connection.test.ts
+++ b/test/unit/cmap/connection.test.ts
@@ -75,7 +75,7 @@ class InputStream extends Readable {
   }
 }
 
-describe.only('new Connection()', function () {
+describe('new Connection()', function () {
   let server;
   after(() => mock.cleanup());
   before(() => mock.createServer().then(s => (server = s)));
@@ -457,13 +457,6 @@ describe.only('new Connection()', function () {
         timeoutSpy = sinon.spy(connection, 'onTimeout');
       });
 
-      afterEach(() => {
-        sinon.restore();
-        timerSandbox.restore();
-        clock.restore();
-        sinon.restore();
-      });
-
       it('delays timeout errors by one tick', async () => {
         expect(connection).to.have.property(kDelayedTimeoutId, null);
 
@@ -512,7 +505,7 @@ describe.only('new Connection()', function () {
         clock.tick(1);
       });
 
-      it('destroys the message stream', () => {
+      it('destroys the MessageStream', () => {
         expect(messageStream.destroyed).to.be.true;
       });
 
@@ -534,17 +527,17 @@ describe.only('new Connection()', function () {
         expect(closeCount).to.equal(1);
       });
 
-      it('removes all listeners on the message stream', () => {
-        expect(messageStream.eventNames()).to.deep.equal([]);
+      it('removes all listeners on the MessageStream', () => {
+        expect(messageStream.eventNames()).to.have.lengthOf(0);
       });
 
       it('removes all listeners on the socket', () => {
-        expect(driverSocket.eventNames()).to.deep.equal([]);
+        expect(driverSocket.eventNames()).to.have.lengthOf(0);
       });
     });
   });
 
-  describe('when the message stream errors', () => {
+  describe('when the MessageStream errors', () => {
     let connection: sinon.SinonSpiedInstance<Connection>;
     let clock: sinon.SinonFakeTimers;
     let timerSandbox: sinon.SinonFakeTimers;
@@ -590,7 +583,7 @@ describe.only('new Connection()', function () {
       clock.restore();
     });
 
-    it('destroys the message stream synchronously', () => {
+    it('destroys the MessageStream synchronously', () => {
       expect(messageStream.destroyed).to.be.true;
     });
 
@@ -617,12 +610,12 @@ describe.only('new Connection()', function () {
       expect(closeCount).to.equal(1);
     });
 
-    it('removes all listeners on the message stream', () => {
-      expect(messageStream.eventNames()).to.deep.equal([]);
+    it('removes all listeners on the MessageStream', () => {
+      expect(messageStream.eventNames()).to.have.lengthOf(0);
     });
 
     it('removes all listeners on the socket', () => {
-      expect(driverSocket.eventNames()).to.deep.equal([]);
+      expect(driverSocket.eventNames()).to.have.lengthOf(0);
     });
   });
 
@@ -671,7 +664,7 @@ describe.only('new Connection()', function () {
       clock.restore();
     });
 
-    it('destroys the message stream synchronously', () => {
+    it('destroys the MessageStream synchronously', () => {
       expect(messageStream.destroyed).to.be.true;
     });
 
@@ -700,12 +693,12 @@ describe.only('new Connection()', function () {
       expect(closeCount).to.equal(1);
     });
 
-    it('removes all listeners on the message stream', () => {
-      expect(messageStream.eventNames()).to.deep.equal([]);
+    it('removes all listeners on the MessageStream', () => {
+      expect(messageStream.eventNames()).to.have.lengthOf(0);
     });
 
     it('removes all listeners on the socket', () => {
-      expect(driverSocket.eventNames()).to.deep.equal([]);
+      expect(driverSocket.eventNames()).to.have.lengthOf(0);
     });
   });
 

--- a/test/unit/cmap/connection.test.ts
+++ b/test/unit/cmap/connection.test.ts
@@ -75,7 +75,7 @@ class InputStream extends Readable {
   }
 }
 
-describe.only('new Connection()', function () {
+describe('new Connection()', function () {
   let server;
   after(() => mock.cleanup());
   before(() => mock.createServer().then(s => (server = s)));
@@ -133,7 +133,7 @@ describe.only('new Connection()', function () {
         expect(err).to.be.instanceOf(MongoNetworkTimeoutError);
         expect(result).to.not.exist;
 
-        expect(conn).property('stream').property('writableEnded', true);
+        expect(conn).property('stream').property('destroyed', true);
 
         done();
       });
@@ -604,22 +604,15 @@ describe.only('new Connection()', function () {
       expect(driverSocket.writableEnded).to.be.true;
     });
 
-    it('destroys the socket after ending it (asynchronously)', () => {
-      expect(driverSocket.writableEnded).to.be.true;
-      expect(driverSocket.destroyed).to.be.false;
-      clock.runAll();
+    it('destroys the socket after ending it (synchronously)', () => {
       expect(driverSocket.destroyed).to.be.true;
     });
 
-    it('passes the error along to any callbacks in the operation description queue (asynchronously)', () => {
-      expect(callbackSpy).not.to.have.been.called;
-      clock.runAll();
+    it('passes the error along to any callbacks in the operation description queue (synchronously)', () => {
       expect(callbackSpy).to.have.been.calledOnceWithExactly(error);
     });
 
-    it('emits a Connection.CLOSE event (asynchronously)', () => {
-      expect(closeCount).to.equal(0);
-      clock.runAll();
+    it('emits a Connection.CLOSE event (synchronously)', () => {
       expect(closeCount).to.equal(1);
     });
 
@@ -696,24 +689,17 @@ describe.only('new Connection()', function () {
       expect(driverSocket.writableEnded).to.be.true;
     });
 
-    it('destroys the socket after ending it (asynchronously)', () => {
-      expect(driverSocket.writableEnded).to.be.true;
-      expect(driverSocket.destroyed).to.be.false;
-      clock.runAll();
+    it('destroys the socket after ending it (synchronously)', () => {
       expect(driverSocket.destroyed).to.be.true;
     });
 
-    it('calls any callbacks in the queue with a MongoNetworkError (asynchronously)', () => {
-      expect(callbackSpy).not.to.have.been.called;
-      clock.runAll();
+    it('calls any callbacks in the queue with a MongoNetworkError (synchronously)', () => {
       expect(callbackSpy).to.have.been.calledOnce;
       const error = callbackSpy.firstCall.args[0];
       expect(error).to.be.instanceof(MongoNetworkError);
     });
 
-    it('emits a Connection.CLOSE event (asynchronously)', () => {
-      expect(closeCount).to.equal(0);
-      clock.runAll();
+    it('emits a Connection.CLOSE event (synchronously)', () => {
       expect(closeCount).to.equal(1);
     });
 

--- a/test/unit/cmap/connection.test.ts
+++ b/test/unit/cmap/connection.test.ts
@@ -31,6 +31,7 @@ const connectionOptionsDefaults = {
 
 /** The absolute minimum socket API needed by Connection as of writing this test */
 class FakeSocket extends EventEmitter {
+  writableEnded: boolean;
   address() {
     // is never called
   }
@@ -39,12 +40,34 @@ class FakeSocket extends EventEmitter {
   }
   destroy() {
     // is called, has no side effects
+    this.writableEnded = true;
+  }
+  end(cb) {
+    this.writableEnded = true;
+    // nextTick to simulate I/O delay
+    if (typeof cb === 'function') {
+      process.nextTick(cb);
+    }
   }
   get remoteAddress() {
     return 'iLoveJavaScript';
   }
   get remotePort() {
     return 123;
+  }
+}
+
+class InputStream extends Readable {
+  writableEnded: boolean;
+  constructor(options?) {
+    super(options);
+  }
+
+  end(cb) {
+    this.writableEnded = true;
+    if (typeof cb === 'function') {
+      process.nextTick(cb);
+    }
   }
 }
 
@@ -106,7 +129,7 @@ describe('new Connection()', function () {
         expect(err).to.be.instanceOf(MongoNetworkTimeoutError);
         expect(result).to.not.exist;
 
-        expect(conn).property('stream').property('destroyed', true);
+        expect(conn).property('stream').property('writableEnded', true);
 
         done();
       });
@@ -175,7 +198,7 @@ describe('new Connection()', function () {
 
       context('when multiple hellos exist on the stream', function () {
         let callbackSpy;
-        const inputStream = new Readable();
+        const inputStream = new InputStream();
         const document = { ok: 1 };
         const last = { isWritablePrimary: true };
 
@@ -394,7 +417,7 @@ describe('new Connection()', function () {
       connection = sinon.spy(new Connection(driverSocket, connectionOptionsDefaults));
       const messageStreamSymbol = getSymbolFrom(connection, 'messageStream');
       kDelayedTimeoutId = getSymbolFrom(connection, 'delayedTimeoutId');
-      messageStream = connection[messageStreamSymbol];
+      messageStream = sinon.spy(connection[messageStreamSymbol]);
     });
 
     afterEach(() => {
@@ -407,13 +430,15 @@ describe('new Connection()', function () {
 
       driverSocket.emit('timeout');
       expect(connection.onTimeout).to.have.been.calledOnce;
+      expect(connection.destroy).to.not.have.been.called;
       expect(connection).to.have.property(kDelayedTimeoutId).that.is.instanceOf(NodeJSTimeoutClass);
       expect(connection).to.have.property('closed', false);
-      expect(driverSocket.destroy).to.not.have.been.called;
+      expect(driverSocket.end).to.not.have.been.called;
 
       clock.tick(1);
 
-      expect(driverSocket.destroy).to.have.been.calledOnce;
+      expect(driverSocket.end).to.have.been.calledOnce;
+      expect(connection.destroy).to.have.been.calledOnce;
       expect(connection).to.have.property('closed', true);
     });
 
@@ -437,6 +462,88 @@ describe('new Connection()', function () {
       expect(driverSocket.destroy).to.not.have.been.called;
       expect(connection).to.have.property('closed', false);
       expect(connection).to.have.property(kDelayedTimeoutId, null);
+    });
+
+    it('destroys the message stream and socket', () => {
+      expect(connection).to.have.property(kDelayedTimeoutId, null);
+
+      driverSocket.emit('timeout');
+
+      clock.tick(1);
+
+      expect(connection.onTimeout).to.have.been.calledOnce;
+      expect(connection).to.have.property(kDelayedTimeoutId).that.is.instanceOf(NodeJSTimeoutClass);
+
+      expect(messageStream.destroy).to.have.been.calledOnce;
+      expect(driverSocket.destroy).to.not.have.been.called;
+      expect(driverSocket.end).to.have.been.calledOnce;
+    });
+  });
+
+  describe('onError()', () => {
+    let connection: sinon.SinonSpiedInstance<Connection>;
+    let clock: sinon.SinonFakeTimers;
+    let timerSandbox: sinon.SinonFakeTimers;
+    let driverSocket: sinon.SinonSpiedInstance<FakeSocket>;
+    let messageStream: MessageStream;
+    beforeEach(() => {
+      timerSandbox = createTimerSandbox();
+      clock = sinon.useFakeTimers();
+      driverSocket = sinon.spy(new FakeSocket());
+      // @ts-expect-error: driverSocket does not fully satisfy the stream type, but that's okay
+      connection = sinon.spy(new Connection(driverSocket, connectionOptionsDefaults));
+      const messageStreamSymbol = getSymbolFrom(connection, 'messageStream');
+      messageStream = sinon.spy(connection[messageStreamSymbol]);
+    });
+
+    afterEach(() => {
+      timerSandbox.restore();
+      clock.restore();
+    });
+
+    it('destroys the message stream and socket', () => {
+      messageStream.emit('error');
+      clock.tick(1);
+      expect(connection.onError).to.have.been.calledOnce;
+      connection.destroy({ force: false });
+      clock.tick(1);
+      expect(messageStream.destroy).to.have.been.called;
+      expect(driverSocket.destroy).to.not.have.been.called;
+      expect(driverSocket.end).to.have.been.calledOnce;
+    });
+  });
+
+  describe('onClose()', () => {
+    let connection: sinon.SinonSpiedInstance<Connection>;
+    let clock: sinon.SinonFakeTimers;
+    let timerSandbox: sinon.SinonFakeTimers;
+    let driverSocket: sinon.SinonSpiedInstance<FakeSocket>;
+    let messageStream: MessageStream;
+    beforeEach(() => {
+      timerSandbox = createTimerSandbox();
+      clock = sinon.useFakeTimers();
+
+      driverSocket = sinon.spy(new FakeSocket());
+      // @ts-expect-error: driverSocket does not fully satisfy the stream type, but that's okay
+      connection = sinon.spy(new Connection(driverSocket, connectionOptionsDefaults));
+      const messageStreamSymbol = getSymbolFrom(connection, 'messageStream');
+      messageStream = sinon.spy(connection[messageStreamSymbol]);
+    });
+
+    afterEach(() => {
+      timerSandbox.restore();
+      clock.restore();
+    });
+
+    it('destroys the message stream and socket', () => {
+      driverSocket.emit('close');
+      clock.tick(1);
+      expect(connection.onClose).to.have.been.calledOnce;
+      connection.destroy({ force: false });
+      clock.tick(1);
+      expect(messageStream.destroy).to.have.been.called;
+      expect(driverSocket.destroy).to.not.have.been.called;
+      expect(driverSocket.end).to.have.been.calledOnce;
     });
   });
 
@@ -488,6 +595,98 @@ describe('new Connection()', function () {
         it('returns false', function () {
           expect(hasSessionSupport(connection)).to.be.false;
         });
+      });
+    });
+  });
+
+  describe('destroy()', () => {
+    let connection: sinon.SinonSpiedInstance<Connection>;
+    let clock: sinon.SinonFakeTimers;
+    let timerSandbox: sinon.SinonFakeTimers;
+    let driverSocket: sinon.SinonSpiedInstance<FakeSocket>;
+    let messageStream: MessageStream;
+    beforeEach(() => {
+      timerSandbox = createTimerSandbox();
+      clock = sinon.useFakeTimers();
+
+      driverSocket = sinon.spy(new FakeSocket());
+      // @ts-expect-error: driverSocket does not fully satisfy the stream type, but that's okay
+      connection = sinon.spy(new Connection(driverSocket, connectionOptionsDefaults));
+      const messageStreamSymbol = getSymbolFrom(connection, 'messageStream');
+      messageStream = sinon.spy(connection[messageStreamSymbol]);
+    });
+
+    afterEach(() => {
+      timerSandbox.restore();
+      clock.restore();
+    });
+
+    context('when options.force == true', function () {
+      it('calls stream.destroy', () => {
+        connection.destroy({ force: true });
+        clock.tick(1);
+        expect(driverSocket.destroy).to.have.been.calledOnce;
+      });
+
+      it('does not call stream.end', () => {
+        connection.destroy({ force: true });
+        clock.tick(1);
+        expect(driverSocket.end).to.not.have.been.called;
+      });
+
+      it('destroys the tcp socket', () => {
+        connection.destroy({ force: true });
+        clock.tick(1);
+        expect(driverSocket.destroy).to.have.been.calledOnce;
+      });
+
+      it('destroys the messageStream', () => {
+        connection.destroy({ force: true });
+        clock.tick(1);
+        expect(messageStream.destroy).to.have.been.calledOnce;
+      });
+
+      it('calls stream.destroy whenever destroy is called ', () => {
+        connection.destroy({ force: true });
+        connection.destroy({ force: true });
+        connection.destroy({ force: true });
+        clock.tick(1);
+        expect(driverSocket.destroy).to.have.been.calledThrice;
+      });
+    });
+
+    context('when options.force == false', function () {
+      it('calls stream.end', () => {
+        connection.destroy({ force: false });
+        clock.tick(1);
+        expect(driverSocket.end).to.have.been.calledOnce;
+      });
+
+      it('does not call stream.destroy', () => {
+        connection.destroy({ force: false });
+        clock.tick(1);
+        expect(driverSocket.destroy).to.not.have.been.called;
+      });
+
+      it('ends the tcp socket', () => {
+        connection.destroy({ force: false });
+        clock.tick(1);
+        expect(driverSocket.end).to.have.been.calledOnce;
+      });
+
+      it('destroys the messageStream', () => {
+        connection.destroy({ force: false });
+        clock.tick(1);
+        expect(messageStream.destroy).to.have.been.calledOnce;
+      });
+
+      it('calls stream.end exactly once when destroy is called multiple times', () => {
+        connection.destroy({ force: false });
+        connection.destroy({ force: false });
+        connection.destroy({ force: false });
+        connection.destroy({ force: false });
+        clock.tick(1);
+        expect(driverSocket.end).to.have.been.calledOnce;
       });
     });
   });

--- a/test/unit/cmap/connection.test.ts
+++ b/test/unit/cmap/connection.test.ts
@@ -80,7 +80,7 @@ describe('new Connection()', function () {
   after(() => mock.cleanup());
   before(() => mock.createServer().then(s => (server = s)));
 
-  it('should support fire-and-forget messages', function (done) {
+  it('supports fire-and-forget messages', function (done) {
     server.setMessageHandler(request => {
       const doc = request.document;
       if (isHello(doc)) {
@@ -109,7 +109,7 @@ describe('new Connection()', function () {
     });
   });
 
-  it('should destroy streams which time out', function (done) {
+  it('destroys streams which time out', function (done) {
     server.setMessageHandler(request => {
       const doc = request.document;
       if (isHello(doc)) {
@@ -140,7 +140,7 @@ describe('new Connection()', function () {
     });
   });
 
-  it('should throw a network error with kBeforeHandshake set to false on timeout after handshake', function (done) {
+  it('throws a network error with kBeforeHandshake set to false on timeout after handshake', function (done) {
     server.setMessageHandler(request => {
       const doc = request.document;
       if (isHello(doc)) {
@@ -169,7 +169,7 @@ describe('new Connection()', function () {
     });
   });
 
-  it('should throw a network error with kBeforeHandshake set to true on timeout before handshake', function (done) {
+  it('throws a network error with kBeforeHandshake set to true on timeout before handshake', function (done) {
     server.setMessageHandler(() => {
       // respond to no requests to trigger timeout event
     });
@@ -464,7 +464,7 @@ describe('new Connection()', function () {
         sinon.restore();
       });
 
-      it('should delay timeout errors by one tick', async () => {
+      it('delays timeout errors by one tick', async () => {
         expect(connection).to.have.property(kDelayedTimeoutId, null);
 
         driverSocket.emit('timeout');
@@ -480,7 +480,7 @@ describe('new Connection()', function () {
         expect(connection).to.have.property('closed', true);
       });
 
-      it('should clear timeout errors if more data is available', () => {
+      it('clears timeout errors if more data is available', () => {
         expect(connection).to.have.property(kDelayedTimeoutId, null);
 
         driverSocket.emit('timeout');

--- a/test/unit/cmap/connection.test.ts
+++ b/test/unit/cmap/connection.test.ts
@@ -75,7 +75,7 @@ class InputStream extends Readable {
   }
 }
 
-describe('new Connection()', function () {
+describe.only('new Connection()', function () {
   let server;
   after(() => mock.cleanup());
   before(() => mock.createServer().then(s => (server = s)));
@@ -433,6 +433,8 @@ describe('new Connection()', function () {
       connection.on('close', () => {
         closeCount++;
       });
+      connection.once(Connection.PINNED, () => {});
+      connection.once(Connection.UNPINNED, () => {});
 
       // Stick an operation description in the queue.
       const queueSymbol = getSymbolFrom(connection, 'queue');
@@ -527,6 +529,14 @@ describe('new Connection()', function () {
         expect(closeCount).to.equal(1);
       });
 
+      it('does NOT remove all Connection.PINNED listeners', () => {
+        expect(connection.listenerCount(Connection.PINNED)).to.equal(1);
+      });
+
+      it('does NOT remove all Connection.UNPINNED listeners', () => {
+        expect(connection.listenerCount(Connection.UNPINNED)).to.equal(1);
+      });
+
       it('removes all listeners on the MessageStream', () => {
         expect(messageStream.eventNames()).to.have.lengthOf(0);
       });
@@ -569,6 +579,9 @@ describe('new Connection()', function () {
         closeCount++;
       });
 
+      connection.once(Connection.PINNED, () => {});
+      connection.once(Connection.UNPINNED, () => {});
+
       // Stick an operation description in the queue.
       const queueSymbol = getSymbolFrom(connection, 'queue');
       connection[queueSymbol].set(1, operationDescription);
@@ -608,6 +621,14 @@ describe('new Connection()', function () {
       expect(closeCount).to.equal(0);
       clock.runAll();
       expect(closeCount).to.equal(1);
+    });
+
+    it('does NOT remove all Connection.PINNED listeners', () => {
+      expect(connection.listenerCount(Connection.PINNED)).to.equal(1);
+    });
+
+    it('does NOT remove all Connection.UNPINNED listeners', () => {
+      expect(connection.listenerCount(Connection.UNPINNED)).to.equal(1);
     });
 
     it('removes all listeners on the MessageStream', () => {
@@ -650,6 +671,9 @@ describe('new Connection()', function () {
         closeCount++;
       });
 
+      connection.once(Connection.PINNED, () => {});
+      connection.once(Connection.UNPINNED, () => {});
+
       // Stick an operation description in the queue.
       const queueSymbol = getSymbolFrom(connection, 'queue');
       connection[queueSymbol].set(1, operationDescription);
@@ -691,6 +715,14 @@ describe('new Connection()', function () {
       expect(closeCount).to.equal(0);
       clock.runAll();
       expect(closeCount).to.equal(1);
+    });
+
+    it('does NOT remove all Connection.PINNED listeners', () => {
+      expect(connection.listenerCount(Connection.PINNED)).to.equal(1);
+    });
+
+    it('does NOT remove all Connection.UNPINNED listeners', () => {
+      expect(connection.listenerCount(Connection.UNPINNED)).to.equal(1);
     });
 
     it('removes all listeners on the MessageStream', () => {
@@ -776,6 +808,18 @@ describe('new Connection()', function () {
     afterEach(() => {
       timerSandbox.restore();
       clock.restore();
+    });
+
+    it('removes all Connection.PINNED listeners', () => {
+      connection.once(Connection.PINNED, () => {});
+      connection.destroy({ force: true });
+      expect(connection.listenerCount(Connection.PINNED)).to.equal(0);
+    });
+
+    it('removes all Connection.UNPINNED listeners', () => {
+      connection.once(Connection.UNPINNED, () => {});
+      connection.destroy({ force: true });
+      expect(connection.listenerCount(Connection.UNPINNED)).to.equal(0);
     });
 
     context('when a callback is provided', () => {

--- a/test/unit/cmap/connection.test.ts
+++ b/test/unit/cmap/connection.test.ts
@@ -389,14 +389,13 @@ describe('new Connection()', function () {
           connection.onMessage(message);
         });
 
-        it('calls all operation description callbacks with an error', function (done) {
+        it('calls all operation description callbacks with an error', function () {
           expect(spyOne).to.be.calledOnce;
           expect(spyTwo).to.be.calledOnce;
           const errorOne = spyOne.firstCall.args[0];
           const errorTwo = spyTwo.firstCall.args[0];
           expect(errorOne).to.be.instanceof(MongoRuntimeError);
           expect(errorTwo).to.be.instanceof(MongoRuntimeError);
-          done();
         });
       });
     });

--- a/test/unit/cmap/connection.test.ts
+++ b/test/unit/cmap/connection.test.ts
@@ -75,7 +75,7 @@ class InputStream extends Readable {
   }
 }
 
-describe('new Connection()', function () {
+describe.only('new Connection()', function () {
   let server;
   after(() => mock.cleanup());
   before(() => mock.createServer().then(s => (server = s)));
@@ -453,7 +453,7 @@ describe('new Connection()', function () {
       let cleanupSpy;
       let timeoutSpy;
       beforeEach(() => {
-        cleanupSpy = sinon.spy(connection, '_cleanup');
+        cleanupSpy = sinon.spy(connection, 'cleanup');
         timeoutSpy = sinon.spy(connection, 'onTimeout');
       });
 
@@ -790,12 +790,12 @@ describe('new Connection()', function () {
         let callbackSpy;
         beforeEach(() => {
           connection.destroy({ force: true });
-          connection._cleanup.resetHistory();
+          connection.cleanup.resetHistory();
           callbackSpy = sinon.spy();
         });
         it('does not attempt to cleanup the socket again', () => {
           connection.destroy({ force: true }, callbackSpy);
-          expect(connection._cleanup).not.to.have.been.called;
+          expect(connection.cleanup).not.to.have.been.called;
         });
 
         it('calls the callback (asynchronously)', () => {
@@ -813,7 +813,7 @@ describe('new Connection()', function () {
         });
         it('cleans up the connection', () => {
           connection.destroy({ force: true }, callbackSpy);
-          expect(connection._cleanup).to.have.been.called;
+          expect(connection.cleanup).to.have.been.called;
         });
 
         it('calls the callback (asynchronously)', () => {


### PR DESCRIPTION
### Description

#### What is changing?

This PR primarily does three things:

- ensures that the message stream is always destroyed and ensure that the socket is always destroyed
- consolidate the connection clean up logic into a single function that is called from each point where the connection is cleaned out
- improves the unit tests to properly assert on the state of the connection after _cleanup has been called. Additionally, the unit tests now in for synchronous versus asynchronous behavior for the various error and clean up scenarios.

Example unit test output:
```
  new Connection()
    ✔ should support fire-and-forget messages
    ✔ should destroy streams which time out (55ms)
    ✔ should throw a network error with kBeforeHandshake set to false on timeout after handshake (56ms)
    ✔ should throw a network error with kBeforeHandshake set to true on timeout before handshake (53ms)
    #onMessage
      when the connection is a monitoring connection
        when multiple hellos exist on the stream
          ✔ calls the callback with the last hello document
        when requestId/responseTo do not match
          ✔ calls the operation description callback with the document
        when requestId/reponseTo match
          ✔ calls the operation description callback with the document
        when no operation description is in the queue
          ✔ does not error
        when more than one operation description is in the queue
          ✔ calls all operation description callbacks with an error
    when the socket times out
      delayed timeout for lambda behavior
        ✔ should delay timeout errors by one tick
        ✔ should clear timeout errors if more data is available
      when the timeout expires and no more data has come in
        ✔ destroys the message stream
        ✔ ends the socket
        ✔ destroys the socket after ending it
        ✔ passes the error along to any callbacks in the operation description queue (asynchronously)
        ✔ emits a Connection.CLOSE event (asynchronously)
        ✔ removes all listeners on the message stream
        ✔ removes all listeners on the socket
    when the message stream errors
      ✔ destroys the message stream synchronously
      ✔ ends the socket
      ✔ destroys the socket after ending it (asynchronously)
      ✔ passes the error along to any callbacks in the operation description queue (asynchronously)
      ✔ emits a Connection.CLOSE event (asynchronously)
      ✔ removes all listeners on the message stream
      ✔ removes all listeners on the socket
    when the underlying socket closes
      ✔ destroys the message stream synchronously
      ✔ ends the socket
      ✔ destroys the socket after ending it (asynchronously)
      ✔ calls any callbacks in the queue with a MongoNetworkError (asynchronously)
      ✔ emits a Connection.CLOSE event (asynchronously)
      ✔ removes all listeners on the message stream
      ✔ removes all listeners on the socket
    .hasSessionSupport
      when logicalSessionTimeoutMinutes is present
        ✔ returns true
      when logicalSessionTimeoutMinutes is not present
        when in load balancing mode
          ✔ returns true
        when not in load balancing mode
          ✔ returns false
    destroy()
      when a callback is provided
        when the connection was already destroyed
          ✔ does not attempt to cleanup the socket again
          ✔ calls the callback (asynchronously)
        when the connection was not destroyed
          ✔ cleans up the connection
          ✔ calls the callback (asynchronously)
      when options.force == true
        ✔ destroys the tcp socket (synchronously)
        ✔ does not call stream.end
        ✔ destroys the messageStream (synchronously)
        ✔ when destroy({ force: true }) is called multiple times, it calls stream.destroy exactly once
      when options.force == false
        ✔ destroys the tcp socket (asynchronously)
        ✔ ends the tcp socket (synchronously)
        ✔ destroys the messageStream (synchronously)
        ✔ calls stream.end exactly once when destroy is called multiple times
```
##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
