### PR TITLE
ci(NODE-5313): change windows hosts to vsCurrent

### DIFF
--- a/.evergreen/ci_matrix_constants.js
+++ b/.evergreen/ci_matrix_constants.js
@@ -16,6 +16,10 @@ const AWS_AUTH_VERSIONS = ['latest', '6.0', '5.0', '4.4'];
 const TLS_VERSIONS = ['latest', '6.0', '5.0', '4.4', '4.2'];
 
 const DEFAULT_OS = 'rhel80-large';
+const WINDOWS_OS = 'windows-vsCurrent-large';
+const MACOS_OS = 'macos-1100';
+const UBUNTU_OS = 'ubuntu1804-large';
+const DEBIAN_OS = 'debian11-small';
 
 module.exports = {
   MONGODB_VERSIONS,
@@ -26,5 +30,9 @@ module.exports = {
   TOPOLOGIES,
   AWS_AUTH_VERSIONS,
   TLS_VERSIONS,
-  DEFAULT_OS
+  DEFAULT_OS,
+  WINDOWS_OS,
+  MACOS_OS,
+  UBUNTU_OS,
+  DEBIAN_OS
 };

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -3407,9 +3407,9 @@ buildvariants:
       - test-tls-support-5.0
       - test-tls-support-4.4
       - test-tls-support-4.2
-  - name: windows-64-vs2019-fermium
-    display_name: Windows (VS2019) Node14
-    run_on: windows-64-vs2019-large
+  - name: windows-vsCurrent-large-fermium
+    display_name: Windows Node14
+    run_on: windows-vsCurrent-large
     expansions:
       NODE_LTS_VERSION: 14
     tasks:
@@ -3451,9 +3451,9 @@ buildvariants:
       - test-tls-support-5.0
       - test-tls-support-4.4
       - test-tls-support-4.2
-  - name: windows-64-vs2019-gallium
-    display_name: Windows (VS2019) Node16
-    run_on: windows-64-vs2019-large
+  - name: windows-vsCurrent-large-gallium
+    display_name: Windows Node16
+    run_on: windows-vsCurrent-large
     expansions:
       NODE_LTS_VERSION: 16
     tasks:
@@ -3493,9 +3493,9 @@ buildvariants:
       - test-tls-support-5.0
       - test-tls-support-4.4
       - test-tls-support-4.2
-  - name: windows-64-vs2019-hydrogen
-    display_name: Windows (VS2019) Node18
-    run_on: windows-64-vs2019-large
+  - name: windows-vsCurrent-large-hydrogen
+    display_name: Windows Node18
+    run_on: windows-vsCurrent-large
     expansions:
       NODE_LTS_VERSION: 18
     tasks:
@@ -3535,9 +3535,9 @@ buildvariants:
       - test-tls-support-5.0
       - test-tls-support-4.4
       - test-tls-support-4.2
-  - name: windows-64-vs2019-Node20
-    display_name: Windows (VS2019) Node20
-    run_on: windows-64-vs2019-large
+  - name: windows-vsCurrent-large-Node20
+    display_name: Windows Node20
+    run_on: windows-vsCurrent-large
     expansions:
       NODE_LTS_VERSION: 20
     tasks:

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -11,19 +11,23 @@ const {
   TOPOLOGIES,
   AWS_AUTH_VERSIONS,
   TLS_VERSIONS,
-  DEFAULT_OS
+  DEFAULT_OS,
+  WINDOWS_OS,
+  MACOS_OS,
+  UBUNTU_OS,
+  DEBIAN_OS
 } = require('./ci_matrix_constants');
 
 const OPERATING_SYSTEMS = [
   {
-    name: 'rhel80-large',
+    name: DEFAULT_OS,
     display_name: 'rhel8',
     run_on: DEFAULT_OS
   },
   {
-    name: 'windows-64-vs2019',
-    display_name: 'Windows (VS2019)',
-    run_on: 'windows-64-vs2019-large',
+    name: WINDOWS_OS,
+    display_name: 'Windows',
+    run_on: WINDOWS_OS,
     clientEncryption: false // TODO(NODE-3401): Unskip when Windows no longer fails to launch mongocryptd occasionally
   }
 ].map(osConfig => ({
@@ -421,11 +425,11 @@ for (const {
 }
 
 BUILD_VARIANTS.push({
-  name: 'macos-1100',
+  name: MACOS_OS,
   display_name: `MacOS 11 Node${
     versions.find(version => version.versionNumber === LATEST_LTS).versionNumber
   }`,
-  run_on: 'macos-1100',
+  run_on: MACOS_OS,
   expansions: {
     NODE_LTS_VERSION: LATEST_LTS,
     CLIENT_ENCRYPTION: true
@@ -545,7 +549,7 @@ BUILD_VARIANTS.push({
 BUILD_VARIANTS.push({
   name: 'mongosh_integration_tests',
   display_name: 'mongosh integration tests',
-  run_on: 'ubuntu1804-large',
+  run_on: UBUNTU_OS,
   tasks: mongoshTasks.map(({ name }) => name)
 });
 
@@ -553,7 +557,7 @@ BUILD_VARIANTS.push({
 BUILD_VARIANTS.push({
   name: 'ubuntu1804-test-mongodb-aws',
   display_name: 'MONGODB-AWS Auth test',
-  run_on: 'ubuntu1804-large',
+  run_on: UBUNTU_OS,
   expansions: {
     NODE_LTS_VERSION: LOWEST_LTS
   },


### PR DESCRIPTION
### Description

#### What is changing?

- vs2019 -> vsCurrent
- Gathered all the hosts into constants, with the intention to make a quick reference of which hosts we depend on

#3687

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

vsCurrent is a more recent OS and is better maintained

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
