### PR TITLE
feat(NODE-4795): deprecate addUser helper

### DIFF
--- a/src/admin.ts
+++ b/src/admin.ts
@@ -106,7 +106,8 @@ export class Admin {
    * @param username - The username for the new user
    * @param passwordOrOptions - An optional password for the new user, or the options for the command
    * @param options - Optional settings for the command
-   * @deprecated Use the createUser command directly instead.
+   * @deprecated Use the createUser command in `db.command()` instead.
+   * @see https://www.mongodb.com/docs/manual/reference/command/createUser/
    */
   async addUser(
     username: string,

--- a/src/admin.ts
+++ b/src/admin.ts
@@ -106,6 +106,7 @@ export class Admin {
    * @param username - The username for the new user
    * @param passwordOrOptions - An optional password for the new user, or the options for the command
    * @param options - Optional settings for the command
+   * @deprecated Use the createUser command directly instead.
    */
   async addUser(
     username: string,

--- a/src/db.ts
+++ b/src/db.ts
@@ -405,7 +405,8 @@ export class Db {
    * @param username - The username for the new user
    * @param passwordOrOptions - An optional password for the new user, or the options for the command
    * @param options - Optional settings for the command
-   * @deprecated Use the createUser command directly instead.
+   * @deprecated Use the createUser command in `db.command()` instead.
+   * @see https://www.mongodb.com/docs/manual/reference/command/createUser/
    */
   async addUser(
     username: string,

--- a/src/db.ts
+++ b/src/db.ts
@@ -405,6 +405,7 @@ export class Db {
    * @param username - The username for the new user
    * @param passwordOrOptions - An optional password for the new user, or the options for the command
    * @param options - Optional settings for the command
+   * @deprecated Use the createUser command directly instead.
    */
   async addUser(
     username: string,

--- a/src/operations/add_user.ts
+++ b/src/operations/add_user.ts
@@ -9,7 +9,10 @@ import { Callback, emitWarningOnce, getTopology } from '../utils';
 import { CommandOperation, CommandOperationOptions } from './command';
 import { Aspect, defineAspects } from './operation';
 
-/** @public */
+/**
+ * @public
+ * @deprecated Use the createUser command directly instead.
+ */
 export interface RoleSpecification {
   /**
    * A role grants privileges to perform sets of actions on defined resources.
@@ -20,7 +23,10 @@ export interface RoleSpecification {
   db: string;
 }
 
-/** @public */
+/**
+ * @public
+ * @deprecated Use the createUser command directly instead.
+ */
 export interface AddUserOptions extends CommandOperationOptions {
   /** Roles associated with the created user */
   roles?: string | string[] | RoleSpecification | RoleSpecification[];


### PR DESCRIPTION
### Description

Deprecates the addUser helper.

#### What is changing?
- Deprecates the addUser helper along with the associated options.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-4795

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
