### PR TITLE
test(DRIVERS-2641): allow int32 or int64 for getMore cursor id

### DIFF
--- a/test/spec/client-side-encryption/tests/legacy/getMore.json
+++ b/test/spec/client-side-encryption/tests/legacy/getMore.json
@@ -216,7 +216,10 @@
           "command_started_event": {
             "command": {
               "getMore": {
-                "$$type": "long"
+                "$$type": [
+                  "int",
+                  "long"
+                ]
               },
               "collection": "default",
               "batchSize": 2

--- a/test/spec/client-side-encryption/tests/legacy/getMore.yml
+++ b/test/spec/client-side-encryption/tests/legacy/getMore.yml
@@ -48,7 +48,7 @@ tests:
           command_name: find
       - command_started_event:
           command:
-            getMore: { $$type: "long" }
+            getMore: { $$type: [ int, long ] }
             collection: *collection_name
             batchSize: 2
           command_name: getMore

--- a/test/spec/load-balancers/cursors.json
+++ b/test/spec/load-balancers/cursors.json
@@ -1,6 +1,6 @@
 {
   "description": "cursors are correctly pinned to connections for load-balanced clusters",
-  "schemaVersion": "1.3",
+  "schemaVersion": "1.4",
   "runOnRequirements": [
     {
       "topologies": [
@@ -222,7 +222,10 @@
                 "reply": {
                   "cursor": {
                     "id": {
-                      "$$type": "long"
+                      "$$type": [
+                        "int",
+                        "long"
+                      ]
                     },
                     "firstBatch": {
                       "$$type": "array"
@@ -239,7 +242,10 @@
               "commandStartedEvent": {
                 "command": {
                   "getMore": {
-                    "$$type": "long"
+                    "$$type": [
+                      "int",
+                      "long"
+                    ]
                   },
                   "collection": "coll0"
                 },
@@ -333,7 +339,10 @@
                 "reply": {
                   "cursor": {
                     "id": {
-                      "$$type": "long"
+                      "$$type": [
+                        "int",
+                        "long"
+                      ]
                     },
                     "firstBatch": {
                       "$$type": "array"
@@ -475,7 +484,10 @@
                 "reply": {
                   "cursor": {
                     "id": {
-                      "$$type": "long"
+                      "$$type": [
+                        "int",
+                        "long"
+                      ]
                     },
                     "firstBatch": {
                       "$$type": "array"
@@ -492,7 +504,10 @@
               "commandStartedEvent": {
                 "command": {
                   "getMore": {
-                    "$$type": "long"
+                    "$$type": [
+                      "int",
+                      "long"
+                    ]
                   },
                   "collection": "coll0"
                 },
@@ -605,7 +620,10 @@
                 "reply": {
                   "cursor": {
                     "id": {
-                      "$$type": "long"
+                      "$$type": [
+                        "int",
+                        "long"
+                      ]
                     },
                     "firstBatch": {
                       "$$type": "array"
@@ -750,7 +768,10 @@
                 "reply": {
                   "cursor": {
                     "id": {
-                      "$$type": "long"
+                      "$$type": [
+                        "int",
+                        "long"
+                      ]
                     },
                     "firstBatch": {
                       "$$type": "array"
@@ -767,7 +788,10 @@
               "commandStartedEvent": {
                 "command": {
                   "getMore": {
-                    "$$type": "long"
+                    "$$type": [
+                      "int",
+                      "long"
+                    ]
                   },
                   "collection": "coll0"
                 },
@@ -858,7 +882,10 @@
               "commandStartedEvent": {
                 "command": {
                   "getMore": {
-                    "$$type": "long"
+                    "$$type": [
+                      "int",
+                      "long"
+                    ]
                   },
                   "collection": "coll0"
                 },
@@ -950,7 +977,10 @@
               "commandStartedEvent": {
                 "command": {
                   "getMore": {
-                    "$$type": "long"
+                    "$$type": [
+                      "int",
+                      "long"
+                    ]
                   },
                   "collection": {
                     "$$type": "string"
@@ -996,11 +1026,6 @@
     },
     {
       "description": "listIndexes pins the cursor to a connection",
-      "runOnRequirements": [
-        {
-          "serverless": "forbid"
-        }
-      ],
       "operations": [
         {
           "name": "createIndex",
@@ -1105,7 +1130,10 @@
               "commandStartedEvent": {
                 "command": {
                   "getMore": {
-                    "$$type": "long"
+                    "$$type": [
+                      "int",
+                      "long"
+                    ]
                   },
                   "collection": "coll0"
                 },

--- a/test/spec/load-balancers/cursors.yml
+++ b/test/spec/load-balancers/cursors.yml
@@ -1,6 +1,6 @@
 description: cursors are correctly pinned to connections for load-balanced clusters
 
-schemaVersion: '1.3'
+schemaVersion: '1.4'
 
 runOnRequirements:
   - topologies: [ load-balanced ]
@@ -126,14 +126,14 @@ tests:
             commandSucceededEvent:
               reply:
                 cursor:
-                  id: { $$type: long }
+                  id: { $$type: [ int, long ] }
                   firstBatch: { $$type: array }
                   ns: { $$type: string }
               commandName: find
           - &getMoreStarted
             commandStartedEvent:
               command:
-                getMore: { $$type: long }
+                getMore: { $$type: [ int, long ] }
                 collection: *collection0Name
               commandName: getMore
           - &getMoreSucceeded
@@ -386,7 +386,7 @@ tests:
           # is not equal to *collection0Name as the command is not executed against a collection.
           - commandStartedEvent:
               command:
-                getMore: { $$type: long }
+                getMore: { $$type: [ int, long ] }
                 collection: { $$type: string }
               commandName: getMore
           - *getMoreSucceeded
@@ -398,8 +398,6 @@ tests:
           - connectionCheckedInEvent: {}
 
   - description: listIndexes pins the cursor to a connection
-    runOnRequirements:
-      - serverless: forbid
     operations:
       # There is an automatic index on _id so we create two more indexes to force multiple batches with batchSize=2.
       - name: createIndex

--- a/test/spec/unified-test-format/valid-pass/entity-cursor-iterateOnce.json
+++ b/test/spec/unified-test-format/valid-pass/entity-cursor-iterateOnce.json
@@ -1,0 +1,111 @@
+{
+  "description": "entity-cursor-iterateOnce",
+  "schemaVersion": "1.9",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "database0"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "databaseName": "database0",
+      "collectionName": "coll0",
+      "documents": [
+        {
+          "_id": 1
+        },
+        {
+          "_id": 2
+        },
+        {
+          "_id": 3
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "iterateOnce",
+      "operations": [
+        {
+          "name": "createFindCursor",
+          "object": "collection0",
+          "arguments": {
+            "filter": {},
+            "batchSize": 2
+          },
+          "saveResultAsEntity": "cursor0"
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "cursor0",
+          "expectResult": {
+            "_id": 1
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "cursor0",
+          "expectResult": {
+            "_id": 2
+          }
+        },
+        {
+          "name": "iterateOnce",
+          "object": "cursor0"
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "coll0",
+                  "filter": {},
+                  "batchSize": 2
+                },
+                "commandName": "find",
+                "databaseName": "database0"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "getMore": {
+                    "$$type": [
+                      "int",
+                      "long"
+                    ]
+                  },
+                  "collection": "coll0"
+                },
+                "commandName": "getMore"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/unified-test-format/valid-pass/entity-cursor-iterateOnce.yml
+++ b/test/spec/unified-test-format/valid-pass/entity-cursor-iterateOnce.yml
@@ -1,0 +1,59 @@
+description: entity-cursor-iterateOnce
+
+# Note: iterateOnce is not technically in the 1.9 schema but was introduced at the same time.
+schemaVersion: "1.9"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name database0
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData:
+  - databaseName: *database0Name
+    collectionName: *collection0Name
+    documents:
+      - _id: 1
+      - _id: 2
+      - _id: 3
+
+tests:
+  - description: iterateOnce
+    operations:
+      - name: createFindCursor
+        object: *collection0
+        arguments:
+          filter: {}
+          batchSize: 2
+        saveResultAsEntity: &cursor0 cursor0
+      - name: iterateUntilDocumentOrError
+        object: *cursor0
+        expectResult: { _id: 1 }
+      - name: iterateUntilDocumentOrError
+        object: *cursor0
+        expectResult: { _id: 2 }
+      # This operation could be iterateUntilDocumentOrError, but we use iterateOne to ensure that drivers support it.
+      - name: iterateOnce
+        object: *cursor0
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                find: *collection0Name
+                filter: {}
+                batchSize: 2
+              commandName: find
+              databaseName: *database0Name
+          - commandStartedEvent:
+              command:
+                getMore: { $$type: [ int, long ] }
+                collection: *collection0Name
+              commandName: getMore

--- a/test/spec/unified-test-format/valid-pass/entity-find-cursor.json
+++ b/test/spec/unified-test-format/valid-pass/entity-find-cursor.json
@@ -109,7 +109,10 @@
                 "reply": {
                   "cursor": {
                     "id": {
-                      "$$type": "long"
+                      "$$type": [
+                        "int",
+                        "long"
+                      ]
                     },
                     "ns": {
                       "$$type": "string"
@@ -126,7 +129,10 @@
               "commandStartedEvent": {
                 "command": {
                   "getMore": {
-                    "$$type": "long"
+                    "$$type": [
+                      "int",
+                      "long"
+                    ]
                   },
                   "collection": "coll0"
                 },
@@ -138,7 +144,10 @@
                 "reply": {
                   "cursor": {
                     "id": {
-                      "$$type": "long"
+                      "$$type": [
+                        "int",
+                        "long"
+                      ]
                     },
                     "ns": {
                       "$$type": "string"

--- a/test/spec/unified-test-format/valid-pass/entity-find-cursor.yml
+++ b/test/spec/unified-test-format/valid-pass/entity-find-cursor.yml
@@ -61,19 +61,19 @@ tests:
           - commandSucceededEvent:
               reply:
                 cursor:
-                  id: { $$type: long }
+                  id: { $$type: [ int, long ] }
                   ns: { $$type: string }
                   firstBatch: { $$type: array } 
               commandName: find
           - commandStartedEvent:
               command:
-                getMore: { $$type: long }
+                getMore: { $$type: [ int, long ] }
                 collection: *collection0Name
               commandName: getMore
           - commandSucceededEvent:
               reply:
                 cursor:
-                  id: { $$type: long }
+                  id: { $$type: [ int, long ] }
                   ns: { $$type: string }
                   nextBatch: { $$type: array } 
               commandName: getMore


### PR DESCRIPTION
### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
