### PR TITLE
fix(NODE-5249): remove strict flag from create collection options

### DIFF
--- a/src/operations/create_collection.ts
+++ b/src/operations/create_collection.ts
@@ -62,8 +62,6 @@ export interface ClusteredCollectionOptions extends Document {
 
 /** @public */
 export interface CreateCollectionOptions extends CommandOperationOptions {
-  /** Returns an error if the collection does not exist */
-  strict?: boolean;
   /** Create a capped collection */
   capped?: boolean;
   /** @deprecated Create an index on the _id field of the document. This option is deprecated in MongoDB 3.2+ and will be removed once no longer supported by the server. */


### PR DESCRIPTION
### Description

#### What is changing?

The `strict` option was removed in driver 4.x but the Typescript was not updated.  This PR removes the `strict` option from the `CreateCollectionOptions` type.

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
