### PR TITLE
ci(Node 5335): clean up instance profile from instance after CI runs

### DIFF
--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -352,6 +352,19 @@ functions:
         args:
           - "${PROJECT_DIRECTORY}/.evergreen/run-mongosh-scope-test.sh"
 
+
+  "reset aws instance profile":
+    - command: shell.exec
+      params:
+        shell: "bash"
+        script: |
+          ${PREPARE_SHELL}
+          cd "${DRIVERS_TOOLS}/.evergreen/auth_aws"
+          if [ -f "./aws_e2e_setup.json" ]; then
+            . ./activate-authawsvenv.sh
+            python ./lib/aws_assign_instance_profile.py
+          fi
+
   "cleanup":
     - command: shell.exec
       params:
@@ -1087,6 +1100,7 @@ pre:
   - func: "make files executable"
 
 post:
+  - func: "reset aws instance profile"
   - func: "upload test results"
   - func: "upload coverage report"
   - func: "cleanup"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -310,6 +310,17 @@ functions:
         binary: bash
         args:
           - ${PROJECT_DIRECTORY}/.evergreen/run-mongosh-scope-test.sh
+  reset aws instance profile:
+    - command: shell.exec
+      params:
+        shell: bash
+        script: |
+          ${PREPARE_SHELL}
+          cd "${DRIVERS_TOOLS}/.evergreen/auth_aws"
+          if [ -f "./aws_e2e_setup.json" ]; then
+            . ./activate-authawsvenv.sh
+            python ./lib/aws_assign_instance_profile.py
+          fi
   cleanup:
     - command: shell.exec
       params:
@@ -3100,6 +3111,7 @@ pre:
   - func: fix absolute paths
   - func: make files executable
 post:
+  - func: reset aws instance profile
   - func: upload test results
   - func: upload coverage report
   - func: cleanup


### PR DESCRIPTION
### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
