### PR TITLE
feat(NODE-4791): deprecate duplicate bulk methods

### DIFF
--- a/src/bulk/common.ts
+++ b/src/bulk/common.ts
@@ -212,37 +212,58 @@ export class BulkWriteResult {
     return this.result.ok;
   }
 
-  /** The number of inserted documents */
+  /**
+   * The number of inserted documents
+   * @deprecated Use insertedCount instead.
+   */
   get nInserted(): number {
     return this.result.nInserted;
   }
 
-  /** Number of upserted documents */
+  /**
+   * Number of upserted documents
+   * @deprecated User upsertedCount instead.
+   */
   get nUpserted(): number {
     return this.result.nUpserted;
   }
 
-  /** Number of matched documents */
+  /**
+   * Number of matched documents
+   * @deprecated Use matchedCount instead.
+   */
   get nMatched(): number {
     return this.result.nMatched;
   }
 
-  /** Number of documents updated physically on disk */
+  /**
+   * Number of documents updated physically on disk
+   * @deprecated Use modifiedCount instead.
+   */
   get nModified(): number {
     return this.result.nModified;
   }
 
-  /** Number of removed documents */
+  /**
+   * Number of removed documents
+   * @deprecated Use deletedCount instead.
+   */
   get nRemoved(): number {
     return this.result.nRemoved;
   }
 
-  /** Returns an array of all inserted ids */
+  /**
+   * Returns an array of all inserted ids
+   * @deprecated Use insertedIds instead.
+   */
   getInsertedIds(): Document[] {
     return this.result.insertedIds;
   }
 
-  /** Returns an array of all upserted ids */
+  /**
+   * Returns an array of all upserted ids
+   * @deprecated Use upsertedIds instead.
+   */
   getUpsertedIds(): Document[] {
     return this.result.upserted;
   }

--- a/test/integration/client-side-encryption/client_side_encryption.prose.test.js
+++ b/test/integration/client-side-encryption/client_side_encryption.prose.test.js
@@ -1960,7 +1960,7 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
           );
 
           expect(rewrapManyDataKeyResult).to.have.property('bulkWriteResult');
-          expect(rewrapManyDataKeyResult.bulkWriteResult).to.have.property('nModified', 1);
+          expect(rewrapManyDataKeyResult.bulkWriteResult).to.have.property('modifiedCount', 1);
 
           // 7. Call ``clientEncryption1.decrypt`` with the ``ciphertext``. Assert the return value is "test".
           const decryptResult1 = await clientEncryption1.decrypt(cipherText);

