### PR TITLE
feat(NODE-5188): add alternative runtime detection to client metadata

### DIFF
--- a/test/unit/cmap/handshake/client_metadata.test.ts
+++ b/test/unit/cmap/handshake/client_metadata.test.ts
@@ -288,6 +288,94 @@ describe('client metadata module', () => {
         });
       });
     });
+
+    context('when globalThis indicates alternative runtime', () => {
+      context('deno', () => {
+        afterEach(() => {
+          expect(delete globalThis.Deno, 'failed to delete Deno global').to.be.true;
+        });
+
+        it('sets platform to Deno', () => {
+          globalThis.Deno = { version: { deno: '1.2.3' } };
+          const metadata = makeClientMetadata({ driverInfo: {} });
+          expect(metadata.platform).to.equal('Deno v1.2.3, LE');
+        });
+
+        it('sets platform to Deno with driverInfo.platform', () => {
+          globalThis.Deno = { version: { deno: '1.2.3' } };
+          const metadata = makeClientMetadata({ driverInfo: { platform: 'myPlatform' } });
+          expect(metadata.platform).to.equal('Deno v1.2.3, LE|myPlatform');
+        });
+
+        it('ignores version if Deno.version.deno is not a string', () => {
+          globalThis.Deno = { version: { deno: 1 } };
+          const metadata = makeClientMetadata({ driverInfo: {} });
+          expect(metadata.platform).to.equal('Deno v0.0.0-unknown, LE');
+        });
+
+        it('ignores version if Deno.version does not have a deno property', () => {
+          globalThis.Deno = { version: { somethingElse: '1.2.3' } };
+          const metadata = makeClientMetadata({ driverInfo: {} });
+          expect(metadata.platform).to.equal('Deno v0.0.0-unknown, LE');
+        });
+
+        it('ignores version if Deno.version is null', () => {
+          globalThis.Deno = { version: null };
+          const metadata = makeClientMetadata({ driverInfo: {} });
+          expect(metadata.platform).to.equal('Deno v0.0.0-unknown, LE');
+        });
+
+        it('ignores version if Deno is nullish', () => {
+          globalThis.Deno = null;
+          const metadata = makeClientMetadata({ driverInfo: {} });
+          expect(metadata.platform).to.equal('Deno v0.0.0-unknown, LE');
+        });
+      });
+
+      context('bun', () => {
+        afterEach(() => {
+          expect(delete globalThis.Bun, 'failed to delete Bun global').to.be.true;
+        });
+
+        it('sets platform to Bun', () => {
+          globalThis.Bun = class {
+            static version = '1.2.3';
+          };
+          const metadata = makeClientMetadata({ driverInfo: {} });
+          expect(metadata.platform).to.equal('Bun v1.2.3, LE');
+        });
+
+        it('sets platform to Bun with driverInfo.platform', () => {
+          globalThis.Bun = class {
+            static version = '1.2.3';
+          };
+          const metadata = makeClientMetadata({ driverInfo: { platform: 'myPlatform' } });
+          expect(metadata.platform).to.equal('Bun v1.2.3, LE|myPlatform');
+        });
+
+        it('ignores version if Bun.version is not a string', () => {
+          globalThis.Bun = class {
+            static version = 1;
+          };
+          const metadata = makeClientMetadata({ driverInfo: {} });
+          expect(metadata.platform).to.equal('Bun v0.0.0-unknown, LE');
+        });
+
+        it('ignores version if Bun.version is not a string and sets driverInfo.platform', () => {
+          globalThis.Bun = class {
+            static version = 1;
+          };
+          const metadata = makeClientMetadata({ driverInfo: { platform: 'myPlatform' } });
+          expect(metadata.platform).to.equal('Bun v0.0.0-unknown, LE|myPlatform');
+        });
+
+        it('ignores version if Bun is nullish', () => {
+          globalThis.Bun = null;
+          const metadata = makeClientMetadata({ driverInfo: { platform: 'myPlatform' } });
+          expect(metadata.platform).to.equal('Bun v0.0.0-unknown, LE|myPlatform');
+        });
+      });
+    });
   });
 
   describe('FAAS metadata application to handshake', () => {


### PR DESCRIPTION
### Description

#### What is changing?

Backport #3636

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
