### PR TITLE
test(NODE-5183): Clean up Azure resources on task failure

### DIFF
--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -1275,6 +1275,10 @@ task_groups:
           file: src/testazurekms-expansions.yml
 
     teardown_group:
+      # Load expansions again. The setup task may have failed before running `expansions.update`.
+      - command: expansions.update
+        params:
+          file: testazurekms-expansions.yml
       - command: subprocess.exec
         params:
           binary: bash

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -3149,6 +3149,10 @@ task_groups:
         params:
           file: src/testazurekms-expansions.yml
     teardown_group:
+      # Load expansions again. The setup task may have failed before running `expansions.update`.
+      - command: expansions.update
+        params:
+          file: testazurekms-expansions.yml
       - command: subprocess.exec
         params:
           binary: bash

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -3149,7 +3149,6 @@ task_groups:
         params:
           file: src/testazurekms-expansions.yml
     teardown_group:
-      # Load expansions again. The setup task may have failed before running `expansions.update`.
       - command: expansions.update
         params:
           file: testazurekms-expansions.yml


### PR DESCRIPTION
### Description

#### What is changing?

- Reload expansions before deleting Azure resources

Verified with this patch: https://spruce.mongodb.com/version/64345805850e61555185df30

##### Is there new documentation needed for these changes?

No.

#### What is the motivation for this change?

This is an improvement to the `testazurekms_task_group` added as part of DRIVERS-2411. https://github.com/mongodb/mongo-c-driver/pull/1234 explains this improvement.

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- ~~[ ] Changes are covered by tests~~ N/A. Only modifies Evergreen config.
- ~~[ ] New TODOs have a related JIRA ticket~~ N/A. No new TODOs were added.
