### PR TITLE
fix(NODE-5225): eagerly clear MongoClient.topology in MongoClient.close()

### DIFF
--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -504,10 +504,14 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> {
       return;
     }
 
+    // clear out references to old topology
+    const topology = this.topology;
+    this.topology = undefined;
+
     // If we would attempt to select a server and get nothing back we short circuit
     // to avoid the server selection timeout.
     const selector = readPreferenceServerSelector(ReadPreference.primaryPreferred);
-    const topologyDescription = this.topology.description;
+    const topologyDescription = topology.description;
     const serverDescriptions = Array.from(topologyDescription.servers.values());
     const servers = selector(topologyDescription, serverDescriptions);
     if (servers.length !== 0) {
@@ -521,10 +525,6 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> {
           .catch(() => null); // outcome does not matter
       }
     }
-
-    // clear out references to old topology
-    const topology = this.topology;
-    this.topology = undefined;
 
     await new Promise<void>((resolve, reject) => {
       topology.close({ force }, error => {

--- a/test/integration/node-specific/mongo_client.test.ts
+++ b/test/integration/node-specific/mongo_client.test.ts
@@ -385,6 +385,14 @@ describe('class MongoClient', function () {
     }
   });
 
+  it('can call close() concurrently', async function () {
+    const client = this.configuration.newClient();
+    await client.connect();
+    // Ensure topology is opened before trying to close
+    await client.db().command({ hello: 1 });
+    await Promise.all([client.close(), client.close()]);
+  });
+
   context('explict #connect()', () => {
     let client: MongoClient;
     beforeEach(function () {


### PR DESCRIPTION
### Description

At the moment, calling `MongoClient.close()` in quick succession leads to an error:

```
TypeError: Cannot read properties of undefined (reading 'close')
  at node-mongodb-native/src/mongo_client.ts:530:16
  at new Promise (<anonymous>)
  at LegacyMongoClient.close (src/mongo_client.ts:529:11)
  at processTicksAndRejections (node:internal/process/task_queues:95:5)
  at async Promise.all (index 1)
  at async Context.<anonymous> (test/integration/node-specific/mongo_client.test.ts:393:5)
```

This happens because:

1. The first call attempts to asynchronously [close][1] the session pool sessions
2. While this is happening, the second call passes the topology [null check][2] (since `this.topology` hasn't yet been [unset][3], and tries to also close session pool sessions
3. Both calls then set [`const topology = this.topology`][4] but the second call will get undefined since the first call [unset][3] `this.topology`
4. The second call now tries to call [`close()`][5] on an `undefined` `topology` and throws

[1]: https://github.com/mongodb/node-mongodb-native/blob/325c4bc37decdf12e957bfad8bd4ee4d28b1bf95/src/mongo_client.ts#L516
[2]: https://github.com/mongodb/node-mongodb-native/blob/325c4bc37decdf12e957bfad8bd4ee4d28b1bf95/src/mongo_client.ts#L503
[3]: https://github.com/mongodb/node-mongodb-native/blob/325c4bc37decdf12e957bfad8bd4ee4d28b1bf95/src/mongo_client.ts#L527
[4]: https://github.com/mongodb/node-mongodb-native/blob/325c4bc37decdf12e957bfad8bd4ee4d28b1bf95/src/mongo_client.ts#L526
[5]: https://github.com/mongodb/node-mongodb-native/blob/325c4bc37decdf12e957bfad8bd4ee4d28b1bf95/src/mongo_client.ts#L530

#### What is changing?

This change fixes the issue by moving the `topology` unset immediately after the `null` check, so we know it's always correctly set.

##### Is there new documentation needed for these changes?

No

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
