### PR TITLE
feat(NODE-5008): add zstd and kerberos to peer deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,11 +69,19 @@
       },
       "peerDependencies": {
         "@aws-sdk/credential-providers": "^3.201.0",
+        "@mongodb-js/zstd": "^1.1.0",
+        "kerberos": "^2.0.1",
         "mongodb-client-encryption": ">=2.3.0 <3",
         "snappy": "^7.2.2"
       },
       "peerDependenciesMeta": {
         "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "kerberos": {
           "optional": true
         },
         "mongodb-client-encryption": {

--- a/package.json
+++ b/package.json
@@ -34,11 +34,19 @@
   },
   "peerDependencies": {
     "@aws-sdk/credential-providers": "^3.201.0",
+    "@mongodb-js/zstd": "^1.1.0",
+    "kerberos": "^2.0.1",
     "mongodb-client-encryption": ">=2.3.0 <3",
     "snappy": "^7.2.2"
   },
   "peerDependenciesMeta": {
     "@aws-sdk/credential-providers": {
+      "optional": true
+    },
+    "@mongodb-js/zstd": {
+      "optional": true
+    },
+    "kerberos": {
       "optional": true
     },
     "snappy": {

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -28,10 +28,15 @@ export let Kerberos: typeof import('kerberos') | { kModuleError: MongoMissingDep
     )
   );
 
-try {
-  // Ensure you always wrap an optional require in the try block NODE-3199
-  Kerberos = require('kerberos');
-} catch {} // eslint-disable-line
+export function getKerberos(): typeof Kerberos | { kModuleError: MongoMissingDependencyError } {
+  try {
+    // Ensure you always wrap an optional require in the try block NODE-3199
+    Kerberos = require('kerberos');
+    return Kerberos;
+  } catch {
+    return Kerberos;
+  }
+}
 
 export interface KerberosClient {
   step(challenge: string): Promise<string>;
@@ -62,9 +67,14 @@ export let ZStandard: ZStandardLib | { kModuleError: MongoMissingDependencyError
     )
   );
 
-try {
-  ZStandard = require('@mongodb-js/zstd');
-} catch {} // eslint-disable-line
+export function getZstdLibrary(): typeof ZStandard | { kModuleError: MongoMissingDependencyError } {
+  try {
+    ZStandard = require('@mongodb-js/zstd');
+    return ZStandard;
+  } catch {
+    return ZStandard;
+  }
+}
 
 type CredentialProvider = {
   fromNodeProviderChain(this: void): () => Promise<AWSCredentials>;

--- a/test/action/dependency.test.ts
+++ b/test/action/dependency.test.ts
@@ -9,6 +9,8 @@ import { dependencies, peerDependencies, peerDependenciesMeta } from '../../pack
 const EXPECTED_DEPENDENCIES = ['bson', 'mongodb-connection-string-url', 'socks'];
 const EXPECTED_PEER_DEPENDENCIES = [
   '@aws-sdk/credential-providers',
+  '@mongodb-js/zstd',
+  'kerberos',
   'snappy',
   'mongodb-client-encryption'
 ];


### PR DESCRIPTION
### Description

Adds zstd and kerberos to peer dependencies.

#### What is changing?

Sets @mongodb-js/zstd and kerberos in the peer dependencies to their latest versions and sets them as optional.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-5008

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
