### PR TITLE
fix(NODE-5316): prevent parallel topology creation in MongoClient.connect

### DIFF
--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -343,6 +343,8 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> {
   topology?: Topology;
   /** @internal */
   readonly mongoLogger: MongoLogger;
+  /** @internal */
+  private connectionLock?: Promise<this>;
 
   /**
    * The consolidate, parsed, transformed and merged options.

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -450,9 +450,7 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> {
 
     return maybeCallback(async () => {
       try {
-        if (this.connectionLock) return await this.connectionLock;
-
-        this.connectionLock = this._connect();
+        this.connectionLock = this.connectionLock ?? this._connect();
         await this.connectionLock;
         return this;
       } finally {

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -449,8 +449,11 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> {
     }
 
     return maybeCallback(async () => {
+      if (this.connectionLock) {
+        return this.connectionLock;
+      }
       try {
-        this.connectionLock = this.connectionLock ?? this._connect();
+        this.connectionLock = this._connect();
         await this.connectionLock;
         return this;
       } finally {


### PR DESCRIPTION
### Description

#### What is changing?

Backports the mongo client connect log fix from https://github.com/mongodb/node-mongodb-native/pull/3596.

##### Is there new documentation needed for these changes?

No.

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
