### PR TITLE
chore(NODE-5344): add alpha skeleton for testing

### DIFF
--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -1,0 +1,28 @@
+on:
+  # Allows us to manually trigger an alpha
+  # workflow_dispatch can be given an alternative 'ref' to release from a feature branch
+  workflow_dispatch:
+    inputs:
+      alphaVersion:
+        description: 'The semver version string. MUST end in -alpha.#'
+        required: true
+        type: string
+      wetRun:
+        description: 'If true, will publish to npm'
+        required: true
+        type: boolean
+
+name: release-alpha
+
+jobs:
+  release-nightly:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          [[ "${{ inputs.alphaVersion }}" =~ '-alpha(\.(0|[1-9][0-9]+))?$' ]] || { echo "Invalid alphaVersion string" ; exit 1; }
+          [[ "${{ inputs.wetRun }}" == "true" || "${{ inputs.wetRun }}" == "false" ]] || { echo "boolean wetRun must be provided" ; exit 1; }
+        shell: bash
+      - run: |
+          echo "${{ inputs.alphaVersion }}"
+          echo "${{ inputs.wetRun }}"
+        shell: bash


### PR DESCRIPTION
### Description

#### What is changing?

Adds a workflow_dispatch, so we can test the actual implementation of the alpha release process.

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
