### PR TITLE
test(NODE-5288): sync flev2 legacy spec tests

### DIFF
--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -293,7 +293,7 @@ functions:
           source ./prepare_client_encryption.sh
           rm -f ./prepare_client_encryption.sh
 
-          export VERSION=latest
+          export VERSION=${VERSION}
           export DRIVERS_TOOLS=${DRIVERS_TOOLS}
 
           source ${PROJECT_DIRECTORY}/.evergreen/prepare-crypt-shared-lib.sh

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -293,7 +293,7 @@ functions:
           source ./prepare_client_encryption.sh
           rm -f ./prepare_client_encryption.sh
 
-          export VERSION=${VERSION}
+          export VERSION=latest
           export DRIVERS_TOOLS=${DRIVERS_TOOLS}
 
           source ${PROJECT_DIRECTORY}/.evergreen/prepare-crypt-shared-lib.sh

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -260,7 +260,7 @@ functions:
           source ./prepare_client_encryption.sh
           rm -f ./prepare_client_encryption.sh
 
-          export VERSION=${VERSION}
+          export VERSION=latest
           export DRIVERS_TOOLS=${DRIVERS_TOOLS}
 
           source ${PROJECT_DIRECTORY}/.evergreen/prepare-crypt-shared-lib.sh

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -260,7 +260,7 @@ functions:
           source ./prepare_client_encryption.sh
           rm -f ./prepare_client_encryption.sh
 
-          export VERSION=latest
+          export VERSION=${VERSION}
           export DRIVERS_TOOLS=${DRIVERS_TOOLS}
 
           source ${PROJECT_DIRECTORY}/.evergreen/prepare-crypt-shared-lib.sh

