### PR TITLE
test(NODE-5147): fix broken range index test

### DIFF
--- a/test/integration/client-side-encryption/client_side_encryption.prose.22.range_explicit_encryption.test.ts
+++ b/test/integration/client-side-encryption/client_side_encryption.prose.22.range_explicit_encryption.test.ts
@@ -241,6 +241,8 @@ describe('Range Explicit Encryption', function () {
           }
         ];
 
+        // Queryable encryption only supports single document inserts, so we must insert the documents
+        // one at a time.
         for (const doc of documents) {
           await encryptedClient.db('db').collection('explicit_encryption').insertOne(doc);
         }

--- a/test/integration/client-side-encryption/client_side_encryption.prose.22.range_explicit_encryption.test.ts
+++ b/test/integration/client-side-encryption/client_side_encryption.prose.22.range_explicit_encryption.test.ts
@@ -222,27 +222,28 @@ describe('Range Explicit Encryption', function () {
         encryptedTwoHundred = await clientEncryption.encrypt(factory(200), opts);
 
         const key = `encrypted${dataType}`;
-        await encryptedClient
-          .db('db')
-          .collection('explicit_encryption')
-          .insertMany([
-            {
-              [key]: encryptedZero,
-              _id: 0
-            },
-            {
-              [key]: encryptedSix,
-              _id: 1
-            },
-            {
-              [key]: encryptedThirty,
-              _id: 2
-            },
-            {
-              [key]: encryptedTwoHundred,
-              _id: 3
-            }
-          ]);
+        const documents = [
+          {
+            [key]: encryptedZero,
+            _id: 0
+          },
+          {
+            [key]: encryptedSix,
+            _id: 1
+          },
+          {
+            [key]: encryptedThirty,
+            _id: 2
+          },
+          {
+            [key]: encryptedTwoHundred,
+            _id: 3
+          }
+        ];
+
+        for (const doc of documents) {
+          await encryptedClient.db('db').collection('explicit_encryption').insertOne(doc);
+        }
 
         await utilClient.close();
       });


### PR DESCRIPTION
### Description

#### What is changing?
Documents are inserted sequentially because bulk inserts are not supported for queryable encryption.

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
