### PR TITLE
ci(NODE-5099): add aarch64 condition to sync with other repos

### DIFF
--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -40,6 +40,8 @@ if [[ $architecture = "x86_64" ]]; then
   architecture="x64"
 elif [[ $architecture = "arm64" ]]; then
   architecture="arm64"
+elif [[ $architecture = "aarch64" ]]; then
+  architecture="arm64"
 elif [[ $architecture == s390* ]]; then
   architecture="s390x"
 elif [[ $architecture == ppc* ]]; then


### PR DESCRIPTION
### Description

#### What is changing?

Keeping 5.x in sync with other repos install scripts

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
