### PR TITLE
feat(NODE-4849): configure log dest from client

### DIFF
--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -16,7 +16,7 @@ import { Db, DbOptions } from './db';
 import type { AutoEncrypter, AutoEncryptionOptions } from './deps';
 import type { Encrypter } from './encrypter';
 import { MongoInvalidArgumentError } from './error';
-import { MongoLogger, MongoLoggerOptions } from './mongo_logger';
+import { MongoDBLogWritable, MongoLogger, MongoLoggerOptions } from './mongo_logger';
 import { TypedEventEmitter } from './mongo_types';
 import type { ReadConcern, ReadConcernLevel, ReadConcernLike } from './read_concern';
 import { ReadPreference, ReadPreferenceMode } from './read_preference';
@@ -253,6 +253,12 @@ export interface MongoClientOptions extends BSONSerializeOptions, SupportedNodeC
   proxyUsername?: string;
   /** Configures a Socks5 proxy password when the proxy in proxyHost requires username/password authentication. */
   proxyPassword?: string;
+
+  /**
+   * Configures the destination that log messages are written to.
+   * @experimental
+   */
+  mongodbLogPath?: string | MongoDBLogWritable;
 
   /** @internal */
   srvPoller?: SrvPoller;

--- a/test/tools/unified-spec-runner/entities.ts
+++ b/test/tools/unified-spec-runner/entities.ts
@@ -192,7 +192,6 @@ export class UnifiedMongoClient extends MongoClient {
       [Symbol.for('@@mdb.skipPingOnConnect')]: true,
       [Symbol.for('@@mdb.enableMongoLogger')]: true,
       [Symbol.for('@@mdb.internalMongoLoggerConfig')]: componentSeverities,
-      // @ts-expect-error TODO(NODE-4849): Remove this once we have support for mongodbLogPath
       mongodbLogPath: logCollector,
       ...getEnvironmentalOptions(),
       ...(description.serverApi ? { serverApi: description.serverApi } : {})


### PR DESCRIPTION
### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
