### PR TITLE
ci(NODE-4698): test csfle with mongocryptd

### DIFF
--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -227,6 +227,7 @@ functions:
             echo "CRYPT_SHARED_LIB_PATH not set; using mongocryptd"
           fi
 
+          TEST_NPM_SCRIPT="${TEST_NPM_SCRIPT|check:integration-coverage}" \
           MONGODB_URI="${MONGODB_URI}" \
           AUTH=${AUTH} SSL=${SSL} TEST_CSFLE=true \
           MONGODB_API_VERSION="${MONGODB_API_VERSION}" \

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -980,40 +980,6 @@ functions:
 
           bash ${PROJECT_DIRECTORY}/.evergreen/run-custom-csfle-tests.sh
 
-  "run csfle tests with mongocryptd":
-    - command: shell.exec
-      type: test
-      params:
-        silent: true
-        working_dir: "src"
-        script: |
-          ${PREPARE_SHELL}
-          cat <<EOT > prepare_client_encryption.sh
-          export CLIENT_ENCRYPTION='${CLIENT_ENCRYPTION}'
-          export CSFLE_KMS_PROVIDERS='${CSFLE_KMS_PROVIDERS}'
-          export AWS_ACCESS_KEY_ID='${AWS_ACCESS_KEY_ID}'
-          export AWS_SECRET_ACCESS_KEY='${AWS_SECRET_ACCESS_KEY}'
-          EOT
-    - command: shell.exec
-      type: test
-      params:
-        working_dir: "src"
-        timeout_secs: 60
-        shell: bash
-        script: |
-          ${PREPARE_SHELL}
-
-          # Disable xtrace (just in case it was accidentally set).
-          set +x
-          source ./prepare_client_encryption.sh
-          rm -f ./prepare_client_encryption.sh
-
-          export VERSION=${VERSION}
-          export DRIVERS_TOOLS=${DRIVERS_TOOLS}
-
-          export MONGODB_URI="${MONGODB_URI}"
-
-          bash ${PROJECT_DIRECTORY}/.evergreen/run-csfle-tests-with-mongocryptd.sh
   "run lambda handler example tests":
     - command: subprocess.exec
       params:

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -191,6 +191,7 @@ functions:
           if [ -n "${CLIENT_ENCRYPTION}" ]; then
             cat <<EOT > prepare_client_encryption.sh
             export CLIENT_ENCRYPTION=${CLIENT_ENCRYPTION}
+            export RUN_WITH_MONGOCRYPTD=${RUN_WITH_MONGOCRYPTD}
             export CSFLE_KMS_PROVIDERS='${CSFLE_KMS_PROVIDERS}'
             export AWS_ACCESS_KEY_ID='${AWS_ACCESS_KEY_ID}'
             export AWS_SECRET_ACCESS_KEY='${AWS_SECRET_ACCESS_KEY}'
@@ -218,9 +219,13 @@ functions:
           export VERSION=${VERSION}
           export DRIVERS_TOOLS=${DRIVERS_TOOLS}
 
-          source ${PROJECT_DIRECTORY}/.evergreen/prepare-crypt-shared-lib.sh
-
-          echo "CRYPT_SHARED_LIB_PATH: $CRYPT_SHARED_LIB_PATH"
+          if [ -z "${RUN_WITH_MONGOCRYPTD}" ]; then
+            # Set up crypt shared lib if we don't want to use mongocryptd
+            source ${PROJECT_DIRECTORY}/.evergreen/prepare-crypt-shared-lib.sh
+            echo "CRYPT_SHARED_LIB_PATH: $CRYPT_SHARED_LIB_PATH"
+          else
+            echo "CRYPT_SHARED_LIB_PATH not set; using mongocryptd"
+          fi
 
           MONGODB_URI="${MONGODB_URI}" \
           AUTH=${AUTH} SSL=${SSL} TEST_CSFLE=true \
@@ -974,6 +979,40 @@ functions:
 
           bash ${PROJECT_DIRECTORY}/.evergreen/run-custom-csfle-tests.sh
 
