### PR TITLE
ci(NODE-5340): add workflow dispatch and dry-run flag

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -4,6 +4,8 @@ on:
     # https://crontab.guru/#0_0_*_*_*
     # At 00:00 every day.
     - cron: '0 0 * * *'
+  workflow_dispatch: {}
+
 
 name: release-nightly
 
@@ -25,6 +27,6 @@ jobs:
       - run: npm run build:nightly
         continue-on-error: true
       - if: ${{ success() }}
-        run: npm publish --provenance --tag=nightly
+        run: npm publish --dry-run --provenance --tag=nightly
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
### Description

#### What is changing?

Adds worflow dispatch for manual triggering, and dry-run flag

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
