### PR TITLE
chore(NODE-4972): sync connection string error tests

### DIFF
--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -215,12 +215,12 @@ function getUIntFromOptions(name: string, value: unknown): number {
   return parsedValue;
 }
 
-function* entriesFromString(value: string): Generator<[string, string]> {
+function* entriesFromString(optionName: string, value: string): Generator<[string, string]> {
   const keyValuePairs = value.split(',');
   for (const keyValue of keyValuePairs) {
     const [key, value] = keyValue.split(':');
     if (value == null) {
-      throw new MongoParseError('Cannot have undefined values in key value pairs');
+      throw new MongoParseError(`malformed entry for key ${optionName}: ${value}`);
     }
 
     yield [key, value];
@@ -651,7 +651,7 @@ interface OptionDescriptor {
   transform?: (args: { name: string; options: MongoOptions; values: unknown[] }) => unknown;
 }
 
-export const OPTIONS = {
+export const OPTIONS: Record<string, OptionDescriptor> = {
   appName: {
     target: 'metadata',
     transform({ options, values: [value] }): DriverInfo {
@@ -710,7 +710,7 @@ export const OPTIONS = {
 
       for (const optionValue of values) {
         if (typeof optionValue === 'string') {
-          for (const [key, value] of entriesFromString(optionValue)) {
+          for (const [key, value] of entriesFromString('authMechanismProperties', optionValue)) {
             try {
               mechanismProperties[key] = getBoolean(key, value);
             } catch {
@@ -1059,7 +1059,7 @@ export const OPTIONS = {
       for (const tag of tags) {
         const readPreferenceTag: TagSet = Object.create(null);
         if (typeof tag === 'string') {
-          for (const [k, v] of entriesFromString(tag)) {
+          for (const [k, v] of entriesFromString('readPreferenceTags', tag)) {
             readPreferenceTag[k] = v;
           }
         }

--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -301,11 +301,19 @@ export function parseOptions(
     urlOptions.set('auth', [auth]);
   }
 
+  const validListOptions = Object.entries(OPTIONS)
+    .filter(([_, { multipleValuesAllowed }]) => multipleValuesAllowed)
+    .map(([key, _]) => key);
+
   for (const key of url.searchParams.keys()) {
     const values = [...url.searchParams.getAll(key)];
 
     if (values.includes('')) {
       throw new MongoAPIError('URI cannot contain options with no value');
+    }
+
+    if (!validListOptions.includes(key) && values.length > 1) {
+      throw new MongoAPIError(`URI option ${key} cannot be specified multiple times.`);
     }
 
     if (!urlOptions.has(key)) {
@@ -632,6 +640,7 @@ interface OptionDescriptor {
   target?: string;
   type?: 'boolean' | 'int' | 'uint' | 'record' | 'string' | 'any';
   default?: any;
+  multipleValuesAllowed?: true;
 
   deprecated?: boolean | string;
   /**
@@ -718,7 +727,8 @@ export const OPTIONS = {
       return MongoCredentials.merge(options.credentials, {
         mechanismProperties
       });
-    }
+    },
+    multipleValuesAllowed: true
   },
   authSource: {
     target: 'credentials',
@@ -784,7 +794,8 @@ export const OPTIONS = {
         }
       }
       return [...compressionList];
-    }
+    },
+    multipleValuesAllowed: true
   },
   connectTimeoutMS: {
     default: 30000,
@@ -1063,7 +1074,8 @@ export const OPTIONS = {
         readPreference: options.readPreference,
         readPreferenceTags
       });
-    }
+    },
+    multipleValuesAllowed: true
   },
   replicaSet: {
     type: 'string'

--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -727,8 +727,7 @@ export const OPTIONS: Record<string, OptionDescriptor> = {
       return MongoCredentials.merge(options.credentials, {
         mechanismProperties
       });
-    },
-    multipleValuesAllowed: true
+    }
   },
   authSource: {
     target: 'credentials',
@@ -794,8 +793,7 @@ export const OPTIONS: Record<string, OptionDescriptor> = {
         }
       }
       return [...compressionList];
-    },
-    multipleValuesAllowed: true
+    }
   },
   connectTimeoutMS: {
     default: 30000,

--- a/test/spec/connection-string/invalid-options.json
+++ b/test/spec/connection-string/invalid-options.json
@@ -5,13 +5,7 @@
       "uri": "mongodb://example.com/?foo=bar",
       "valid": false,
       "warning": false,
-      "hosts": [
-        {
-          "type": "hostname",
-          "host": "example.com",
-          "port": null
-        }
-      ],
+      "hosts": null,
       "auth": null,
       "options": null
     },
@@ -20,13 +14,7 @@
       "uri": "mongodb://example.com/?fsync=ifPossible",
       "valid": false,
       "warning": false,
-      "hosts": [
-        {
-          "type": "hostname",
-          "host": "example.com",
-          "port": null
-        }
-      ],
+      "hosts": null,
       "auth": null,
       "options": null
     },
@@ -35,96 +23,52 @@
       "uri": "mongodb://example.com/?replicaSet=test&replicaSet=test",
       "valid": false,
       "warning": false,
-      "hosts": [
-        {
-          "type": "hostname",
-          "host": "example.com",
-          "port": null
-        }
-      ],
+      "hosts": null,
       "auth": null,
-      "options": {
-        "replicaset": "test"
-      }
+      "options": null
     },
     {
       "description": "Repeated option keys with different values",
       "uri": "mongodb://example.com/?replicaSet=test1&replicaSet=test2",
       "valid": false,
       "warning": false,
-      "hosts": [
-        {
-          "type": "hostname",
-          "host": "example.com",
-          "port": null
-        }
-      ],
+      "hosts": null,
       "auth": null,
-      "options": {
-        "replicaset": "test"
-      }
+      "options": null
     },
     {
       "description": "List option with one empty option specified",
       "uri": "mongodb://example.com/?readPreferenceTags=dc:ny,rack:1&readPreferenceTags=dc:ny&readPreferenceTags=",
       "valid": false,
       "warning": false,
-      "hosts": [
-        {
-          "type": "hostname",
-          "host": "example.com",
-          "port": null
-        }
-      ],
+      "hosts": null,
       "auth": null,
-      "options": {
-        "replicaset": "test"
-      }
+      "options": null
     },
     {
       "description": "List option with an invalid option specified",
       "uri": "mongodb://example.com/?readPreferenceTags=dc:ny,rack:1&readPreferenceTags=dc:ny&readPreferenceTags=foobarbaz",
       "valid": false,
       "warning": false,
-      "hosts": [
-        {
-          "type": "hostname",
-          "host": "example.com",
-          "port": null
-        }
-      ],
+      "hosts": null,
       "auth": null,
-      "options": {
-        "replicaset": "test"
-      }
+      "options": null
     },
     {
       "description": "Error on empty integer option values",
       "uri": "mongodb://localhost/?maxIdleTimeMS=",
       "valid": false,
       "warning": false,
-      "hosts": [
-        {
-          "type": "hostname",
-          "host": "localhost",
-          "port": null
-        }
-      ],
+      "hosts": null,
       "auth": null,
       "options": null
     },
     {
-      "description": "Error on empty non-integer value for integer option",
-      "uri": "mongodb://localhost/?maxIdleTimeMS=",
+      "description": "Error on non-empty invalid value for integer option",
+      "uri": "mongodb://localhost/?maxIdleTimeMS=aString",
       "valid": false,
       "warning": false,
-      "hosts": [
-        {
-          "type": "hostname",
-          "host": "localhost",
-          "port": null
-        }
-      ],
+      "hosts": null,
       "auth": null,
       "options": null
     },
@@ -133,13 +77,7 @@
       "uri": "mongodb://localhost/?journal=",
       "valid": false,
       "warning": false,
-      "hosts": [
-        {
-          "type": "hostname",
-          "host": "localhost",
-          "port": null
-        }
-      ],
+      "hosts": null,
       "auth": null,
       "options": null
     },
@@ -148,13 +86,7 @@
       "uri": "mongodb://localhost/?journal=stringValue",
       "valid": false,
       "warning": false,
-      "hosts": [
-        {
-          "type": "hostname",
-          "host": "localhost",
-          "port": null
-        }
-      ],
+      "hosts": null,
       "auth": null,
       "options": null
     }

--- a/test/spec/connection-string/invalid-options.json
+++ b/test/spec/connection-string/invalid-options.json
@@ -1,0 +1,128 @@
+{
+  "tests": [
+    {
+      "description": "Error on unrecognized option keys",
+      "uri": "mongodb://example.com/?foo=bar",
+      "valid": false,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "example.com",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Error on unsupported option values",
+      "uri": "mongodb://example.com/?fsync=ifPossible",
+      "valid": false,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "example.com",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Repeated option keys with the same value",
+      "uri": "mongodb://example.com/?replicaSet=test&replicaSet=test",
+      "valid": false,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "example.com",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": {
+        "replicaset": "test"
+      }
+    },
+    {
+      "description": "Repeated option keys with different values",
+      "uri": "mongodb://example.com/?replicaSet=test1&replicaSet=test2",
+      "valid": false,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "example.com",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": {
+        "replicaset": "test"
+      }
+    },
+    {
+      "description": "Error on empty integer option values",
+      "uri": "mongodb://localhost/?maxIdleTimeMS=",
+      "valid": false,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "localhost",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Error on empty non-integer value for integer option",
+      "uri": "mongodb://localhost/?maxIdleTimeMS=",
+      "valid": false,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "localhost",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Error on empty boolean option value",
+      "uri": "mongodb://localhost/?journal=",
+      "valid": false,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "localhost",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Error on non-empty invalid value for boolean option",
+      "uri": "mongodb://localhost/?journal=stringValue",
+      "valid": false,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "localhost",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
+    }
+  ]
+}

--- a/test/spec/connection-string/invalid-options.json
+++ b/test/spec/connection-string/invalid-options.json
@@ -65,6 +65,40 @@
       }
     },
     {
+      "description": "List option with one empty option specified",
+      "uri": "mongodb://example.com/?readPreferenceTags=dc:ny,rack:1&readPreferenceTags=dc:ny&readPreferenceTags=",
+      "valid": false,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "example.com",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": {
+        "replicaset": "test"
+      }
+    },
+    {
+      "description": "List option with an invalid option specified",
+      "uri": "mongodb://example.com/?readPreferenceTags=dc:ny,rack:1&readPreferenceTags=dc:ny&readPreferenceTags=foobarbaz",
+      "valid": false,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "example.com",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": {
+        "replicaset": "test"
+      }
+    },
+    {
       "description": "Error on empty integer option values",
       "uri": "mongodb://localhost/?maxIdleTimeMS=",
       "valid": false,

--- a/test/spec/connection-string/invalid-options.yml
+++ b/test/spec/connection-string/invalid-options.yml
@@ -51,6 +51,32 @@ tests:
         options:
             replicaset: "test"
     -
+        description: "List option with one empty option specified"
+        uri: "mongodb://example.com/?readPreferenceTags=dc:ny,rack:1&readPreferenceTags=dc:ny&readPreferenceTags="
+        valid: false
+        warning: false
+        hosts:
+            -
+                type: "hostname"
+                host: "example.com"
+                port: ~
+        auth: ~
+        options:
+            replicaset: "test"
+    -
+        description: "List option with an invalid option specified"
+        uri: "mongodb://example.com/?readPreferenceTags=dc:ny,rack:1&readPreferenceTags=dc:ny&readPreferenceTags=foobarbaz"
+        valid: false
+        warning: false
+        hosts:
+            -
+                type: "hostname"
+                host: "example.com"
+                port: ~
+        auth: ~
+        options:
+            replicaset: "test"
+    -
         description: "Error on empty integer option values"
         uri: "mongodb://localhost/?maxIdleTimeMS="
         valid: false

--- a/test/spec/connection-string/invalid-options.yml
+++ b/test/spec/connection-string/invalid-options.yml
@@ -1,0 +1,100 @@
+tests:
+    -
+        description: "Error on unrecognized option keys"
+        uri: "mongodb://example.com/?foo=bar"
+        valid: false
+        warning: false
+        hosts:
+            -
+                type: "hostname"
+                host: "example.com"
+                port: ~
+        auth: ~
+        options: ~
+    -
+        description: "Error on unsupported option values"
+        uri: "mongodb://example.com/?fsync=ifPossible"
+        valid: false
+        warning: false
+        hosts:
+            -
+                type: "hostname"
+                host: "example.com"
+                port: ~
+        auth: ~
+        options: ~
+    -
+        description: "Repeated option keys with the same value"
+        uri: "mongodb://example.com/?replicaSet=test&replicaSet=test"
+        valid: false
+        warning: false
+        hosts:
+            -
+                type: "hostname"
+                host: "example.com"
+                port: ~
+        auth: ~
+        options:
+            replicaset: "test"
+
+    -
+        description: "Repeated option keys with different values"
+        uri: "mongodb://example.com/?replicaSet=test1&replicaSet=test2"
+        valid: false
+        warning: false
+        hosts:
+            -
+                type: "hostname"
+                host: "example.com"
+                port: ~
+        auth: ~
+        options:
+            replicaset: "test"
+    -
+        description: "Error on empty integer option values"
+        uri: "mongodb://localhost/?maxIdleTimeMS="
+        valid: false
+        warning: false
+        hosts:
+            -
+                type: "hostname"
+                host: "localhost"
+                port: ~
+        auth: ~
+        options: ~
+    -
+        description: "Error on empty non-integer value for integer option"
+        uri: "mongodb://localhost/?maxIdleTimeMS="
+        valid: false
+        warning: false
+        hosts:
+            -
+                type: "hostname"
+                host: "localhost"
+                port: ~
+        auth: ~
+        options: ~
+    -
+        description: "Error on empty boolean option value"
+        uri: "mongodb://localhost/?journal="
+        valid: false
+        warning: false
+        hosts:
+            -
+                type: "hostname"
+                host: "localhost"
+                port: ~
+        auth: ~
+        options: ~
+    -
+        description: "Error on non-empty invalid value for boolean option"
+        uri: "mongodb://localhost/?journal=stringValue"
+        valid: false
+        warning: false
+        hosts:
+            -
+                type: "hostname"
+                host: "localhost"
+                port: ~
+        auth: ~
+        options: ~

--- a/test/spec/connection-string/invalid-options.yml
+++ b/test/spec/connection-string/invalid-options.yml
@@ -4,11 +4,7 @@ tests:
         uri: "mongodb://example.com/?foo=bar"
         valid: false
         warning: false
-        hosts:
-            -
-                type: "hostname"
-                host: "example.com"
-                port: ~
+        hosts: ~
         auth: ~
         options: ~
     -
@@ -16,11 +12,7 @@ tests:
         uri: "mongodb://example.com/?fsync=ifPossible"
         valid: false
         warning: false
-        hosts:
-            -
-                type: "hostname"
-                host: "example.com"
-                port: ~
+        hosts: ~
         auth: ~
         options: ~
     -
@@ -28,76 +20,47 @@ tests:
         uri: "mongodb://example.com/?replicaSet=test&replicaSet=test"
         valid: false
         warning: false
-        hosts:
-            -
-                type: "hostname"
-                host: "example.com"
-                port: ~
+        hosts: ~
         auth: ~
-        options:
-            replicaset: "test"
-
+        options: ~
     -
         description: "Repeated option keys with different values"
         uri: "mongodb://example.com/?replicaSet=test1&replicaSet=test2"
         valid: false
         warning: false
-        hosts:
-            -
-                type: "hostname"
-                host: "example.com"
-                port: ~
+        hosts: ~
         auth: ~
-        options:
-            replicaset: "test"
+        options: ~
     -
         description: "List option with one empty option specified"
         uri: "mongodb://example.com/?readPreferenceTags=dc:ny,rack:1&readPreferenceTags=dc:ny&readPreferenceTags="
         valid: false
         warning: false
-        hosts:
-            -
-                type: "hostname"
-                host: "example.com"
-                port: ~
+        hosts: ~
         auth: ~
-        options:
-            replicaset: "test"
+        options: ~
     -
         description: "List option with an invalid option specified"
         uri: "mongodb://example.com/?readPreferenceTags=dc:ny,rack:1&readPreferenceTags=dc:ny&readPreferenceTags=foobarbaz"
         valid: false
         warning: false
-        hosts:
-            -
-                type: "hostname"
-                host: "example.com"
-                port: ~
+        hosts: ~
         auth: ~
-        options:
-            replicaset: "test"
+        options: ~
     -
         description: "Error on empty integer option values"
         uri: "mongodb://localhost/?maxIdleTimeMS="
         valid: false
         warning: false
-        hosts:
-            -
-                type: "hostname"
-                host: "localhost"
-                port: ~
+        hosts: ~
         auth: ~
         options: ~
     -
-        description: "Error on empty non-integer value for integer option"
-        uri: "mongodb://localhost/?maxIdleTimeMS="
+        description: "Error on non-empty invalid value for integer option"
+        uri: "mongodb://localhost/?maxIdleTimeMS=aString"
         valid: false
         warning: false
-        hosts:
-            -
-                type: "hostname"
-                host: "localhost"
-                port: ~
+        hosts: ~
         auth: ~
         options: ~
     -
@@ -105,11 +68,7 @@ tests:
         uri: "mongodb://localhost/?journal="
         valid: false
         warning: false
-        hosts:
-            -
-                type: "hostname"
-                host: "localhost"
-                port: ~
+        hosts: ~
         auth: ~
         options: ~
     -
@@ -117,10 +76,6 @@ tests:
         uri: "mongodb://localhost/?journal=stringValue"
         valid: false
         warning: false
-        hosts:
-            -
-                type: "hostname"
-                host: "localhost"
-                port: ~
+        hosts: ~
         auth: ~
         options: ~

--- a/test/spec/connection-string/valid-warnings.json
+++ b/test/spec/connection-string/valid-warnings.json
@@ -1,53 +1,6 @@
 {
   "tests": [
     {
-      "description": "Unrecognized option keys are ignored",
-      "uri": "mongodb://example.com/?foo=bar",
-      "valid": true,
-      "warning": true,
-      "hosts": [
-        {
-          "type": "hostname",
-          "host": "example.com",
-          "port": null
-        }
-      ],
-      "auth": null,
-      "options": null
-    },
-    {
-      "description": "Unsupported option values are ignored",
-      "uri": "mongodb://example.com/?fsync=ifPossible",
-      "valid": true,
-      "warning": true,
-      "hosts": [
-        {
-          "type": "hostname",
-          "host": "example.com",
-          "port": null
-        }
-      ],
-      "auth": null,
-      "options": null
-    },
-    {
-      "description": "Repeated option keys",
-      "uri": "mongodb://example.com/?replicaSet=test&replicaSet=test",
-      "valid": true,
-      "warning": true,
-      "hosts": [
-        {
-          "type": "hostname",
-          "host": "example.com",
-          "port": null
-        }
-      ],
-      "auth": null,
-      "options": {
-        "replicaset": "test"
-      }
-    },
-    {
       "description": "Deprecated (or unknown) options are ignored if replacement exists",
       "uri": "mongodb://example.com/?wtimeout=5&wtimeoutMS=10",
       "valid": true,

--- a/test/spec/connection-string/valid-warnings.yml
+++ b/test/spec/connection-string/valid-warnings.yml
@@ -1,42 +1,5 @@
 tests:
     -
-        description: "Unrecognized option keys are ignored"
-        uri: "mongodb://example.com/?foo=bar"
-        valid: true
-        warning: true
-        hosts:
-            -
-                type: "hostname"
-                host: "example.com"
-                port: ~
-        auth: ~
-        options: ~
-    -
-        description: "Unsupported option values are ignored"
-        uri: "mongodb://example.com/?fsync=ifPossible"
-        valid: true
-        warning: true
-        hosts:
-            -
-                type: "hostname"
-                host: "example.com"
-                port: ~
-        auth: ~
-        options: ~
-    -
-        description: "Repeated option keys"
-        uri: "mongodb://example.com/?replicaSet=test&replicaSet=test"
-        valid: true
-        warning: true
-        hosts:
-            -
-                type: "hostname"
-                host: "example.com"
-                port: ~
-        auth: ~
-        options:
-            replicaset: "test"
-    -
         description: "Deprecated (or unknown) options are ignored if replacement exists"
         uri: "mongodb://example.com/?wtimeout=5&wtimeoutMS=10"
         valid: true

--- a/test/unit/mongo_client.test.js
+++ b/test/unit/mongo_client.test.js
@@ -430,13 +430,13 @@ describe('MongoOptions', function () {
 
   it('throws an error if multiple tls parameters are not all set to the same value', () => {
     expect(() => parseOptions('mongodb://localhost?tls=true&tls=false')).to.throw(
-      'All values of tls/ssl must be the same.'
+      'URI option tls cannot be specified multiple times.'
     );
   });
 
   it('throws an error if multiple ssl parameters are not all set to the same value', () => {
     expect(() => parseOptions('mongodb://localhost?ssl=true&ssl=false')).to.throw(
-      'All values of tls/ssl must be the same.'
+      'URI option ssl cannot be specified multiple times.'
     );
   });
 
@@ -447,16 +447,6 @@ describe('MongoOptions', function () {
     expect(() => parseOptions('mongodb://localhost?tls=false&ssl=true')).to.throw(
       'All values of tls/ssl must be the same.'
     );
-  });
-
-  it('correctly sets tls if multiple tls parameters are all set to the same value', () => {
-    expect(parseOptions('mongodb://localhost?tls=true&tls=true')).to.have.property('tls', true);
-    expect(parseOptions('mongodb://localhost?tls=false&tls=false')).to.have.property('tls', false);
-  });
-
-  it('correctly sets tls if multiple ssl parameters are all set to the same value', () => {
-    expect(parseOptions('mongodb://localhost?ssl=true&ssl=true')).to.have.property('tls', true);
-    expect(parseOptions('mongodb://localhost?ssl=false&ssl=false')).to.have.property('tls', false);
   });
 
   it('correctly sets tls if tls and ssl parameters are all set to the same value', () => {


### PR DESCRIPTION
### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