+  "run csfle tests with mongocryptd":
+    - command: shell.exec
+      type: test
+      params:
+        silent: true
+        working_dir: "src"
+        script: |
+          ${PREPARE_SHELL}
+          cat <<EOT > prepare_client_encryption.sh
+          export CLIENT_ENCRYPTION='${CLIENT_ENCRYPTION}'
+          export CSFLE_KMS_PROVIDERS='${CSFLE_KMS_PROVIDERS}'
+          export AWS_ACCESS_KEY_ID='${AWS_ACCESS_KEY_ID}'
+          export AWS_SECRET_ACCESS_KEY='${AWS_SECRET_ACCESS_KEY}'
+          EOT
+    - command: shell.exec
+      type: test
+      params:
+        working_dir: "src"
+        timeout_secs: 60
+        shell: bash
+        script: |
+          ${PREPARE_SHELL}
+
+          # Disable xtrace (just in case it was accidentally set).
+          set +x
+          source ./prepare_client_encryption.sh
+          rm -f ./prepare_client_encryption.sh
+
+          export VERSION=${VERSION}
+          export DRIVERS_TOOLS=${DRIVERS_TOOLS}
+
+          export MONGODB_URI="${MONGODB_URI}"
+
+          bash ${PROJECT_DIRECTORY}/.evergreen/run-csfle-tests-with-mongocryptd.sh
   "run lambda handler example tests":
     - command: subprocess.exec
       params:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -3090,37 +3090,7 @@ tasks:
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run lambda handler example tests with aws auth
-  - name: test-7.0-server-csfle-mongocryptd
-    tags:
-      - '7.0'
-      - server
-    commands:
-      - func: install dependencies
-      - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '7.0'
-          TOPOLOGY: server
-          AUTH: auth
-      - func: bootstrap kms servers
-      - func: run tests
-        vars:
-          TEST_NPM_SCRIPT: check:csfle
-  - name: test-7.0-replica_set-csfle-mongocryptd
-    tags:
-      - '7.0'
-      - replica_set
-    commands:
-      - func: install dependencies
-      - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '7.0'
-          TOPOLOGY: replica_set
-          AUTH: auth
-      - func: bootstrap kms servers
-      - func: run tests
-        vars:
-          TEST_NPM_SCRIPT: check:csfle
-  - name: test-7.0-sharded_cluster-csfle-mongocryptd
+  - name: test-7.0-csfle-mongocryptd
     tags:
       - '7.0'
       - sharded_cluster
@@ -3135,37 +3105,7 @@ tasks:
       - func: run tests
         vars:
           TEST_NPM_SCRIPT: check:csfle
-  - name: test-6.0-server-csfle-mongocryptd
-    tags:
-      - '6.0'
-      - server
-    commands:
-      - func: install dependencies
-      - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '6.0'
-          TOPOLOGY: server
-          AUTH: auth
-      - func: bootstrap kms servers
-      - func: run tests
-        vars:
-          TEST_NPM_SCRIPT: check:csfle
-  - name: test-6.0-replica_set-csfle-mongocryptd
-    tags:
-      - '6.0'
-      - replica_set
-    commands:
-      - func: install dependencies
-      - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '6.0'
-          TOPOLOGY: replica_set
-          AUTH: auth
-      - func: bootstrap kms servers
-      - func: run tests
-        vars:
-          TEST_NPM_SCRIPT: check:csfle
-  - name: test-6.0-sharded_cluster-csfle-mongocryptd
+  - name: test-6.0-csfle-mongocryptd
     tags:
       - '6.0'
       - sharded_cluster
@@ -3180,37 +3120,7 @@ tasks:
       - func: run tests
         vars:
           TEST_NPM_SCRIPT: check:csfle
-  - name: test-5.0-server-csfle-mongocryptd
-    tags:
-      - '5.0'
-      - server
-    commands:
-      - func: install dependencies
-      - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '5.0'
-          TOPOLOGY: server
-          AUTH: auth
-      - func: bootstrap kms servers
-      - func: run tests
-        vars:
-          TEST_NPM_SCRIPT: check:csfle
-  - name: test-5.0-replica_set-csfle-mongocryptd
-    tags:
-      - '5.0'
-      - replica_set
-    commands:
-      - func: install dependencies
-      - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '5.0'
-          TOPOLOGY: replica_set
-          AUTH: auth
-      - func: bootstrap kms servers
-      - func: run tests
-        vars:
-          TEST_NPM_SCRIPT: check:csfle
-  - name: test-5.0-sharded_cluster-csfle-mongocryptd
+  - name: test-5.0-csfle-mongocryptd
     tags:
       - '5.0'
       - sharded_cluster
@@ -3225,37 +3135,7 @@ tasks:
       - func: run tests
         vars:
           TEST_NPM_SCRIPT: check:csfle
-  - name: test-4.4-server-csfle-mongocryptd
-    tags:
-      - '4.4'
-      - server
-    commands:
-      - func: install dependencies
-      - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.4'
-          TOPOLOGY: server
-          AUTH: auth
-      - func: bootstrap kms servers
-      - func: run tests
-        vars:
-          TEST_NPM_SCRIPT: check:csfle
-  - name: test-4.4-replica_set-csfle-mongocryptd
-    tags:
-      - '4.4'
-      - replica_set
-    commands:
-      - func: install dependencies
-      - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.4'
-          TOPOLOGY: replica_set
-          AUTH: auth
-      - func: bootstrap kms servers
-      - func: run tests
-        vars:
-          TEST_NPM_SCRIPT: check:csfle
-  - name: test-4.4-sharded_cluster-csfle-mongocryptd
+  - name: test-4.4-csfle-mongocryptd
     tags:
       - '4.4'
       - sharded_cluster
@@ -3270,37 +3150,7 @@ tasks:
       - func: run tests
         vars:
           TEST_NPM_SCRIPT: check:csfle
