### PR TITLE
docs(NODE-4778): update tls option notes

### DIFF
--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -790,7 +790,7 @@ export interface MongoOptions
    * | see note below        | `tlsInsecure`                                 | N/A                | `boolean`          |
    *
    * If `tlsInsecure` is set to `true`, then it will set the node native options `checkServerIdentity`
-   * to a no-op and `rejectUnauthorized` to `false.
+   * to a no-op and `rejectUnauthorized` to `false`.
    *
    * If `tlsInsecure` is set to `false`, then it will set the node native options `checkServerIdentity`
    * to a no-op and `rejectUnauthorized` to the inverse value of `tlsAllowInvalidCertificates`. If

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -778,17 +778,23 @@ export interface MongoOptions
    *
    * ### Additional options:
    *
-   * | nodejs native option | driver spec compliant option name             | legacy option name | driver option type |
-   * |:---------------------|:----------------------------------------------|:-------------------|:-------------------|
-   * | `ca`                 | `tlsCAFile`                                   | `sslCA`            | `string`           |
-   * | `crl`                | N/A                                           | `sslCRL`           | `string`           |
-   * | `cert`               | `tlsCertificateFile`, `tlsCertificateKeyFile` | `sslCert`          | `string`           |
-   * | `key`                | `tlsCertificateKeyFile`                       | `sslKey`           | `string`           |
-   * | `passphrase`         | `tlsCertificateKeyFilePassword`               | `sslPass`          | `string`           |
-   * | `rejectUnauthorized` | `tlsAllowInvalidCertificates`                 | `sslValidate`      | `boolean`          |
-   * | N/A                  | `tlsAllowInvalidHostnames`                    | N/A                | `boolean`          |
-   * | N/A                  | `tlsInsecure`                                 | N/A                | `boolean`          |
+   * | nodejs native option  | driver spec compliant option name             | legacy option name | driver option type |
+   * |:----------------------|:----------------------------------------------|:-------------------|:-------------------|
+   * | `ca`                  | `tlsCAFile`                                   | `sslCA`            | `string`           |
+   * | `crl`                 | N/A                                           | `sslCRL`           | `string`           |
+   * | `cert`                | `tlsCertificateFile`, `tlsCertificateKeyFile` | `sslCert`          | `string`           |
+   * | `key`                 | `tlsCertificateKeyFile`                       | `sslKey`           | `string`           |
+   * | `passphrase`          | `tlsCertificateKeyFilePassword`               | `sslPass`          | `string`           |
+   * | `rejectUnauthorized`  | `tlsAllowInvalidCertificates`                 | `sslValidate`      | `boolean`          |
+   * | `checkServerIdentity` | `tlsAllowInvalidHostnames`                    | N/A                | `boolean`          |
+   * | see note below        | `tlsInsecure`                                 | N/A                | `boolean`          |
    *
+   * If `tlsInsecure` is set to `true`, then it will set the node native options `checkServerIdentity`
+   * to a no-op and `rejectUnauthorized` to `false.
+   *
+   * If `tlsInsecure` is set to `false`, then it will set the node native options `checkServerIdentity`
+   * to a no-op and `rejectUnauthorized` to the inverse value of `tlsAllowInvalidCertificates`. If
+   * `tlsAllowInvalidCertificates` is not set, then `rejectUnauthorized` will be set to `true`.
    */
   tls: boolean;
 

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -774,14 +774,17 @@ export interface MongoOptions
    *
    * If set TLS enabled, equivalent to setting the ssl option.
    *
+   * Spec complicant options: ssl, tls, tlsCAFile, tlsCertificateKeyFile, tlsCertificateKeyFilePassworda, tlsAllowInvalidCertificates,
+   * tlsAllowInvalidHostnames, tlsInsecure. All others will be deprecated and subsequently removed in future versions.
+   *
    * ### Additional options:
    *
    * |    nodejs option     | MongoDB equivalent                                       | type                                   |
    * |:---------------------|--------------------------------------------------------- |:---------------------------------------|
-   * | `ca`                 | `sslCA`, `tlsCAFile`                                     | `string \| Buffer \| Buffer[]`         |
-   * | `crl`                | `sslCRL`                                                 | `string \| Buffer \| Buffer[]`         |
-   * | `cert`               | `sslCert`, `tlsCertificateFile`, `tlsCertificateKeyFile` | `string \| Buffer \| Buffer[]`         |
-   * | `key`                | `sslKey`, `tlsCertificateKeyFile`                        | `string \| Buffer \| KeyObject[]`      |
+   * | `ca`                 | `sslCA`, `tlsCAFile`                                     | `string`                               |
+   * | `crl`                | `sslCRL`                                                 | `string`                               |
+   * | `cert`               | `sslCert`, `tlsCertificateFile`, `tlsCertificateKeyFile` | `string`                               |
+   * | `key`                | `sslKey`, `tlsCertificateKeyFile`                        | `string`                               |
    * | `passphrase`         | `sslPass`, `tlsCertificateKeyFilePassword`               | `string`                               |
    * | `rejectUnauthorized` | `sslValidate`                                            | `boolean`                              |
    *

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -774,18 +774,20 @@ export interface MongoOptions
    *
    * If `tls` is provided as an option, it is equivalent to setting the `ssl` option.
    *
