### PR TITLE
test(NODE-5092): fix fle2 collection names in legacy fle2 tests

### DIFF
--- a/test/spec/client-side-encryption/tests/legacy/fle2-CreateCollection.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2-CreateCollection.json
@@ -21,9 +21,9 @@
           },
           "encryptedFieldsMap": {
             "default.encryptedCollection": {
-              "escCollection": "encryptedCollection.esc",
-              "eccCollection": "encryptedCollection.ecc",
-              "ecocCollection": "encryptedCollection.ecoc",
+              "escCollection": "enxcol_.encryptedCollection.esc",
+              "eccCollection": "enxcol_.encryptedCollection.ecc",
+              "ecocCollection": "enxcol_.encryptedCollection.ecoc",
               "fields": [
                 {
                   "path": "firstName",
@@ -60,7 +60,7 @@
           "object": "testRunner",
           "arguments": {
             "database": "default",
-            "collection": "encryptedCollection.esc"
+            "collection": "enxcol_.encryptedCollection.esc"
           }
         },
         {
@@ -68,7 +68,7 @@
           "object": "testRunner",
           "arguments": {
             "database": "default",
-            "collection": "encryptedCollection.ecc"
+            "collection": "enxcol_.encryptedCollection.ecc"
           }
         },
         {
@@ -76,7 +76,7 @@
           "object": "testRunner",
           "arguments": {
             "database": "default",
-            "collection": "encryptedCollection.ecoc"
+            "collection": "enxcol_.encryptedCollection.ecoc"
           }
         },
         {
@@ -101,7 +101,7 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "encryptedCollection.esc"
+              "drop": "enxcol_.encryptedCollection.esc"
             },
             "command_name": "drop",
             "database_name": "default"
@@ -110,7 +110,7 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "encryptedCollection.ecc"
+              "drop": "enxcol_.encryptedCollection.ecc"
             },
             "command_name": "drop",
             "database_name": "default"
@@ -119,7 +119,7 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "encryptedCollection.ecoc"
+              "drop": "enxcol_.encryptedCollection.ecoc"
             },
             "command_name": "drop",
             "database_name": "default"
@@ -137,7 +137,7 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection.esc",
+              "create": "enxcol_.encryptedCollection.esc",
               "clusteredIndex": {
                 "key": {
                   "_id": 1
@@ -152,7 +152,7 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection.ecc",
+              "create": "enxcol_.encryptedCollection.ecc",
               "clusteredIndex": {
                 "key": {
                   "_id": 1
@@ -167,7 +167,7 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection.ecoc",
+              "create": "enxcol_.encryptedCollection.ecoc",
               "clusteredIndex": {
                 "key": {
                   "_id": 1
@@ -184,9 +184,9 @@
             "command": {
               "create": "encryptedCollection",
               "encryptedFields": {
-                "escCollection": "encryptedCollection.esc",
-                "eccCollection": "encryptedCollection.ecc",
-                "ecocCollection": "encryptedCollection.ecoc",
+                "escCollection": "enxcol_.encryptedCollection.esc",
+                "eccCollection": "enxcol_.encryptedCollection.ecc",
+                "ecocCollection": "enxcol_.encryptedCollection.ecoc",
                 "fields": [
                   {
                     "path": "firstName",
@@ -745,9 +745,9 @@
           },
           "encryptedFieldsMap": {
             "default.encryptedCollection": {
-              "escCollection": "encryptedCollection.esc",
-              "eccCollection": "encryptedCollection.ecc",
-              "ecocCollection": "encryptedCollection.ecoc",
+              "escCollection": "enxcol_.encryptedCollection.esc",
+              "eccCollection": "enxcol_.encryptedCollection.ecc",
+              "ecocCollection": "enxcol_.encryptedCollection.ecoc",
               "fields": [
                 {
                   "path": "firstName",
@@ -762,9 +762,9 @@
               ]
             },
             "default.encryptedCollection.esc": {
-              "escCollection": "encryptedCollection",
-              "eccCollection": "encryptedCollection.ecc",
-              "ecocCollection": "encryptedCollection.ecoc",
+              "escCollection": "enxcol_.encryptedCollection.esc",
+              "eccCollection": "enxcol_.encryptedCollection.ecc",
+              "ecocCollection": "enxcol_.encryptedCollection.ecoc",
               "fields": [
                 {
                   "path": "firstName",
@@ -801,7 +801,7 @@
           "object": "testRunner",
           "arguments": {
             "database": "default",
-            "collection": "encryptedCollection.esc"
+            "collection": "enxcol_.encryptedCollection.esc"
           }
         },
         {
@@ -809,7 +809,7 @@
           "object": "testRunner",
           "arguments": {
             "database": "default",
-            "collection": "encryptedCollection.ecc"
+            "collection": "enxcol_.encryptedCollection.ecc"
           }
         },
         {
@@ -817,7 +817,7 @@
           "object": "testRunner",
           "arguments": {
             "database": "default",
-            "collection": "encryptedCollection.ecoc"
+            "collection": "enxcol_.encryptedCollection.ecoc"
           }
         },
         {
@@ -842,7 +842,7 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "encryptedCollection.esc"
+              "drop": "enxcol_.encryptedCollection.esc"
             },
             "command_name": "drop",
             "database_name": "default"
@@ -851,7 +851,7 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "encryptedCollection.ecc"
+              "drop": "enxcol_.encryptedCollection.ecc"
             },
             "command_name": "drop",
             "database_name": "default"
@@ -860,7 +860,7 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "encryptedCollection.ecoc"
+              "drop": "enxcol_.encryptedCollection.ecoc"
             },
             "command_name": "drop",
             "database_name": "default"
@@ -878,7 +878,7 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection.esc",
+              "create": "enxcol_.encryptedCollection.esc",
               "clusteredIndex": {
                 "key": {
                   "_id": 1
@@ -893,7 +893,7 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection.ecc",
+              "create": "enxcol_.encryptedCollection.ecc",
               "clusteredIndex": {
                 "key": {
                   "_id": 1
@@ -908,7 +908,7 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection.ecoc",
+              "create": "enxcol_.encryptedCollection.ecoc",
               "clusteredIndex": {
                 "key": {
                   "_id": 1
@@ -925,9 +925,9 @@
             "command": {
               "create": "encryptedCollection",
               "encryptedFields": {
-                "escCollection": "encryptedCollection.esc",
-                "eccCollection": "encryptedCollection.ecc",
-                "ecocCollection": "encryptedCollection.ecoc",
+                "escCollection": "enxcol_.encryptedCollection.esc",
+                "eccCollection": "enxcol_.encryptedCollection.ecc",
+                "ecocCollection": "enxcol_.encryptedCollection.ecoc",
                 "fields": [
                   {
                     "path": "firstName",
@@ -974,9 +974,9 @@
           },
           "encryptedFieldsMap": {
             "default.encryptedCollection": {
-              "escCollection": "encryptedCollection.esc",
-              "eccCollection": "encryptedCollection.ecc",
-              "ecocCollection": "encryptedCollection.ecoc",
+              "escCollection": "enxcol_.encryptedCollection.esc",
+              "eccCollection": "enxcol_.encryptedCollection.ecc",
+              "ecocCollection": "enxcol_.encryptedCollection.ecoc",
               "fields": [
                 {
                   "path": "firstName",
@@ -1059,9 +1059,9 @@
           },
           "encryptedFieldsMap": {
             "default.encryptedCollection": {
-              "escCollection": "encryptedCollection.esc",
-              "eccCollection": "encryptedCollection.ecc",
-              "ecocCollection": "encryptedCollection.ecoc",
+              "escCollection": "enxcol_.encryptedCollection.esc",
+              "eccCollection": "enxcol_.encryptedCollection.ecc",
+              "ecocCollection": "enxcol_.encryptedCollection.ecoc",
               "fields": [
                 {
                   "path": "firstName",
@@ -1098,7 +1098,7 @@
           "object": "testRunner",
           "arguments": {
             "database": "default",
-            "collection": "encryptedCollection.esc"
+            "collection": "enxcol_.encryptedCollection.esc"
           }
         },
         {
@@ -1106,7 +1106,7 @@
           "object": "testRunner",
           "arguments": {
             "database": "default",
-            "collection": "encryptedCollection.ecc"
+            "collection": "enxcol_.encryptedCollection.ecc"
           }
         },
         {
@@ -1114,7 +1114,7 @@
           "object": "testRunner",
           "arguments": {
             "database": "default",
-            "collection": "encryptedCollection.ecoc"
+            "collection": "enxcol_.encryptedCollection.ecoc"
           }
         },
         {
@@ -1139,7 +1139,7 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "encryptedCollection.esc"
+              "drop": "enxcol_.encryptedCollection.esc"
             },
             "command_name": "drop",
             "database_name": "default"
@@ -1148,7 +1148,7 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "encryptedCollection.ecc"
+              "drop": "enxcol_.encryptedCollection.ecc"
             },
             "command_name": "drop",
             "database_name": "default"
@@ -1157,7 +1157,7 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "encryptedCollection.ecoc"
+              "drop": "enxcol_.encryptedCollection.ecoc"
             },
             "command_name": "drop",
             "database_name": "default"
@@ -1175,7 +1175,7 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection.esc",
+              "create": "enxcol_.encryptedCollection.esc",
               "clusteredIndex": {
                 "key": {
                   "_id": 1
@@ -1190,7 +1190,7 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection.ecc",
+              "create": "enxcol_.encryptedCollection.ecc",
               "clusteredIndex": {
                 "key": {
                   "_id": 1
@@ -1205,7 +1205,7 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection.ecoc",
+              "create": "enxcol_.encryptedCollection.ecoc",
               "clusteredIndex": {
                 "key": {
                   "_id": 1
@@ -1222,9 +1222,9 @@
             "command": {
               "create": "encryptedCollection",
               "encryptedFields": {
-                "escCollection": "encryptedCollection.esc",
-                "eccCollection": "encryptedCollection.ecc",
-                "ecocCollection": "encryptedCollection.ecoc",
+                "escCollection": "enxcol_.encryptedCollection.esc",
+                "eccCollection": "enxcol_.encryptedCollection.ecc",
+                "ecocCollection": "enxcol_.encryptedCollection.ecoc",
                 "fields": [
                   {
                     "path": "firstName",
@@ -1278,9 +1278,9 @@
           "arguments": {
             "collection": "encryptedCollection",
             "encryptedFields": {
-              "escCollection": "encryptedCollection.esc",
-              "eccCollection": "encryptedCollection.ecc",
-              "ecocCollection": "encryptedCollection.ecoc",
+              "escCollection": "enxcol_.encryptedCollection.esc",
+              "eccCollection": "enxcol_.encryptedCollection.ecc",
+              "ecocCollection": "enxcol_.encryptedCollection.ecoc",
               "fields": [
                 {
                   "path": "firstName",
@@ -1302,9 +1302,9 @@
           "arguments": {
             "collection": "encryptedCollection",
             "encryptedFields": {
-              "escCollection": "encryptedCollection.esc",
-              "eccCollection": "encryptedCollection.ecc",
-              "ecocCollection": "encryptedCollection.ecoc",
+              "escCollection": "enxcol_.encryptedCollection.esc",
+              "eccCollection": "enxcol_.encryptedCollection.ecc",
+              "ecocCollection": "enxcol_.encryptedCollection.ecoc",
               "fields": [
                 {
                   "path": "firstName",
@@ -1325,7 +1325,7 @@
           "object": "testRunner",
           "arguments": {
             "database": "default",
-            "collection": "encryptedCollection.esc"
+            "collection": "enxcol_.encryptedCollection.esc"
           }
         },
         {
@@ -1333,7 +1333,7 @@
           "object": "testRunner",
           "arguments": {
             "database": "default",
-            "collection": "encryptedCollection.ecc"
+            "collection": "enxcol_.encryptedCollection.ecc"
           }
         },
         {
@@ -1341,7 +1341,7 @@
           "object": "testRunner",
           "arguments": {
             "database": "default",
-            "collection": "encryptedCollection.ecoc"
+            "collection": "enxcol_.encryptedCollection.ecoc"
           }
         },
         {
@@ -1366,7 +1366,7 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "encryptedCollection.esc"
+              "drop": "enxcol_.encryptedCollection.esc"
             },
             "command_name": "drop",
             "database_name": "default"
@@ -1375,7 +1375,7 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "encryptedCollection.ecc"
+              "drop": "enxcol_.encryptedCollection.ecc"
             },
             "command_name": "drop",
             "database_name": "default"
@@ -1384,7 +1384,7 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "encryptedCollection.ecoc"
+              "drop": "enxcol_.encryptedCollection.ecoc"
             },
             "command_name": "drop",
             "database_name": "default"
@@ -1402,7 +1402,7 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection.esc",
+              "create": "enxcol_.encryptedCollection.esc",
               "clusteredIndex": {
                 "key": {
                   "_id": 1
@@ -1417,7 +1417,7 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection.ecc",
+              "create": "enxcol_.encryptedCollection.ecc",
               "clusteredIndex": {
                 "key": {
                   "_id": 1
@@ -1432,7 +1432,7 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection.ecoc",
+              "create": "enxcol_.encryptedCollection.ecoc",
               "clusteredIndex": {
                 "key": {
                   "_id": 1
@@ -1449,9 +1449,9 @@
             "command": {
               "create": "encryptedCollection",
               "encryptedFields": {
-                "escCollection": "encryptedCollection.esc",
-                "eccCollection": "encryptedCollection.ecc",
-                "ecocCollection": "encryptedCollection.ecoc",
+                "escCollection": "enxcol_.encryptedCollection.esc",
+                "eccCollection": "enxcol_.encryptedCollection.ecc",
+                "ecocCollection": "enxcol_.encryptedCollection.ecoc",
                 "fields": [
                   {
                     "path": "firstName",
@@ -1510,9 +1510,9 @@
           },
           "encryptedFieldsMap": {
             "default.encryptedCollection": {
-              "escCollection": "encryptedCollection.esc",
-              "eccCollection": "encryptedCollection.ecc",
-              "ecocCollection": "encryptedCollection.ecoc",
+              "escCollection": "enxcol_.encryptedCollection.esc",
+              "eccCollection": "enxcol_.encryptedCollection.ecc",
+              "ecocCollection": "enxcol_.encryptedCollection.ecoc",
               "fields": [
                 {
                   "path": "firstName",
@@ -1542,7 +1542,7 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "encryptedCollection.esc"
+              "drop": "enxcol_.encryptedCollection.esc"
             },
             "command_name": "drop",
             "database_name": "default"
@@ -1551,7 +1551,7 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "encryptedCollection.ecc"
+              "drop": "enxcol_.encryptedCollection.ecc"
             },
             "command_name": "drop",
             "database_name": "default"
@@ -1560,7 +1560,7 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "encryptedCollection.ecoc"
+              "drop": "enxcol_.encryptedCollection.ecoc"
             },
             "command_name": "drop",
             "database_name": "default"
@@ -1594,9 +1594,9 @@
           "arguments": {
             "collection": "encryptedCollection",
             "encryptedFields": {
-              "escCollection": "encryptedCollection.esc",
-              "eccCollection": "encryptedCollection.ecc",
-              "ecocCollection": "encryptedCollection.ecoc",
+              "escCollection": "enxcol_.encryptedCollection.esc",
+              "eccCollection": "enxcol_.encryptedCollection.ecc",
+              "ecocCollection": "enxcol_.encryptedCollection.ecoc",
               "fields": [
                 {
                   "path": "firstName",
@@ -1618,9 +1618,9 @@
           "arguments": {
             "collection": "encryptedCollection",
             "encryptedFields": {
-              "escCollection": "encryptedCollection.esc",
-              "eccCollection": "encryptedCollection.ecc",
-              "ecocCollection": "encryptedCollection.ecoc",
+              "escCollection": "enxcol_.encryptedCollection.esc",
+              "eccCollection": "enxcol_.encryptedCollection.ecc",
+              "ecocCollection": "enxcol_.encryptedCollection.ecoc",
               "fields": [
                 {
                   "path": "firstName",
@@ -1641,7 +1641,7 @@
           "object": "testRunner",
           "arguments": {
             "database": "default",
-            "collection": "encryptedCollection.esc"
+            "collection": "enxcol_.encryptedCollection.esc"
           }
         },
         {
@@ -1649,7 +1649,7 @@
           "object": "testRunner",
           "arguments": {
             "database": "default",
-            "collection": "encryptedCollection.ecc"
+            "collection": "enxcol_.encryptedCollection.ecc"
           }
         },
         {
@@ -1657,7 +1657,7 @@
           "object": "testRunner",
           "arguments": {
             "database": "default",
-            "collection": "encryptedCollection.ecoc"
+            "collection": "enxcol_.encryptedCollection.ecoc"
           }
         },
         {
@@ -1683,9 +1683,9 @@
           "arguments": {
             "collection": "encryptedCollection",
             "encryptedFields": {
-              "escCollection": "encryptedCollection.esc",
-              "eccCollection": "encryptedCollection.ecc",
-              "ecocCollection": "encryptedCollection.ecoc",
+              "escCollection": "enxcol_.encryptedCollection.esc",
+              "eccCollection": "enxcol_.encryptedCollection.ecc",
+              "ecocCollection": "enxcol_.encryptedCollection.ecoc",
               "fields": [
                 {
                   "path": "firstName",
@@ -1706,7 +1706,7 @@
           "object": "testRunner",
           "arguments": {
             "database": "default",
-            "collection": "encryptedCollection.esc"
+            "collection": "enxcol_.encryptedCollection.esc"
           }
         },
         {
@@ -1714,7 +1714,7 @@
           "object": "testRunner",
           "arguments": {
             "database": "default",
-            "collection": "encryptedCollection.ecc"
+            "collection": "enxcol_.encryptedCollection.ecc"
           }
         },
         {
@@ -1722,7 +1722,7 @@
           "object": "testRunner",
           "arguments": {
             "database": "default",
-            "collection": "encryptedCollection.ecoc"
+            "collection": "enxcol_.encryptedCollection.ecoc"
           }
         },
         {
@@ -1738,7 +1738,7 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "encryptedCollection.esc"
+              "drop": "enxcol_.encryptedCollection.esc"
             },
             "command_name": "drop",
             "database_name": "default"
@@ -1747,7 +1747,7 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "encryptedCollection.ecc"
+              "drop": "enxcol_.encryptedCollection.ecc"
             },
             "command_name": "drop",
             "database_name": "default"
@@ -1756,7 +1756,7 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "encryptedCollection.ecoc"
+              "drop": "enxcol_.encryptedCollection.ecoc"
             },
             "command_name": "drop",
             "database_name": "default"
@@ -1774,7 +1774,7 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection.esc",
+              "create": "enxcol_.encryptedCollection.esc",
               "clusteredIndex": {
                 "key": {
                   "_id": 1
@@ -1789,7 +1789,7 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection.ecc",
+              "create": "enxcol_.encryptedCollection.ecc",
               "clusteredIndex": {
                 "key": {
                   "_id": 1
@@ -1804,7 +1804,7 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection.ecoc",
+              "create": "enxcol_.encryptedCollection.ecoc",
               "clusteredIndex": {
                 "key": {
                   "_id": 1
@@ -1821,9 +1821,9 @@
             "command": {
               "create": "encryptedCollection",
               "encryptedFields": {
-                "escCollection": "encryptedCollection.esc",
-                "eccCollection": "encryptedCollection.ecc",
-                "ecocCollection": "encryptedCollection.ecoc",
+                "escCollection": "enxcol_.encryptedCollection.esc",
+                "eccCollection": "enxcol_.encryptedCollection.ecc",
+                "ecocCollection": "enxcol_.encryptedCollection.ecoc",
                 "fields": [
                   {
                     "path": "firstName",
@@ -1874,7 +1874,7 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "encryptedCollection.esc"
+              "drop": "enxcol_.encryptedCollection.esc"
             },
             "command_name": "drop",
             "database_name": "default"
@@ -1883,7 +1883,7 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "encryptedCollection.ecc"
+              "drop": "enxcol_.encryptedCollection.ecc"
             },
             "command_name": "drop",
             "database_name": "default"
@@ -1892,7 +1892,7 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "encryptedCollection.ecoc"
+              "drop": "enxcol_.encryptedCollection.ecoc"
             },
             "command_name": "drop",
             "database_name": "default"
@@ -1926,9 +1926,9 @@
           "arguments": {
             "collection": "encryptedCollection",
             "encryptedFields": {
-              "escCollection": "encryptedCollection.esc",
-              "eccCollection": "encryptedCollection.ecc",
-              "ecocCollection": "encryptedCollection.ecoc",
+              "escCollection": "enxcol_.encryptedCollection.esc",
+              "eccCollection": "enxcol_.encryptedCollection.ecc",
+              "ecocCollection": "enxcol_.encryptedCollection.ecoc",
               "fields": [
                 {
                   "path": "firstName",
@@ -1950,9 +1950,9 @@
           "arguments": {
             "collection": "encryptedCollection",
             "encryptedFields": {
-              "escCollection": "encryptedCollection.esc",
-              "eccCollection": "encryptedCollection.ecc",
-              "ecocCollection": "encryptedCollection.ecoc",
+              "escCollection": "enxcol_.encryptedCollection.esc",
+              "eccCollection": "enxcol_.encryptedCollection.ecc",
+              "ecocCollection": "enxcol_.encryptedCollection.ecoc",
               "fields": [
                 {
                   "path": "firstName",
@@ -1973,7 +1973,7 @@
           "object": "testRunner",
           "arguments": {
             "database": "default",
-            "collection": "encryptedCollection.esc"
+            "collection": "enxcol_.encryptedCollection.esc"
           }
         },
         {
@@ -1981,7 +1981,7 @@
           "object": "testRunner",
           "arguments": {
             "database": "default",
-            "collection": "encryptedCollection.ecc"
+            "collection": "enxcol_.encryptedCollection.ecc"
           }
         },
         {
@@ -1989,7 +1989,7 @@
           "object": "testRunner",
           "arguments": {
             "database": "default",
-            "collection": "encryptedCollection.ecoc"
+            "collection": "enxcol_.encryptedCollection.ecoc"
           }
         },
         {
@@ -2021,7 +2021,7 @@
           "object": "testRunner",
           "arguments": {
             "database": "default",
-            "collection": "encryptedCollection.esc"
+            "collection": "enxcol_.encryptedCollection.esc"
           }
         },
         {
@@ -2029,7 +2029,7 @@
           "object": "testRunner",
           "arguments": {
             "database": "default",
-            "collection": "encryptedCollection.ecc"
+            "collection": "enxcol_.encryptedCollection.ecc"
           }
         },
         {
@@ -2037,7 +2037,7 @@
           "object": "testRunner",
           "arguments": {
             "database": "default",
-            "collection": "encryptedCollection.ecoc"
+            "collection": "enxcol_.encryptedCollection.ecoc"
           }
         },
         {
@@ -2053,7 +2053,7 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "encryptedCollection.esc"
+              "drop": "enxcol_.encryptedCollection.esc"
             },
             "command_name": "drop",
             "database_name": "default"
@@ -2062,7 +2062,7 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "encryptedCollection.ecc"
+              "drop": "enxcol_.encryptedCollection.ecc"
             },
             "command_name": "drop",
             "database_name": "default"
@@ -2071,7 +2071,7 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "encryptedCollection.ecoc"
+              "drop": "enxcol_.encryptedCollection.ecoc"
             },
             "command_name": "drop",
             "database_name": "default"
@@ -2089,7 +2089,7 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection.esc",
+              "create": "enxcol_.encryptedCollection.esc",
               "clusteredIndex": {
                 "key": {
                   "_id": 1
@@ -2104,7 +2104,7 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection.ecc",
+              "create": "enxcol_.encryptedCollection.ecc",
               "clusteredIndex": {
                 "key": {
                   "_id": 1
@@ -2119,7 +2119,7 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection.ecoc",
+              "create": "enxcol_.encryptedCollection.ecoc",
               "clusteredIndex": {
                 "key": {
                   "_id": 1
@@ -2136,9 +2136,9 @@
             "command": {
               "create": "encryptedCollection",
               "encryptedFields": {
-                "escCollection": "encryptedCollection.esc",
-                "eccCollection": "encryptedCollection.ecc",
-                "ecocCollection": "encryptedCollection.ecoc",
+                "escCollection": "enxcol_.encryptedCollection.esc",
+                "eccCollection": "enxcol_.encryptedCollection.ecc",
+                "ecocCollection": "enxcol_.encryptedCollection.ecoc",
                 "fields": [
                   {
                     "path": "firstName",
@@ -2201,7 +2201,7 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "encryptedCollection.esc"
+              "drop": "enxcol_.encryptedCollection.esc"
             },
             "command_name": "drop",
             "database_name": "default"
@@ -2210,7 +2210,7 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "encryptedCollection.ecc"
+              "drop": "enxcol_.encryptedCollection.ecc"
             },
             "command_name": "drop",
             "database_name": "default"
@@ -2219,7 +2219,7 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "encryptedCollection.ecoc"
+              "drop": "enxcol_.encryptedCollection.ecoc"
             },
             "command_name": "drop",
             "database_name": "default"

--- a/test/spec/client-side-encryption/tests/legacy/fle2-CreateCollection.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2-CreateCollection.yml
@@ -15,9 +15,9 @@ tests:
           aws: {} # Credentials filled in from environment.
         encryptedFieldsMap:
           default.encryptedCollection: &encrypted_fields0 {
-                "escCollection": "encryptedCollection.esc",
-                "eccCollection": "encryptedCollection.ecc",
-                "ecocCollection": "encryptedCollection.ecoc",
+                "escCollection": "enxcol_.encryptedCollection.esc",
+                "eccCollection": "enxcol_.encryptedCollection.ecc",
+                "ecocCollection": "enxcol_.encryptedCollection.ecoc",
                 "fields": [
                     {
                         "path": "firstName",
@@ -41,17 +41,17 @@ tests:
         object: testRunner
         arguments:
           database: *database_name
-          collection: "encryptedCollection.esc"
+          collection: "enxcol_.encryptedCollection.esc"
       - name: assertCollectionExists
         object: testRunner
         arguments:
           database: *database_name
-          collection: "encryptedCollection.ecc"
+          collection: "enxcol_.encryptedCollection.ecc"
       - name: assertCollectionExists
         object: testRunner
         arguments:
           database: *database_name
-          collection: "encryptedCollection.ecoc"
+          collection: "enxcol_.encryptedCollection.ecoc"
       - name: assertCollectionExists
         object: testRunner
         arguments:
@@ -68,17 +68,17 @@ tests:
         # events from dropCollection ... begin
         - command_started_event:
             command:
-              drop: "encryptedCollection.esc"
+              drop: "enxcol_.encryptedCollection.esc"
             command_name: drop
             database_name: *database_name
         - command_started_event:
             command:
-              drop: "encryptedCollection.ecc"
+              drop: "enxcol_.encryptedCollection.ecc"
             command_name: drop
             database_name: *database_name
         - command_started_event:
             command:
-              drop: "encryptedCollection.ecoc"
+              drop: "enxcol_.encryptedCollection.ecoc"
             command_name: drop
             database_name: *database_name
         - command_started_event:
@@ -91,19 +91,19 @@ tests:
         # State collections are created first.
         - command_started_event:
             command:
-              create: "encryptedCollection.esc"
+              create: "enxcol_.encryptedCollection.esc"
               clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
         - command_started_event:
             command:
-              create: "encryptedCollection.ecc"
+              create: "enxcol_.encryptedCollection.ecc"
               clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
         - command_started_event:
             command:
-              create: "encryptedCollection.ecoc"
+              create: "enxcol_.encryptedCollection.ecoc"
               clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
@@ -418,9 +418,9 @@ tests:
           # encryptedCollection has encryptedCollection.esc as the escCollection.
           # encryptedCollection.esc has encryptedCollection as the escCollection.
           default.encryptedCollection: &encrypted_fields3 {
-                "escCollection": "encryptedCollection.esc",
-                "eccCollection": "encryptedCollection.ecc",
-                "ecocCollection": "encryptedCollection.ecoc",
+                "escCollection": "enxcol_.encryptedCollection.esc",
+                "eccCollection": "enxcol_.encryptedCollection.ecc",
+                "ecocCollection": "enxcol_.encryptedCollection.ecoc",
                 "fields": [
                     {
                         "path": "firstName",
@@ -430,9 +430,9 @@ tests:
                 ]
             }
           default.encryptedCollection.esc: {
-              "escCollection": "encryptedCollection",
-              "eccCollection": "encryptedCollection.ecc",
-              "ecocCollection": "encryptedCollection.ecoc",
+              "escCollection": "enxcol_.encryptedCollection.esc",
+              "eccCollection": "enxcol_.encryptedCollection.ecc",
+              "ecocCollection": "enxcol_.encryptedCollection.ecoc",
               "fields": [
                   {
                       "path": "firstName",
@@ -455,17 +455,17 @@ tests:
         object: testRunner
         arguments:
           database: *database_name
-          collection: "encryptedCollection.esc"
+          collection: "enxcol_.encryptedCollection.esc"
       - name: assertCollectionExists
         object: testRunner
         arguments:
           database: *database_name
-          collection: "encryptedCollection.ecc"
+          collection: "enxcol_.encryptedCollection.ecc"
       - name: assertCollectionExists
         object: testRunner
         arguments:
           database: *database_name
-          collection: "encryptedCollection.ecoc"
+          collection: "enxcol_.encryptedCollection.ecoc"
       - name: assertCollectionExists
         object: testRunner
         arguments:
@@ -481,17 +481,17 @@ tests:
         # events from dropCollection ... begin
         - command_started_event:
             command:
-              drop: "encryptedCollection.esc"
+              drop: "enxcol_.encryptedCollection.esc"
             command_name: drop
             database_name: *database_name
         - command_started_event:
             command:
-              drop: "encryptedCollection.ecc"
+              drop: "enxcol_.encryptedCollection.ecc"
             command_name: drop
             database_name: *database_name
         - command_started_event:
             command:
-              drop: "encryptedCollection.ecoc"
+              drop: "enxcol_.encryptedCollection.ecoc"
             command_name: drop
             database_name: *database_name
         - command_started_event:
@@ -504,19 +504,19 @@ tests:
         # State collections are created first.
         - command_started_event:
             command:
-              create: "encryptedCollection.esc"
+              create: "enxcol_.encryptedCollection.esc"
               clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
         - command_started_event:
             command:
-              create: "encryptedCollection.ecc"
+              create: "enxcol_.encryptedCollection.ecc"
               clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
         - command_started_event:
             command:
-              create: "encryptedCollection.ecoc"
+              create: "enxcol_.encryptedCollection.ecoc"
               clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
@@ -544,9 +544,9 @@ tests:
           aws: {} # Credentials filled in from environment.
         encryptedFieldsMap:
           default.encryptedCollection: {
-                "escCollection": "encryptedCollection.esc",
-                "eccCollection": "encryptedCollection.ecc",
-                "ecocCollection": "encryptedCollection.ecoc",
+                "escCollection": "enxcol_.encryptedCollection.esc",
+                "eccCollection": "enxcol_.encryptedCollection.ecc",
+                "ecocCollection": "enxcol_.encryptedCollection.ecoc",
                 "fields": [
                     {
                         "path": "firstName",
@@ -598,9 +598,9 @@ tests:
           aws: {} # Credentials filled in from environment.
         encryptedFieldsMap:
           default.encryptedCollection: &encrypted_fields4 {
-                "escCollection": "encryptedCollection.esc",
-                "eccCollection": "encryptedCollection.ecc",
-                "ecocCollection": "encryptedCollection.ecoc",
+                "escCollection": "enxcol_.encryptedCollection.esc",
+                "eccCollection": "enxcol_.encryptedCollection.ecc",
+                "ecocCollection": "enxcol_.encryptedCollection.ecoc",
                 "fields": [
                     {
                         "path": "firstName",
@@ -623,17 +623,17 @@ tests:
         object: testRunner
         arguments:
           database: *database_name
-          collection: "encryptedCollection.esc"
+          collection: "enxcol_.encryptedCollection.esc"
       - name: assertCollectionExists
         object: testRunner
         arguments:
           database: *database_name
-          collection: "encryptedCollection.ecc"
+          collection: "enxcol_.encryptedCollection.ecc"
       - name: assertCollectionExists
         object: testRunner
         arguments:
           database: *database_name
-          collection: "encryptedCollection.ecoc"
+          collection: "enxcol_.encryptedCollection.ecoc"
       - name: assertCollectionExists
         object: testRunner
         arguments:
@@ -650,17 +650,17 @@ tests:
         # events from dropCollection ... begin
         - command_started_event:
             command:
-              drop: "encryptedCollection.esc"
+              drop: "enxcol_.encryptedCollection.esc"
             command_name: drop
             database_name: *database_name
         - command_started_event:
             command:
-              drop: "encryptedCollection.ecc"
+              drop: "enxcol_.encryptedCollection.ecc"
             command_name: drop
             database_name: *database_name
         - command_started_event:
             command:
-              drop: "encryptedCollection.ecoc"
+              drop: "enxcol_.encryptedCollection.ecoc"
             command_name: drop
             database_name: *database_name
         - command_started_event:
@@ -673,19 +673,19 @@ tests:
         # State collections are created first.
         - command_started_event:
             command:
-              create: "encryptedCollection.esc"
+              create: "enxcol_.encryptedCollection.esc"
               clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
         - command_started_event:
             command:
-              create: "encryptedCollection.ecc"
+              create: "enxcol_.encryptedCollection.ecc"
               clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
         - command_started_event:
             command:
-              create: "encryptedCollection.ecoc"
+              create: "enxcol_.encryptedCollection.ecoc"
               clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
@@ -718,9 +718,9 @@ tests:
         arguments:
           collection: "encryptedCollection"
           encryptedFields: {
-                "escCollection": "encryptedCollection.esc",
-                "eccCollection": "encryptedCollection.ecc",
-                "ecocCollection": "encryptedCollection.ecoc",
+                "escCollection": "enxcol_.encryptedCollection.esc",
+                "eccCollection": "enxcol_.encryptedCollection.ecc",
+                "ecocCollection": "enxcol_.encryptedCollection.ecoc",
                 "fields": [
                     {
                         "path": "firstName",
@@ -734,9 +734,9 @@ tests:
         arguments:
           collection: "encryptedCollection"
           encryptedFields: &encrypted_fields5 {
-                "escCollection": "encryptedCollection.esc",
-                "eccCollection": "encryptedCollection.ecc",
-                "ecocCollection": "encryptedCollection.ecoc",
+                "escCollection": "enxcol_.encryptedCollection.esc",
+                "eccCollection": "enxcol_.encryptedCollection.ecc",
+                "ecocCollection": "enxcol_.encryptedCollection.ecoc",
                 "fields": [
                     {
                         "path": "firstName",
@@ -749,17 +749,17 @@ tests:
         object: testRunner
         arguments:
           database: *database_name
-          collection: "encryptedCollection.esc"
+          collection: "enxcol_.encryptedCollection.esc"
       - name: assertCollectionExists
         object: testRunner
         arguments:
           database: *database_name
-          collection: "encryptedCollection.ecc"
+          collection: "enxcol_.encryptedCollection.ecc"
       - name: assertCollectionExists
         object: testRunner
         arguments:
           database: *database_name
-          collection: "encryptedCollection.ecoc"
+          collection: "enxcol_.encryptedCollection.ecoc"
       - name: assertCollectionExists
         object: testRunner
         arguments:
@@ -776,17 +776,17 @@ tests:
         # events from dropCollection ... begin
         - command_started_event:
             command:
-              drop: "encryptedCollection.esc"
+              drop: "enxcol_.encryptedCollection.esc"
             command_name: drop
             database_name: *database_name
         - command_started_event:
             command:
-              drop: "encryptedCollection.ecc"
+              drop: "enxcol_.encryptedCollection.ecc"
             command_name: drop
             database_name: *database_name
         - command_started_event:
             command:
-              drop: "encryptedCollection.ecoc"
+              drop: "enxcol_.encryptedCollection.ecoc"
             command_name: drop
             database_name: *database_name
         - command_started_event:
@@ -799,19 +799,19 @@ tests:
         # State collections are created first.
         - command_started_event:
             command:
-              create: "encryptedCollection.esc"
+              create: "enxcol_.encryptedCollection.esc"
               clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
         - command_started_event:
             command:
-              create: "encryptedCollection.ecc"
+              create: "enxcol_.encryptedCollection.ecc"
               clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
         - command_started_event:
             command:
-              create: "encryptedCollection.ecoc"
+              create: "enxcol_.encryptedCollection.ecoc"
               clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
@@ -847,9 +847,9 @@ tests:
           aws: {} # Credentials filled in from environment.
         encryptedFieldsMap:
           default.encryptedCollection: {
-                "escCollection": "encryptedCollection.esc",
-                "eccCollection": "encryptedCollection.ecc",
-                "ecocCollection": "encryptedCollection.ecoc",
+                "escCollection": "enxcol_.encryptedCollection.esc",
+                "eccCollection": "enxcol_.encryptedCollection.ecc",
+                "ecocCollection": "enxcol_.encryptedCollection.ecoc",
                 "fields": [
                     {
                         "path": "firstName",
@@ -867,17 +867,17 @@ tests:
         # events from dropCollection ... begin
         - command_started_event:
             command:
-              drop: "encryptedCollection.esc"
+              drop: "enxcol_.encryptedCollection.esc"
             command_name: drop
             database_name: *database_name
         - command_started_event:
             command:
-              drop: "encryptedCollection.ecc"
+              drop: "enxcol_.encryptedCollection.ecc"
             command_name: drop
             database_name: *database_name
         - command_started_event:
             command:
-              drop: "encryptedCollection.ecoc"
+              drop: "enxcol_.encryptedCollection.ecoc"
             command_name: drop
             database_name: *database_name
         - command_started_event:
@@ -899,9 +899,9 @@ tests:
         arguments:
           collection: "encryptedCollection"
           encryptedFields: {
-                "escCollection": "encryptedCollection.esc",
-                "eccCollection": "encryptedCollection.ecc",
-                "ecocCollection": "encryptedCollection.ecoc",
+                "escCollection": "enxcol_.encryptedCollection.esc",
+                "eccCollection": "enxcol_.encryptedCollection.ecc",
+                "ecocCollection": "enxcol_.encryptedCollection.ecoc",
                 "fields": [
                     {
                         "path": "firstName",
@@ -915,9 +915,9 @@ tests:
         arguments:
           collection: "encryptedCollection"
           encryptedFields: {
-                "escCollection": "encryptedCollection.esc",
-                "eccCollection": "encryptedCollection.ecc",
-                "ecocCollection": "encryptedCollection.ecoc",
+                "escCollection": "enxcol_.encryptedCollection.esc",
+                "eccCollection": "enxcol_.encryptedCollection.ecc",
+                "ecocCollection": "enxcol_.encryptedCollection.ecoc",
                 "fields": [
                     {
                         "path": "firstName",
@@ -930,17 +930,17 @@ tests:
         object: testRunner
         arguments:
           database: *database_name
-          collection: "encryptedCollection.esc"
+          collection: "enxcol_.encryptedCollection.esc"
       - name: assertCollectionExists
         object: testRunner
         arguments:
           database: *database_name
-          collection: "encryptedCollection.ecc"
+          collection: "enxcol_.encryptedCollection.ecc"
       - name: assertCollectionExists
         object: testRunner
         arguments:
           database: *database_name
-          collection: "encryptedCollection.ecoc"
+          collection: "enxcol_.encryptedCollection.ecoc"
       - name: assertCollectionExists
         object: testRunner
         arguments:
@@ -957,9 +957,9 @@ tests:
         arguments:
           collection: "encryptedCollection"
           encryptedFields: &encrypted_fields6 {
-                "escCollection": "encryptedCollection.esc",
-                "eccCollection": "encryptedCollection.ecc",
-                "ecocCollection": "encryptedCollection.ecoc",
+                "escCollection": "enxcol_.encryptedCollection.esc",
+                "eccCollection": "enxcol_.encryptedCollection.ecc",
+                "ecocCollection": "enxcol_.encryptedCollection.ecoc",
                 "fields": [
                     {
                         "path": "firstName",
@@ -972,17 +972,17 @@ tests:
         object: testRunner
         arguments:
           database: *database_name
-          collection: "encryptedCollection.esc"
+          collection: "enxcol_.encryptedCollection.esc"
       - name: assertCollectionNotExists
         object: testRunner
         arguments:
           database: *database_name
-          collection: "encryptedCollection.ecc"
+          collection: "enxcol_.encryptedCollection.ecc"
       - name: assertCollectionNotExists
         object: testRunner
         arguments:
           database: *database_name
-          collection: "encryptedCollection.ecoc"
+          collection: "enxcol_.encryptedCollection.ecoc"
       - name: assertCollectionNotExists
         object: testRunner
         arguments:
@@ -992,17 +992,17 @@ tests:
         # events from dropCollection ... begin
         - command_started_event:
             command:
-              drop: "encryptedCollection.esc"
+              drop: "enxcol_.encryptedCollection.esc"
             command_name: drop
             database_name: *database_name
         - command_started_event:
             command:
-              drop: "encryptedCollection.ecc"
+              drop: "enxcol_.encryptedCollection.ecc"
             command_name: drop
             database_name: *database_name
         - command_started_event:
             command:
-              drop: "encryptedCollection.ecoc"
+              drop: "enxcol_.encryptedCollection.ecoc"
             command_name: drop
             database_name: *database_name
         - command_started_event:
@@ -1014,19 +1014,19 @@ tests:
         # events from createCollection ... begin
         - command_started_event:
             command:
-              create: "encryptedCollection.esc"
+              create: "enxcol_.encryptedCollection.esc"
               clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
         - command_started_event:
             command:
-              create: "encryptedCollection.ecc"
+              create: "enxcol_.encryptedCollection.ecc"
               clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
         - command_started_event:
             command:
-              create: "encryptedCollection.ecoc"
+              create: "enxcol_.encryptedCollection.ecoc"
               clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
@@ -1056,17 +1056,17 @@ tests:
         # events from dropCollection ... begin
         - command_started_event:
             command:
-              drop: "encryptedCollection.esc"
+              drop: "enxcol_.encryptedCollection.esc"
             command_name: drop
             database_name: *database_name
         - command_started_event:
             command:
-              drop: "encryptedCollection.ecc"
+              drop: "enxcol_.encryptedCollection.ecc"
             command_name: drop
             database_name: *database_name
         - command_started_event:
             command:
-              drop: "encryptedCollection.ecoc"
+              drop: "enxcol_.encryptedCollection.ecoc"
             command_name: drop
             database_name: *database_name
         - command_started_event:
@@ -1090,9 +1090,9 @@ tests:
         arguments:
           collection: "encryptedCollection"
           encryptedFields: {
-                "escCollection": "encryptedCollection.esc",
-                "eccCollection": "encryptedCollection.ecc",
-                "ecocCollection": "encryptedCollection.ecoc",
+                "escCollection": "enxcol_.encryptedCollection.esc",
+                "eccCollection": "enxcol_.encryptedCollection.ecc",
+                "ecocCollection": "enxcol_.encryptedCollection.ecoc",
                 "fields": [
                     {
                         "path": "firstName",
@@ -1106,9 +1106,9 @@ tests:
         arguments:
           collection: "encryptedCollection"
           encryptedFields: &encrypted_fields7 {
-                "escCollection": "encryptedCollection.esc",
-                "eccCollection": "encryptedCollection.ecc",
-                "ecocCollection": "encryptedCollection.ecoc",
+                "escCollection": "enxcol_.encryptedCollection.esc",
+                "eccCollection": "enxcol_.encryptedCollection.ecc",
+                "ecocCollection": "enxcol_.encryptedCollection.ecoc",
                 "fields": [
                     {
                         "path": "firstName",
@@ -1121,17 +1121,17 @@ tests:
         object: testRunner
         arguments:
           database: *database_name
-          collection: "encryptedCollection.esc"
+          collection: "enxcol_.encryptedCollection.esc"
       - name: assertCollectionExists
         object: testRunner
         arguments:
           database: *database_name
-          collection: "encryptedCollection.ecc"
+          collection: "enxcol_.encryptedCollection.ecc"
       - name: assertCollectionExists
         object: testRunner
         arguments:
           database: *database_name
-          collection: "encryptedCollection.ecoc"
+          collection: "enxcol_.encryptedCollection.ecoc"
       - name: assertCollectionExists
         object: testRunner
         arguments:
@@ -1151,17 +1151,17 @@ tests:
         object: testRunner
         arguments:
           database: *database_name
-          collection: "encryptedCollection.esc"
+          collection: "enxcol_.encryptedCollection.esc"
       - name: assertCollectionNotExists
         object: testRunner
         arguments:
           database: *database_name
-          collection: "encryptedCollection.ecc"
+          collection: "enxcol_.encryptedCollection.ecc"
       - name: assertCollectionNotExists
         object: testRunner
         arguments:
           database: *database_name
-          collection: "encryptedCollection.ecoc"
+          collection: "enxcol_.encryptedCollection.ecoc"
       - name: assertCollectionNotExists
         object: testRunner
         arguments:
@@ -1172,17 +1172,17 @@ tests:
         # events from dropCollection ... begin
         - command_started_event:
             command:
-              drop: "encryptedCollection.esc"
+              drop: "enxcol_.encryptedCollection.esc"
             command_name: drop
             database_name: *database_name
         - command_started_event:
             command:
-              drop: "encryptedCollection.ecc"
+              drop: "enxcol_.encryptedCollection.ecc"
             command_name: drop
             database_name: *database_name
         - command_started_event:
             command:
-              drop: "encryptedCollection.ecoc"
+              drop: "enxcol_.encryptedCollection.ecoc"
             command_name: drop
             database_name: *database_name
         - command_started_event:
@@ -1194,19 +1194,19 @@ tests:
         # events from createCollection ... begin
         - command_started_event:
             command:
-              create: "encryptedCollection.esc"
+              create: "enxcol_.encryptedCollection.esc"
               clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
         - command_started_event:
             command:
-              create: "encryptedCollection.ecc"
+              create: "enxcol_.encryptedCollection.ecc"
               clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
         - command_started_event:
             command:
-              create: "encryptedCollection.ecoc"
+              create: "enxcol_.encryptedCollection.ecoc"
               clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
@@ -1242,17 +1242,17 @@ tests:
             database_name: *database_name
         - command_started_event:
             command:
-              drop: "encryptedCollection.esc"
+              drop: "enxcol_.encryptedCollection.esc"
             command_name: drop
             database_name: *database_name
         - command_started_event:
             command:
-              drop: "encryptedCollection.ecc"
+              drop: "enxcol_.encryptedCollection.ecc"
             command_name: drop
             database_name: *database_name
         - command_started_event:
             command:
-              drop: "encryptedCollection.ecoc"
+              drop: "enxcol_.encryptedCollection.ecoc"
             command_name: drop
             database_name: *database_name
         - command_started_event:

--- a/test/spec/client-side-encryption/tests/legacy/fle2-EncryptedFields-vs-EncryptedFieldsMap.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2-EncryptedFields-vs-EncryptedFieldsMap.json
@@ -94,9 +94,9 @@
           },
           "encryptedFieldsMap": {
             "default.default": {
-              "escCollection": "esc",
-              "eccCollection": "ecc",
-              "ecocCollection": "ecoc",
+              "escCollection": "enxcol_.default.esc",
+              "eccCollection": "enxcol_.default.ecc",
+              "ecocCollection": "enxcol_.default.ecoc",
               "fields": []
             }
           }

--- a/test/spec/client-side-encryption/tests/legacy/fle2-EncryptedFields-vs-EncryptedFieldsMap.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2-EncryptedFields-vs-EncryptedFieldsMap.yml
@@ -15,9 +15,9 @@ tests:
           local: {'key': {'$binary': {'base64': 'Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk', 'subType': '00'}}}
         encryptedFieldsMap: {
           "default.default": {
-            "escCollection": "esc",
-            "eccCollection": "ecc",
-            "ecocCollection": "ecoc",
+            "escCollection": "enxcol_.default.esc",
+            "eccCollection": "enxcol_.default.ecc",
+            "ecocCollection": "enxcol_.default.ecoc",
             "fields": []
           }
         }


### PR DESCRIPTION
### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
