### PR TITLE
docs(NODE-5280): mark QE equality stable

### DIFF
--- a/src/deps.ts
+++ b/src/deps.ts
@@ -309,11 +309,11 @@ export interface AutoEncryptionOptions {
    * Other validation rules in the JSON schema will not be enforced by the driver and will result in an error.
    */
   schemaMap?: Document;
-  /** @experimental Public Technical Preview: Supply a schema for the encrypted fields in the document  */
+  /** Supply a schema for the encrypted fields in the document  */
   encryptedFieldsMap?: Document;
   /** Allows the user to bypass auto encryption, maintaining implicit decryption */
   bypassAutoEncryption?: boolean;
-  /** @experimental Public Technical Preview: Allows users to bypass query analysis */
+  /** Allows users to bypass query analysis */
   bypassQueryAnalysis?: boolean;
   options?: {
     /** An optional hook to catch logging messages from the underlying encryption engine */


### PR DESCRIPTION
### Description

#### What is changing?

QE equality API is marked stable in anticipation of 7.0.

##### Is there new documentation needed for these changes?

Yes.

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