+   * NodeJS native TLS options are passed through to the socket and retain their original types.
+   *
    * ### Additional options:
    *
-   * | nodejs option        | MongoDB driver spec compliant                 | Legacy option name | type      |
-   * |:---------------------|:----------------------------------------------|:-------------------|:----------|
-   * | `ca`                 | `tlsCAFile`                                   | `sslCA`            | `string`  |
-   * | `crl`                | N/A                                           | `sslCRL`           | `string`  |
-   * | `cert`               | `tlsCertificateFile`, `tlsCertificateKeyFile` | `sslCert`          | `string`  |
-   * | `key`                | `tlsCertificateKeyFile`                       | `sslKey`           | `string`  |
-   * | `passphrase`         | `tlsCertificateKeyFilePassword`               | `sslPass`          | `string`  |
-   * | `rejectUnauthorized` | `tlsAllowInvalidCertificates`                 | `sslValidate`      | `boolean` |
-   * | N/A                  | `tlsAllowInvalidHostnames`                    | N/A                | `boolean` |
-   * | N/A                  | `tlsInsecure`                                 | N/A                | `boolean` |
+   * | nodejs native option | driver spec compliant option name             | legacy option name | driver option type |
+   * |:---------------------|:----------------------------------------------|:-------------------|:-------------------|
+   * | `ca`                 | `tlsCAFile`                                   | `sslCA`            | `string`           |
+   * | `crl`                | N/A                                           | `sslCRL`           | `string`           |
+   * | `cert`               | `tlsCertificateFile`, `tlsCertificateKeyFile` | `sslCert`          | `string`           |
+   * | `key`                | `tlsCertificateKeyFile`                       | `sslKey`           | `string`           |
+   * | `passphrase`         | `tlsCertificateKeyFilePassword`               | `sslPass`          | `string`           |
+   * | `rejectUnauthorized` | `tlsAllowInvalidCertificates`                 | `sslValidate`      | `boolean`          |
+   * | N/A                  | `tlsAllowInvalidHostnames`                    | N/A                | `boolean`          |
+   * | N/A                  | `tlsInsecure`                                 | N/A                | `boolean`          |
    *
    */
   tls: boolean;

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -772,21 +772,20 @@ export interface MongoOptions
   /**
    * # NOTE ABOUT TLS Options
    *
-   * If set TLS enabled, equivalent to setting the ssl option.
-   *
-   * Spec complicant options: ssl, tls, tlsCAFile, tlsCertificateKeyFile, tlsCertificateKeyFilePassworda, tlsAllowInvalidCertificates,
-   * tlsAllowInvalidHostnames, tlsInsecure. All others will be deprecated and subsequently removed in future versions.
+   * If `tls` is provided as an option, it is equivalent to setting the `ssl` option.
    *
    * ### Additional options:
    *
-   * |    nodejs option     | MongoDB equivalent                                       | type                                   |
-   * |:---------------------|--------------------------------------------------------- |:---------------------------------------|
-   * | `ca`                 | `sslCA`, `tlsCAFile`                                     | `string`                               |
-   * | `crl`                | `sslCRL`                                                 | `string`                               |
-   * | `cert`               | `sslCert`, `tlsCertificateFile`, `tlsCertificateKeyFile` | `string`                               |
-   * | `key`                | `sslKey`, `tlsCertificateKeyFile`                        | `string`                               |
-   * | `passphrase`         | `sslPass`, `tlsCertificateKeyFilePassword`               | `string`                               |
-   * | `rejectUnauthorized` | `sslValidate`                                            | `boolean`                              |
+   * | nodejs option        | MongoDB driver spec compliant                 | Legacy option name | type      |
+   * |:---------------------|:----------------------------------------------|:-------------------|:----------|
+   * | `ca`                 | `tlsCAFile`                                   | `sslCA`            | `string`  |
+   * | `crl`                | N/A                                           | `sslCRL`           | `string`  |
+   * | `cert`               | `tlsCertificateFile`, `tlsCertificateKeyFile` | `sslCert`          | `string`  |
+   * | `key`                | `tlsCertificateKeyFile`                       | `sslKey`           | `string`  |
+   * | `passphrase`         | `tlsCertificateKeyFilePassword`               | `sslPass`          | `string`  |
+   * | `rejectUnauthorized` | `tlsAllowInvalidCertificates`                 | `sslValidate`      | `boolean` |
+   * | N/A                  | `tlsAllowInvalidHostnames`                    | N/A                | `boolean` |
+   * | N/A                  | `tlsInsecure`                                 | N/A                | `boolean` |
    *
    */
   tls: boolean;


### PR DESCRIPTION
### Description

Updates the TLS comments in `MongoClient` to note the spec compliant options, that others will be deprecated and removed, and fixed the type comments on the existing options.

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

NODE-4778

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
