### PR TITLE
ci(NODE-5322): fix lambda handler aws test

### DIFF
--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -1042,15 +1042,19 @@ functions:
     - command: shell.exec
       type: test
       params:
-        working_dir: "src"
+        working_dir: src
         silent: true
+        shell: bash
         script: |
+          set -ex
           cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
-          ${MONGODB_BINARIES}/mongo --verbose aws_e2e_regular_aws.js
+          . ./activate-authawsvenv.sh
+          python aws_tester.py regular
           cd -
           cat <<EOF > "${PROJECT_DIRECTORY}/prepare_mongodb_aws.sh"
             export AWS_ACCESS_KEY_ID=${iam_auth_ecs_account}
             export AWS_SECRET_ACCESS_KEY=${iam_auth_ecs_secret_access_key}
+            export MONGODB_URI="mongodb://localhost:27017/aws?authMechanism=MONGODB-AWS"
           EOF
     - command: shell.exec
       type: test

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -988,13 +988,17 @@ functions:
       params:
         working_dir: src
         silent: true
+        shell: bash
         script: |
+          set -ex
           cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
-          ${MONGODB_BINARIES}/mongo --verbose aws_e2e_regular_aws.js
+          . ./activate-authawsvenv.sh
+          python aws_tester.py regular
           cd -
           cat <<EOF > "${PROJECT_DIRECTORY}/prepare_mongodb_aws.sh"
             export AWS_ACCESS_KEY_ID=${iam_auth_ecs_account}
             export AWS_SECRET_ACCESS_KEY=${iam_auth_ecs_secret_access_key}
+            export MONGODB_URI="mongodb://localhost:27017/aws?authMechanism=MONGODB-AWS"
           EOF
     - command: shell.exec
       type: test

--- a/.evergreen/prepare-shell.sh
+++ b/.evergreen/prepare-shell.sh
@@ -34,6 +34,8 @@ if [ ! -d "$DRIVERS_TOOLS" ]; then
   git clone --depth=1 "https://github.com/mongodb-labs/drivers-evergreen-tools.git" "${DRIVERS_TOOLS}"
 fi
 
+echo "installed DRIVERS_EVERGREEN_TOOLS from commit $(git -C $DRIVERS_EVERGREEN_TOOLS rev-parse HEAD)"
+
 cat <<EOT > "$MONGO_ORCHESTRATION_HOME/orchestration.config"
 {
   "releases": {


### PR DESCRIPTION
### Description

#### What is changing?

Updates the aws auth lambda handler test to use the new drivers-evergreen-tools setup for AWS authentication.

##### Is there new documentation needed for these changes?

No.
