### PR TITLE
feat(NODE-5188): add alternative runtime detection to client metadata

### DIFF
--- a/src/cmap/handshake/client_metadata.ts
+++ b/src/cmap/handshake/client_metadata.ts
@@ -237,17 +237,13 @@ export function getFAASEnv(): Map<string, string | Int32> | null {
 
 /**
  * @internal
- * This type represents the global Deno object and the minimal type contract we
- * expect it to satisfy. In order to not ship code in the driver that would break
- * future versions of this runtime assume all properties are nullish.
+ * This type represents the global Deno object and the minimal type contract we expect it to satisfy.
  */
 declare const Deno: { version?: { deno?: string } } | undefined;
 
 /**
  * @internal
- * This type represents the global Bun object and the minimal type contract we
- * expect it to satisfy. In order to not ship code in the driver that would break
- * future versions of this runtime assume all properties are nullish.
+ * This type represents the global Bun object and the minimal type contract we expect it to satisfy.
  */
 declare const Bun: { (): void; version?: string } | undefined;
 
@@ -255,9 +251,9 @@ declare const Bun: { (): void; version?: string } | undefined;
  * @internal
  * Get current JavaScript runtime platform
  *
- * NOTE: The version information fetching is intentionally written aggressively defensive
+ * NOTE: The version information fetching is intentionally written defensively
  * to avoid having a released driver version that becomes incompatible
- * with a future change to these global objects
+ * with a future change to these global objects.
  */
 function getRuntimeInfo(): string {
   if ('Deno' in globalThis) {

--- a/src/cmap/handshake/client_metadata.ts
+++ b/src/cmap/handshake/client_metadata.ts
@@ -277,7 +277,10 @@ function getRuntimeInfo(): string {
 
   if ('Bun' in globalThis) {
     const version =
-      Bun != null && typeof Bun === 'object' && 'version' in Bun && typeof Bun.version === 'string'
+      Bun != null &&
+      (typeof Bun === 'function' || typeof Bun === 'object') &&
+      'version' in Bun &&
+      typeof Bun.version === 'string'
         ? Bun.version
         : '0.0.0';
 

--- a/src/cmap/handshake/client_metadata.ts
+++ b/src/cmap/handshake/client_metadata.ts
@@ -116,12 +116,12 @@ export function makeClientMetadata(options: MakeClientMetadataOptions): ClientMe
     );
   }
 
-  const platformInfo =
-    platform.length > 0
-      ? `Node.js ${process.version}, ${os.endianness()}|${platform}`
-      : `Node.js ${process.version}, ${os.endianness()}`;
+  let runtimeInfo = getRuntimeInfo();
+  if (platform.length > 0) {
+    runtimeInfo = `${runtimeInfo}|${platform}`;
+  }
 
-  if (!metadataDocument.ifItFitsItSits('platform', platformInfo)) {
+  if (!metadataDocument.ifItFitsItSits('platform', runtimeInfo)) {
     throw new MongoInvalidArgumentError(
       'Unable to include driverInfo platform, metadata cannot exceed 512 bytes'
     );
@@ -233,4 +233,56 @@ export function getFAASEnv(): Map<string, string | Int32> | null {
   }
 
   return null;
+}
+
+/**
+ * @internal
+ * This type represents the global Deno object and the minimal type contract we
+ * expect it to satisfy. In order to not ship code in the driver that would break
+ * future versions of this runtime assume all properties are nullish.
+ */
+declare const Deno: { version?: { deno?: string } } | undefined;
+
+/**
+ * @internal
+ * This type represents the global Bun object and the minimal type contract we
+ * expect it to satisfy. In order to not ship code in the driver that would break
+ * future versions of this runtime assume all properties are nullish.
+ */
+declare const Bun: { version?: string } | undefined;
+
+/**
+ * @internal
+ * Get current JavaScript runtime platform
+ *
+ * NOTE: The version information fetching is intentionally written aggressively defensive
+ * to avoid having a released driver version that becomes incompatible
+ * with a future change to these global objects
+ */
+function getRuntimeInfo(): string {
+  if ('Deno' in globalThis) {
+    const version =
+      Deno != null &&
+      typeof Deno === 'object' &&
+      'version' in Deno &&
+      Deno.version != null &&
+      typeof Deno.version === 'object' &&
+      'deno' in Deno.version &&
+      typeof Deno.version.deno === 'string'
+        ? Deno.version.deno
+        : '0.0.0';
+
+    return `Deno v${version}, ${os.endianness()}`;
+  }
+
+  if ('Bun' in globalThis) {
+    const version =
+      Bun != null && typeof Bun === 'object' && 'version' in Bun && typeof Bun.version === 'string'
+        ? Bun.version
+        : '0.0.0';
+
+    return `Bun v${version}, ${os.endianness()}`;
+  }
+
+  return `Node.js ${process.version}, ${os.endianness()}`;
 }

--- a/src/cmap/handshake/client_metadata.ts
+++ b/src/cmap/handshake/client_metadata.ts
@@ -249,7 +249,7 @@ declare const Deno: { version?: { deno?: string } } | undefined;
  * expect it to satisfy. In order to not ship code in the driver that would break
  * future versions of this runtime assume all properties are nullish.
  */
-declare const Bun: { version?: string } | undefined;
+declare const Bun: { (): void; version?: string } | undefined;
 
 /**
  * @internal
@@ -278,7 +278,7 @@ function getRuntimeInfo(): string {
   if ('Bun' in globalThis) {
     const version =
       Bun != null &&
-      (typeof Bun === 'function' || typeof Bun === 'object') &&
+      typeof Bun === 'function' &&
       'version' in Bun &&
       typeof Bun.version === 'string'
         ? Bun.version

--- a/src/cmap/handshake/client_metadata.ts
+++ b/src/cmap/handshake/client_metadata.ts
@@ -261,28 +261,13 @@ declare const Bun: { (): void; version?: string } | undefined;
  */
 function getRuntimeInfo(): string {
   if ('Deno' in globalThis) {
-    const version =
-      Deno != null &&
-      typeof Deno === 'object' &&
-      'version' in Deno &&
-      Deno.version != null &&
-      typeof Deno.version === 'object' &&
-      'deno' in Deno.version &&
-      typeof Deno.version.deno === 'string'
-        ? Deno.version.deno
-        : '0.0.0';
+    const version = typeof Deno?.version?.deno === 'string' ? Deno?.version?.deno : '0.0.0-unknown';
 
     return `Deno v${version}, ${os.endianness()}`;
   }
 
   if ('Bun' in globalThis) {
-    const version =
-      Bun != null &&
-      typeof Bun === 'function' &&
-      'version' in Bun &&
-      typeof Bun.version === 'string'
-        ? Bun.version
-        : '0.0.0';
+    const version = typeof Bun?.version === 'string' ? Bun?.version : '0.0.0-unknown';
 
     return `Bun v${version}, ${os.endianness()}`;
   }

--- a/test/unit/cmap/handshake/client_metadata.test.ts
+++ b/test/unit/cmap/handshake/client_metadata.test.ts
@@ -344,8 +344,18 @@ describe('client metadata module', () => {
           expect(delete globalThis.Bun, 'failed to delete Bun global').to.be.true;
         });
 
-        it('sets platform to Bun', () => {
+        it('sets platform to Bun if typeof is object', () => {
           globalThis.Bun = { version: '1.2.3' };
+          const metadata = makeClientMetadata({ driverInfo: {} });
+          expect(metadata.platform).to.equal('Bun v1.2.3, LE');
+        });
+
+        it('sets platform to Bun if typeof is function', () => {
+          function Bun() {
+            return null;
+          }
+          Bun.version = '1.2.3';
+          globalThis.Bun = Bun;
           const metadata = makeClientMetadata({ driverInfo: {} });
           expect(metadata.platform).to.equal('Bun v1.2.3, LE');
         });

--- a/test/unit/cmap/handshake/client_metadata.test.ts
+++ b/test/unit/cmap/handshake/client_metadata.test.ts
@@ -344,18 +344,10 @@ describe('client metadata module', () => {
           expect(delete globalThis.Bun, 'failed to delete Bun global').to.be.true;
         });
 
-        it('sets platform to Bun if typeof is object', () => {
-          globalThis.Bun = { version: '1.2.3' };
-          const metadata = makeClientMetadata({ driverInfo: {} });
-          expect(metadata.platform).to.equal('Bun v1.2.3, LE');
-        });
-
-        it('sets platform to Bun if typeof is function', () => {
-          function Bun() {
-            return null;
-          }
-          Bun.version = '1.2.3';
-          globalThis.Bun = Bun;
+        it('sets platform to Bun', () => {
+          globalThis.Bun = class {
+            static version = '1.2.3';
+          };
           const metadata = makeClientMetadata({ driverInfo: {} });
           expect(metadata.platform).to.equal('Bun v1.2.3, LE');
         });

--- a/test/unit/cmap/handshake/client_metadata.test.ts
+++ b/test/unit/cmap/handshake/client_metadata.test.ts
@@ -290,7 +290,7 @@ describe('client metadata module', () => {
       });
     });
 
-    context('when globalThis indicates alternative runtime', () => {
+    context.only('when globalThis indicates alternative runtime', () => {
       context('deno', () => {
         afterEach(() => {
           expect(delete globalThis.Deno, 'failed to delete Deno global').to.be.true;
@@ -353,19 +353,31 @@ describe('client metadata module', () => {
         });
 
         it('sets platform to Bun with driverInfo.platform', () => {
-          globalThis.Bun = { version: '1.2.3' };
+          globalThis.Bun = class {
+            static version = '1.2.3';
+          };
           const metadata = makeClientMetadata({ driverInfo: { platform: 'myPlatform' } });
           expect(metadata.platform).to.equal('Bun v1.2.3, LE|myPlatform');
         });
 
         it('ignores version if Bun.version is not a string', () => {
-          globalThis.Bun = { version: 1 };
+          globalThis.Bun = class {
+            static version = 1;
+          };
           const metadata = makeClientMetadata({ driverInfo: {} });
           expect(metadata.platform).to.equal('Bun v0.0.0, LE');
         });
 
         it('ignores version if Bun.version is not a string and sets driverInfo.platform', () => {
-          globalThis.Bun = { version: 1 };
+          globalThis.Bun = class {
+            static version = 1;
+          };
+          const metadata = makeClientMetadata({ driverInfo: { platform: 'myPlatform' } });
+          expect(metadata.platform).to.equal('Bun v0.0.0, LE|myPlatform');
+        });
+
+        it('ignores version if Bun is not a function', () => {
+          globalThis.Bun = { version: '1.2.3' };
           const metadata = makeClientMetadata({ driverInfo: { platform: 'myPlatform' } });
           expect(metadata.platform).to.equal('Bun v0.0.0, LE|myPlatform');
         });

--- a/test/unit/cmap/handshake/client_metadata.test.ts
+++ b/test/unit/cmap/handshake/client_metadata.test.ts
@@ -289,6 +289,86 @@ describe('client metadata module', () => {
         });
       });
     });
+
+    context('when globalThis indicates alternative runtime', () => {
+      context('deno', () => {
+        afterEach(() => {
+          expect(delete globalThis.Deno, 'failed to delete Deno global').to.be.true;
+        });
+
+        it('sets platform to Deno', () => {
+          globalThis.Deno = { version: { deno: '1.2.3' } };
+          const metadata = makeClientMetadata({ driverInfo: {} });
+          expect(metadata.platform).to.equal('Deno v1.2.3, LE');
+        });
+
+        it('sets platform to Deno with driverInfo.platform', () => {
+          globalThis.Deno = { version: { deno: '1.2.3' } };
+          const metadata = makeClientMetadata({ driverInfo: { platform: 'myPlatform' } });
+          expect(metadata.platform).to.equal('Deno v1.2.3, LE|myPlatform');
+        });
+
+        it('ignores version if Deno.version.deno is not a string', () => {
+          globalThis.Deno = { version: { deno: 1 } };
+          const metadata = makeClientMetadata({ driverInfo: {} });
+          expect(metadata.platform).to.equal('Deno v0.0.0, LE');
+        });
+
+        it('ignores version if Deno.version.deno is not a string and sets driverInfo.platform', () => {
+          globalThis.Deno = { version: { deno: 1 } };
+          const metadata = makeClientMetadata({ driverInfo: { platform: 'myPlatform' } });
+          expect(metadata.platform).to.equal('Deno v0.0.0, LE|myPlatform');
+        });
+
+        it('ignores version if Deno.version does not have a deno property', () => {
+          globalThis.Deno = { version: { somethingElse: '1.2.3' } };
+          const metadata = makeClientMetadata({ driverInfo: {} });
+          expect(metadata.platform).to.equal('Deno v0.0.0, LE');
+        });
+
+        it('ignores version if Deno.version is null', () => {
+          globalThis.Deno = { version: null };
+          const metadata = makeClientMetadata({ driverInfo: {} });
+          expect(metadata.platform).to.equal('Deno v0.0.0, LE');
+        });
+
+        it('ignores version if Deno does not have a version property', () => {
+          globalThis.Deno = { version: null };
+          const metadata = makeClientMetadata({ driverInfo: {} });
+          expect(metadata.platform).to.equal('Deno v0.0.0, LE');
+        });
+      });
+
+      context('bun', () => {
+        afterEach(() => {
+          expect(delete globalThis.Bun, 'failed to delete Bun global').to.be.true;
+        });
+
+        it('sets platform to Bun', () => {
+          globalThis.Bun = { version: '1.2.3' };
+          const metadata = makeClientMetadata({ driverInfo: {} });
+          expect(metadata.platform).to.equal('Bun v1.2.3, LE');
+        });
+
+        it('sets platform to Bun with driverInfo.platform', () => {
+          globalThis.Bun = { version: '1.2.3' };
+          const metadata = makeClientMetadata({ driverInfo: { platform: 'myPlatform' } });
+          expect(metadata.platform).to.equal('Bun v1.2.3, LE|myPlatform');
+        });
+
+        it('ignores version if Bun.version is not a string', () => {
+          globalThis.Bun = { version: 1 };
+          const metadata = makeClientMetadata({ driverInfo: {} });
+          expect(metadata.platform).to.equal('Bun v0.0.0, LE');
+        });
+
+        it('ignores version if Bun.version is not a string and sets driverInfo.platform', () => {
+          globalThis.Bun = { version: 1 };
+          const metadata = makeClientMetadata({ driverInfo: { platform: 'myPlatform' } });
+          expect(metadata.platform).to.equal('Bun v0.0.0, LE|myPlatform');
+        });
+      });
+    });
   });
 
   describe('FAAS metadata application to handshake', () => {

--- a/test/unit/cmap/handshake/client_metadata.test.ts
+++ b/test/unit/cmap/handshake/client_metadata.test.ts
@@ -311,31 +311,25 @@ describe('client metadata module', () => {
         it('ignores version if Deno.version.deno is not a string', () => {
           globalThis.Deno = { version: { deno: 1 } };
           const metadata = makeClientMetadata({ driverInfo: {} });
-          expect(metadata.platform).to.equal('Deno v0.0.0, LE');
-        });
-
-        it('ignores version if Deno.version.deno is not a string and sets driverInfo.platform', () => {
-          globalThis.Deno = { version: { deno: 1 } };
-          const metadata = makeClientMetadata({ driverInfo: { platform: 'myPlatform' } });
-          expect(metadata.platform).to.equal('Deno v0.0.0, LE|myPlatform');
+          expect(metadata.platform).to.equal('Deno v0.0.0-unknown, LE');
         });
 
         it('ignores version if Deno.version does not have a deno property', () => {
           globalThis.Deno = { version: { somethingElse: '1.2.3' } };
           const metadata = makeClientMetadata({ driverInfo: {} });
-          expect(metadata.platform).to.equal('Deno v0.0.0, LE');
+          expect(metadata.platform).to.equal('Deno v0.0.0-unknown, LE');
         });
 
         it('ignores version if Deno.version is null', () => {
           globalThis.Deno = { version: null };
           const metadata = makeClientMetadata({ driverInfo: {} });
-          expect(metadata.platform).to.equal('Deno v0.0.0, LE');
+          expect(metadata.platform).to.equal('Deno v0.0.0-unknown, LE');
         });
 
-        it('ignores version if Deno does not have a version property', () => {
-          globalThis.Deno = { version: null };
+        it('ignores version if Deno is nullish', () => {
+          globalThis.Deno = null;
           const metadata = makeClientMetadata({ driverInfo: {} });
-          expect(metadata.platform).to.equal('Deno v0.0.0, LE');
+          expect(metadata.platform).to.equal('Deno v0.0.0-unknown, LE');
         });
       });
 
@@ -365,7 +359,7 @@ describe('client metadata module', () => {
             static version = 1;
           };
           const metadata = makeClientMetadata({ driverInfo: {} });
-          expect(metadata.platform).to.equal('Bun v0.0.0, LE');
+          expect(metadata.platform).to.equal('Bun v0.0.0-unknown, LE');
         });
 
         it('ignores version if Bun.version is not a string and sets driverInfo.platform', () => {
@@ -373,13 +367,13 @@ describe('client metadata module', () => {
             static version = 1;
           };
           const metadata = makeClientMetadata({ driverInfo: { platform: 'myPlatform' } });
-          expect(metadata.platform).to.equal('Bun v0.0.0, LE|myPlatform');
+          expect(metadata.platform).to.equal('Bun v0.0.0-unknown, LE|myPlatform');
         });
 
-        it('ignores version if Bun is not a function', () => {
-          globalThis.Bun = { version: '1.2.3' };
+        it('ignores version if Bun is nullish', () => {
+          globalThis.Bun = null;
           const metadata = makeClientMetadata({ driverInfo: { platform: 'myPlatform' } });
-          expect(metadata.platform).to.equal('Bun v0.0.0, LE|myPlatform');
+          expect(metadata.platform).to.equal('Bun v0.0.0-unknown, LE|myPlatform');
         });
       });
     });

--- a/test/unit/cmap/handshake/client_metadata.test.ts
+++ b/test/unit/cmap/handshake/client_metadata.test.ts
@@ -290,7 +290,7 @@ describe('client metadata module', () => {
       });
     });
 
-    context.only('when globalThis indicates alternative runtime', () => {
+    context('when globalThis indicates alternative runtime', () => {
       context('deno', () => {
         afterEach(() => {
           expect(delete globalThis.Deno, 'failed to delete Deno global').to.be.true;


### PR DESCRIPTION
### Description

#### What is changing?

Changes platform metadata based on globals in the driver's runtime environement.

#### What is the motivation for this change?

Node.js compatibility in Deno and Bun have made it possible to run the driver, it is useful to denote the difference between the runtimes in the platform information.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
