### PR TITLE
feat(NODE-5203): emit `INIT` from `ChangeStream`

### DIFF
--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -43,7 +43,7 @@ const CHANGE_DOMAIN_TYPES = {
   CLUSTER: Symbol('Cluster')
 };
 
-const CHANGE_STREAM_EVENTS = [RESUME_TOKEN_CHANGED, END, CLOSE];
+const CHANGE_STREAM_EVENTS = [INIT, RESUME_TOKEN_CHANGED, END, CLOSE];
 
 const NO_RESUME_TOKEN_ERROR =
   'A change stream document has been received that lacks a resume token (_id).';

--- a/src/cursor/change_stream_cursor.ts
+++ b/src/cursor/change_stream_cursor.ts
@@ -42,7 +42,7 @@ export type ChangeStreamAggregateRawResult<TChange> = {
 export class ChangeStreamCursor<
   TSchema extends Document = Document,
   TChange extends Document = ChangeStreamDocument<TSchema>
-> extends AbstractCursor<TChange, ChangeStreamEvents> {
+> extends AbstractCursor<TChange, ChangeStreamEvents<TSchema, TChange>> {
   _resumeToken: ResumeToken;
   startAtOperationTime?: OperationTime;
   hasReceived?: boolean;

--- a/test/integration/node-specific/examples/change_streams.test.js
+++ b/test/integration/node-specific/examples/change_streams.test.js
@@ -66,6 +66,7 @@ maybeDescribe('examples(change-stream):', function () {
       // Start Changestream Example 1
       const collection = db.collection('inventory');
       const changeStream = collection.watch();
+      await new Promise(resolve => changeStream.once('init', resolve));
       changeStream.on('change', next => {
         // process next document
       });


### PR DESCRIPTION
### Description

#### What is changing?

Emit `INIT` event from `ChangeStream`

##### Is there new documentation needed for these changes?

No, the docs [already list this as a valid event](https://mongodb.github.io/node-mongodb-native/5.2/classes/ChangeStream.html#INIT), even though it's not currently emitted.

#### What is the motivation for this change?

We currently have a test that runs against MongoDB and looks like this:

```ts
it('subscribes to a change stream', async () => {
  const mongo = await new MongoClient(...).connect();
  const changeStream = mongo.collection(...).watch(...);
 
  mongo.collection(...).insertOne({...});
  await new Promise((resolve) => changeStream.once('change', resolve));
})
```
Most of the time (~99%), this test passes fine, even with the synchronous calls of `ChangeStream.watch()` followed immediately by `Collection.insertOne()`

However, this occasionally fails. I've done some digging and the cases where it fails are when the change stream's `cursor` is initialised later than the insertion completes (which is understandable).

What I'd like to do is change the test (and similar code that relies on a stream being initialised) to look like this:

```ts
it('subscribes to a change stream', async () => {
  const mongo = await new MongoClient(...).connect();
  const changeStream = mongo.collection(...).watch(...);
 
  // This line was added and would ensure our stream is subscribed
  // before trying to manipulate the collection:
  await new Promise((resolve) => changeStream.once('init', resolve));
 
  mongo.collection(...).insertOne({...});
  await new Promise((resolve) => changeStream.once('change', resolve));
});
```

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