-  - name: test-4.2-server-csfle-mongocryptd
-    tags:
-      - '4.2'
-      - server
-    commands:
-      - func: install dependencies
-      - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.2'
-          TOPOLOGY: server
-          AUTH: auth
-      - func: bootstrap kms servers
-      - func: run tests
-        vars:
-          TEST_NPM_SCRIPT: check:csfle
-  - name: test-4.2-replica_set-csfle-mongocryptd
-    tags:
-      - '4.2'
-      - replica_set
-    commands:
-      - func: install dependencies
-      - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.2'
-          TOPOLOGY: replica_set
-          AUTH: auth
-      - func: bootstrap kms servers
-      - func: run tests
-        vars:
-          TEST_NPM_SCRIPT: check:csfle
-  - name: test-4.2-sharded_cluster-csfle-mongocryptd
+  - name: test-4.2-csfle-mongocryptd
     tags:
       - '4.2'
       - sharded_cluster
@@ -3955,21 +3805,11 @@ buildvariants:
       RUN_WITH_MONGOCRYPTD: true
       NODE_LTS_VERSION: 14
     tasks:
-      - test-7.0-server-csfle-mongocryptd
-      - test-7.0-replica_set-csfle-mongocryptd
-      - test-7.0-sharded_cluster-csfle-mongocryptd
-      - test-6.0-server-csfle-mongocryptd
-      - test-6.0-replica_set-csfle-mongocryptd
-      - test-6.0-sharded_cluster-csfle-mongocryptd
-      - test-5.0-server-csfle-mongocryptd
-      - test-5.0-replica_set-csfle-mongocryptd
-      - test-5.0-sharded_cluster-csfle-mongocryptd
-      - test-4.4-server-csfle-mongocryptd
-      - test-4.4-replica_set-csfle-mongocryptd
-      - test-4.4-sharded_cluster-csfle-mongocryptd
-      - test-4.2-server-csfle-mongocryptd
-      - test-4.2-replica_set-csfle-mongocryptd
-      - test-4.2-sharded_cluster-csfle-mongocryptd
+      - test-7.0-csfle-mongocryptd
+      - test-6.0-csfle-mongocryptd
+      - test-5.0-csfle-mongocryptd
+      - test-4.4-csfle-mongocryptd
+      - test-4.2-csfle-mongocryptd
   - name: rhel8-node20-test-csfle-mongocryptd
     display_name: rhel 8 Node20 test mongocryptd
     run_on: rhel80-large
@@ -3978,21 +3818,11 @@ buildvariants:
       RUN_WITH_MONGOCRYPTD: true
       NODE_LTS_VERSION: 14
     tasks:
-      - test-7.0-server-csfle-mongocryptd
-      - test-7.0-replica_set-csfle-mongocryptd
-      - test-7.0-sharded_cluster-csfle-mongocryptd
-      - test-6.0-server-csfle-mongocryptd
-      - test-6.0-replica_set-csfle-mongocryptd
-      - test-6.0-sharded_cluster-csfle-mongocryptd
-      - test-5.0-server-csfle-mongocryptd
-      - test-5.0-replica_set-csfle-mongocryptd
-      - test-5.0-sharded_cluster-csfle-mongocryptd
-      - test-4.4-server-csfle-mongocryptd
-      - test-4.4-replica_set-csfle-mongocryptd
-      - test-4.4-sharded_cluster-csfle-mongocryptd
-      - test-4.2-server-csfle-mongocryptd
-      - test-4.2-replica_set-csfle-mongocryptd
-      - test-4.2-sharded_cluster-csfle-mongocryptd
+      - test-7.0-csfle-mongocryptd
+      - test-6.0-csfle-mongocryptd
+      - test-5.0-csfle-mongocryptd
+      - test-4.4-csfle-mongocryptd
+      - test-4.2-csfle-mongocryptd
   - name: macos-1100
     display_name: MacOS 11 Node20
     run_on: macos-1100

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -928,40 +928,6 @@ functions:
           echo "CRYPT_SHARED_LIB_PATH: $CRYPT_SHARED_LIB_PATH"
 
           bash ${PROJECT_DIRECTORY}/.evergreen/run-custom-csfle-tests.sh
-  run csfle tests with mongocryptd:
-    - command: shell.exec
-      type: test
-      params:
-        silent: true
-        working_dir: src
-        script: |
-          ${PREPARE_SHELL}
-          cat <<EOT > prepare_client_encryption.sh
-          export CLIENT_ENCRYPTION='${CLIENT_ENCRYPTION}'
-          export CSFLE_KMS_PROVIDERS='${CSFLE_KMS_PROVIDERS}'
-          export AWS_ACCESS_KEY_ID='${AWS_ACCESS_KEY_ID}'
-          export AWS_SECRET_ACCESS_KEY='${AWS_SECRET_ACCESS_KEY}'
-          EOT
-    - command: shell.exec
-      type: test
-      params:
-        working_dir: src
-        timeout_secs: 60
-        shell: bash
-        script: |
-          ${PREPARE_SHELL}
-
-          # Disable xtrace (just in case it was accidentally set).
-          set +x
-          source ./prepare_client_encryption.sh
-          rm -f ./prepare_client_encryption.sh
-
-          export VERSION=${VERSION}
-          export DRIVERS_TOOLS=${DRIVERS_TOOLS}
-
-          export MONGODB_URI="${MONGODB_URI}"
-
-          bash ${PROJECT_DIRECTORY}/.evergreen/run-csfle-tests-with-mongocryptd.sh
   run lambda handler example tests:
     - command: subprocess.exec
       params:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -3954,7 +3954,6 @@ buildvariants:
       CLIENT_ENCRYPTION: true
       RUN_WITH_MONGOCRYPTD: true
       NODE_LTS_VERSION: 14
