### PR TITLE
fix(NODE-5296): construct error messages for AggregateErrors in Node16+ 

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -12,6 +12,7 @@ declare global {
       serverless?: 'forbid' | 'allow' | 'require';
       auth?: 'enabled' | 'disabled';
       idmsMockServer?: true;
+      nodejs?: string;
     };
 
     sessions?: {

--- a/test/integration/node-specific/errors.ts
+++ b/test/integration/node-specific/errors.ts
@@ -1,0 +1,40 @@
+import { expect } from 'chai';
+
+import { MongoClient, MongoError } from '../../mongodb';
+
+describe('Error (Integration)', function () {
+  describe('AggregateErrors', function () {
+    it('constructs the message properly', { requires: { nodejs: '>=16' } }, () => {
+      for (const { errors, message } of [
+        { errors: [], message: 'Aggregate Error: ' },
+        { errors: [new Error('message 1')], message: 'Aggregate Error: message 1' },
+        {
+          errors: [new Error('message 1'), new Error('message 2')],
+          message: 'Aggregate Error: message 1, message 2'
+        }
+      ]) {
+        const error = new AggregateError(errors);
+        const mongoError = new MongoError(error);
+
+        expect(
+          mongoError.message,
+          `built the message properly with an array of ${errors.length} errors`
+        ).to.equal(message);
+      }
+    });
+
+    it('sets the aggregate error to the cause property', { requires: { nodejs: '>=16' } }, () => {
+      const error = new AggregateError([new Error('error 1')]);
+      const mongoError = new MongoError(error);
+      expect(mongoError.cause).to.equal(error);
+    });
+  });
+
+  it('NODE-5296: handles aggregate errors from dns lookup', async function () {
+    const error = await MongoClient.connect('mongodb://localhost:27222', {
+      serverSelectionTimeoutMS: 1000
+    }).catch(e => e);
+    expect(error).to.be.instanceOf(Error);
+    expect(error.message).to.match(/ECONNREFUSED/);
+  });
+});

--- a/test/tools/runner/filters/node_version_filter.js
+++ b/test/tools/runner/filters/node_version_filter.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const { satisfies } = require('semver');
+
+/**
+ * Filter for specific nodejs versions
+ *
+ * example:
+ * metadata: {
+ *    requires: {
+ *      nodejs: '>=14'
+ *    }
+ * }
+ */
+class NodeVersionFilter {
+  filter(test) {
+    const nodeVersionRange = test?.metadata?.requires?.nodejs;
+    if (!nodeVersionRange) {
+      return true;
+    }
+
+    return satisfies(process.version, nodeVersionRange);
+  }
+}
+
+module.exports = NodeVersionFilter;


### PR DESCRIPTION
### Description

#### What is changing?

MongoErrors now appropriately handle AggregateErrors and construct a message from the error messages of each sub-error.

##### Is there new documentation needed for these changes?

No.

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
