### PR TITLE
ci(NODE-5341): remove browser repl from mongosh CI

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -3246,17 +3246,6 @@ tasks:
       - func: run tests
         vars:
           TEST_NPM_SCRIPT: check:csfle
-  - name: run-mongosh-browser-repl
-    tags:
-      - run-mongosh-integration-tests
-    depends_on: compile-mongosh
-    commands:
-      - func: install dependencies
-        vars:
-          NODE_LTS_VERSION: 16
-      - func: run mongosh tests for package
-        vars:
-          mongosh_package: browser-repl
   - name: run-mongosh-browser-runtime-electron
     tags:
       - run-mongosh-integration-tests
@@ -3919,7 +3908,6 @@ buildvariants:
     display_name: mongosh integration tests
     run_on: ubuntu1804-large
     tasks:
-      - run-mongosh-browser-repl
       - run-mongosh-browser-runtime-electron
       - run-mongosh-cli-repl
       - run-mongosh-connectivity-tests

--- a/.evergreen/generate_mongosh_tasks.js
+++ b/.evergreen/generate_mongosh_tasks.js
@@ -1,5 +1,4 @@
 const scopes = [
-  'browser-repl',
   'browser-runtime-electron',
   'cli-repl',
   'connectivity-tests',


### PR DESCRIPTION
### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
