### PR TITLE
fix(NODE-5171): allow `upsertedId` to be null in `UpdateResult`

### DIFF
--- a/src/collection.ts
+++ b/src/collection.ts
@@ -334,7 +334,7 @@ export class Collection<TSchema extends Document = Document> {
     filter: Filter<TSchema>,
     update: UpdateFilter<TSchema> | Partial<TSchema>,
     options?: UpdateOptions
-  ): Promise<UpdateResult> {
+  ): Promise<UpdateResult<TSchema>> {
     return executeOperation(
       this.s.db.s.client,
       new UpdateOneOperation(
@@ -357,7 +357,7 @@ export class Collection<TSchema extends Document = Document> {
     filter: Filter<TSchema>,
     replacement: WithoutId<TSchema>,
     options?: ReplaceOptions
-  ): Promise<UpdateResult | Document> {
+  ): Promise<UpdateResult<TSchema> | Document> {
     return executeOperation(
       this.s.db.s.client,
       new ReplaceOneOperation(
@@ -380,7 +380,7 @@ export class Collection<TSchema extends Document = Document> {
     filter: Filter<TSchema>,
     update: UpdateFilter<TSchema>,
     options?: UpdateOptions
-  ): Promise<UpdateResult> {
+  ): Promise<UpdateResult<TSchema>> {
     return executeOperation(
       this.s.db.s.client,
       new UpdateManyOperation(

--- a/src/operations/update.ts
+++ b/src/operations/update.ts
@@ -23,8 +23,11 @@ export interface UpdateOptions extends CommandOperationOptions {
   let?: Document;
 }
 
-/** @public */
-export interface UpdateResult {
+/**
+ * @public
+ * `TSchema` is the schema of the collection
+ */
+export interface UpdateResult<TSchema = Document> {
   /** Indicates whether this write result was acknowledged. If not, then all other members of this result will be undefined */
   acknowledged: boolean;
   /** The number of documents that matched the filter */
@@ -34,7 +37,7 @@ export interface UpdateResult {
   /** The number of documents that were upserted */
   upsertedCount: number;
   /** The identifier of the inserted document if an upsert took place */
-  upsertedId: ObjectId | null;
+  upsertedId: InferIdType<TSchema> | null;
 }
 
 /** @public */

--- a/src/operations/update.ts
+++ b/src/operations/update.ts
@@ -28,7 +28,7 @@ export interface UpdateOptions extends CommandOperationOptions {
  * @public
  * `TSchema` is the schema of the collection
  */
-export interface UpdateResult<TSchema = Document> {
+export interface UpdateResult<TSchema extends Document = Document> {
   /** Indicates whether this write result was acknowledged. If not, then all other members of this result will be undefined */
   acknowledged: boolean;
   /** The number of documents that matched the filter */

--- a/src/operations/update.ts
+++ b/src/operations/update.ts
@@ -29,12 +29,12 @@ export interface UpdateResult {
   acknowledged: boolean;
   /** The number of documents that matched the filter */
   matchedCount: number;
-  /** The number of documents that were modified */
+  /** The number of documents ∂that were modified */
   modifiedCount: number;
   /** The number of documents that were upserted */
   upsertedCount: number;
   /** The identifier of the inserted document if an upsert took place */
-  upsertedId: ObjectId;
+  upsertedId: ObjectId | null;
 }
 
 /** @public */

--- a/src/operations/update.ts
+++ b/src/operations/update.ts
@@ -1,6 +1,7 @@
-import type { Document, ObjectId } from '../bson';
+import type { Document } from '../bson';
 import type { Collection } from '../collection';
 import { MongoCompatibilityError, MongoInvalidArgumentError, MongoServerError } from '../error';
+import type { InferIdType } from '../mongo_types';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
 import { Callback, hasAtomicOperators, MongoDBNamespace } from '../utils';
@@ -32,7 +33,7 @@ export interface UpdateResult<TSchema = Document> {
   acknowledged: boolean;
   /** The number of documents that matched the filter */
   matchedCount: number;
-  /** The number of documents ∂that were modified */
+  /** The number of documents that were modified */
   modifiedCount: number;
   /** The number of documents that were upserted */
   upsertedCount: number;

--- a/test/types/community/collection/updateX.test-d.ts
+++ b/test/types/community/collection/updateX.test-d.ts
@@ -3,6 +3,7 @@ import { expectAssignable, expectError, expectNotAssignable, expectNotType } fro
 import type {
   AddToSetOperators,
   ArrayOperator,
+  Collection,
   MatchKeysAndValues,
   PullAllOperator,
   PullOperator,
@@ -422,4 +423,17 @@ export async function testPushWithId(): Promise<void> {
       }
     }
   );
+}
+
+{
+  // NODE-5171 - UpdateResult is generic over the collection schema and infers the id type
+  const collection = {} as any as Collection;
+  expectAssignable<Promise<{ upsertedId: ObjectId | null }>>(collection.updateOne({}, {}));
+  expectAssignable<Promise<{ upsertedId: ObjectId | null }>>(collection.updateMany({}, {}));
+
+  const collectionWithSchema = {} as any as Collection<{ _id: number }>;
+  expectAssignable<Promise<{ upsertedId: number | null }>>(
+    collectionWithSchema.updateOne({ _id: 1234 }, {})
+  );
+  expectAssignable<Promise<{ upsertedId: number | null }>>(collectionWithSchema.updateMany({}, {}));
 }

--- a/test/types/community/collection/updateX.test-d.ts
+++ b/test/types/community/collection/updateX.test-d.ts
@@ -431,9 +431,18 @@ export async function testPushWithId(): Promise<void> {
   expectAssignable<Promise<{ upsertedId: ObjectId | null }>>(collection.updateOne({}, {}));
   expectAssignable<Promise<{ upsertedId: ObjectId | null }>>(collection.updateMany({}, {}));
 
+  expectNotAssignable<Promise<{ upsertedId: number | null }>>(collection.updateOne({}, {}));
+  expectNotAssignable<Promise<{ upsertedId: number | null }>>(collection.updateMany({}, {}));
+
   const collectionWithSchema = {} as any as Collection<{ _id: number }>;
   expectAssignable<Promise<{ upsertedId: number | null }>>(
     collectionWithSchema.updateOne({ _id: 1234 }, {})
   );
   expectAssignable<Promise<{ upsertedId: number | null }>>(collectionWithSchema.updateMany({}, {}));
+  expectNotAssignable<Promise<{ upsertedId: ObjectId | null }>>(
+    collectionWithSchema.updateOne({ _id: 1234 }, {})
+  );
+  expectNotAssignable<Promise<{ upsertedId: ObjectId | null }>>(
+    collectionWithSchema.updateMany({}, {})
+  );
 }


### PR DESCRIPTION
### Description

#### What is changing?

`UpdateResult` is now generic over a collection schema type.  `UpdateResult.upsertedId` has two changes: it can now be null, and the type is inferred from the collection schema.  

`Collection.update*` methods now return an `UpdateResult` that is generic over the collection's schema.

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
