### PR TITLE
ci(NODE-5110): update curl flags

### DIFF
--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -6,6 +6,7 @@ NODE_ARTIFACTS_PATH="${PROJECT_DIRECTORY:-$(pwd)}/node-artifacts"
 if [[ "$OS" = "Windows_NT" ]]; then NODE_ARTIFACTS_PATH=$(cygpath --unix "$NODE_ARTIFACTS_PATH"); fi
 
 CURL_FLAGS=(
+  --fail          # Exit code 1 if request fails
   --compressed    # Request a compressed response should keep fetching fast
   --location      # Follow a redirect
   --retry 8       # Retry HTTP 408, 429, 500, 502, 503 or 504, 8 times

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -6,7 +6,6 @@ NODE_ARTIFACTS_PATH="${PROJECT_DIRECTORY:-$(pwd)}/node-artifacts"
 if [[ "$OS" = "Windows_NT" ]]; then NODE_ARTIFACTS_PATH=$(cygpath --unix "$NODE_ARTIFACTS_PATH"); fi
 
 CURL_FLAGS=(
-  --fail          # Exit code 1 if request fails
   --compressed    # Request a compressed response should keep fetching fast
   --location      # Follow a redirect
   --retry 8       # Retry HTTP 408, 429, 500, 502, 503 or 504, 8 times

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -13,7 +13,7 @@ shopt -s nocasematch
 # index.tab is a sorted tab separated values file with the following headers
 # 0       1    2     3   4  5  6    7       8       9   10
 # version date files npm v8 uv zlib openssl modules lts security
-curl --retry 8 -sS "https://nodejs.org/dist/index.tab" --max-time 300 --output node_index.tab
+curl --compressed -C - -L --retry 8 -sS "https://nodejs.org/dist/index.tab" --max-time 900 --output node_index.tab
 
 while IFS=$'\t' read -r -a row; do
   node_index_version="${row[0]}"
@@ -63,7 +63,7 @@ echo "Node.js ${node_index_version} for ${operating_system}-${architecture} rele
 
 set -o xtrace
 
-curl --fail --retry 8 -sS "${node_download_url}" --max-time 300 --output "$node_archive_path"
+curl --compressed -C - -L --fail --retry 8 -sS "${node_download_url}" --max-time 900 --output "$node_archive_path"
 
 if [[ "$file_extension" = "zip" ]]; then
   unzip -q "$node_archive_path" -d "${NODE_ARTIFACTS_PATH}"

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -5,6 +5,8 @@ NODE_LTS_NAME=${NODE_LTS_NAME:-fermium}
 NODE_ARTIFACTS_PATH="${PROJECT_DIRECTORY:-$(pwd)}/node-artifacts"
 if [[ "$OS" = "Windows_NT" ]]; then NODE_ARTIFACTS_PATH=$(cygpath --unix "$NODE_ARTIFACTS_PATH"); fi
 
+CURL_FLAGS=(--compressed --location --retry 8 --silent --show-error --max-time 900 --continue-at -)
+
 mkdir -p "$NODE_ARTIFACTS_PATH/npm_global"
 
 # Comparisons are all case insensitive
@@ -13,7 +15,7 @@ shopt -s nocasematch
 # index.tab is a sorted tab separated values file with the following headers
 # 0       1    2     3   4  5  6    7       8       9   10
 # version date files npm v8 uv zlib openssl modules lts security
-curl --compressed -C - -L --retry 8 -sS "https://nodejs.org/dist/index.tab" --max-time 900 --output node_index.tab
+curl "${CURL_FLAGS[@]}" "https://nodejs.org/dist/index.tab" --output node_index.tab
 
 while IFS=$'\t' read -r -a row; do
   node_index_version="${row[0]}"
@@ -63,7 +65,7 @@ echo "Node.js ${node_index_version} for ${operating_system}-${architecture} rele
 
 set -o xtrace
 
-curl --compressed -C - -L --fail --retry 8 -sS "${node_download_url}" --max-time 900 --output "$node_archive_path"
+curl "${CURL_FLAGS[@]}" "${node_download_url}" --output "$node_archive_path"
 
 if [[ "$file_extension" = "zip" ]]; then
   unzip -q "$node_archive_path" -d "${NODE_ARTIFACTS_PATH}"

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -5,7 +5,15 @@ NODE_LTS_NAME=${NODE_LTS_NAME:-fermium}
 NODE_ARTIFACTS_PATH="${PROJECT_DIRECTORY:-$(pwd)}/node-artifacts"
 if [[ "$OS" = "Windows_NT" ]]; then NODE_ARTIFACTS_PATH=$(cygpath --unix "$NODE_ARTIFACTS_PATH"); fi
 
-CURL_FLAGS=(--compressed --location --retry 8 --silent --show-error --max-time 900 --continue-at -)
+CURL_FLAGS=(
+  --compressed    # Request a compressed response should keep fetching fast
+  --location      # Follow a redirect
+  --retry 8       # Retry HTTP 408, 429, 500, 502, 503 or 504, 8 times
+  --silent        # Do not print a progress bar
+  --show-error    # Despite the silent flag still print out errors
+  --max-time 900  # 900 seconds is 15 minutes, evergreen times out at 20
+  --continue-at - # If a download is interrupted it can figure out where to resume
+)
 
 mkdir -p "$NODE_ARTIFACTS_PATH/npm_global"
 


### PR DESCRIPTION
### Description

#### What is changing?

Added Curl flags
- compressed - should fetch compressed data
- location - will follow redirects
- continue-at - will resume interrupted downloads

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