-      TEST_NPM_SCRIPT: check:csfle
     tasks:
       - test-7.0-server-csfle-mongocryptd
       - test-7.0-replica_set-csfle-mongocryptd
@@ -3978,7 +3977,6 @@ buildvariants:
       CLIENT_ENCRYPTION: true
       RUN_WITH_MONGOCRYPTD: true
       NODE_LTS_VERSION: 14
-      TEST_NPM_SCRIPT: check:csfle
     tasks:
       - test-7.0-server-csfle-mongocryptd
       - test-7.0-replica_set-csfle-mongocryptd

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -3090,6 +3090,36 @@ tasks:
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run lambda handler example tests with aws auth
+  - name: test-latest-csfle-mongocryptd
+    tags:
+      - latest
+      - sharded_cluster
+    commands:
+      - func: install dependencies
+      - func: bootstrap mongo-orchestration
+        vars:
+          VERSION: latest
+          TOPOLOGY: sharded_cluster
+          AUTH: auth
+      - func: bootstrap kms servers
+      - func: run tests
+        vars:
+          TEST_NPM_SCRIPT: check:csfle
+  - name: test-rapid-csfle-mongocryptd
+    tags:
+      - rapid
+      - sharded_cluster
+    commands:
+      - func: install dependencies
+      - func: bootstrap mongo-orchestration
+        vars:
+          VERSION: rapid
+          TOPOLOGY: sharded_cluster
+          AUTH: auth
+      - func: bootstrap kms servers
+      - func: run tests
+        vars:
+          TEST_NPM_SCRIPT: check:csfle
   - name: test-7.0-csfle-mongocryptd
     tags:
       - '7.0'
@@ -3805,6 +3835,8 @@ buildvariants:
       RUN_WITH_MONGOCRYPTD: true
       NODE_LTS_VERSION: 14
     tasks:
+      - test-latest-csfle-mongocryptd
+      - test-rapid-csfle-mongocryptd
       - test-7.0-csfle-mongocryptd
       - test-6.0-csfle-mongocryptd
       - test-5.0-csfle-mongocryptd
@@ -3818,6 +3850,8 @@ buildvariants:
       RUN_WITH_MONGOCRYPTD: true
       NODE_LTS_VERSION: 14
     tasks:
+      - test-latest-csfle-mongocryptd
+      - test-rapid-csfle-mongocryptd
       - test-7.0-csfle-mongocryptd
       - test-6.0-csfle-mongocryptd
       - test-5.0-csfle-mongocryptd

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -196,6 +196,7 @@ functions:
             echo "CRYPT_SHARED_LIB_PATH not set; using mongocryptd"
           fi
 
+          TEST_NPM_SCRIPT="${TEST_NPM_SCRIPT|check:integration-coverage}" \
           MONGODB_URI="${MONGODB_URI}" \
           AUTH=${AUTH} SSL=${SSL} TEST_CSFLE=true \
           MONGODB_API_VERSION="${MONGODB_API_VERSION}" \
@@ -3987,6 +3988,7 @@ buildvariants:
       CLIENT_ENCRYPTION: true
       RUN_WITH_MONGOCRYPTD: true
       NODE_LTS_VERSION: 14
+      TEST_NPM_SCRIPT: check:csfle
     tasks:
       - test-7.0-server-csfle-mongocryptd
       - test-7.0-replica_set-csfle-mongocryptd
@@ -4010,6 +4012,7 @@ buildvariants:
       CLIENT_ENCRYPTION: true
       RUN_WITH_MONGOCRYPTD: true
       NODE_LTS_VERSION: 14
+      TEST_NPM_SCRIPT: check:csfle
     tasks:
       - test-7.0-server-csfle-mongocryptd
       - test-7.0-replica_set-csfle-mongocryptd

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -160,6 +160,7 @@ functions:
           if [ -n "${CLIENT_ENCRYPTION}" ]; then
             cat <<EOT > prepare_client_encryption.sh
             export CLIENT_ENCRYPTION=${CLIENT_ENCRYPTION}
+            export RUN_WITH_MONGOCRYPTD=${RUN_WITH_MONGOCRYPTD}
             export CSFLE_KMS_PROVIDERS='${CSFLE_KMS_PROVIDERS}'
             export AWS_ACCESS_KEY_ID='${AWS_ACCESS_KEY_ID}'
             export AWS_SECRET_ACCESS_KEY='${AWS_SECRET_ACCESS_KEY}'
