### PR TITLE
test(NODE-3359): add spec tests for db names with commas

### DIFF
--- a/test/spec/initial-dns-seedlist-discovery/replica-set/dbname-with-commas-escaped.json
+++ b/test/spec/initial-dns-seedlist-discovery/replica-set/dbname-with-commas-escaped.json
@@ -1,0 +1,19 @@
+{
+  "uri": "mongodb+srv://test1.test.build.10gen.cc/some%2Cdb?replicaSet=repl0",
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017",
+    "localhost.test.build.10gen.cc:27018"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "replicaSet": "repl0",
+    "ssl": true
+  },
+  "parsed_options": {
+    "defaultDatabase": "some,db"
+  }
+}

--- a/test/spec/initial-dns-seedlist-discovery/replica-set/dbname-with-commas-escaped.yml
+++ b/test/spec/initial-dns-seedlist-discovery/replica-set/dbname-with-commas-escaped.yml
@@ -1,0 +1,13 @@
+uri: "mongodb+srv://test1.test.build.10gen.cc/some%2Cdb?replicaSet=repl0"
+seeds:
+  - localhost.test.build.10gen.cc:27017
+  - localhost.test.build.10gen.cc:27018
+hosts:
+  - localhost:27017
+  - localhost:27018
+  - localhost:27019
+options:
+  replicaSet: repl0
+  ssl: true
+parsed_options:
+  defaultDatabase: some,db

--- a/test/spec/initial-dns-seedlist-discovery/replica-set/dbname-with-commas.json
+++ b/test/spec/initial-dns-seedlist-discovery/replica-set/dbname-with-commas.json
@@ -1,0 +1,19 @@
+{
+  "uri": "mongodb+srv://test1.test.build.10gen.cc/some,db?replicaSet=repl0",
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017",
+    "localhost.test.build.10gen.cc:27018"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "replicaSet": "repl0",
+    "ssl": true
+  },
+  "parsed_options": {
+    "defaultDatabase": "some,db"
+  }
+}

--- a/test/spec/initial-dns-seedlist-discovery/replica-set/dbname-with-commas.yml
+++ b/test/spec/initial-dns-seedlist-discovery/replica-set/dbname-with-commas.yml
@@ -1,0 +1,13 @@
+uri: "mongodb+srv://test1.test.build.10gen.cc/some,db?replicaSet=repl0"
+seeds:
+  - localhost.test.build.10gen.cc:27017
+  - localhost.test.build.10gen.cc:27018
+hosts:
+  - localhost:27017
+  - localhost:27018
+  - localhost:27019
+options:
+  replicaSet: repl0
+  ssl: true
+parsed_options:
+  defaultDatabase: some,db


### PR DESCRIPTION
### Description
NODE-3359/DRIVERS-1777

#### What is changing?
- Sync initial dns seedlist discovery spec tests for db names with commas

##### Is there new documentation needed for these changes?
No

#### What is the motivation for this change?
Spec compliance

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
