### PR TITLE
test(NODE-5265): fix flaky operation count test

### DIFF
--- a/src/sdam/server.ts
+++ b/src/sdam/server.ts
@@ -343,13 +343,13 @@ export class Server extends TypedEventEmitter<ServerEvents> {
       return;
     }
 
-    this.s.operationCount += 1;
+    this.incrementOperationCount();
 
     this.pool.withConnection(
       conn,
       (err, conn, cb) => {
         if (err || !conn) {
-          this.s.operationCount -= 1;
+          this.decrementOperationCount();
           if (!err) {
             return cb(new MongoRuntimeError('Failed to create connection without error'));
           }
@@ -364,7 +364,7 @@ export class Server extends TypedEventEmitter<ServerEvents> {
           cmd,
           finalOptions,
           makeOperationHandler(this, conn, cmd, finalOptions, (error, response) => {
-            this.s.operationCount -= 1;
+            this.decrementOperationCount();
             cb(error, response);
           })
         );
@@ -419,6 +419,20 @@ export class Server extends TypedEventEmitter<ServerEvents> {
         }
       }
     }
+  }
+
+  /**
+   * Decrement the operation count, returning the new count.
+   */
+  private decrementOperationCount(): number {
+    return (this.s.operationCount -= 1);
+  }
+
+  /**
+   * Increment the operation count, returning the new count.
+   */
+  private incrementOperationCount(): number {
+    return (this.s.operationCount += 1);
   }
 }
 


### PR DESCRIPTION
### Description

Fixes operation count flaky test.

#### What is changing?

Wraps the increment/decrement of the server's operation count in 2 methods, that then can be spied on to assert the number of times each was called.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-5265

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