@@ -187,9 +188,13 @@ functions:
           export VERSION=${VERSION}
           export DRIVERS_TOOLS=${DRIVERS_TOOLS}
 
-          source ${PROJECT_DIRECTORY}/.evergreen/prepare-crypt-shared-lib.sh
-
-          echo "CRYPT_SHARED_LIB_PATH: $CRYPT_SHARED_LIB_PATH"
+          if [ -z "${RUN_WITH_MONGOCRYPTD}" ]; then
+            # Set up crypt shared lib if we don't want to use mongocryptd
+            source ${PROJECT_DIRECTORY}/.evergreen/prepare-crypt-shared-lib.sh
+            echo "CRYPT_SHARED_LIB_PATH: $CRYPT_SHARED_LIB_PATH"
+          else
+            echo "CRYPT_SHARED_LIB_PATH not set; using mongocryptd"
+          fi
 
           MONGODB_URI="${MONGODB_URI}" \
           AUTH=${AUTH} SSL=${SSL} TEST_CSFLE=true \
@@ -922,6 +927,40 @@ functions:
           echo "CRYPT_SHARED_LIB_PATH: $CRYPT_SHARED_LIB_PATH"
 
           bash ${PROJECT_DIRECTORY}/.evergreen/run-custom-csfle-tests.sh
+  run csfle tests with mongocryptd:
+    - command: shell.exec
+      type: test
+      params:
+        silent: true
+        working_dir: src
+        script: |
+          ${PREPARE_SHELL}
+          cat <<EOT > prepare_client_encryption.sh
+          export CLIENT_ENCRYPTION='${CLIENT_ENCRYPTION}'
+          export CSFLE_KMS_PROVIDERS='${CSFLE_KMS_PROVIDERS}'
+          export AWS_ACCESS_KEY_ID='${AWS_ACCESS_KEY_ID}'
+          export AWS_SECRET_ACCESS_KEY='${AWS_SECRET_ACCESS_KEY}'
+          EOT
+    - command: shell.exec
+      type: test
+      params:
+        working_dir: src
+        timeout_secs: 60
+        shell: bash
+        script: |
+          ${PREPARE_SHELL}
+
+          # Disable xtrace (just in case it was accidentally set).
+          set +x
+          source ./prepare_client_encryption.sh
+          rm -f ./prepare_client_encryption.sh
+
+          export VERSION=${VERSION}
+          export DRIVERS_TOOLS=${DRIVERS_TOOLS}
+
+          export MONGODB_URI="${MONGODB_URI}"
+
+          bash ${PROJECT_DIRECTORY}/.evergreen/run-csfle-tests-with-mongocryptd.sh
   run lambda handler example tests:
     - command: subprocess.exec
       params:
