### PR TITLE
feat(NODE-4815): stringify and truncate BSON documents in log messages

### DIFF
--- a/src/mongo_logger.ts
+++ b/src/mongo_logger.ts
@@ -257,15 +257,12 @@ export interface LogConvertible extends Record<string, any> {
 }
 
 /** @internal */
-export function maybeTruncate(
-  ejson: string,
-  maxDocumentLength: number = DEFAULT_MAX_DOCUMENT_LENGTH
-): string {
-  if (maxDocumentLength === 0) {
-    return ejson;
-  }
+export function stringifyWithMaxLen(value: any, maxDocumentLength: number): string {
+  const ejson = EJSON.stringify(value);
 
-  return ejson.length > maxDocumentLength ? `${ejson.slice(0, maxDocumentLength)}...` : ejson;
+  return maxDocumentLength !== 0 && ejson.length > maxDocumentLength
+    ? `${ejson.slice(0, maxDocumentLength)}...`
+    : ejson;
 }
 
 /** @internal */
@@ -315,14 +312,14 @@ function defaultLogTransform(
     case COMMAND_STARTED:
       log = attachCommandFields(log, logObject);
       log.message = 'Command started';
-      log.command = maybeTruncate(EJSON.stringify(logObject.command), maxDocumentLength);
+      log.command = stringifyWithMaxLen(logObject.command, maxDocumentLength);
       log.databaseName = logObject.databaseName;
       return log;
     case COMMAND_SUCCEEDED:
       log = attachCommandFields(log, logObject);
       log.message = 'Command succeeded';
       log.durationMS = logObject.duration;
-      log.reply = maybeTruncate(EJSON.stringify(logObject.reply), maxDocumentLength);
+      log.reply = stringifyWithMaxLen(logObject.reply, maxDocumentLength);
       return log;
     case COMMAND_FAILED:
       log = attachCommandFields(log, logObject);


### PR DESCRIPTION
### Description

#### What is changing?

Adds the `maybeTruncate` helper and calls it in the `defaultLogTransform` helper function to produce spec-compliant logs.

##### Is there new documentation needed for these changes?
### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
