### PR TITLE
chore: update BSON to v4.7.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.14.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "bson": "^4.7.0",
+        "bson": "^4.7.2",
         "mongodb-connection-string-url": "^2.5.4",
         "socks": "^2.7.1"
       },
@@ -2808,9 +2808,9 @@
       }
     },
     "node_modules/bson": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-4.7.0.tgz",
-      "integrity": "sha512-VrlEE4vuiO1WTpfof4VmaVolCVYkYTgB9iWgYNOrVlnifpME/06fhFRmONgBhClD5pFC1t9ZWqFUQEQAzY43bA==",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.7.2.tgz",
+      "integrity": "sha512-Ry9wCtIZ5kGqkJoi6aD8KjxFZEx78guTQDnpXWiNthsxzrxAK/i8E6pCHAIZTbaEFWcOCvbecMukfK7XUvyLpQ==",
       "dependencies": {
         "buffer": "^5.6.0"
       },
@@ -11422,9 +11422,9 @@
       }
     },
     "bson": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-4.7.0.tgz",
-      "integrity": "sha512-VrlEE4vuiO1WTpfof4VmaVolCVYkYTgB9iWgYNOrVlnifpME/06fhFRmONgBhClD5pFC1t9ZWqFUQEQAzY43bA==",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.7.2.tgz",
+      "integrity": "sha512-Ry9wCtIZ5kGqkJoi6aD8KjxFZEx78guTQDnpXWiNthsxzrxAK/i8E6pCHAIZTbaEFWcOCvbecMukfK7XUvyLpQ==",
       "requires": {
         "buffer": "^5.6.0"
       }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "email": "dbx-node@mongodb.com"
   },
   "dependencies": {
-    "bson": "^4.7.0",
+    "bson": "^4.7.2",
     "mongodb-connection-string-url": "^2.5.4",
     "socks": "^2.7.1"
   },


### PR DESCRIPTION
### Description

#### What is changing?

Update BSON to v4.7.2

#### What is the motivation for this change?

Pulls in BSON bug fixes so that the next 4.x version of the driver will pull in the fixes as well.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
