### PR TITLE
feat(NODE-4774): deprecate cursor forEach

### DIFF
--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -397,6 +397,7 @@ export abstract class AbstractCursor<
    * If the iterator returns `false`, iteration will stop.
    *
    * @param iterator - The iteration callback.
+   * @deprecated - Will be removed in a future release. Use for await...of instead.
    */
   async forEach(iterator: (doc: TSchema) => boolean | void): Promise<void> {
     if (typeof iterator !== 'function') {


### PR DESCRIPTION
### Description

Deprecates `AbstractCursor.forEach()`

#### What is changing?

Deprecates the method in favour of `for await...of`.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-4774

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
