### PR TITLE
fix(NODE-5155) release connection lock when topology closed

### DIFF
--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -450,6 +450,9 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> {
     topology.client = this;
 
     topology.once(Topology.OPEN, () => this.emit('open', this));
+    topology.on(Topology.TOPOLOGY_CLOSED, () => {
+      this.connectionLock = undefined;
+    });
 
     for (const event of MONGO_CLIENT_EVENTS) {
       topology.on(event, (...args: any[]) => this.emit(event, ...(args as any)));

--- a/test/integration/node-specific/mongo_client.test.ts
+++ b/test/integration/node-specific/mongo_client.test.ts
@@ -574,6 +574,16 @@ describe('class MongoClient', function () {
       expect(topologyOpenEvents).to.have.lengthOf(1);
       expect(client.topology?.isConnected()).to.be.true;
     });
+
+    it('releases the lock if the topology is closed before connection is complete', function (done) {
+      clientConnect();
+      client.close();
+      client.once('topologyClosed', async () => {
+        await clientConnect();
+        expect(client.topology?.isConnected()).to.be.true;
+        done();
+      });
+    });
   });
 
   context('#close()', () => {


### PR DESCRIPTION
### Description

Fix inability to reconnect when topology closed during connection.

#### What is changing?

The connection lock will be released on the `topologyClosed` event

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

https://github.com/mongodb/node-mongodb-native/pull/3596 added a welcome fix to stop topologies leaking (which we've previously been working around).

However, it doesn't address another issue we've seen with this sort of lock, which is that if the topology is closed during connection, a reconnection attempt never resolves.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
