### PR TITLE
fix(NODE-5346): update typedoc version

### DIFF
--- a/etc/docs/build.ts
+++ b/etc/docs/build.ts
@@ -24,7 +24,7 @@ const RELEASES_JSON_FILE = './template/static/versions.json';
 
 const copyGeneratedDocsToDocsFolder = () => exec(`cp -R temp/. ../../docs/.`);
 const removeTempDirectory = () => exec('rm -rf temp');
-const installDependencies = () => exec('npm i --no-save --legacy-peer-deps typedoc@0.22.13');
+const installDependencies = () => exec('npm i --no-save --legacy-peer-deps typedoc@0.24.8');
 const buildDocs = ({ tag }: VersionSchema) => {
   const revision = tag === LATEST_TAG ? 'main' : `v${tag}.0`;
   return exec(`npm run build:typedoc -- --gitRevision ${revision}`);


### PR DESCRIPTION
### Description

Bump typedoc to 0.24.8 to support TS 5.

#### What is changing?

Bumps typedoc to 0.24.8

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-5346

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
