### PR TITLE
ci(NODE-5328): change format of nightly versions

### DIFF
--- a/.github/scripts/nightly.mjs
+++ b/.github/scripts/nightly.mjs
@@ -13,15 +13,15 @@ const pkgFilePath = path.join(__dirname, '..', '..', 'package.json');
 process.env.TZ = 'Etc/UTC';
 
 /**
- * FORMAT : M.M.P-dev+YYYYMMDD.sha.##########
- * EXAMPLE: 5.6.0-dev+20230601.sha.0853c6957c
+ * FORMAT : M.M.P-dev.YYYYMMDD.sha.##########
+ * EXAMPLE: 5.6.0-dev.20230601.sha.0853c6957c
  */
 class NightlyVersion {
   /** @param {string} version */
   constructor(version) {
     /** @type {string} */
     this.version = version;
-    const [, meta] = this.version.split('+');
+    const [, meta] = this.version.split('dev.');
     const [dateString, commit] = meta.split('.sha.');
     /** @type {string} */
     this.commit = commit;
@@ -32,7 +32,7 @@ class NightlyVersion {
     const { stdout } = await exec('npm show --json mongodb', { encoding: 'utf8' });
     /** @type {{'dist-tags': {nightly?: string} }} */
     const showInfo = JSON.parse(stdout);
-    const version = showInfo?.['dist-tags']?.nightly ?? '0.0.0-dev+YYYYMMDD.sha.##########';
+    const version = showInfo?.['dist-tags']?.nightly ?? '0.0.0-dev.YYYYMMDD.sha.##########';
     return new NightlyVersion(version);
   }
   static async currentCommit() {
@@ -51,7 +51,7 @@ class NightlyVersion {
     const pkg = JSON.parse(await fs.readFile(pkgFilePath, { encoding: 'utf8' }));
 
     console.log('package.json version is:', pkg.version);
-    pkg.version = `${pkg.version}-dev+${yyyymmdd}.sha.${currentCommit}`;
+    pkg.version = `${pkg.version}-dev.${yyyymmdd}.sha.${currentCommit}`;
     console.log('package.json version updated to:', pkg.version);
 
     await fs.writeFile(pkgFilePath, JSON.stringify(pkg, undefined, 2), { encoding: 'utf8' });

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -3,7 +3,7 @@ on:
     # Timezone is UTC
     # https://crontab.guru/#0_20_*_*_1-5
     # At 20:00 on every day-of-week from Monday through Friday.
-    - cron: '0 20 * * 1-5'
+    - cron: '35 20 * * 1-5'
 
 name: release-nightly
 


### PR DESCRIPTION
### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
