### PR TITLE
chore(NODE-5336): finalize nightly release time

### DIFF
--- a/.github/scripts/nightly.mjs
+++ b/.github/scripts/nightly.mjs
@@ -43,8 +43,8 @@ class NightlyVersion {
     console.log('Generating new nightly version');
     const currentCommit = await NightlyVersion.currentCommit();
     const today = new Date();
-    const year = `${today.getFullYear()}`;
-    const month = `${today.getMonth()}`.padStart(2, '0');
+    const year = `${today.getUTCFullYear()}`;
+    const month = `${today.getUTCMonth() + 1}`.padStart(2, '0');
     const day = `${today.getUTCDate()}`.padStart(2, '0');
     const yyyymmdd = `${year}${month}${day}`;
 

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -1,9 +1,9 @@
 on:
   schedule:
     # Timezone is UTC
-    # https://crontab.guru/#0_12_*_*_1-5
-    # At 12:00 on every day-of-week from Monday through Friday.
-    - cron: '0 12 * * 1-5'
+    # https://crontab.guru/#0_0_*_*_*
+    # At 00:00 every day.
+    - cron: '0 0 * * *'
 
 name: release-nightly
 

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -1,9 +1,9 @@
 on:
   schedule:
     # Timezone is UTC
-    # https://crontab.guru/#0_20_*_*_1-5
-    # At 20:00 on every day-of-week from Monday through Friday.
-    - cron: '35 20 * * 1-5'
+    # https://crontab.guru/#0_12_*_*_1-5
+    # At 12:00 on every day-of-week from Monday through Friday.
+    - cron: '0 12 * * 1-5'
 
 name: release-nightly
 
@@ -25,6 +25,6 @@ jobs:
       - run: npm run build:nightly
         continue-on-error: true
       - if: ${{ success() }}
-        run: npm publish --dry-run --provenance --tag=nightly
+        run: npm publish --provenance --tag=nightly
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
### Description

#### What is changing?

Tested locally:
```
version:       5.6.0-dev.20230602.sha.357472cd1            
filename:      mongodb-5.6.0-dev.20230602.sha.357472cd1.tgz
```
month is fixed

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
