### PR TITLE
chore: update BSON to v5.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "bson": "^5.0.1",
+        "bson": "^5.1.0",
         "mongodb-connection-string-url": "^2.6.0",
         "socks": "^2.7.1"
       },
@@ -3317,9 +3317,9 @@
       }
     },
     "node_modules/bson": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-5.0.1.tgz",
-      "integrity": "sha512-y09gBGusgHtinMon/GVbv1J6FrXhnr/+6hqLlSmEFzkz6PodqF6TxjyvfvY3AfO+oG1mgUtbC86xSbOlwvM62Q==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-5.1.0.tgz",
+      "integrity": "sha512-FEecNHkhYRBe7X9KDkdG12xNuz5VHGeH6mCE0B5sBmYtiR/Ux/9vUH/v4NUoBCDr6NuEhvahjoLiiRogptVW0A==",
       "engines": {
         "node": ">=14.20.1"
       }
@@ -12433,9 +12433,9 @@
       }
     },
     "bson": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-5.0.1.tgz",
-      "integrity": "sha512-y09gBGusgHtinMon/GVbv1J6FrXhnr/+6hqLlSmEFzkz6PodqF6TxjyvfvY3AfO+oG1mgUtbC86xSbOlwvM62Q=="
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-5.1.0.tgz",
+      "integrity": "sha512-FEecNHkhYRBe7X9KDkdG12xNuz5VHGeH6mCE0B5sBmYtiR/Ux/9vUH/v4NUoBCDr6NuEhvahjoLiiRogptVW0A=="
     },
     "buffer-from": {
       "version": "1.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "bson": "^5.1.0",
+        "bson": "^5.2.0",
         "mongodb-connection-string-url": "^2.6.0",
         "socks": "^2.7.1"
       },
@@ -3317,9 +3317,9 @@
       }
     },
     "node_modules/bson": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-5.1.0.tgz",
-      "integrity": "sha512-FEecNHkhYRBe7X9KDkdG12xNuz5VHGeH6mCE0B5sBmYtiR/Ux/9vUH/v4NUoBCDr6NuEhvahjoLiiRogptVW0A==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-5.2.0.tgz",
+      "integrity": "sha512-HevkSpDbpUfsrHWmWiAsNavANKYIErV2ePXllp1bwq5CDreAaFVj6RVlZpJnxK4WWDCJ/5jMUpaY6G526q3Hjg==",
       "engines": {
         "node": ">=14.20.1"
       }
@@ -12433,9 +12433,9 @@
       }
     },
     "bson": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-5.1.0.tgz",
-      "integrity": "sha512-FEecNHkhYRBe7X9KDkdG12xNuz5VHGeH6mCE0B5sBmYtiR/Ux/9vUH/v4NUoBCDr6NuEhvahjoLiiRogptVW0A=="
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-5.2.0.tgz",
+      "integrity": "sha512-HevkSpDbpUfsrHWmWiAsNavANKYIErV2ePXllp1bwq5CDreAaFVj6RVlZpJnxK4WWDCJ/5jMUpaY6G526q3Hjg=="
     },
     "buffer-from": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "email": "dbx-node@mongodb.com"
   },
   "dependencies": {
-    "bson": "^5.0.1",
+    "bson": "^5.1.0",
     "mongodb-connection-string-url": "^2.6.0",
     "socks": "^2.7.1"
   },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "email": "dbx-node@mongodb.com"
   },
   "dependencies": {
-    "bson": "^5.1.0",
+    "bson": "^5.2.0",
     "mongodb-connection-string-url": "^2.6.0",
     "socks": "^2.7.1"
   },


### PR DESCRIPTION
### Description

#### What is changing?

Update BSON to v5.1.0.

#### What is the motivation for this change?

We typically pin to latest BSON before each driver release to ensure a consistent expirence.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
