### PR TITLE
ci: use perf distro and pinned server and node versions for testing

### DIFF
--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -1407,6 +1407,6 @@ ignore:
 buildvariants:
   - name: performance-tests
     display_name: Performance Test
-    run_on: rhel80-large
+    run_on: rhel90-dbx-perf-large
     tasks:
       - run-spec-benchmark-tests

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -1145,7 +1145,7 @@ tasks:
           NODE_LTS_VERSION: 20
       - func: bootstrap mongo-orchestration
         vars:
-          VERSION: rapid
+          VERSION: v6.0-perf
           TOPOLOGY: server
           AUTH: noauth
       - func: run spec driver benchmarks

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -1142,7 +1142,7 @@ tasks:
     commands:
       - func: install dependencies
         vars:
-          NODE_LTS_VERSION: 18
+          NODE_LTS_VERSION: 20
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: rapid

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -1134,7 +1134,7 @@ tasks:
       - func: bootstrap kms servers
       - func: "run serverless tests"
 
-  - name: run-spec-benchmark-tests
+  - name: run-spec-benchmark-tests-node-18-server-6.0
     tags:
       - run-spec-benchmark-tests
       - performance
@@ -1142,7 +1142,7 @@ tasks:
     commands:
       - func: install dependencies
         vars:
-          NODE_LTS_VERSION: 20
+          NODE_LTS_VERSION: v18.16.0
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: v6.0-perf
@@ -1409,4 +1409,4 @@ buildvariants:
     display_name: Performance Test
     run_on: rhel90-dbx-perf-large
     tasks:
-      - run-spec-benchmark-tests
+      - run-spec-benchmark-tests-node-18-server-6.0

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1080,7 +1080,7 @@ tasks:
           NODE_LTS_VERSION: 20
       - func: bootstrap mongo-orchestration
         vars:
-          VERSION: rapid
+          VERSION: v6.0-perf
           TOPOLOGY: server
           AUTH: noauth
       - func: run spec driver benchmarks

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -3465,7 +3465,7 @@ ignore:
 buildvariants:
   - name: performance-tests
     display_name: Performance Test
-    run_on: rhel80-large
+    run_on: rhel90-dbx-perf-large
     tasks:
       - run-spec-benchmark-tests
   - name: rhel80-large-fermium

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1077,7 +1077,7 @@ tasks:
     commands:
       - func: install dependencies
         vars:
-          NODE_LTS_VERSION: 18
+          NODE_LTS_VERSION: 20
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: rapid

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1069,7 +1069,7 @@ tasks:
       - func: install dependencies
       - func: bootstrap kms servers
       - func: run serverless tests
-  - name: run-spec-benchmark-tests
+  - name: run-spec-benchmark-tests-node-18-server-6.0
     tags:
       - run-spec-benchmark-tests
       - performance
@@ -1077,7 +1077,7 @@ tasks:
     commands:
       - func: install dependencies
         vars:
-          NODE_LTS_VERSION: 20
+          NODE_LTS_VERSION: v18.16.0
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: v6.0-perf
@@ -3467,7 +3467,7 @@ buildvariants:
     display_name: Performance Test
     run_on: rhel90-dbx-perf-large
     tasks:
-      - run-spec-benchmark-tests
+      - run-spec-benchmark-tests-node-18-server-6.0
   - name: rhel80-large-fermium
     display_name: rhel8 Node14
     run_on: rhel80-large

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -36,6 +36,7 @@ while IFS=$'\t' read -r -a row; do
   node_index_lts="${row[9]}"
   [[ "$node_index_version" = "version" ]] && continue # skip tsv header
   [[ "$NODE_LTS_VERSION" = "latest" ]] && break # first line is latest
+  [[ "$NODE_LTS_VERSION" = "$node_index_version" ]] && break # match full version if specified
   [[ "$NODE_LTS_VERSION" = "$node_index_major_version" ]] && break # case insensitive compare
 done < node_index.tab
 


### PR DESCRIPTION
### Description

#### What is changing?

- Updates the distro used for perf testing to the dedicated rhel90-dbx-perf-large
- Updates the node version for perf testing to a pinned 18.6.0
- Updates the server version for perf testing to a pinned 6.0.6

##### Is there new documentation needed for these changes?
No

#### What is the motivation for this change?
Consistent build for perf testing

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
