### PR TITLE
ci(NODE-5124): ignore curl 92 errors when downloading node

### DIFF
--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -76,7 +76,7 @@ set -o xtrace
 
 set +o errexit
 curl "${CURL_FLAGS[@]}" "${node_download_url}" --output "$node_archive_path"
-if [[ $? -ne 0 && $? -ne 92 ]]; then echo "neither zero nor 92 exit code while downloading Node.js: got $code"; fi
+if [[ $? -ne 0 && $? -ne 92 ]]; then echo "neither zero nor 92 exit code while downloading Node.js: got $?"; fi
 set -o errexit
 
 

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -76,8 +76,7 @@ set -o xtrace
 
 set +o errexit
 curl "${CURL_FLAGS[@]}" "${node_download_url}" --output "$node_archive_path"
-code=$?
-if [ $code -ne 0 ] && [ $code -ne 92 ]; then echo "non-zero or 92 exit code while downloading NodeJS $code"; fi
+if [[ $? -ne 0 && $? -ne 92 ]]; then echo "neither zero nor 92 exit code while downloading Node.js: got $code"; fi
 set -o errexit
 
 

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -74,7 +74,11 @@ echo "Node.js ${node_index_version} for ${operating_system}-${architecture} rele
 
 set -o xtrace
 
+set +o errexit
 curl "${CURL_FLAGS[@]}" "${node_download_url}" --output "$node_archive_path"
+if [[ $? -eq 92 ]]; then exit 1; fi
+set -o errexit
+
 
 if [[ "$file_extension" = "zip" ]]; then
   unzip -q "$node_archive_path" -d "${NODE_ARTIFACTS_PATH}"

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -76,7 +76,8 @@ set -o xtrace
 
 set +o errexit
 curl "${CURL_FLAGS[@]}" "${node_download_url}" --output "$node_archive_path"
-if [[ $? -eq 92 ]]; then exit 1; fi
+code=$?
+if [ $code -ne 0 ] && [ $code -ne 92 ]; then echo "non-zero or 92 exit code while downloading NodeJS $code"; fi
 set -o errexit
 
 


### PR DESCRIPTION
### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