--- a/src/operations/create_collection.ts
+++ b/src/operations/create_collection.ts
@@ -137,8 +137,10 @@ export class CreateCollectionOperation extends CommandOperation<Collection> {
 
       if (encryptedFields) {
         // Creating a QE collection required min server of 7.0.0
-        if (server.description.maxWireVersion < MIN_SUPPORTED_QE_WIRE_VERSION) {
-          console.log('SERVER DESCRIPTION', server.description);
+        if (
+          !server.loadBalanced &&
+          server.description.maxWireVersion < MIN_SUPPORTED_QE_WIRE_VERSION
+        ) {
           throw new MongoCompatibilityError(
             `${INVALID_QE_VERSION} The minimum server version required is ${MIN_SUPPORTED_QE_SERVER_VERSION}`
           );

--- a/src/operations/create_collection.ts
+++ b/src/operations/create_collection.ts
@@ -138,6 +138,11 @@ export class CreateCollectionOperation extends CommandOperation<Collection> {
       if (encryptedFields) {
         // Creating a QE collection required min server of 7.0.0
         if (server.description.maxWireVersion < MIN_SUPPORTED_QE_WIRE_VERSION) {
+          console.log(
+            'SERVER WIRE VERSION',
+            server.description.maxWireVersion,
+            MIN_SUPPORTED_QE_WIRE_VERSION
+          );
           throw new MongoCompatibilityError(
             `${INVALID_QE_VERSION} The minimum server version required is ${MIN_SUPPORTED_QE_SERVER_VERSION}`
           );

--- a/src/operations/create_collection.ts
+++ b/src/operations/create_collection.ts
@@ -137,6 +137,7 @@ export class CreateCollectionOperation extends CommandOperation<Collection> {
 
       if (encryptedFields) {
         // Creating a QE collection required min server of 7.0.0
+        // TODO(NODE-5353): Get wire version information from connection.
         if (
           !server.loadBalanced &&
           server.description.maxWireVersion < MIN_SUPPORTED_QE_WIRE_VERSION

--- a/src/operations/create_collection.ts
+++ b/src/operations/create_collection.ts
@@ -138,11 +138,7 @@ export class CreateCollectionOperation extends CommandOperation<Collection> {
       if (encryptedFields) {
         // Creating a QE collection required min server of 7.0.0
         if (server.description.maxWireVersion < MIN_SUPPORTED_QE_WIRE_VERSION) {
-          console.log(
-            'SERVER WIRE VERSION',
-            server.description.maxWireVersion,
-            MIN_SUPPORTED_QE_WIRE_VERSION
-          );
+          console.log('SERVER DESCRIPTION', server.description);
           throw new MongoCompatibilityError(
             `${INVALID_QE_VERSION} The minimum server version required is ${MIN_SUPPORTED_QE_SERVER_VERSION}`
           );

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-BypassQueryAnalysis.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-BypassQueryAnalysis.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-BypassQueryAnalysis.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-BypassQueryAnalysis.yml
@@ -1,7 +1,6 @@
 # Requires libmongocrypt 1.8.0.
 runOn:
   - minServerVersion: "7.0.0"
-    serverless: "forbid"
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Compact.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Compact.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Compact.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Compact.yml
@@ -1,7 +1,6 @@
 # Requires libmongocrypt 1.8.0.
 runOn:
   - minServerVersion: "7.0.0"
-    serverless: "forbid"
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-CreateCollection-OldServer.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-CreateCollection-OldServer.json
@@ -55,6 +55,38 @@
           "result": {
             "errorContains": "Driver support of Queryable Encryption is incompatible with server. Upgrade server to use Queryable Encryption."
           }
+        },
+        {
+          "name": "assertCollectionNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "enxcol_.encryptedCollection.esc"
+          }
+        },
+        {
+          "name": "assertCollectionNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "enxcol_.encryptedCollection.ecc"
+          }
+        },
+        {
+          "name": "assertCollectionNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "enxcol_.encryptedCollection.ecoc"
+          }
+        },
+        {
+          "name": "assertCollectionNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection"
+          }
         }
       ]
     }

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-CreateCollection-OldServer.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-CreateCollection-OldServer.yml
@@ -37,3 +37,25 @@ tests:
           collection: "encryptedCollection"
         result:
           errorContains: "Driver support of Queryable Encryption is incompatible with server. Upgrade server to use Queryable Encryption."
+      # Assert no collections were created.
+      - name: assertCollectionNotExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: &esc_collection_name "enxcol_.encryptedCollection.esc"
+      # ecc collection is no longer created for QEv2
+      - name: assertCollectionNotExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: &ecc_collection_name "enxcol_.encryptedCollection.ecc"
+      - name: assertCollectionNotExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: &ecoc_collection_name "enxcol_.encryptedCollection.ecoc"
+      - name: assertCollectionNotExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: encryptedCollection

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-CreateCollection.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-CreateCollection.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
@@ -158,9 +157,6 @@
             "command": {
               "create": "encryptedCollection",
               "encryptedFields": {
-                "escCollection": null,
-                "ecocCollection": null,
-                "eccCollection": null,
                 "fields": [
                   {
                     "path": "firstName",
@@ -343,9 +339,6 @@
             "command": {
               "create": "encryptedCollection",
               "encryptedFields": {
-                "escCollection": null,
-                "ecocCollection": null,
-                "eccCollection": null,
                 "fields": [
                   {
                     "path": "firstName",
@@ -851,9 +844,6 @@
             "command": {
               "create": "encryptedCollection",
               "encryptedFields": {
-                "escCollection": null,
-                "ecocCollection": null,
-                "eccCollection": null,
                 "fields": [
                   {
                     "path": "firstName",
@@ -1048,9 +1038,6 @@
             "command": {
               "create": "encryptedCollection",
               "encryptedFields": {
-                "escCollection": null,
-                "ecocCollection": null,
-                "eccCollection": null,
                 "fields": [
                   {
                     "path": "firstName",
@@ -1367,9 +1354,6 @@
             "command": {
               "create": "encryptedCollection",
               "encryptedFields": {
-                "escCollection": null,
-                "ecocCollection": null,
-                "eccCollection": null,
                 "fields": [
                   {
                     "path": "firstName",
@@ -1635,9 +1619,6 @@
             "command": {
               "create": "encryptedCollection",
               "encryptedFields": {
-                "escCollection": null,
-                "ecocCollection": null,
-                "eccCollection": null,
                 "fields": [
                   {
                     "path": "firstName",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-CreateCollection.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-CreateCollection.yml
@@ -1,7 +1,6 @@
 # Requires libmongocrypt 1.8.0.
 runOn:
   - minServerVersion: "7.0.0"
-    serverless: "forbid"
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
@@ -101,10 +100,6 @@ tests:
             command:
               create: *encrypted_collection_name
               encryptedFields: &encrypted_fields_expectation {
-                # Expect state collections are not included in the encryptedFields sent to the server.
-                "escCollection": null,
-                "ecocCollection": null,
-                "eccCollection": null,
                 "fields": [
                     {
                         "path": "firstName",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-DecryptExistingData.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-DecryptExistingData.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-DecryptExistingData.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-DecryptExistingData.yml
@@ -1,7 +1,6 @@
 # Requires libmongocrypt 1.8.0.
 runOn:
   - minServerVersion: "7.0.0"
-    serverless: "forbid"
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Delete.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Delete.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Delete.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Delete.yml
@@ -1,7 +1,6 @@
 # Requires libmongocrypt 1.8.0.
 runOn:
   - minServerVersion: "7.0.0"
-    serverless: "forbid"
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-EncryptedFields-vs-EncryptedFieldsMap.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-EncryptedFields-vs-EncryptedFieldsMap.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-EncryptedFields-vs-EncryptedFieldsMap.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-EncryptedFields-vs-EncryptedFieldsMap.yml
@@ -1,7 +1,6 @@
 # Requires libmongocrypt 1.8.0.
 runOn:
   - minServerVersion: "7.0.0"
-    serverless: "forbid"
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-EncryptedFields-vs-jsonSchema.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-EncryptedFields-vs-jsonSchema.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-EncryptedFields-vs-jsonSchema.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-EncryptedFields-vs-jsonSchema.yml
@@ -1,7 +1,6 @@
 # Requires libmongocrypt 1.8.0.
 runOn:
   - minServerVersion: "7.0.0"
-    serverless: "forbid"
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-EncryptedFieldsMap-defaults.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-EncryptedFieldsMap-defaults.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-EncryptedFieldsMap-defaults.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-EncryptedFieldsMap-defaults.yml
@@ -1,7 +1,6 @@
 # Requires libmongocrypt 1.8.0.
 runOn:
   - minServerVersion: "7.0.0"
-    serverless: "forbid"
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-FindOneAndUpdate.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-FindOneAndUpdate.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-FindOneAndUpdate.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-FindOneAndUpdate.yml
@@ -1,7 +1,6 @@
 # Requires libmongocrypt 1.8.0.
 runOn:
   - minServerVersion: "7.0.0"
-    serverless: "forbid"
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-InsertFind-Indexed.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-InsertFind-Indexed.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-InsertFind-Indexed.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-InsertFind-Indexed.yml
@@ -1,7 +1,6 @@
 # Requires libmongocrypt 1.8.0.
 runOn:
   - minServerVersion: "7.0.0"
-    serverless: "forbid"
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-InsertFind-Unindexed.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-InsertFind-Unindexed.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-InsertFind-Unindexed.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-InsertFind-Unindexed.yml
@@ -1,7 +1,6 @@
 # Requires libmongocrypt 1.8.0.
 runOn:
   - minServerVersion: "7.0.0"
-    serverless: "forbid"
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-MissingKey.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-MissingKey.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-MissingKey.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-MissingKey.yml
@@ -1,7 +1,6 @@
 # Requires libmongocrypt 1.8.0.
 runOn:
   - minServerVersion: "7.0.0"
-    serverless: "forbid"
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-NoEncryption.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-NoEncryption.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-NoEncryption.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-NoEncryption.yml
@@ -1,7 +1,6 @@
 # Requires libmongocrypt 1.8.0.
 runOn:
   - minServerVersion: "7.0.0"
-    serverless: "forbid"
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Date-Aggregate.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Date-Aggregate.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Date-Aggregate.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Date-Aggregate.yml
@@ -2,7 +2,6 @@
 # Requires libmongocrypt 1.8.0.
 runOn:
   - minServerVersion: "7.0.0"
-    serverless: "forbid"
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Date-Correctness.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Date-Correctness.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Date-Correctness.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Date-Correctness.yml
@@ -4,7 +4,6 @@
 # Requires libmongocrypt 1.8.0.
 runOn:
   - minServerVersion: "7.0.0"
-    serverless: "forbid"
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Date-Delete.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Date-Delete.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Date-Delete.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Date-Delete.yml
@@ -2,7 +2,6 @@
 # Requires libmongocrypt 1.8.0.
 runOn:
   - minServerVersion: "7.0.0"
-    serverless: "forbid"
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Date-FindOneAndUpdate.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Date-FindOneAndUpdate.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Date-FindOneAndUpdate.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Date-FindOneAndUpdate.yml
@@ -2,7 +2,6 @@
 # Requires libmongocrypt 1.8.0.
 runOn:
   - minServerVersion: "7.0.0"
-    serverless: "forbid"
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Date-InsertFind.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Date-InsertFind.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Date-InsertFind.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Date-InsertFind.yml
@@ -2,7 +2,6 @@
 # Requires libmongocrypt 1.8.0.
 runOn:
   - minServerVersion: "7.0.0"
-    serverless: "forbid"
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Date-Update.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Date-Update.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Date-Update.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Date-Update.yml
@@ -2,7 +2,6 @@
 # Requires libmongocrypt 1.8.0.
 runOn:
   - minServerVersion: "7.0.0"
-    serverless: "forbid"
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-Aggregate.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-Aggregate.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset"
       ]

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-Aggregate.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-Aggregate.yml
@@ -2,7 +2,6 @@
 # Requires libmongocrypt 1.8.0.
 runOn:
   - minServerVersion: "7.0.0"
-    serverless: "forbid"
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     # Tests for Decimal (without precision) must only run against a replica set. Decimal (without precision) queries are expected to take a long time and may exceed the default mongos timeout.

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-Correctness.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-Correctness.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset"
       ]

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-Correctness.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-Correctness.yml
@@ -4,7 +4,6 @@
 # Requires libmongocrypt 1.8.0.
 runOn:
   - minServerVersion: "7.0.0"
-    serverless: "forbid"
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     # Tests for Decimal (without precision) must only run against a replica set. Decimal (without precision) queries are expected to take a long time and may exceed the default mongos timeout.

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-Delete.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-Delete.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset"
       ]

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-Delete.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-Delete.yml
@@ -2,7 +2,6 @@
 # Requires libmongocrypt 1.8.0.
 runOn:
   - minServerVersion: "7.0.0"
-    serverless: "forbid"
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     # Tests for Decimal (without precision) must only run against a replica set. Decimal (without precision) queries are expected to take a long time and may exceed the default mongos timeout.

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-FindOneAndUpdate.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-FindOneAndUpdate.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset"
       ]

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-FindOneAndUpdate.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-FindOneAndUpdate.yml
@@ -2,7 +2,6 @@
 # Requires libmongocrypt 1.8.0.
 runOn:
   - minServerVersion: "7.0.0"
-    serverless: "forbid"
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     # Tests for Decimal (without precision) must only run against a replica set. Decimal (without precision) queries are expected to take a long time and may exceed the default mongos timeout.

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-InsertFind.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-InsertFind.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset"
       ]

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-InsertFind.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-InsertFind.yml
@@ -2,7 +2,6 @@
 # Requires libmongocrypt 1.8.0.
 runOn:
   - minServerVersion: "7.0.0"
-    serverless: "forbid"
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     # Tests for Decimal (without precision) must only run against a replica set. Decimal (without precision) queries are expected to take a long time and may exceed the default mongos timeout.

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-Update.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-Update.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset"
       ]

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-Update.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-Update.yml
@@ -2,7 +2,6 @@
 # Requires libmongocrypt 1.8.0.
 runOn:
   - minServerVersion: "7.0.0"
-    serverless: "forbid"
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     # Tests for Decimal (without precision) must only run against a replica set. Decimal (without precision) queries are expected to take a long time and may exceed the default mongos timeout.

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-Aggregate.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-Aggregate.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-Aggregate.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-Aggregate.yml
@@ -2,7 +2,6 @@
 # Requires libmongocrypt 1.8.0.
 runOn:
   - minServerVersion: "7.0.0"
-    serverless: "forbid"
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-Correctness.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-Correctness.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-Correctness.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-Correctness.yml
@@ -4,7 +4,6 @@
 # Requires libmongocrypt 1.8.0.
 runOn:
   - minServerVersion: "7.0.0"
-    serverless: "forbid"
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-Delete.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-Delete.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-Delete.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-Delete.yml
@@ -2,7 +2,6 @@
 # Requires libmongocrypt 1.8.0.
 runOn:
   - minServerVersion: "7.0.0"
-    serverless: "forbid"
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-FindOneAndUpdate.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-FindOneAndUpdate.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-FindOneAndUpdate.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-FindOneAndUpdate.yml
@@ -2,7 +2,6 @@
 # Requires libmongocrypt 1.8.0.
 runOn:
   - minServerVersion: "7.0.0"
-    serverless: "forbid"
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-InsertFind.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-InsertFind.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-InsertFind.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-InsertFind.yml
@@ -2,7 +2,6 @@
 # Requires libmongocrypt 1.8.0.
 runOn:
   - minServerVersion: "7.0.0"
-    serverless: "forbid"
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-Update.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-Update.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-Update.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-Update.yml
@@ -2,7 +2,6 @@
 # Requires libmongocrypt 1.8.0.
 runOn:
   - minServerVersion: "7.0.0"
-    serverless: "forbid"
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Double-Aggregate.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Double-Aggregate.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Double-Aggregate.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Double-Aggregate.yml
@@ -2,7 +2,6 @@
 # Requires libmongocrypt 1.8.0.
 runOn:
   - minServerVersion: "7.0.0"
-    serverless: "forbid"
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Double-Correctness.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Double-Correctness.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Double-Correctness.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Double-Correctness.yml
@@ -4,7 +4,6 @@
 # Requires libmongocrypt 1.8.0.
 runOn:
   - minServerVersion: "7.0.0"
-    serverless: "forbid"
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Double-Delete.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Double-Delete.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Double-Delete.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Double-Delete.yml
@@ -2,7 +2,6 @@
 # Requires libmongocrypt 1.8.0.
 runOn:
   - minServerVersion: "7.0.0"
-    serverless: "forbid"
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Double-FindOneAndUpdate.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Double-FindOneAndUpdate.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Double-FindOneAndUpdate.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Double-FindOneAndUpdate.yml
@@ -2,7 +2,6 @@
 # Requires libmongocrypt 1.8.0.
 runOn:
   - minServerVersion: "7.0.0"
-    serverless: "forbid"
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Double-InsertFind.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Double-InsertFind.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Double-InsertFind.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Double-InsertFind.yml
@@ -2,7 +2,6 @@
 # Requires libmongocrypt 1.8.0.
 runOn:
   - minServerVersion: "7.0.0"
-    serverless: "forbid"
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Double-Update.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Double-Update.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Double-Update.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Double-Update.yml
@@ -2,7 +2,6 @@
 # Requires libmongocrypt 1.8.0.
 runOn:
   - minServerVersion: "7.0.0"
-    serverless: "forbid"
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-Aggregate.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-Aggregate.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-Aggregate.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-Aggregate.yml
@@ -2,7 +2,6 @@
 # Requires libmongocrypt 1.8.0.
 runOn:
   - minServerVersion: "7.0.0"
-    serverless: "forbid"
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-Correctness.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-Correctness.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-Correctness.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-Correctness.yml
@@ -4,7 +4,6 @@
 # Requires libmongocrypt 1.8.0.
 runOn:
   - minServerVersion: "7.0.0"
-    serverless: "forbid"
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-Delete.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-Delete.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-Delete.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-Delete.yml
@@ -2,7 +2,6 @@
 # Requires libmongocrypt 1.8.0.
 runOn:
   - minServerVersion: "7.0.0"
-    serverless: "forbid"
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-FindOneAndUpdate.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-FindOneAndUpdate.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-FindOneAndUpdate.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-FindOneAndUpdate.yml
@@ -2,7 +2,6 @@
 # Requires libmongocrypt 1.8.0.
 runOn:
   - minServerVersion: "7.0.0"
-    serverless: "forbid"
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-InsertFind.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-InsertFind.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-InsertFind.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-InsertFind.yml
@@ -2,7 +2,6 @@
 # Requires libmongocrypt 1.8.0.
 runOn:
   - minServerVersion: "7.0.0"
-    serverless: "forbid"
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-Update.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-Update.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-Update.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-Update.yml
@@ -2,7 +2,6 @@
 # Requires libmongocrypt 1.8.0.
 runOn:
   - minServerVersion: "7.0.0"
-    serverless: "forbid"
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Int-Aggregate.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Int-Aggregate.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Int-Aggregate.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Int-Aggregate.yml
@@ -2,7 +2,6 @@
 # Requires libmongocrypt 1.8.0.
 runOn:
   - minServerVersion: "7.0.0"
-    serverless: "forbid"
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Int-Correctness.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Int-Correctness.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Int-Correctness.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Int-Correctness.yml
@@ -4,7 +4,6 @@
 # Requires libmongocrypt 1.8.0.
 runOn:
   - minServerVersion: "7.0.0"
-    serverless: "forbid"
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Int-Delete.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Int-Delete.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Int-Delete.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Int-Delete.yml
@@ -2,7 +2,6 @@
 # Requires libmongocrypt 1.8.0.
 runOn:
   - minServerVersion: "7.0.0"
-    serverless: "forbid"
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Int-FindOneAndUpdate.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Int-FindOneAndUpdate.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Int-FindOneAndUpdate.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Int-FindOneAndUpdate.yml
@@ -2,7 +2,6 @@
 # Requires libmongocrypt 1.8.0.
 runOn:
   - minServerVersion: "7.0.0"
-    serverless: "forbid"
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Int-InsertFind.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Int-InsertFind.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Int-InsertFind.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Int-InsertFind.yml
@@ -2,7 +2,6 @@
 # Requires libmongocrypt 1.8.0.
 runOn:
   - minServerVersion: "7.0.0"
-    serverless: "forbid"
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Int-Update.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Int-Update.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Int-Update.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Int-Update.yml
@@ -2,7 +2,6 @@
 # Requires libmongocrypt 1.8.0.
 runOn:
   - minServerVersion: "7.0.0"
-    serverless: "forbid"
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Long-Aggregate.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Long-Aggregate.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Long-Aggregate.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Long-Aggregate.yml
@@ -2,7 +2,6 @@
 # Requires libmongocrypt 1.8.0.
 runOn:
   - minServerVersion: "7.0.0"
-    serverless: "forbid"
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Long-Correctness.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Long-Correctness.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Long-Correctness.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Long-Correctness.yml
@@ -4,7 +4,6 @@
 # Requires libmongocrypt 1.8.0.
 runOn:
   - minServerVersion: "7.0.0"
-    serverless: "forbid"
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Long-Delete.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Long-Delete.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Long-Delete.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Long-Delete.yml
@@ -2,7 +2,6 @@
 # Requires libmongocrypt 1.8.0.
 runOn:
   - minServerVersion: "7.0.0"
-    serverless: "forbid"
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Long-FindOneAndUpdate.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Long-FindOneAndUpdate.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Long-FindOneAndUpdate.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Long-FindOneAndUpdate.yml
@@ -2,7 +2,6 @@
 # Requires libmongocrypt 1.8.0.
 runOn:
   - minServerVersion: "7.0.0"
-    serverless: "forbid"
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Long-InsertFind.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Long-InsertFind.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Long-InsertFind.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Long-InsertFind.yml
@@ -2,7 +2,6 @@
 # Requires libmongocrypt 1.8.0.
 runOn:
   - minServerVersion: "7.0.0"
-    serverless: "forbid"
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Long-Update.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Long-Update.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Long-Update.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Long-Update.yml
@@ -2,7 +2,6 @@
 # Requires libmongocrypt 1.8.0.
 runOn:
   - minServerVersion: "7.0.0"
-    serverless: "forbid"
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-WrongType.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-WrongType.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-WrongType.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-WrongType.yml
@@ -4,7 +4,6 @@
 # Requires libmongocrypt 1.8.0.
 runOn:
   - minServerVersion: "7.0.0"
-    serverless: "forbid"
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Update.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Update.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Update.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Update.yml
@@ -1,7 +1,6 @@
 # Requires libmongocrypt 1.8.0.
 runOn:
   - minServerVersion: "7.0.0"
-    serverless: "forbid"
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-validatorAndPartialFieldExpression.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-validatorAndPartialFieldExpression.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-validatorAndPartialFieldExpression.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-validatorAndPartialFieldExpression.yml
@@ -2,7 +2,6 @@
 runOn:
     # Require server version 6.0.0 to get behavior added in SERVER-64911.
     - minServerVersion: "7.0.0"
-      serverless: "forbid"
       # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
       # FLE 2 Encrypted collections are not supported on standalone.
       topology: [ "replicaset", "sharded", "load-balanced" ]


### PR DESCRIPTION
### Description

Updates FLE2 tests to run on serverless.

#### What is changing?
- Syncs FLE2 tests to latest.
- Allows wire version checks to skip load balanced mode.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-5288

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
