### PR TITLE
chore(NODE-5133): remove broken filter as binary from find operation

### DIFF
--- a/src/operations/find.ts
+++ b/src/operations/find.ts
@@ -93,16 +93,6 @@ export class FindOperation extends CommandOperation<Document> {
       throw new MongoInvalidArgumentError('Query filter must be a plain object or ObjectId');
     }
 
-    // If the filter is a buffer, validate that is a valid BSON document
-    if (Buffer.isBuffer(filter)) {
-      const objectSize = filter[0] | (filter[1] << 8) | (filter[2] << 16) | (filter[3] << 24);
-      if (objectSize !== filter.length) {
-        throw new MongoInvalidArgumentError(
-          `Query filter raw message size does not match message header size [${filter.length}] != [${objectSize}]`
-        );
-      }
-    }
-
     // special case passing in an ObjectId as a filter
     this.filter = filter != null && filter._bsontype === 'ObjectId' ? { _id: filter } : filter;
   }


### PR DESCRIPTION
### Description

#### What is changing?

Logic to support `Binary` objects as filter predicates has been removed from the `find` operation.

##### Is there new documentation needed for these changes?

No.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
