### PR TITLE
chore: update mtools link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,7 +150,7 @@ Reviewers should use the following questions to evaluate the implementation for 
 [code-of-conduct]: CODE_OF_CONDUCT.md
 [github-perfect-pr]: https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/
 [mdb-core-values]: https://www.mongodb.com/company/
-[mtools-install]: http://blog.rueckstiess.com/mtools/install.html
+[mtools-install]: https://rueckstiess.github.io/mtools/
 [nvm-windows]: https://github.com/coreybutler/nvm-windows#installation--upgrades
 [nvm-unix]: https://github.com/nvm-sh/nvm#install--update-script
 [workspace-file]: https://gist.githubusercontent.com/nbbeeken/d831a3801b4c463648c077b27da5057b/raw/8e986843e5e28019f7c0cebe5c6fa72407bf8afb/node-mongodb-native.code-workspace


### PR DESCRIPTION
### Description

Update dead mtools link in CONTRIBUTING.md

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

Remove dead link

### Double check the following

- [X] Ran `npm run check:lint` script
- [X] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [X] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
