### PR TITLE
fix(NODE-5262, NODE-5311): batch backport

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2448,7 +2448,7 @@ tasks:
       - func: bootstrap kms servers
       - func: run custom csfle tests
         vars:
-          CSFLE_GIT_REF: 1524eac203e4145e9f4835e519f1e4663ff15953
+          CSFLE_GIT_REF: c56c70340093070b1ef5c8a28190187eea21a6e9
   - name: run-custom-csfle-tests-5.0-master
     tags:
       - run-custom-dependency-tests
@@ -2478,7 +2478,7 @@ tasks:
       - func: bootstrap kms servers
       - func: run custom csfle tests
         vars:
-          CSFLE_GIT_REF: 1524eac203e4145e9f4835e519f1e4663ff15953
+          CSFLE_GIT_REF: c56c70340093070b1ef5c8a28190187eea21a6e9
   - name: run-custom-csfle-tests-rapid-master
     tags:
       - run-custom-dependency-tests
@@ -2508,7 +2508,7 @@ tasks:
       - func: bootstrap kms servers
       - func: run custom csfle tests
         vars:
-          CSFLE_GIT_REF: 1524eac203e4145e9f4835e519f1e4663ff15953
+          CSFLE_GIT_REF: c56c70340093070b1ef5c8a28190187eea21a6e9
   - name: run-custom-csfle-tests-latest-master
     tags:
       - run-custom-dependency-tests

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -605,7 +605,7 @@ const oneOffFuncAsTasks = oneOffFuncs.map(oneOffFunc => ({
   ]
 }));
 
