### PR TITLE
test(NODE-5091): introduce observeSensitiveCommands

### DIFF
--- a/src/cmap/command_monitoring_events.ts
+++ b/src/cmap/command_monitoring_events.ts
@@ -149,8 +149,11 @@ export class CommandFailedEvent {
   }
 }
 
-/** Commands that we want to redact because of the sensitive nature of their contents */
-const SENSITIVE_COMMANDS = new Set([
+/**
+ * Commands that we want to redact because of the sensitive nature of their contents
+ * @internal
+ */
+export const SENSITIVE_COMMANDS = new Set([
   'authenticate',
   'saslStart',
   'saslContinue',

--- a/test/tools/unified-spec-runner/entities.ts
+++ b/test/tools/unified-spec-runner/entities.ts
@@ -29,6 +29,7 @@ import {
   MongoCredentials,
   ReadConcern,
   ReadPreference,
+  SENSITIVE_COMMANDS,
   ServerDescriptionChangedEvent,
   TopologyDescription,
   WriteConcern
@@ -159,6 +160,10 @@ export class UnifiedMongoClient extends MongoClient {
       ...(description.ignoreCommandMonitoringEvents ?? []),
       'configureFailPoint'
     ];
+
+    if (!description.observeSensitiveCommands) {
+      this.ignoredEvents.push(...Array.from(SENSITIVE_COMMANDS));
+    }
 
     this.observedCommandEvents = (description.observeEvents ?? [])
       .map(e => UnifiedMongoClient.COMMAND_EVENT_NAME_LOOKUP[e])

--- a/test/tools/unified-spec-runner/schema.ts
+++ b/test/tools/unified-spec-runner/schema.ts
@@ -134,6 +134,7 @@ export interface ClientEntity {
   observeEvents?: (ObservableCommandEventId | ObservableCmapEventId)[];
   ignoreCommandMonitoringEvents?: string[];
   serverApi?: ServerApi;
+  observeSensitiveCommands?: boolean;
 }
 export interface DatabaseEntity {
   id: string;


### PR DESCRIPTION
### Description

Introduces `observeSensitiveCommands` to the unified spec runner.

#### What is changing?
- Adds the `observeSensitiveCommands` option to the client entity.
- Adds the sensitive commands to the ignored event list.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-5091

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
