### PR TITLE
spike(NODE-4739): read TLS files async

### DIFF
--- a/src/cmap/auth/mongodb_oidc/aws_service_workflow.ts
+++ b/src/cmap/auth/mongodb_oidc/aws_service_workflow.ts
@@ -1,4 +1,4 @@
-import { readFile } from 'fs/promises';
+import { promises as fs } from 'fs';
 
 import { MongoAWSError } from '../../../error';
 import { ServiceWorkflow } from './service_workflow';
@@ -21,6 +21,6 @@ export class AwsServiceWorkflow extends ServiceWorkflow {
     if (!tokenFile) {
       throw new MongoAWSError('AWS_WEB_IDENTITY_TOKEN_FILE must be set in the environment.');
     }
-    return readFile(tokenFile, 'utf8');
+    return fs.readFile(tokenFile, 'utf8');
   }
 }

--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -1,5 +1,4 @@
-import * as dns from 'dns';
-import * as fs from 'fs';
+import { promises as dns } from 'dns';
 import ConnectionString from 'mongodb-connection-string-url';
 import { URLSearchParams } from 'url';
 
@@ -80,9 +79,7 @@ export async function resolveSRVRecord(options: MongoOptions): Promise<HostAddre
 
   // Resolve the SRV record and use the result as the list of hosts to connect to.
   const lookupAddress = options.srvHost;
-  const addresses = await dns.promises.resolveSrv(
-    `_${options.srvServiceName}._tcp.${lookupAddress}`
-  );
+  const addresses = await dns.resolveSrv(`_${options.srvServiceName}._tcp.${lookupAddress}`);
 
   if (addresses.length === 0) {
     throw new MongoAPIError('No addresses found at host');
@@ -101,7 +98,7 @@ export async function resolveSRVRecord(options: MongoOptions): Promise<HostAddre
   // Resolve TXT record and add options from there if they exist.
   let record;
   try {
-    record = await dns.promises.resolveTxt(lookupAddress);
+    record = await dns.resolveTxt(lookupAddress);
   } catch (error) {
     if (error.code !== 'ENODATA' && error.code !== 'ENOTFOUND') {
       throw error;
@@ -1103,28 +1100,20 @@ export const OPTIONS = {
     type: 'boolean'
   },
   sslCA: {
-    target: 'ca',
-    transform({ values: [value] }) {
-      return fs.readFileSync(String(value), { encoding: 'ascii' });
-    }
+    target: 'caFileName',
+    type: 'string'
   },
   sslCRL: {
-    target: 'crl',
-    transform({ values: [value] }) {
-      return fs.readFileSync(String(value), { encoding: 'ascii' });
-    }
+    target: 'crlFileName',
+    type: 'string'
   },
   sslCert: {
-    target: 'cert',
-    transform({ values: [value] }) {
-      return fs.readFileSync(String(value), { encoding: 'ascii' });
-    }
+    target: 'certFileName',
+    type: 'string'
   },
   sslKey: {
-    target: 'key',
-    transform({ values: [value] }) {
-      return fs.readFileSync(String(value), { encoding: 'ascii' });
-    }
+    target: 'keyFileName',
+    type: 'string'
   },
   sslPass: {
     deprecated: true,
@@ -1153,22 +1142,16 @@ export const OPTIONS = {
     }
   },
   tlsCAFile: {
-    target: 'ca',
-    transform({ values: [value] }) {
-      return fs.readFileSync(String(value), { encoding: 'ascii' });
-    }
+    target: 'caFileName',
+    type: 'string'
   },
   tlsCertificateFile: {
-    target: 'cert',
-    transform({ values: [value] }) {
-      return fs.readFileSync(String(value), { encoding: 'ascii' });
-    }
+    target: 'certFileName',
+    type: 'string'
   },
   tlsCertificateKeyFile: {
-    target: 'key',
-    transform({ values: [value] }) {
-      return fs.readFileSync(String(value), { encoding: 'ascii' });
-    }
+    target: 'keyFileName',
+    type: 'string'
   },
   tlsCertificateKeyFilePassword: {
     target: 'passphrase',

--- a/test/unit/connection_string.test.ts
+++ b/test/unit/connection_string.test.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import * as dns from 'dns';
+import { promises as fs } from 'fs';
 import * as sinon from 'sinon';
 
 import {
@@ -15,7 +16,8 @@ import {
   MongoParseError,
   MongoRuntimeError,
   parseOptions,
-  resolveSRVRecord
+  resolveSRVRecord,
+  Topology
 } from '../mongodb';
 
 describe('Connection String', function () {
@@ -393,6 +395,47 @@ describe('Connection String', function () {
           }).to.throw(MongoParseError, 'All values of tls/ssl must be the same.');
         });
       });
+    });
+  });
+
+  context('when tls filepaths are provided', () => {
+    beforeEach(async () => {
+      sinon.stub(Topology.prototype, 'connect').yieldsRight();
+      await fs.writeFile('caFileName.txt', 'abc', { encoding: 'utf8' });
+      await fs.writeFile('crlFileName.txt', 'abc', { encoding: 'utf8' });
+      await fs.writeFile('certFileName.txt', 'abc', { encoding: 'utf8' });
+      await fs.writeFile('keyFileName.txt', 'abc', { encoding: 'utf8' });
+    });
+
+    afterEach(() => sinon.restore());
+    afterEach(() => fs.unlink('caFileName.txt'));
+    afterEach(() => fs.unlink('crlFileName.txt'));
+    afterEach(() => fs.unlink('certFileName.txt'));
+    afterEach(() => fs.unlink('keyFileName.txt'));
+
+    it.only('should read in files async', async () => {
+      const client = new MongoClient('mongodb://iLoveJavaScript?tls=true', {
+        sslCA: 'caFileName.txt',
+        sslCRL: 'crlFileName.txt',
+        sslCert: 'certFileName.txt',
+        sslKey: 'keyFileName.txt'
+      });
+
+      expect(client.options).property('caFileName', 'caFileName.txt');
+      expect(client.options).property('crlFileName', 'crlFileName.txt');
+      expect(client.options).property('certFileName', 'certFileName.txt');
+      expect(client.options).property('keyFileName', 'keyFileName.txt');
+      expect(client.options).not.have.property('ca');
+      expect(client.options).not.have.property('crl');
+      expect(client.options).not.have.property('cert');
+      expect(client.options).not.have.property('key');
+
+      await client.connect();
+
+      expect(client.options).property('ca', 'abc');
+      expect(client.options).property('crl', 'abc');
+      expect(client.options).property('cert', 'abc');
+      expect(client.options).property('key', 'abc');
     });
   });
 


### PR DESCRIPTION
### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
