### PR TITLE
test(NODE-5149): fix broken range index test

### DIFF
--- a/test/integration/client-side-encryption/client_side_encryption.prose.22.range_explicit_encryption.test.ts
+++ b/test/integration/client-side-encryption/client_side_encryption.prose.22.range_explicit_encryption.test.ts
@@ -224,27 +224,30 @@ describe('Range Explicit Encryption', function () {
         encryptedTwoHundred = await clientEncryption.encrypt(factory(200), opts);
 
         const key = `encrypted${dataType}`;
-        await encryptedClient
-          .db('db')
-          .collection('explicit_encryption')
-          .insertMany([
-            {
-              [key]: encryptedZero,
-              _id: 0
-            },
-            {
-              [key]: encryptedSix,
-              _id: 1
-            },
-            {
-              [key]: encryptedThirty,
-              _id: 2
-            },
-            {
-              [key]: encryptedTwoHundred,
-              _id: 3
-            }
-          ]);
+        const documents = [
+          {
+            [key]: encryptedZero,
+            _id: 0
+          },
+          {
+            [key]: encryptedSix,
+            _id: 1
+          },
+          {
+            [key]: encryptedThirty,
+            _id: 2
+          },
+          {
+            [key]: encryptedTwoHundred,
+            _id: 3
+          }
+        ];
+
+        // Queryable encryption only supports single document inserts, so we must insert the documents
+        // one at a time.
+        for (const doc of documents) {
+          await encryptedClient.db('db').collection('explicit_encryption').insertOne(doc);
+        }
 
         await utilClient.close();
       });


### PR DESCRIPTION
### Description

Backport of range index test fix.

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
