### PR TITLE
test(NODE-5180): bump mongodb-client-encryption pinned commits to 2.8.0 release 

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2558,7 +2558,7 @@ tasks:
       - func: bootstrap kms servers
       - func: run custom csfle tests
         vars:
-          CSFLE_GIT_REF: 1524eac203e4145e9f4835e519f1e4663ff15953
+          CSFLE_GIT_REF: c56c70340093070b1ef5c8a28190187eea21a6e9
   - name: run-custom-csfle-tests-5.0-master
     tags:
       - run-custom-dependency-tests
@@ -2588,7 +2588,7 @@ tasks:
       - func: bootstrap kms servers
       - func: run custom csfle tests
         vars:
-          CSFLE_GIT_REF: 1524eac203e4145e9f4835e519f1e4663ff15953
+          CSFLE_GIT_REF: c56c70340093070b1ef5c8a28190187eea21a6e9
   - name: run-custom-csfle-tests-rapid-master
     tags:
       - run-custom-dependency-tests
@@ -2618,7 +2618,7 @@ tasks:
       - func: bootstrap kms servers
       - func: run custom csfle tests
         vars:
-          CSFLE_GIT_REF: 1524eac203e4145e9f4835e519f1e4663ff15953
+          CSFLE_GIT_REF: c56c70340093070b1ef5c8a28190187eea21a6e9
   - name: run-custom-csfle-tests-latest-master
     tags:
       - run-custom-dependency-tests

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -605,7 +605,7 @@ BUILD_VARIANTS.push({
 
 const oneOffFuncAsTasks = [];
 
-const FLE_PINNED_COMMIT = '1524eac203e4145e9f4835e519f1e4663ff15953';
+const FLE_PINNED_COMMIT = 'c56c70340093070b1ef5c8a28190187eea21a6e9';
 
 for (const version of ['5.0', 'rapid', 'latest']) {
   for (const ref of [FLE_PINNED_COMMIT, 'master']) {

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -105,4 +105,4 @@ fi
 
 echo "npm version: $(npm -v)"
 
-npm install --force "${NPM_OPTIONS}"
+npm install "${NPM_OPTIONS}"

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -105,5 +105,4 @@ fi
 
 echo "npm version: $(npm -v)"
 
-# TODO(NODE-5180): remove --force option
 npm install --force "${NPM_OPTIONS}"

--- a/.evergreen/run-azure-kms-tests.sh
+++ b/.evergreen/run-azure-kms-tests.sh
@@ -9,8 +9,7 @@ source ".evergreen/init-nvm.sh"
 
 set -o xtrace
 
-# TODO(NODE-5180): remove --force option
-npm install --force 'mongodb-client-encryption'
+npm install mongodb-client-encryption
 
 export MONGODB_URI="mongodb://localhost:27017"
 

--- a/.evergreen/run-azure-kms-tests.sh
+++ b/.evergreen/run-azure-kms-tests.sh
@@ -10,7 +10,7 @@ source ".evergreen/init-nvm.sh"
 set -o xtrace
 
 # TODO(NODE-5180): remove --force option
-npm install --force 'mongodb-client-encryption@alpha'
+npm install --force 'mongodb-client-encryption'
 
 export MONGODB_URI="mongodb://localhost:27017"
 

--- a/.evergreen/run-custom-csfle-tests.sh
+++ b/.evergreen/run-custom-csfle-tests.sh
@@ -52,8 +52,7 @@ popd # mongo-c-driver
 
 pushd libmongocrypt/bindings/node
 
-# TODO(NODE-5180): remove --force option
-npm install --force --production --ignore-scripts
+npm install --production --ignore-scripts
 bash ./etc/build-static.sh
 
 popd # libmongocrypt/bindings/node
@@ -82,8 +81,7 @@ pushd ../csfle-deps-tmp/libmongocrypt/bindings/node
 killall mongocryptd || true
 
 # only prod deps were installed earlier, install devDependencies here (except for mongodb!)
-# TODO(NODE-5180): remove --force option
-npm install --force --ignore-scripts
+npm install --ignore-scripts
 
 # copy mongodb into CSFLE's node_modules
 rm -rf node_modules/mongodb

--- a/.evergreen/run-gcp-kms-tests.sh
+++ b/.evergreen/run-gcp-kms-tests.sh
@@ -9,9 +9,8 @@ source ".evergreen/init-nvm.sh"
 
 set -o xtrace
 
-# TODO(NODE-5180): remove --force option
-npm install --force 'mongodb-client-encryption'
-npm install --force 'gcp-metadata'
+npm install mongodb-client-encryption
+npm install gcp-metadata
 
 export MONGODB_URI="mongodb://localhost:27017"
 

--- a/.evergreen/run-gcp-kms-tests.sh
+++ b/.evergreen/run-gcp-kms-tests.sh
@@ -10,7 +10,7 @@ source ".evergreen/init-nvm.sh"
 set -o xtrace
 
 # TODO(NODE-5180): remove --force option
-npm install --force 'mongodb-client-encryption@alpha'
+npm install --force 'mongodb-client-encryption'
 npm install --force 'gcp-metadata'
 
 export MONGODB_URI="mongodb://localhost:27017"

--- a/.evergreen/run-serverless-tests.sh
+++ b/.evergreen/run-serverless-tests.sh
@@ -11,7 +11,7 @@ if [ -z ${SERVERLESS_ATLAS_USER+omitted} ]; then echo "SERVERLESS_ATLAS_USER is 
 if [ -z ${SERVERLESS_ATLAS_PASSWORD+omitted} ]; then echo "SERVERLESS_ATLAS_PASSWORD is unset" && exit 1; fi
 
 # TODO(NODE-5180): remove --force option
-npm install --force 'mongodb-client-encryption@alpha'
+npm install --force 'mongodb-client-encryption'
 
 npx mocha \
   --config test/mocha_mongodb.json \

--- a/.evergreen/run-serverless-tests.sh
+++ b/.evergreen/run-serverless-tests.sh
@@ -10,8 +10,7 @@ if [ -z ${MONGODB_URI+omitted} ]; then echo "MONGODB_URI is unset" && exit 1; fi
 if [ -z ${SERVERLESS_ATLAS_USER+omitted} ]; then echo "SERVERLESS_ATLAS_USER is unset" && exit 1; fi
 if [ -z ${SERVERLESS_ATLAS_PASSWORD+omitted} ]; then echo "SERVERLESS_ATLAS_PASSWORD is unset" && exit 1; fi
 
-# TODO(NODE-5180): remove --force option
-npm install --force 'mongodb-client-encryption'
+npm install mongodb-client-encryption
 
 npx mocha \
   --config test/mocha_mongodb.json \

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -53,7 +53,7 @@ else
 fi
 
 # TODO(NODE-5180): remove --force option
-npm install --force 'mongodb-client-encryption@alpha'
+npm install --force 'mongodb-client-encryption'
 npm install --force @mongodb-js/zstd
 npm install --force snappy
 

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -52,10 +52,9 @@ else
   source "$DRIVERS_TOOLS"/.evergreen/csfle/set-temp-creds.sh
 fi
 
-# TODO(NODE-5180): remove --force option
-npm install --force 'mongodb-client-encryption'
-npm install --force @mongodb-js/zstd
-npm install --force snappy
+npm install mongodb-client-encryption
+npm install @mongodb-js/zstd
+npm install snappy
 
 export AUTH=$AUTH
 export SINGLE_MONGOS_LB_URI=${SINGLE_MONGOS_LB_URI}


### PR DESCRIPTION
### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
