### PR TITLE
fix(NODE-5213): `ChangeStream.tryNext()` should return TChange type

### DIFF
--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -700,7 +700,7 @@ export class ChangeStream<
   /**
    * Try to get the next available document from the Change Stream's cursor or `null` if an empty batch is returned
    */
-  async tryNext(): Promise<Document | null> {
+  async tryNext(): Promise<TChange | null> {
     this._setIsIterator();
     // Change streams must resume indefinitely while each resume event succeeds.
     // This loop continues until either a change event is received or until a resume attempt

--- a/test/types/change_stream.test-d.ts
+++ b/test/types/change_stream.test-d.ts
@@ -1,6 +1,7 @@
 import { expectError, expectType } from 'tsd';
 
 import type {
+  ChangeStream,
   ChangeStreamCollModDocument,
   ChangeStreamCreateDocument,
   ChangeStreamCreateIndexDocument,
@@ -15,8 +16,11 @@ import type {
   ChangeStreamInvalidateDocument,
   ChangeStreamNameSpace,
   ChangeStreamOptions,
+  ChangeStreamRefineCollectionShardKeyDocument,
   ChangeStreamRenameDocument,
   ChangeStreamReplaceDocument,
+  ChangeStreamReshardCollectionDocument,
+  ChangeStreamShardCollectionDocument,
   ChangeStreamUpdateDocument,
   Collection,
   Document,
@@ -24,11 +28,6 @@ import type {
   ServerSessionId,
   Timestamp,
   UpdateDescription
-} from '../../src';
-import type {
-  ChangeStreamRefineCollectionShardKeyDocument,
-  ChangeStreamReshardCollectionDocument,
-  ChangeStreamShardCollectionDocument
 } from '../mongodb';
 
 declare const changeStreamOptions: ChangeStreamOptions;
@@ -217,4 +216,21 @@ collection
 
 expectType<AsyncGenerator<ChangeStreamDocument<Schema>, void, void>>(
   collection.watch()[Symbol.asyncIterator]()
+);
+
+// Change type returned to user is equivalent across next/tryNext/on/once/addListener
+declare let changeStream: ChangeStream<Schema>;
+expectType<ChangeStreamDocument<Schema> | null>(await changeStream.tryNext());
+expectType<ChangeStreamDocument<Schema>>(await changeStream.next());
+changeStream.on('change', change => expectType<ChangeStreamDocument<Schema>>(change));
+changeStream.once('change', change => expectType<ChangeStreamDocument<Schema>>(change));
+changeStream.addListener('change', change => expectType<ChangeStreamDocument<Schema>>(change));
+
+declare let changeStreamNoSchema: ChangeStream;
+expectType<ChangeStreamDocument<Document> | null>(await changeStreamNoSchema.tryNext());
+expectType<ChangeStreamDocument<Document>>(await changeStreamNoSchema.next());
+changeStreamNoSchema.on('change', change => expectType<ChangeStreamDocument<Document>>(change));
+changeStreamNoSchema.once('change', change => expectType<ChangeStreamDocument<Document>>(change));
+changeStreamNoSchema.addListener('change', change =>
+  expectType<ChangeStreamDocument<Document>>(change)
 );

--- a/test/types/change_stream.test-d.ts
+++ b/test/types/change_stream.test-d.ts
@@ -1,7 +1,6 @@
 import { expectError, expectType } from 'tsd';
 
 import type {
-  ChangeStream,
   ChangeStreamCollModDocument,
   ChangeStreamCreateDocument,
   ChangeStreamCreateIndexDocument,
@@ -219,14 +218,15 @@ expectType<AsyncGenerator<ChangeStreamDocument<Schema>, void, void>>(
 );
 
 // Change type returned to user is equivalent across next/tryNext/on/once/addListener
-declare let changeStream: ChangeStream<Schema>;
+const changeStream = collection.watch();
 expectType<ChangeStreamDocument<Schema> | null>(await changeStream.tryNext());
 expectType<ChangeStreamDocument<Schema>>(await changeStream.next());
 changeStream.on('change', change => expectType<ChangeStreamDocument<Schema>>(change));
 changeStream.once('change', change => expectType<ChangeStreamDocument<Schema>>(change));
 changeStream.addListener('change', change => expectType<ChangeStreamDocument<Schema>>(change));
 
-declare let changeStreamNoSchema: ChangeStream;
+declare const noSchemaCollection: Collection;
+const changeStreamNoSchema = noSchemaCollection.watch();
 expectType<ChangeStreamDocument<Document> | null>(await changeStreamNoSchema.tryNext());
 expectType<ChangeStreamDocument<Document>>(await changeStreamNoSchema.next());
 changeStreamNoSchema.on('change', change => expectType<ChangeStreamDocument<Document>>(change));


### PR DESCRIPTION
### Description

#### What is changing?

Update [ChangeStream.tryNext()](https://github.com/mongodb/node-mongodb-native/blob/d6bd1d1602c213e5c46a702163351d1865cdc727/src/change_stream.ts#L703) return type to be consistent with [ChangeStream.next()](https://github.com/mongodb/node-mongodb-native/blob/d6bd1d1602c213e5c46a702163351d1865cdc727/src/change_stream.ts#L674).

The underlying AbstractCursor has the [same return type](https://github.com/mongodb/node-mongodb-native/blob/d6bd1d1602c213e5c46a702163351d1865cdc727/src/cursor/abstract_cursor.ts#L375-L386) for both.

#### Is there new documentation needed for these changes?

If [these API docs](https://mongodb.github.io/node-mongodb-native/5.3/classes/ChangeStream.html#tryNext) aren't auto-generated, then yes.

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

Avoiding having to cast when using ChangeStream.tryNext().

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