--- a/test/integration/crud/bulk.test.ts
+++ b/test/integration/crud/bulk.test.ts
@@ -161,7 +161,7 @@ describe('Bulk', function () {
         result = err.result;
 
         // Basic properties check
-        test.equal(1, result.nInserted);
+        test.equal(1, result.insertedCount);
         test.equal(true, result.hasWriteErrors());
         test.equal(1, result.getWriteErrorCount());
 
@@ -322,7 +322,7 @@ describe('Bulk', function () {
         // Basic properties check
         result = err.result;
         test.equal(err instanceof Error, true);
-        test.equal(1, result.nInserted);
+        test.equal(1, result.insertedCount);
         test.equal(true, result.hasWriteErrors());
         test.ok(1, result.getWriteErrorCount());
 
@@ -387,7 +387,7 @@ describe('Bulk', function () {
     // Execute the operations
     batch.execute(function (err, result) {
       // Basic properties check
-      test.equal(6, result.nInserted);
+      test.equal(6, result.insertedCount);
       test.equal(false, result.hasWriteErrors());
 
       // Finish up test
@@ -412,10 +412,10 @@ describe('Bulk', function () {
 
     // Test basic settings
     const result = thrownError.result;
-    expect(result).to.have.property('nInserted', 1);
-    expect(result).to.have.property('nMatched', 1);
+    expect(result).to.have.property('insertedCount', 1);
+    expect(result).to.have.property('matchedCount', 1);
     expect(result)
-      .to.have.property('nModified')
+      .to.have.property('modifiedCount')
       .that.satisfies(v => v == null || v === 1);
     expect(result).to.have.property('hasWriteErrors').that.is.a('function');
     expect(result).to.have.property('getWriteErrorCount').that.is.a('function');
@@ -455,10 +455,10 @@ describe('Bulk', function () {
 
     // Test basic settings
     const result = originalError.result;
-    test.equal(1, result.nInserted);
-    test.equal(2, result.nUpserted);
-    test.equal(1, result.nMatched);
-    test.ok(1 === result.nModified || result.nModified == null);
+    test.equal(1, result.insertedCount);
+    test.equal(2, result.upsertedCount);
+    test.equal(1, result.matchedCount);
+    test.ok(1 === result.modifiedCount || result.modifiedCount == null);
     test.equal(true, result.hasWriteErrors());
     test.equal(1, result.getWriteErrorCount());
 
@@ -470,7 +470,7 @@ describe('Bulk', function () {
     test.equal(1, error.getOperation().b);
 
     // Check for upserted values
-    const ids = result.getUpsertedIds();
+    const ids = result.result.upserted;
     test.equal(2, ids.length);
     test.equal(2, ids[0].index);
     test.ok(ids[0]._id != null);
@@ -498,13 +498,13 @@ describe('Bulk', function () {
         // Execute the operations
         batch.execute(function (err, result) {
           // Check state of result
-          test.equal(1, result.nUpserted);
-          test.equal(0, result.nInserted);
-          test.equal(0, result.nMatched);
-          test.ok(0 === result.nModified || result.nModified == null);
-          test.equal(0, result.nRemoved);
+          test.equal(1, result.upsertedCount);
+          test.equal(0, result.insertedCount);
+          test.equal(0, result.matchedCount);
+          test.ok(0 === result.modifiedCount || result.modifiedCount == null);
+          test.equal(0, result.deletedCount);
 
-          const upserts = result.getUpsertedIds();
+          const upserts = result.result.upserted;
           test.equal(1, upserts.length);
           test.equal(0, upserts[0].index);
           test.equal(2, upserts[0]._id);
@@ -551,11 +551,11 @@ describe('Bulk', function () {
 
       bulk.execute({ writeConcern: { w: 0 } }, function (err, result) {
         expect(err).to.not.exist;
-        test.equal(0, result.nUpserted);
-        test.equal(0, result.nInserted);
-        test.equal(0, result.nMatched);
-        test.ok(0 === result.nModified || result.nModified == null);
-        test.equal(0, result.nRemoved);
+        test.equal(0, result.upsertedCount);
+        test.equal(0, result.insertedCount);
+        test.equal(0, result.matchedCount);
+        test.ok(0 === result.modifiedCount || result.modifiedCount == null);
+        test.equal(0, result.deletedCount);
         test.equal(false, result.hasWriteErrors());
 
         client.close(done);
@@ -591,10 +591,10 @@ describe('Bulk', function () {
           // Basic properties check
           result = err.result;
           test.equal(err instanceof Error, true);
-          test.equal(2, result.nInserted);
-          test.equal(0, result.nUpserted);
-          test.equal(0, result.nMatched);
-          test.ok(0 === result.nModified || result.nModified == null);
+          test.equal(2, result.insertedCount);
+          test.equal(0, result.upsertedCount);
+          test.equal(0, result.matchedCount);
+          test.ok(0 === result.modifiedCount || result.modifiedCount == null);
           test.equal(true, result.hasWriteErrors());
           test.equal(1, result.getWriteErrorCount());
 
@@ -644,7 +644,7 @@ describe('Bulk', function () {
 
           // Basic properties check
           result = err.result;
-          expect(result.nInserted).to.equal(1);
+          expect(result.insertedCount).to.equal(1);
           expect(result.hasWriteErrors()).to.equal(true);
           expect(result.getWriteErrorCount()).to.equal(1);
 
@@ -718,7 +718,7 @@ describe('Bulk', function () {
         // Execute the operations
         batch.execute(function (err, result) {
           // Basic properties check
-          test.equal(6, result.nInserted);
+          test.equal(6, result.insertedCount);
           test.equal(false, result.hasWriteErrors());
 
           // Finish up test
@@ -760,7 +760,7 @@ describe('Bulk', function () {
 
           // Test basic settings
           result = err.result;
-          test.equal(2, result.nInserted);
+          test.equal(2, result.insertedCount);
           test.equal(true, result.hasWriteErrors());
           test.ok(result.getWriteErrorCount() === 4 || result.getWriteErrorCount() === 3);
 
@@ -808,7 +808,7 @@ describe('Bulk', function () {
 
             // Test basic settings
             result = err.result;
-            expect(result.nInserted).to.equal(1);
+            expect(result.insertedCount).to.equal(1);
             expect(result.hasWriteErrors()).to.equal(true);
             expect(result.getWriteErrorCount() === 1).to.equal(true);
 
@@ -863,10 +863,10 @@ describe('Bulk', function () {
 
               // Test basic settings
               result = err.result;
-              test.equal(2, result.nInserted);
-              test.equal(2, result.nUpserted);
-              test.ok(0 === result.nModified || result.nModified == null);
-              test.equal(0, result.nRemoved);
+              test.equal(2, result.insertedCount);
+              test.equal(2, result.upsertedCount);
+              test.ok(0 === result.modifiedCount || result.modifiedCount == null);
+              test.equal(0, result.deletedCount);
               test.equal(true, result.hasWriteErrors());
               test.ok(1, result.getWriteErrorCount());
 
@@ -877,7 +877,7 @@ describe('Bulk', function () {
               test.equal(1, error.getOperation().u['$set'].b);
 
               // Check for upserted values
-              const ids = result.getUpsertedIds();
+              const ids = result.result.upserted;
               test.equal(2, ids.length);
               test.equal(2, ids[0].index);
               test.ok(ids[0]._id != null);
@@ -907,13 +907,13 @@ describe('Bulk', function () {
       // Execute the operations
       batch.execute({}, function (err, result) {
         // Check state of result
-        test.equal(1, result.nUpserted);
-        test.equal(0, result.nInserted);
-        test.equal(0, result.nMatched);
-        test.ok(0 === result.nModified || result.nModified == null);
-        test.equal(0, result.nRemoved);
+        test.equal(1, result.upsertedCount);
+        test.equal(0, result.insertedCount);
+        test.equal(0, result.matchedCount);
+        test.ok(0 === result.modifiedCount || result.modifiedCount == null);
+        test.equal(0, result.deletedCount);
 
-        const upserts = result.getUpsertedIds();
+        const upserts = result.result.upserted;
         test.equal(1, upserts.length);
         test.equal(0, upserts[0].index);
         test.equal(2, upserts[0]._id);
@@ -991,11 +991,11 @@ describe('Bulk', function () {
 
         bulk.execute({ writeConcern: { w: 0 } }, function (err, result) {
           expect(err).to.not.exist;
-          test.equal(0, result.nUpserted);
-          test.equal(0, result.nInserted);
-          test.equal(0, result.nMatched);
-          test.ok(0 === result.nModified || result.nModified == null);
-          test.equal(0, result.nRemoved);
+          test.equal(0, result.upsertedCount);
+          test.equal(0, result.insertedCount);
+          test.equal(0, result.matchedCount);
+          test.ok(0 === result.modifiedCount || result.modifiedCount == null);
+          test.equal(0, result.deletedCount);
           test.equal(false, result.hasWriteErrors());
 
           client.close(done);

--- a/test/integration/crud/crud_api.test.ts
+++ b/test/integration/crud/crud_api.test.ts
@@ -342,9 +342,9 @@ describe('CRUD API', function () {
             { ordered: false, writeConcern: { w: 1 } },
             function (err, r) {
               expect(err).to.not.exist;
-              test.equal(3, r.nInserted);
-              test.equal(1, r.nUpserted);
-              test.equal(1, r.nRemoved);
+              test.equal(3, r.insertedCount);
+              test.equal(1, r.upsertedCount);
+              test.equal(1, r.deletedCount);
 
               // Crud fields
               test.equal(3, r.insertedCount);
@@ -384,9 +384,9 @@ describe('CRUD API', function () {
               { ordered: false, writeConcern: { w: 1 } },
               function (err, r) {
                 expect(err).to.not.exist;
-                test.equal(1, r.nInserted);
-                test.equal(2, r.nUpserted);
-                test.equal(2, r.nRemoved);
+                test.equal(1, r.insertedCount);
+                test.equal(2, r.upsertedCount);
+                test.equal(2, r.deletedCount);
 
                 // Crud fields
                 test.equal(1, r.insertedCount);
@@ -425,9 +425,9 @@ describe('CRUD API', function () {
             { ordered: true, writeConcern: { w: 1 } },
             function (err, r) {
               expect(err).to.not.exist;
-              test.equal(3, r.nInserted);
-              test.equal(1, r.nUpserted);
-              test.equal(1, r.nRemoved);
+              test.equal(3, r.insertedCount);
+              test.equal(1, r.upsertedCount);
+              test.equal(1, r.deletedCount);
 
               // Crud fields
               test.equal(3, r.insertedCount);
@@ -463,9 +463,9 @@ describe('CRUD API', function () {
             { ordered: true, writeConcern: { w: 1 } },
             function (err, r) {
               // expect(err).to.not.exist;
-              test.equal(1, r.nInserted);
-              test.equal(2, r.nUpserted);
-              test.equal(1, r.nRemoved);
+              test.equal(1, r.insertedCount);
+              test.equal(2, r.upsertedCount);
+              test.equal(1, r.deletedCount);
 
               // Crud fields
               test.equal(1, r.insertedCount);

--- a/test/integration/node-specific/operation_examples.test.ts
+++ b/test/integration/node-specific/operation_examples.test.ts
@@ -3776,15 +3776,15 @@ describe('Operations', function () {
         // Execute the operations
         return batch.execute().then(function (result) {
           // Check state of result
-          expect(result.nInserted).to.equal(2);
-          expect(result.nUpserted).to.equal(1);
-          expect(result.nMatched).to.equal(1);
+          expect(result.insertedCount).to.equal(2);
+          expect(result.upsertedCount).to.equal(1);
+          expect(result.matchedCount).to.equal(1);
           expect(
-            1 === result.nModified || result.nModified === 0 || result.nModified == null
+            1 === result.modifiedCount || result.modifiedCount === 0 || result.modifiedCount == null
           ).to.exist;
-          expect(result.nRemoved).to.equal(1);
+          expect(result.deletedCount).to.equal(1);
 
-          const upserts = result.getUpsertedIds();
+          const upserts = result.result.upserted;
           expect(upserts.length).to.equal(1);
           expect(upserts[0].index).to.equal(2);
           expect(upserts[0]._id != null).to.exist;
@@ -3845,15 +3845,15 @@ describe('Operations', function () {
         // Execute the operations
         return batch.execute().then(function (result) {
           // Check state of result
-          expect(result.nInserted).to.equal(2);
-          expect(result.nUpserted).to.equal(1);
-          expect(result.nMatched).to.equal(1);
+          expect(result.insertedCount).to.equal(2);
+          expect(result.upsertedCount).to.equal(1);
+          expect(result.matchedCount).to.equal(1);
           expect(
-            1 === result.nModified || result.nModified === 0 || result.nModified == null
+            1 === result.modifiedCount || result.modifiedCount === 0 || result.modifiedCount == null
           ).to.exist;
-          expect(result.nRemoved).to.equal(1);
+          expect(result.deletedCount).to.equal(1);
 
-          const upserts = result.getUpsertedIds();
+          const upserts = result.result.upserted;
           expect(upserts.length).to.equal(1);
           expect(upserts[0].index).to.equal(2);
           expect(upserts[0]._id != null).to.exist;
@@ -4169,9 +4169,9 @@ describe('Operations', function () {
             { ordered: true, writeConcern: { w: 1 } }
           )
           .then(function (r) {
-            expect(r.nInserted).to.equal(1);
-            expect(r.nUpserted).to.equal(2);
-            expect(r.nRemoved).to.equal(0);
+            expect(r.insertedCount).to.equal(1);
+            expect(r.upsertedCount).to.equal(2);
+            expect(r.deletedCount).to.equal(0);
             // Crud fields
             expect(r.insertedCount).to.equal(1);
             expect(Object.keys(r.insertedIds).length).to.equal(1);


### PR DESCRIPTION
### Description

Deprecates duplicate bulk write methods.

#### What is changing?
- Deprecates all the "n..." duplicate getters
- Deprecates select duplicate getters starting with "get".
- Updates tests to use the non-deprecated bulk properties.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-4791

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
