### PR TITLE
feat(NODE-4696): add faas env handshake metadata

### DIFF
--- a/src/cmap/auth/auth_provider.ts
+++ b/src/cmap/auth/auth_provider.ts
@@ -1,8 +1,8 @@
 import type { Document } from '../../bson';
 import { MongoRuntimeError } from '../../error';
 import type { Callback, ClientMetadataOptions } from '../../utils';
-import type { HandshakeDocument } from '../connect';
 import type { Connection, ConnectionOptions } from '../connection';
+import type { HandshakeDocument } from '../handshake/handshake_generator';
 import type { MongoCredentials } from './mongo_credentials';
 
 export type AuthContextOptions = ConnectionOptions & ClientMetadataOptions;
@@ -32,20 +32,17 @@ export class AuthContext {
   }
 }
 
-export class AuthProvider {
+export abstract class AuthProvider {
   /**
    * Prepare the handshake document before the initial handshake.
    *
    * @param handshakeDoc - The document used for the initial handshake on a connection
    * @param authContext - Context for authentication flow
    */
-  prepare(
+  abstract prepare(
     handshakeDoc: HandshakeDocument,
-    authContext: AuthContext,
-    callback: Callback<HandshakeDocument>
-  ): void {
-    callback(undefined, handshakeDoc);
-  }
+    authContext: AuthContext
+  ): Promise<HandshakeDocument>;
 
   /**
    * Authenticate

--- a/src/cmap/auth/gssapi.ts
+++ b/src/cmap/auth/gssapi.ts
@@ -10,6 +10,7 @@ import {
   MongoRuntimeError
 } from '../../error';
 import { Callback, ns } from '../../utils';
+import type { HandshakeDocument } from '../handshake/handshake_generator';
 import { AuthContext, AuthProvider } from './auth_provider';
 
 /** @public */
@@ -33,6 +34,9 @@ type MechanismProperties = {
 };
 
 export class GSSAPI extends AuthProvider {
+  prepare(handshakeDoc: HandshakeDocument): Promise<HandshakeDocument> {
+    return Promise.resolve(handshakeDoc);
+  }
   override auth(authContext: AuthContext, callback: Callback): void {
     const { connection, credentials } = authContext;
     if (credentials == null)

--- a/src/cmap/auth/mongocr.ts
+++ b/src/cmap/auth/mongocr.ts
@@ -2,9 +2,13 @@ import * as crypto from 'crypto';
 
 import { MongoMissingCredentialsError } from '../../error';
 import { Callback, ns } from '../../utils';
+import type { HandshakeDocument } from '../handshake/handshake_generator';
 import { AuthContext, AuthProvider } from './auth_provider';
 
 export class MongoCR extends AuthProvider {
+  prepare(handshakeDoc: HandshakeDocument): Promise<HandshakeDocument> {
+    return Promise.resolve(handshakeDoc);
+  }
   override auth(authContext: AuthContext, callback: Callback): void {
     const { connection, credentials } = authContext;
     if (!credentials) {

--- a/src/cmap/auth/mongodb_aws.ts
+++ b/src/cmap/auth/mongodb_aws.ts
@@ -12,6 +12,7 @@ import {
   MongoRuntimeError
 } from '../../error';
 import { ByteUtils, Callback, maxWireVersion, ns } from '../../utils';
+import type { HandshakeDocument } from '../handshake/handshake_generator';
 import { AuthContext, AuthProvider } from './auth_provider';
 import { MongoCredentials } from './mongo_credentials';
 import { AuthMechanism } from './providers';
@@ -35,6 +36,9 @@ interface AWSSaslContinuePayload {
 }
 
 export class MongoDBAWS extends AuthProvider {
+  prepare(handshakeDoc: HandshakeDocument): Promise<HandshakeDocument> {
+    return Promise.resolve(handshakeDoc);
+  }
   override auth(authContext: AuthContext, callback: Callback): void {
     const { connection, credentials } = authContext;
     if (!credentials) {

--- a/src/cmap/auth/plain.ts
+++ b/src/cmap/auth/plain.ts
@@ -1,9 +1,13 @@
 import { Binary } from '../../bson';
 import { MongoMissingCredentialsError } from '../../error';
 import { Callback, ns } from '../../utils';
+import type { HandshakeDocument } from '../handshake/handshake_generator';
 import { AuthContext, AuthProvider } from './auth_provider';
 
 export class Plain extends AuthProvider {
+  prepare(handshakeDoc: HandshakeDocument): Promise<HandshakeDocument> {
+    return Promise.resolve(handshakeDoc);
+  }
   override auth(authContext: AuthContext, callback: Callback): void {
     const { connection, credentials } = authContext;
     if (!credentials) {

--- a/src/cmap/auth/x509.ts
+++ b/src/cmap/auth/x509.ts
@@ -1,25 +1,24 @@
 import type { Document } from '../../bson';
 import { MongoMissingCredentialsError } from '../../error';
 import { Callback, ns } from '../../utils';
-import type { HandshakeDocument } from '../connect';
+import type { HandshakeDocument } from '../handshake/handshake_generator';
 import { AuthContext, AuthProvider } from './auth_provider';
 import type { MongoCredentials } from './mongo_credentials';
 
 export class X509 extends AuthProvider {
   override prepare(
     handshakeDoc: HandshakeDocument,
-    authContext: AuthContext,
-    callback: Callback
-  ): void {
+    authContext: AuthContext
+  ): Promise<HandshakeDocument> {
     const { credentials } = authContext;
     if (!credentials) {
-      return callback(new MongoMissingCredentialsError('AuthContext must provide credentials.'));
+      throw new MongoMissingCredentialsError('AuthContext must provide credentials.');
     }
     Object.assign(handshakeDoc, {
       speculativeAuthenticate: x509AuthenticateCommand(credentials)
     });
 
-    callback(undefined, handshakeDoc);
+    return Promise.resolve(handshakeDoc);
   }
 
   override auth(authContext: AuthContext, callback: Callback): void {

--- a/src/cmap/handshake/auth_decorator.ts
+++ b/src/cmap/handshake/auth_decorator.ts
@@ -1,0 +1,43 @@
+import { MongoInvalidArgumentError } from '../../error';
+import type { AuthContext, AuthProvider } from '../auth/auth_provider';
+import { AuthMechanism } from '../auth/providers';
+import { AUTH_PROVIDERS } from '../connect';
+import type { HandshakeDecorator } from './handshake_decorator';
+import type { HandshakeDocument } from './handshake_generator';
+
+/**
+ * Handles decoration of the handshake doc with speculative auth.
+ */
+export class AuthDecorator implements HandshakeDecorator {
+  /**
+   * Decorate the handshake doc with speculative authentication.
+   */
+  async decorate(
+    handshake: HandshakeDocument,
+    authContext: AuthContext
+  ): Promise<HandshakeDocument> {
+    const credentials = authContext.credentials;
+    if (credentials) {
+      if (credentials.mechanism === AuthMechanism.MONGODB_DEFAULT && credentials.username) {
+        handshake.saslSupportedMechs = `${credentials.source}.${credentials.username}`;
+        const provider = getProvider(AuthMechanism.MONGODB_SCRAM_SHA256);
+        await provider.prepare(handshake, authContext);
+      } else {
+        const provider = getProvider(credentials.mechanism);
+        await provider.prepare(handshake, authContext);
+      }
+    }
+    return handshake;
+  }
+}
+
+/**
+ * Get a provider for the mechanism
+ */
+function getProvider(mechanism: string): AuthProvider {
+  const provider = AUTH_PROVIDERS.get(mechanism);
+  if (!provider) {
+    throw new MongoInvalidArgumentError(`No AuthProvider for ${mechanism} defined.`);
+  }
+  return provider;
+}

--- a/src/cmap/handshake/faas_env_decorator.ts
+++ b/src/cmap/handshake/faas_env_decorator.ts
@@ -1,0 +1,119 @@
+import { BSON } from 'bson';
+
+import type { HandshakeDecorator } from './handshake_decorator';
+import type { HandshakeDocument } from './handshake_generator';
+
+/**
+ * FaaS environment metadata.
+ * @internal
+ */
+export interface FaasMetadata {
+  /** All metadata has a name */
+  name: string;
+  /** Lambda/GCP/Vercel */
+  region?: string;
+  /** Lambda/GCP */
+  memoryMb?: string;
+  /** GCP */
+  timeoutSec?: string;
+  /** Vercel */
+  url?: string;
+}
+
+/** @internal */
+export const FaasProvider = Object.freeze({
+  AWS: 'aws',
+  AZURE: 'azure',
+  GCP: 'gcp',
+  VERCEL: 'vercel'
+} as const);
+
+/** @internal */
+export type FaasProvider = typeof FaasProvider[keyof typeof FaasProvider];
+
+/** @internal */
+const MAX_HANDSHAKE_BYTES = 512;
+
+/**
+ * Decorates the handshake doc with FaaS environment information.
+ */
+export class FaasEnvDecorator implements HandshakeDecorator {
+  /**
+   * Decorate the handshake document.
+   */
+  decorate(handshake: HandshakeDocument): Promise<HandshakeDocument> {
+    // Check in which environment we are.
+    switch (determineFaasProvider()) {
+      case FaasProvider.AWS:
+        modifyHandshake(handshake, {
+          name: process.env.AWS_EXECUTION_ENV || FaasProvider.AWS,
+          region: process.env.AWS_REGION,
+          memoryMb: process.env.AWS_LAMBDA_FUNCTION_MEMORY_SIZE
+        });
+        break;
+      case FaasProvider.AZURE:
+        modifyHandshake(handshake, {
+          name: process.env.FUNCTIONS_WORKER_RUNTIME || FaasProvider.AZURE
+        });
+        break;
+      case FaasProvider.GCP:
+        modifyHandshake(handshake, {
+          name: process.env.FUNCTION_NAME || FaasProvider.GCP,
+          region: process.env.FUNCTION_REGION,
+          memoryMb: process.env.FUNCTION_MEMORY_MB,
+          timeoutSec: process.env.FUNCTION_TIMEOUT_SEC
+        });
+        break;
+      case FaasProvider.VERCEL:
+        modifyHandshake(handshake, {
+          name: process.env.VERCEL || FaasProvider.VERCEL,
+          region: process.env.VERCEL_REGION,
+          url: process.env.VERCEL_URL
+        });
+        break;
+    }
+    return Promise.resolve(handshake);
+  }
+}
+
+/**
+ * Determine the FaaS provider.
+ */
+function determineFaasProvider(): FaasProvider | undefined {
+  if (process.env.VERCEL) {
+    return FaasProvider.VERCEL;
+  }
+  if (process.env.AWS_EXECUTION_ENV) {
+    return FaasProvider.AWS;
+  }
+  if (process.env.FUNCTIONS_WORKER_RUNTIME) {
+    return FaasProvider.GCP;
+  }
+  if (process.env.FUNCTION_NAME) {
+    return FaasProvider.AZURE;
+  }
+  return undefined;
+}
+
+/**
+ * Modify the handshake document.
+ */
+function modifyHandshake(handshake: HandshakeDocument, metadata: FaasMetadata): void {
+  let raw;
+  // Add the env document.
+  handshake.env = metadata;
+  // Serialize the document.
+  raw = BSON.serialize(handshake);
+  // Check if the handshake is less than 512 bytes.
+  if (raw.length > MAX_HANDSHAKE_BYTES) {
+    // If too large, set only the name.
+    handshake.env = { name: metadata.name };
+    // Serialize the document.
+    raw = BSON.serialize(handshake);
+    // Check if the handshake is less than 512 bytes.
+    if (raw.length > MAX_HANDSHAKE_BYTES) {
+      // If so remove the env metadata.
+      delete handshake.env;
+    }
+  }
+}

--- a/src/cmap/handshake/handshake_decorator.ts
+++ b/src/cmap/handshake/handshake_decorator.ts
@@ -1,0 +1,12 @@
+import type { AuthContext } from '../auth/auth_provider';
+import type { HandshakeDocument } from './handshake_generator';
+
+/**
+ * Decorates the initial handshake.
+ */
+export interface HandshakeDecorator {
+  /**
+   * Decorate the handshake document.
+   */
+  decorate(handshake: HandshakeDocument, authContext: AuthContext): Promise<HandshakeDocument>;
+}

--- a/src/cmap/handshake/handshake_generator.ts
+++ b/src/cmap/handshake/handshake_generator.ts
@@ -1,0 +1,73 @@
+import type { Document } from 'bson';
+
+import { LEGACY_HELLO_COMMAND } from '../../constants';
+import { ClientMetadata, makeClientMetadata } from '../../utils';
+import type { AuthContext } from '../auth/auth_provider';
+import { AuthDecorator } from './auth_decorator';
+import { FaasEnvDecorator, FaasMetadata } from './faas_env_decorator';
+import type { HandshakeDecorator } from './handshake_decorator';
+
+export interface HandshakeDocument extends Document {
+  /**
+   * @deprecated Use hello instead
+   */
+  ismaster?: boolean;
+  hello?: boolean;
+  helloOk?: boolean;
+  client: ClientMetadata;
+  compression: string[];
+  saslSupportedMechs?: string;
+  loadBalanced?: boolean;
+  speculativeAuthenticate?: Document;
+  env?: FaasMetadata;
+}
+
+/**
+ * Handshake doc decorators.
+ * @internal
+ */
+export const HANDSHAKE_DECORATORS: HandshakeDecorator[] = [
+  new AuthDecorator(),
+  new FaasEnvDecorator()
+];
+
+/**
+ * Generates the initial handshake.
+ */
+export class HandshakeGenerator {
+  decorators: HandshakeDecorator[];
+
+  /**
+   * Instantiate the generator. Inject the decorator array to be able to
+   * unit test in isolation.
+   */
+  constructor(decorators: HandshakeDecorator[]) {
+    this.decorators = decorators;
+  }
+
+  /**
+   * Generate the initial handshake.
+   */
+  async generate(authContext: AuthContext): Promise<HandshakeDocument> {
+    const options = authContext.options;
+    const compressors = options.compressors ? options.compressors : [];
+    const { serverApi } = authContext.connection;
+
+    const handshakeDoc: HandshakeDocument = {
+      [serverApi?.version ? 'hello' : LEGACY_HELLO_COMMAND]: 1,
+      helloOk: true,
+      client: options.metadata || makeClientMetadata(options),
+      compression: compressors
+    };
+
+    if (options.loadBalanced === true) {
+      handshakeDoc.loadBalanced = true;
+    }
+
+    for (const decorator of this.decorators) {
+      await decorator.decorate(handshakeDoc, authContext);
+    }
+
+    return handshakeDoc;
+  }
+}


### PR DESCRIPTION
### Description

Adds FaaS metadata to the initial handshake when applicable.

#### What is changing?
- Moves the generation of the initial handshake out of the connect module and into a `HandshakeGenerator`.
- Uses a decorator pattern in the generator to decorate the handshake with speculative auth and FaaS information when applicable.
- Refactors the auth provider's `prepare` method to no longer use callbacks and updates all implementations.

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