-const FLE_PINNED_COMMIT = '1524eac203e4145e9f4835e519f1e4663ff15953'
+const FLE_PINNED_COMMIT = 'c56c70340093070b1ef5c8a28190187eea21a6e9';
 
 for (const version of ['5.0', 'rapid', 'latest']) {
   for (const ref of [FLE_PINNED_COMMIT, 'master']) {

--- a/.evergreen/run-custom-csfle-tests.sh
+++ b/.evergreen/run-custom-csfle-tests.sh
@@ -52,8 +52,7 @@ popd # mongo-c-driver
 
 pushd libmongocrypt/bindings/node
 
-# TODO(NODE-5180): remove --force option
-npm install --force --production --ignore-scripts
+npm install --production --ignore-scripts
 bash ./etc/build-static.sh
 
 popd # libmongocrypt/bindings/node
@@ -82,8 +81,7 @@ pushd ../csfle-deps-tmp/libmongocrypt/bindings/node
 killall mongocryptd || true
 
 # only prod deps were installed earlier, install devDependencies here (except for mongodb!)
-# TODO(NODE-5180): remove --force option
-npm install --force --ignore-scripts
+npm install --ignore-scripts
 
 # copy mongodb into CSFLE's node_modules
 rm -rf node_modules/mongodb

--- a/.evergreen/run-serverless-tests.sh
+++ b/.evergreen/run-serverless-tests.sh
@@ -10,8 +10,7 @@ if [ -z ${MONGODB_URI+omitted} ]; then echo "MONGODB_URI is unset" && exit 1; fi
 if [ -z ${SERVERLESS_ATLAS_USER+omitted} ]; then echo "SERVERLESS_ATLAS_USER is unset" && exit 1; fi
 if [ -z ${SERVERLESS_ATLAS_PASSWORD+omitted} ]; then echo "SERVERLESS_ATLAS_PASSWORD is unset" && exit 1; fi
 
-# TODO(NODE-5180): remove --force option
-npm install --force 'mongodb-client-encryption@alpha'
+npm install mongodb-client-encryption
 
 npx mocha \
   --config test/mocha_mongodb.json \

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -52,10 +52,9 @@ else
   source "$DRIVERS_TOOLS"/.evergreen/csfle/set-temp-creds.sh
 fi
 
-# TODO(NODE-5180): remove --force option
-npm install --force 'mongodb-client-encryption@alpha'
-npm install --force @mongodb-js/zstd
-npm install --force snappy
+npm install mongodb-client-encryption
+npm install @mongodb-js/zstd
+npm install snappy
 
 export AUTH=$AUTH
 export SINGLE_MONGOS_LB_URI=${SINGLE_MONGOS_LB_URI}

--- a/global.d.ts
+++ b/global.d.ts
@@ -11,6 +11,7 @@ declare global {
       clientSideEncryption?: boolean;
       serverless?: 'forbid' | 'allow' | 'require';
       auth?: 'enabled' | 'disabled';
+      nodejs?: string;
     };
 
     sessions?: {

--- a/src/cmap/handshake/client_metadata.ts
+++ b/src/cmap/handshake/client_metadata.ts
@@ -176,7 +176,8 @@ export function getFAASEnv(): Map<string, string | Int32> | null {
     VERCEL_REGION = ''
   } = process.env;
 
-  const isAWSFaaS = AWS_EXECUTION_ENV.length > 0 || AWS_LAMBDA_RUNTIME_API.length > 0;
+  const isAWSFaaS =
+    AWS_EXECUTION_ENV.startsWith('AWS_Lambda_') || AWS_LAMBDA_RUNTIME_API.length > 0;
   const isAzureFaaS = FUNCTIONS_WORKER_RUNTIME.length > 0;
   const isGCPFaaS = K_SERVICE.length > 0 || FUNCTION_NAME.length > 0;
   const isVercelFaaS = VERCEL.length > 0;

--- a/src/error.ts
+++ b/src/error.ts
@@ -107,6 +107,10 @@ export interface ErrorDescription extends Document {
   errInfo?: Document;
 }
 
+function isAggregateError(e: Error): e is Error & { errors: Error[] } {
+  return 'errors' in e && Array.isArray(e.errors);
+}
+
 /**
  * @public
  * @category Error
@@ -130,13 +134,26 @@ export class MongoError extends Error {
   cause?: Error; // depending on the node version, this may or may not exist on the base
 
   constructor(message: string | Error) {
+    super(MongoError.buildErrorMessage(message));
     if (message instanceof Error) {
-      super(message.message);
       this.cause = message;
-    } else {
-      super(message);
     }
+
     this[kErrorLabels] = new Set();
+  }
+
+  /** @internal */
+  private static buildErrorMessage(e: Error | string): string {
+    if (typeof e === 'string') {
+      return e;
+    }
+    if (isAggregateError(e) && e.message.length === 0) {
+      return e.errors.length === 0
+        ? 'AggregateError has an empty errors array. Please check the `cause` property for more information.'
+        : e.errors.map(({ message }) => message).join(', ');
+    }
+
+    return e.message;
   }
 
   override get name(): string {

--- a/test/integration/mongodb-handshake/mongodb-handshake.prose.test.ts
+++ b/test/integration/mongodb-handshake/mongodb-handshake.prose.test.ts
@@ -71,6 +71,11 @@ describe('Handshake Prose Tests', function () {
         ['AWS_EXECUTION_ENV', 'AWS_Lambda_java8'],
         ['AWS_LAMBDA_FUNCTION_MEMORY_SIZE', 'big']
       ]
+    },
+    {
+      expectedProvider: undefined,
+      context: '8. Invalid - AWS_EXECUTION_ENV does not start with "AWS_Lambda_"',
+      env: [['AWS_EXECUTION_ENV', 'EC2']]
     }
   ];
 

--- a/test/integration/node-specific/errors.ts
+++ b/test/integration/node-specific/errors.ts
@@ -1,0 +1,54 @@
+import { expect } from 'chai';
+
+import { MongoClient, MongoError, MongoServerSelectionError } from '../../../src';
+
+describe('Error (Integration)', function () {
+  describe('AggregateErrors', function () {
+    for (const { errors, message } of [
+      {
+        errors: [],
+        message:
+          'AggregateError has an empty errors array. Please check the `cause` property for more information.'
+      },
+      { errors: [new Error('message 1')], message: 'message 1' },
+      {
+        errors: [new Error('message 1'), new Error('message 2')],
+        message: 'message 1, message 2'
+      }
+    ]) {
+      it(
+        `constructs the message properly with an array of ${errors.length} errors`,
+        { requires: { nodejs: '>=16' } },
+        () => {
+          const error = new AggregateError(errors);
+          const mongoError = new MongoError(error);
+
+          expect(mongoError.message).to.equal(message);
+        }
+      );
+    }
+
+    context('when the message on the AggregateError is non-empty', () => {
+      it(`uses the AggregateError's message`, { requires: { nodejs: '>=16' } }, () => {
+        const error = new AggregateError([new Error('non-empty')]);
+        error.message = 'custom error message';
+        const mongoError = new MongoError(error);
+        expect(mongoError.message).to.equal('custom error message');
+      });
+    });
+
+    it('sets the AggregateError to the cause property', { requires: { nodejs: '>=16' } }, () => {
+      const error = new AggregateError([new Error('error 1')]);
+      const mongoError = new MongoError(error);
+      expect(mongoError.cause).to.equal(error);
+    });
+  });
+
+  it('NODE-5296: handles aggregate errors from dns lookup', async function () {
+    const error = await MongoClient.connect('mongodb://localhost:27222', {
+      serverSelectionTimeoutMS: 1000
+    }).catch(e => e);
+    expect(error).to.be.instanceOf(MongoServerSelectionError);
+    expect(error.message).not.to.be.empty;
+  });
+});

--- a/test/tools/runner/filters/node_version_filter.js
+++ b/test/tools/runner/filters/node_version_filter.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const { satisfies } = require('semver');
+
+/**
+ * Filter for specific nodejs versions
+ *
+ * example:
+ * metadata: {
+ *    requires: {
+ *      nodejs: '>=14'
+ *    }
+ * }
+ */
+class NodeVersionFilter {
+  filter(test) {
+    if (!test.metadata) return true;
+    if (!test.metadata.requires) return true;
+    if (!test.metadata.requires.nodejs) return true;
+
+    return satisfies(process.version, test.metadata.requires.nodejs);
+  }
+}
+
+module.exports = NodeVersionFilter;

--- a/test/unit/cmap/handshake/client_metadata.test.ts
+++ b/test/unit/cmap/handshake/client_metadata.test.ts
@@ -37,8 +37,7 @@ describe('client metadata module', () => {
   });
 
   describe('getFAASEnv()', function () {
-    const tests: Array<[string, string]> = [
-      ['AWS_EXECUTION_ENV', 'aws.lambda'],
+    const tests: Array<[envVariable: string, provider: string]> = [
       ['AWS_LAMBDA_RUNTIME_API', 'aws.lambda'],
       ['FUNCTIONS_WORKER_RUNTIME', 'azure.func'],
       ['K_SERVICE', 'gcp.func'],
@@ -46,9 +45,9 @@ describe('client metadata module', () => {
       ['VERCEL', 'vercel']
     ];
     for (const [envVariable, provider] of tests) {
-      context(`when ${envVariable} is in the environment`, () => {
+      context(`when ${envVariable} is set to a non-empty string`, () => {
         before(() => {
-          process.env[envVariable] = 'non empty string';
+          process.env[envVariable] = 'non_empty_string';
         });
         after(() => {
           delete process.env[envVariable];
@@ -56,8 +55,44 @@ describe('client metadata module', () => {
         it('determines the correct provider', () => {
           expect(getFAASEnv()?.get('name')).to.equal(provider);
         });
+
+        context(`when ${envVariable} is set to an empty string`, () => {
+          before(() => {
+            process.env[envVariable] = '';
+          });
+          after(() => {
+            delete process.env[envVariable];
+          });
+          it('returns null', () => {
+            expect(getFAASEnv()).to.be.null;
+          });
+        });
       });
     }
+
+    context('when AWS_EXECUTION_ENV starts with "AWS_Lambda_"', () => {
+      before(() => {
+        process.env.AWS_EXECUTION_ENV = 'AWS_Lambda_correctStartString';
+      });
+      after(() => {
+        delete process.env.AWS_EXECUTION_ENV;
+      });
+      it('indicates the runtime is aws lambda', () => {
+        expect(getFAASEnv()?.get('name')).to.equal('aws.lambda');
+      });
+    });
+
+    context('when AWS_EXECUTION_ENV does not start with "AWS_Lambda_"', () => {
+      before(() => {
+        process.env.AWS_EXECUTION_ENV = 'AWS_LambdaIncorrectStartString';
+      });
+      after(() => {
+        delete process.env.AWS_EXECUTION_ENV;
+      });
+      it('returns null', () => {
+        expect(getFAASEnv()).to.be.null;
+      });
+    });
 
     context('when there is no FAAS provider data in the env', () => {
       it('returns null', () => {
@@ -69,9 +104,9 @@ describe('client metadata module', () => {
       context('unrelated environments', () => {
         before(() => {
           // aws
-          process.env.AWS_EXECUTION_ENV = 'non-empty-string';
+          process.env.AWS_EXECUTION_ENV = 'AWS_Lambda_non_empty_string';
           // azure
-          process.env.FUNCTIONS_WORKER_RUNTIME = 'non-empty-string';
+          process.env.FUNCTIONS_WORKER_RUNTIME = 'non_empty_string';
         });
         after(() => {
           delete process.env.AWS_EXECUTION_ENV;
@@ -85,10 +120,10 @@ describe('client metadata module', () => {
       context('vercel and aws which share env variables', () => {
         before(() => {
           // vercel
-          process.env.VERCEL = 'non-empty-string';
+          process.env.VERCEL = 'non_empty_string';
           // aws
-          process.env.AWS_EXECUTION_ENV = 'non-empty-string';
-          process.env.AWS_LAMBDA_RUNTIME_API = 'non-empty-string';
+          process.env.AWS_EXECUTION_ENV = 'non_empty_string';
+          process.env.AWS_LAMBDA_RUNTIME_API = 'non_empty_string';
         });
         after(() => {
           delete process.env.VERCEL;
@@ -383,7 +418,7 @@ describe('client metadata module', () => {
       aws: [
         {
           context: 'no additional metadata',
-          env: [['AWS_EXECUTION_ENV', 'non-empty string']],
+          env: [['AWS_EXECUTION_ENV', 'AWS_Lambda_non_empty_string']],
           outcome: {
             name: 'aws.lambda'
           }
@@ -391,7 +426,7 @@ describe('client metadata module', () => {
         {
           context: 'AWS_REGION provided',
           env: [
-            ['AWS_EXECUTION_ENV', 'non-empty string'],
+            ['AWS_EXECUTION_ENV', 'AWS_Lambda_non_empty_string'],
             ['AWS_REGION', 'non-null']
           ],
           outcome: {
@@ -402,7 +437,7 @@ describe('client metadata module', () => {
         {
           context: 'AWS_LAMBDA_FUNCTION_MEMORY_SIZE provided',
           env: [
-            ['AWS_EXECUTION_ENV', 'non-empty string'],
+            ['AWS_EXECUTION_ENV', 'AWS_Lambda_non_empty_string'],
             ['AWS_LAMBDA_FUNCTION_MEMORY_SIZE', '3']
           ],
           outcome: {
@@ -506,7 +541,7 @@ describe('client metadata module', () => {
 
     context('when a numeric FAAS env variable is not numerically parsable', () => {
       before(() => {
-        process.env.AWS_EXECUTION_ENV = 'non-empty-string';
+        process.env.AWS_EXECUTION_ENV = 'AWS_Lambda_non_empty_string';
         process.env.AWS_LAMBDA_FUNCTION_MEMORY_SIZE = '123not numeric';
       });
 
@@ -525,7 +560,7 @@ describe('client metadata module', () => {
     context('when faas region is too large', () => {
       beforeEach('1. Omit fields from `env` except `env.name`.', () => {
         sinon.stub(process, 'env').get(() => ({
-          AWS_EXECUTION_ENV: 'iLoveJavaScript',
+          AWS_EXECUTION_ENV: 'AWS_Lambda_iLoveJavaScript',
           AWS_REGION: 'a'.repeat(512)
         }));
       });
@@ -542,7 +577,7 @@ describe('client metadata module', () => {
       context('release too large', () => {
         beforeEach('2. Omit fields from `os` except `os.type`.', () => {
           sinon.stub(process, 'env').get(() => ({
-            AWS_EXECUTION_ENV: 'iLoveJavaScript',
+            AWS_EXECUTION_ENV: 'AWS_Lambda_iLoveJavaScript',
             AWS_REGION: 'abc'
           }));
           sinon.stub(os, 'release').returns('a'.repeat(512));


### PR DESCRIPTION
### Description

#### What is changing?

Backports https://github.com/mongodb/node-mongodb-native/pull/3663 and https://github.com/mongodb/node-mongodb-native/pull/3682.

Also updates CI scripts to pull in mongodb-client-encryption@2.8.0.


##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