@@ -3084,6 +3123,231 @@ tasks:
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run lambda handler example tests with aws auth
+  - name: test-7.0-server-csfle-mongocryptd
+    tags:
+      - '7.0'
+      - server
+    commands:
+      - func: install dependencies
+      - func: bootstrap mongo-orchestration
+        vars:
+          VERSION: '7.0'
+          TOPOLOGY: server
+          AUTH: auth
+      - func: bootstrap kms servers
+      - func: run tests
+        vars:
+          TEST_NPM_SCRIPT: check:csfle
+  - name: test-7.0-replica_set-csfle-mongocryptd
+    tags:
+      - '7.0'
+      - replica_set
+    commands:
+      - func: install dependencies
+      - func: bootstrap mongo-orchestration
+        vars:
+          VERSION: '7.0'
+          TOPOLOGY: replica_set
+          AUTH: auth
+      - func: bootstrap kms servers
+      - func: run tests
+        vars:
+          TEST_NPM_SCRIPT: check:csfle
+  - name: test-7.0-sharded_cluster-csfle-mongocryptd
+    tags:
+      - '7.0'
+      - sharded_cluster
+    commands:
+      - func: install dependencies
+      - func: bootstrap mongo-orchestration
+        vars:
+          VERSION: '7.0'
+          TOPOLOGY: sharded_cluster
+          AUTH: auth
+      - func: bootstrap kms servers
+      - func: run tests
+        vars:
+          TEST_NPM_SCRIPT: check:csfle
+  - name: test-6.0-server-csfle-mongocryptd
+    tags:
+      - '6.0'
+      - server
+    commands:
+      - func: install dependencies
+      - func: bootstrap mongo-orchestration
+        vars:
+          VERSION: '6.0'
+          TOPOLOGY: server
+          AUTH: auth
+      - func: bootstrap kms servers
+      - func: run tests
+        vars:
+          TEST_NPM_SCRIPT: check:csfle
+  - name: test-6.0-replica_set-csfle-mongocryptd
+    tags:
+      - '6.0'
+      - replica_set
+    commands:
+      - func: install dependencies
+      - func: bootstrap mongo-orchestration
+        vars:
+          VERSION: '6.0'
+          TOPOLOGY: replica_set
+          AUTH: auth
+      - func: bootstrap kms servers
+      - func: run tests
+        vars:
+          TEST_NPM_SCRIPT: check:csfle
+  - name: test-6.0-sharded_cluster-csfle-mongocryptd
+    tags:
+      - '6.0'
+      - sharded_cluster
+    commands:
+      - func: install dependencies
+      - func: bootstrap mongo-orchestration
+        vars:
+          VERSION: '6.0'
+          TOPOLOGY: sharded_cluster
+          AUTH: auth
+      - func: bootstrap kms servers
+      - func: run tests
+        vars:
+          TEST_NPM_SCRIPT: check:csfle
+  - name: test-5.0-server-csfle-mongocryptd
+    tags:
+      - '5.0'
+      - server
+    commands:
+      - func: install dependencies
+      - func: bootstrap mongo-orchestration
+        vars:
+          VERSION: '5.0'
+          TOPOLOGY: server
+          AUTH: auth
+      - func: bootstrap kms servers
+      - func: run tests
+        vars:
+          TEST_NPM_SCRIPT: check:csfle
+  - name: test-5.0-replica_set-csfle-mongocryptd
+    tags:
+      - '5.0'
+      - replica_set
+    commands:
+      - func: install dependencies
+      - func: bootstrap mongo-orchestration
+        vars:
+          VERSION: '5.0'
+          TOPOLOGY: replica_set
+          AUTH: auth
+      - func: bootstrap kms servers
+      - func: run tests
+        vars:
+          TEST_NPM_SCRIPT: check:csfle
+  - name: test-5.0-sharded_cluster-csfle-mongocryptd
+    tags:
+      - '5.0'
+      - sharded_cluster
+    commands:
+      - func: install dependencies
+      - func: bootstrap mongo-orchestration
+        vars:
+          VERSION: '5.0'
+          TOPOLOGY: sharded_cluster
+          AUTH: auth
+      - func: bootstrap kms servers
+      - func: run tests
+        vars:
+          TEST_NPM_SCRIPT: check:csfle
+  - name: test-4.4-server-csfle-mongocryptd
+    tags:
+      - '4.4'
+      - server
+    commands:
+      - func: install dependencies
+      - func: bootstrap mongo-orchestration
+        vars:
+          VERSION: '4.4'
+          TOPOLOGY: server
+          AUTH: auth
+      - func: bootstrap kms servers
+      - func: run tests
+        vars:
+          TEST_NPM_SCRIPT: check:csfle
+  - name: test-4.4-replica_set-csfle-mongocryptd
+    tags:
+      - '4.4'
+      - replica_set
+    commands:
+      - func: install dependencies
+      - func: bootstrap mongo-orchestration
+        vars:
+          VERSION: '4.4'
+          TOPOLOGY: replica_set
+          AUTH: auth
+      - func: bootstrap kms servers
+      - func: run tests
+        vars:
+          TEST_NPM_SCRIPT: check:csfle
+  - name: test-4.4-sharded_cluster-csfle-mongocryptd
+    tags:
+      - '4.4'
+      - sharded_cluster
+    commands:
+      - func: install dependencies
+      - func: bootstrap mongo-orchestration
+        vars:
+          VERSION: '4.4'
+          TOPOLOGY: sharded_cluster
+          AUTH: auth
+      - func: bootstrap kms servers
+      - func: run tests
+        vars:
+          TEST_NPM_SCRIPT: check:csfle
+  - name: test-4.2-server-csfle-mongocryptd
+    tags:
+      - '4.2'
+      - server
+    commands:
+      - func: install dependencies
+      - func: bootstrap mongo-orchestration
+        vars:
+          VERSION: '4.2'
+          TOPOLOGY: server
+          AUTH: auth
+      - func: bootstrap kms servers
+      - func: run tests
+        vars:
+          TEST_NPM_SCRIPT: check:csfle
+  - name: test-4.2-replica_set-csfle-mongocryptd
+    tags:
+      - '4.2'
+      - replica_set
+    commands:
+      - func: install dependencies
+      - func: bootstrap mongo-orchestration
+        vars:
+          VERSION: '4.2'
+          TOPOLOGY: replica_set
+          AUTH: auth
+      - func: bootstrap kms servers
+      - func: run tests
+        vars:
+          TEST_NPM_SCRIPT: check:csfle
+  - name: test-4.2-sharded_cluster-csfle-mongocryptd
+    tags:
+      - '4.2'
+      - sharded_cluster
+    commands:
+      - func: install dependencies
+      - func: bootstrap mongo-orchestration
+        vars:
+          VERSION: '4.2'
+          TOPOLOGY: sharded_cluster
+          AUTH: auth
+      - func: bootstrap kms servers
+      - func: run tests
+        vars:
+          TEST_NPM_SCRIPT: check:csfle
   - name: run-mongosh-browser-repl
     tags:
       - run-mongosh-integration-tests
@@ -3716,6 +3980,52 @@ buildvariants:
       - test-tls-support-5.0
       - test-tls-support-4.4
       - test-tls-support-4.2
+  - name: rhel8-node14-test-csfle-mongocryptd
+    display_name: rhel 8 Node14 test mongocryptd
+    run_on: rhel80-large
+    expansions:
+      CLIENT_ENCRYPTION: true
+      RUN_WITH_MONGOCRYPTD: true
+      NODE_LTS_VERSION: 14
+    tasks:
+      - test-7.0-server-csfle-mongocryptd
+      - test-7.0-replica_set-csfle-mongocryptd
+      - test-7.0-sharded_cluster-csfle-mongocryptd
+      - test-6.0-server-csfle-mongocryptd
+      - test-6.0-replica_set-csfle-mongocryptd
+      - test-6.0-sharded_cluster-csfle-mongocryptd
+      - test-5.0-server-csfle-mongocryptd
+      - test-5.0-replica_set-csfle-mongocryptd
+      - test-5.0-sharded_cluster-csfle-mongocryptd
+      - test-4.4-server-csfle-mongocryptd
+      - test-4.4-replica_set-csfle-mongocryptd
+      - test-4.4-sharded_cluster-csfle-mongocryptd
+      - test-4.2-server-csfle-mongocryptd
+      - test-4.2-replica_set-csfle-mongocryptd
+      - test-4.2-sharded_cluster-csfle-mongocryptd
+  - name: rhel8-node20-test-csfle-mongocryptd
+    display_name: rhel 8 Node20 test mongocryptd
+    run_on: rhel80-large
+    expansions:
+      CLIENT_ENCRYPTION: true
+      RUN_WITH_MONGOCRYPTD: true
+      NODE_LTS_VERSION: 14
+    tasks:
+      - test-7.0-server-csfle-mongocryptd
+      - test-7.0-replica_set-csfle-mongocryptd
+      - test-7.0-sharded_cluster-csfle-mongocryptd
+      - test-6.0-server-csfle-mongocryptd
+      - test-6.0-replica_set-csfle-mongocryptd
+      - test-6.0-sharded_cluster-csfle-mongocryptd
+      - test-5.0-server-csfle-mongocryptd
+      - test-5.0-replica_set-csfle-mongocryptd
+      - test-5.0-sharded_cluster-csfle-mongocryptd
+      - test-4.4-server-csfle-mongocryptd
+      - test-4.4-replica_set-csfle-mongocryptd
+      - test-4.4-sharded_cluster-csfle-mongocryptd
+      - test-4.2-server-csfle-mongocryptd
+      - test-4.2-replica_set-csfle-mongocryptd
+      - test-4.2-sharded_cluster-csfle-mongocryptd
   - name: macos-1100
     display_name: MacOS 11 Node20
     run_on: macos-1100

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const yaml = require('js-yaml');
+const semver = require('semver');
 const { mongoshTasks } = require('./generate_mongosh_tasks');
 
 const {
@@ -463,10 +464,8 @@ for (const {
 
 // Running CSFLE tests with mongocryptd
 const MONGOCRYPTD_CSFLE_TASKS = MONGODB_VERSIONS
-  .filter((mongoVersion) => { // Only run on server versions >= 4.2
-    const numericVersion = Number(mongoVersion);
-    return !Number.isNaN(numericVersion) && numericVersion >= 4.2;
-  })
+  .filter(mongoVersion => ['latest', 'rapid'].includes(mongoVersion)
+    || semver.gte(semver.coerce(mongoVersion), semver.coerce('4.2')))
   .map((mongoVersion) => {
     return {
       name: `test-${mongoVersion}-csfle-mongocryptd`,

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -456,7 +456,6 @@ for (const {
     };
     if (clientEncryption) {
       buildVariantData.expansions.CLIENT_ENCRYPTION = true;
-      //BUILD_VARIANTS.push({ ...buildVariantData, expansions: { ...buildVariantData.expansions, RUN_WITH_MONGOCRYPTD: true } })
     }
 
     BUILD_VARIANTS.push(buildVariantData);

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -463,7 +463,7 @@ for (const {
 
 // Running CSFLE tests with mongocryptd
 const MONGOCRYPTD_CSFLE_TASKS = generateVersionTopologyMatrix()
-  .filter(({ mongoVersion }) => {
+  .filter(({ mongoVersion }) => { // Only run on server versions >= 4.2
     const numericVersion = Number(mongoVersion);
     return !Number.isNaN(numericVersion) && numericVersion >= 4.2;
   })
@@ -506,7 +506,6 @@ for (const nodeVersion of [LOWEST_LTS, LATEST_LTS]) {
       TEST_NPM_SCRIPT: 'check:csfle'
     },
     tasks:
-      // TODO(NODE-4698): Add relevant task
       MONGOCRYPTD_CSFLE_TASKS.map(task => task.name)
   });
 }
@@ -747,7 +746,6 @@ BUILD_VARIANTS.push({
   run_on: DEFAULT_OS,
   tasks: ['test-lambda-example', 'test-lambda-aws-auth-example', 'test-deployed-lambda']
 });
-
 
 // TODO(NODE-4575): unskip zstd and snappy on node 16
 for (const variant of BUILD_VARIANTS.filter(

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -465,7 +465,7 @@ for (const {
 // Running CSFLE tests with mongocryptd
 const MONGOCRYPTD_CSFLE_TASKS = MONGODB_VERSIONS
   .filter(mongoVersion => ['latest', 'rapid'].includes(mongoVersion)
-    || semver.gte(semver.coerce(mongoVersion), semver.coerce('4.2')))
+    || semver.gte(`${mongoVersion}.0`, '4.2.0'))
   .map((mongoVersion) => {
     return {
       name: `test-${mongoVersion}-csfle-mongocryptd`,

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -468,6 +468,7 @@ const MONGOCRYPTD_SERVER_VERSIONS = MONGODB_VERSIONS
     const numericVersion = Number(version);
     return !Number.isNaN(numericVersion) && numericVersion >= 4.2;
   });
+
 const MONGOCRYPTD_CSFLE_TASKS = [];
 for (const version of MONGOCRYPTD_SERVER_VERSIONS) {
   for (const topology of TOPOLOGIES) {
@@ -505,7 +506,8 @@ for (const nodeVersion of [LOWEST_LTS, LATEST_LTS]) {
     expansions: {
       CLIENT_ENCRYPTION: true,
       RUN_WITH_MONGOCRYPTD: true,
-      NODE_LTS_VERSION: LOWEST_LTS
+      NODE_LTS_VERSION: LOWEST_LTS,
+      TEST_NPM_SCRIPT: 'check:csfle'
     },
     tasks:
       // TODO(NODE-4698): Add relevant task

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -502,8 +502,7 @@ for (const nodeVersion of [LOWEST_LTS, LATEST_LTS]) {
     expansions: {
       CLIENT_ENCRYPTION: true,
       RUN_WITH_MONGOCRYPTD: true,
-      NODE_LTS_VERSION: LOWEST_LTS,
-      TEST_NPM_SCRIPT: 'check:csfle'
+      NODE_LTS_VERSION: LOWEST_LTS
     },
     tasks:
       MONGOCRYPTD_CSFLE_TASKS.map(task => task.name)

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -462,22 +462,22 @@ for (const {
 }
 
 // Running CSFLE tests with mongocryptd
-const MONGOCRYPTD_CSFLE_TASKS = generateVersionTopologyMatrix()
-  .filter(({ mongoVersion }) => { // Only run on server versions >= 4.2
+const MONGOCRYPTD_CSFLE_TASKS = MONGODB_VERSIONS
+  .filter((mongoVersion) => { // Only run on server versions >= 4.2
     const numericVersion = Number(mongoVersion);
     return !Number.isNaN(numericVersion) && numericVersion >= 4.2;
   })
-  .map(({ mongoVersion, topology }) => {
+  .map((mongoVersion) => {
     return {
-      name: `test-${mongoVersion}-${topology}-csfle-mongocryptd`,
-      tags: [mongoVersion, topology],
+      name: `test-${mongoVersion}-csfle-mongocryptd`,
+      tags: [mongoVersion, 'sharded_cluster'],
       commands: [
         { func: 'install dependencies' },
         {
           func: 'bootstrap mongo-orchestration',
           vars: {
             VERSION: mongoVersion,
-            TOPOLOGY: topology,
+            TOPOLOGY: 'sharded_cluster',
             AUTH: 'auth'
           }
         },

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -52,10 +52,6 @@ else
   source "$DRIVERS_TOOLS"/.evergreen/csfle/set-temp-creds.sh
 fi
 
-if [ -n ${RUN_WITH_MONGOCRYPTD} ]; then
-  unset CRYPT_SHARED_LIB_PATH;
-fi
-
 npm install mongodb-client-encryption
 npm install @mongodb-js/zstd
 npm install snappy

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -52,6 +52,10 @@ else
   source "$DRIVERS_TOOLS"/.evergreen/csfle/set-temp-creds.sh
 fi
 
+if [ -n ${RUN_WITH_MONGOCRYPTD} ]; then
+  unset CRYPT_SHARED_LIB_PATH;
+fi
+
 npm install mongodb-client-encryption
 npm install @mongodb-js/zstd
 npm install snappy


### PR DESCRIPTION
### Description

#### What is changing?
*Summary*
Adding new CI variants to run CSFLE tests with mongocryptd instead of crypt_shared, which we already had coverage for.

##### changes to `config.in.yml`
- script in "run tests" now conditionally executes `.evergreen/prepare-crypt-shared-lib.sh`
- script in "run tests" now sets the `TEST_NPM_SCRIPT` env variable

##### changes to `generate_evergreen_tasks.js`
- Added new tasks that only run the csfle integration suite on relevant server versions and topologies using mongocryptd

##### Is there new documentation needed for these changes?
No

#### What is the motivation for this change?

Spec compliance

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
