### PR TITLE
refactor(NODE-5352): refactor AbstractOperation to use async

### DIFF
--- a/src/bulk/common.ts
+++ b/src/bulk/common.ts
@@ -13,7 +13,7 @@ import type { CollationOptions, CommandOperationOptions } from '../operations/co
 import { DeleteOperation, type DeleteStatement, makeDeleteStatement } from '../operations/delete';
 import { executeOperation } from '../operations/execute_operation';
 import { InsertOperation } from '../operations/insert';
-import { AbstractOperation, type Hint } from '../operations/operation';
+import { AbstractCallbackOperation, type Hint } from '../operations/operation';
 import { makeUpdateStatement, UpdateOperation, type UpdateStatement } from '../operations/update';
 import type { Server } from '../sdam/server';
 import type { Topology } from '../sdam/topology';
@@ -881,14 +881,18 @@ export interface BulkWriteOptions extends CommandOperationOptions {
  * We would like this logic to simply live inside the BulkWriteOperation class
  * @internal
  */
-class BulkWriteShimOperation extends AbstractOperation {
+class BulkWriteShimOperation extends AbstractCallbackOperation {
   bulkOperation: BulkOperationBase;
   constructor(bulkOperation: BulkOperationBase, options: BulkWriteOptions) {
     super(options);
     this.bulkOperation = bulkOperation;
   }
 
-  execute(server: Server, session: ClientSession | undefined, callback: Callback<any>): void {
+  executeCallback(
+    server: Server,
+    session: ClientSession | undefined,
+    callback: Callback<any>
+  ): void {
     if (this.options.session == null) {
       // An implicit session could have been created by 'executeOperation'
       // So if we stick it on finalOptions here, each bulk operation

--- a/src/index.ts
+++ b/src/index.ts
@@ -419,7 +419,12 @@ export type {
 export type { InsertManyResult, InsertOneOptions, InsertOneResult } from './operations/insert';
 export type { CollectionInfo, ListCollectionsOptions } from './operations/list_collections';
 export type { ListDatabasesOptions, ListDatabasesResult } from './operations/list_databases';
-export type { AbstractOperation, Hint, OperationOptions } from './operations/operation';
+export type {
+  AbstractCallbackOperation,
+  AbstractOperation,
+  Hint,
+  OperationOptions
+} from './operations/operation';
 export type { ProfilingLevelOptions } from './operations/profiling_level';
 export type { RemoveUserOptions } from './operations/remove_user';
 export type { RenameOptions } from './operations/rename';

--- a/src/operations/add_user.ts
+++ b/src/operations/add_user.ts
@@ -50,7 +50,7 @@ export class AddUserOperation extends CommandOperation<Document> {
     this.options = options ?? {};
   }
 
-  override execute(
+  override executeCallback(
     server: Server,
     session: ClientSession | undefined,
     callback: Callback<Document>

--- a/src/operations/aggregate.ts
+++ b/src/operations/aggregate.ts
@@ -88,7 +88,7 @@ export class AggregateOperation<T = Document> extends CommandOperation<T> {
     this.pipeline.push(stage);
   }
 
-  override execute(
+  override executeCallback(
     server: Server,
     session: ClientSession | undefined,
     callback: Callback<T>

--- a/src/operations/bulk_write.ts
+++ b/src/operations/bulk_write.ts
@@ -8,10 +8,10 @@ import type { Collection } from '../collection';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
 import type { Callback } from '../utils';
-import { AbstractOperation, Aspect, defineAspects } from './operation';
+import { AbstractCallbackOperation, Aspect, defineAspects } from './operation';
 
 /** @internal */
-export class BulkWriteOperation extends AbstractOperation<BulkWriteResult> {
+export class BulkWriteOperation extends AbstractCallbackOperation<BulkWriteResult> {
   override options: BulkWriteOptions;
   collection: Collection;
   operations: AnyBulkWriteOperation[];
@@ -27,7 +27,7 @@ export class BulkWriteOperation extends AbstractOperation<BulkWriteResult> {
     this.operations = operations;
   }
 
-  override execute(
+  override executeCallback(
     server: Server,
     session: ClientSession | undefined,
     callback: Callback<BulkWriteResult>

--- a/src/operations/collections.ts
+++ b/src/operations/collections.ts
@@ -3,14 +3,14 @@ import type { Db } from '../db';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
 import type { Callback } from '../utils';
-import { AbstractOperation, type OperationOptions } from './operation';
+import { AbstractCallbackOperation, type OperationOptions } from './operation';
 
 export interface CollectionsOptions extends OperationOptions {
   nameOnly?: boolean;
 }
 
 /** @internal */
-export class CollectionsOperation extends AbstractOperation<Collection[]> {
+export class CollectionsOperation extends AbstractCallbackOperation<Collection[]> {
   override options: CollectionsOptions;
   db: Db;
 
@@ -20,7 +20,7 @@ export class CollectionsOperation extends AbstractOperation<Collection[]> {
     this.db = db;
   }
 
-  override execute(
+  override executeCallback(
     server: Server,
     session: ClientSession | undefined,
     callback: Callback<Collection[]>

--- a/src/operations/command.ts
+++ b/src/operations/command.ts
@@ -15,7 +15,7 @@ import {
 } from '../utils';
 import { WriteConcern, type WriteConcernOptions } from '../write_concern';
 import type { ReadConcernLike } from './../read_concern';
-import { AbstractOperation, Aspect, type OperationOptions } from './operation';
+import { AbstractCallbackOperation, Aspect, type OperationOptions } from './operation';
 
 /** @public */
 export interface CollationOptions {
@@ -68,7 +68,7 @@ export interface OperationParent {
 }
 
 /** @internal */
-export abstract class CommandOperation<T> extends AbstractOperation<T> {
+export abstract class CommandOperation<T> extends AbstractCallbackOperation<T> {
   override options: CommandOperationOptions;
   readConcern?: ReadConcern;
   writeConcern?: WriteConcern;

--- a/src/operations/count.ts
+++ b/src/operations/count.ts
@@ -32,7 +32,7 @@ export class CountOperation extends CommandOperation<number> {
     this.query = filter;
   }
 
-  override execute(
+  override executeCallback(
     server: Server,
     session: ClientSession | undefined,
     callback: Callback<number>

--- a/src/operations/count_documents.ts
+++ b/src/operations/count_documents.ts
@@ -32,12 +32,12 @@ export class CountDocumentsOperation extends AggregateOperation<number> {
     super(collection.s.namespace, pipeline, options);
   }
 
-  override execute(
+  override executeCallback(
     server: Server,
     session: ClientSession | undefined,
     callback: Callback<number>
   ): void {
-    super.execute(server, session, (err, result) => {
+    super.executeCallback(server, session, (err, result) => {
       if (err || !result) {
         callback(err);
         return;

--- a/src/operations/create_collection.ts
+++ b/src/operations/create_collection.ts
@@ -121,7 +121,7 @@ export class CreateCollectionOperation extends CommandOperation<Collection> {
     this.name = name;
   }
 
-  override execute(
+  override executeCallback(
     server: Server,
     session: ClientSession | undefined,
     callback: Callback<Collection>
@@ -170,9 +170,7 @@ export class CreateCollectionOperation extends CommandOperation<Collection> {
       if (encryptedFields) {
         // Create the required index for queryable encryption support.
         const createIndexOp = new CreateIndexOperation(db, name, { __safeContent__: 1 }, {});
-        await new Promise<void>((resolve, reject) => {
-          createIndexOp.execute(server, session, err => (err ? reject(err) : resolve()));
-        });
+        await createIndexOp.execute(server, session);
       }
 
       return coll;

--- a/src/operations/delete.ts
+++ b/src/operations/delete.ts
@@ -60,7 +60,11 @@ export class DeleteOperation extends CommandOperation<DeleteResult> {
     return this.statements.every(op => (op.limit != null ? op.limit > 0 : true));
   }
 
-  override execute(server: Server, session: ClientSession | undefined, callback: Callback): void {
+  override executeCallback(
+    server: Server,
+    session: ClientSession | undefined,
+    callback: Callback
+  ): void {
     const options = this.options ?? {};
     const ordered = typeof options.ordered === 'boolean' ? options.ordered : true;
     const command: Document = {
@@ -97,12 +101,12 @@ export class DeleteOneOperation extends DeleteOperation {
     super(collection.s.namespace, [makeDeleteStatement(filter, { ...options, limit: 1 })], options);
   }
 
-  override execute(
+  override executeCallback(
     server: Server,
     session: ClientSession | undefined,
     callback: Callback<DeleteResult>
   ): void {
-    super.execute(server, session, (err, res) => {
+    super.executeCallback(server, session, (err, res) => {
       if (err || res == null) return callback(err);
       if (res.code) return callback(new MongoServerError(res));
       if (res.writeErrors) return callback(new MongoServerError(res.writeErrors[0]));
@@ -121,12 +125,12 @@ export class DeleteManyOperation extends DeleteOperation {
     super(collection.s.namespace, [makeDeleteStatement(filter, options)], options);
   }
 
-  override execute(
+  override executeCallback(
     server: Server,
     session: ClientSession | undefined,
     callback: Callback<DeleteResult>
   ): void {
-    super.execute(server, session, (err, res) => {
+    super.executeCallback(server, session, (err, res) => {
       if (err || res == null) return callback(err);
       if (res.code) return callback(new MongoServerError(res));
       if (res.writeErrors) return callback(new MongoServerError(res.writeErrors[0]));

--- a/src/operations/distinct.ts
+++ b/src/operations/distinct.ts
@@ -38,7 +38,7 @@ export class DistinctOperation extends CommandOperation<any[]> {
     this.query = query;
   }
 
-  override execute(
+  override executeCallback(
     server: Server,
     session: ClientSession | undefined,
     callback: Callback<any[]>

--- a/src/operations/drop.ts
+++ b/src/operations/drop.ts
@@ -26,7 +26,7 @@ export class DropCollectionOperation extends CommandOperation<boolean> {
     this.name = name;
   }
 
-  override execute(
+  override executeCallback(
     server: Server,
     session: ClientSession | undefined,
     callback: Callback<boolean>
@@ -102,7 +102,7 @@ export class DropDatabaseOperation extends CommandOperation<boolean> {
     super(db, options);
     this.options = options;
   }
-  override execute(
+  override executeCallback(
     server: Server,
     session: ClientSession | undefined,
     callback: Callback<boolean>

--- a/src/operations/estimated_document_count.ts
+++ b/src/operations/estimated_document_count.ts
@@ -27,7 +27,7 @@ export class EstimatedDocumentCountOperation extends CommandOperation<number> {
     this.collectionName = collection.collectionName;
   }
 
-  override execute(
+  override executeCallback(
     server: Server,
     session: ClientSession | undefined,
     callback: Callback<number>

--- a/src/operations/eval.ts
+++ b/src/operations/eval.ts
@@ -38,7 +38,7 @@ export class EvalOperation extends CommandOperation<Document> {
     });
   }
 
-  override execute(
+  override executeCallback(
     server: Server,
     session: ClientSession | undefined,
     callback: Callback<Document>

--- a/src/operations/execute_operation.ts
+++ b/src/operations/execute_operation.ts
@@ -25,13 +25,13 @@ import {
 import type { Topology } from '../sdam/topology';
 import type { ClientSession } from '../sessions';
 import { type Callback, maybeCallback, supportsRetryableWrites } from '../utils';
-import { AbstractCallbackOperation, Aspect } from './operation';
+import { AbstractCallbackOperation, type AbstractOperation, Aspect } from './operation';
 
 const MMAPv1_RETRY_WRITES_ERROR_CODE = MONGODB_ERROR_CODES.IllegalOperation;
 const MMAPv1_RETRY_WRITES_ERROR_MESSAGE =
   'This MongoDB deployment does not support retryable writes. Please add retryWrites=false to your connection string.';
 
-type ResultTypeFromOperation<TOperation> = TOperation extends AbstractCallbackOperation<infer K>
+type ResultTypeFromOperation<TOperation> = TOperation extends AbstractOperation<infer K>
   ? K
   : never;
 

--- a/src/operations/execute_operation.ts
+++ b/src/operations/execute_operation.ts
@@ -25,13 +25,13 @@ import {
 import type { Topology } from '../sdam/topology';
 import type { ClientSession } from '../sessions';
 import { type Callback, maybeCallback, supportsRetryableWrites } from '../utils';
-import { AbstractCallbackOperation, type AbstractOperation, Aspect } from './operation';
+import { AbstractCallbackOperation, Aspect } from './operation';
 
 const MMAPv1_RETRY_WRITES_ERROR_CODE = MONGODB_ERROR_CODES.IllegalOperation;
 const MMAPv1_RETRY_WRITES_ERROR_MESSAGE =
   'This MongoDB deployment does not support retryable writes. Please add retryWrites=false to your connection string.';
 
-type ResultTypeFromOperation<TOperation> = TOperation extends AbstractOperation<infer K>
+type ResultTypeFromOperation<TOperation> = TOperation extends AbstractCallbackOperation<infer K>
   ? K
   : never;
 

--- a/src/operations/find.ts
+++ b/src/operations/find.ts
@@ -102,7 +102,7 @@ export class FindOperation extends CommandOperation<Document> {
     this.filter = filter != null && filter._bsontype === 'ObjectId' ? { _id: filter } : filter;
   }
 
-  override execute(
+  override executeCallback(
     server: Server,
     session: ClientSession | undefined,
     callback: Callback<Document>

--- a/src/operations/find_and_modify.ts
+++ b/src/operations/find_and_modify.ts
@@ -179,7 +179,7 @@ class FindAndModifyOperation extends CommandOperation<Document> {
     this.query = query;
   }
 
-  override execute(
+  override executeCallback(
     server: Server,
     session: ClientSession | undefined,
     callback: Callback<Document>

--- a/src/operations/get_more.ts
+++ b/src/operations/get_more.ts
@@ -3,7 +3,12 @@ import { MongoRuntimeError } from '../error';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
 import { type Callback, maxWireVersion, type MongoDBNamespace } from '../utils';
-import { AbstractOperation, Aspect, defineAspects, type OperationOptions } from './operation';
+import {
+  AbstractCallbackOperation,
+  Aspect,
+  defineAspects,
+  type OperationOptions
+} from './operation';
 
 /** @internal */
 export interface GetMoreOptions extends OperationOptions {
@@ -35,7 +40,7 @@ export interface GetMoreCommand {
 }
 
 /** @internal */
-export class GetMoreOperation extends AbstractOperation {
+export class GetMoreOperation extends AbstractCallbackOperation {
   cursorId: Long;
   override options: GetMoreOptions;
 
@@ -52,7 +57,7 @@ export class GetMoreOperation extends AbstractOperation {
    * Although there is a server already associated with the get more operation, the signature
    * for execute passes a server so we will just use that one.
    */
-  override execute(
+  override executeCallback(
     server: Server,
     session: ClientSession | undefined,
     callback: Callback<Document>

--- a/src/operations/is_capped.ts
+++ b/src/operations/is_capped.ts
@@ -3,10 +3,10 @@ import { MongoAPIError } from '../error';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
 import type { Callback } from '../utils';
-import { AbstractOperation, type OperationOptions } from './operation';
+import { AbstractCallbackOperation, type OperationOptions } from './operation';
 
 /** @internal */
-export class IsCappedOperation extends AbstractOperation<boolean> {
+export class IsCappedOperation extends AbstractCallbackOperation<boolean> {
   override options: OperationOptions;
   collection: Collection;
 
@@ -16,7 +16,7 @@ export class IsCappedOperation extends AbstractOperation<boolean> {
     this.collection = collection;
   }
 
-  override execute(
+  override executeCallback(
     server: Server,
     session: ClientSession | undefined,
     callback: Callback<boolean>

--- a/src/operations/kill_cursors.ts
+++ b/src/operations/kill_cursors.ts
@@ -3,7 +3,12 @@ import { MongoRuntimeError } from '../error';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
 import type { Callback, MongoDBNamespace } from '../utils';
-import { AbstractOperation, Aspect, defineAspects, type OperationOptions } from './operation';
+import {
+  AbstractCallbackOperation,
+  Aspect,
+  defineAspects,
+  type OperationOptions
+} from './operation';
 
 /**
  * https://www.mongodb.com/docs/manual/reference/command/killCursors/
@@ -15,7 +20,7 @@ interface KillCursorsCommand {
   comment?: unknown;
 }
 
-export class KillCursorsOperation extends AbstractOperation {
+export class KillCursorsOperation extends AbstractCallbackOperation {
   cursorId: Long;
 
   constructor(cursorId: Long, ns: MongoDBNamespace, server: Server, options: OperationOptions) {
@@ -25,7 +30,11 @@ export class KillCursorsOperation extends AbstractOperation {
     this.server = server;
   }
 
-  execute(server: Server, session: ClientSession | undefined, callback: Callback<void>): void {
+  executeCallback(
+    server: Server,
+    session: ClientSession | undefined,
+    callback: Callback<void>
+  ): void {
     if (server !== this.server) {
       return callback(
         new MongoRuntimeError('Killcursor must run on the same server operation began on')

--- a/src/operations/list_collections.ts
+++ b/src/operations/list_collections.ts
@@ -47,7 +47,7 @@ export class ListCollectionsOperation extends CommandOperation<string[]> {
     }
   }
 
-  override execute(
+  override executeCallback(
     server: Server,
     session: ClientSession | undefined,
     callback: Callback<string[]>

--- a/src/operations/list_databases.ts
+++ b/src/operations/list_databases.ts
@@ -34,7 +34,7 @@ export class ListDatabasesOperation extends CommandOperation<ListDatabasesResult
     this.ns = new MongoDBNamespace('admin', '$cmd');
   }
 
-  override execute(
+  override executeCallback(
     server: Server,
     session: ClientSession | undefined,
     callback: Callback<ListDatabasesResult>

--- a/src/operations/operation.ts
+++ b/src/operations/operation.ts
@@ -106,16 +106,15 @@ export abstract class AbstractOperation<TResult = any> {
 }
 
 /** @internal */
-export abstract class AbstractCallbackOperation<TResult> extends AbstractOperation<TResult> {
+export abstract class AbstractCallbackOperation<TResult = any> extends AbstractOperation {
   constructor(options: OperationOptions = {}) {
     super(options);
   }
 
   execute(server: Server, session: ClientSession | undefined): Promise<TResult> {
-    const x = promisify((callback: (e: Error, r: TResult) => void) => {
+    return promisify((callback: (e: Error, r: TResult) => void) => {
       this.executeCallback(server, session, callback as any);
-    });
-    return x();
+    })();
   }
 
   protected abstract executeCallback(

--- a/src/operations/operation.ts
+++ b/src/operations/operation.ts
@@ -62,19 +62,7 @@ export abstract class AbstractOperation<TResult = any> {
 
   [kSession]: ClientSession | undefined;
 
-  // executeAsync: (server: Server, session: ClientSession | undefined) => Promise<TResult>;
-
   constructor(options: OperationOptions = {}) {
-    // this.executeAsync = promisify(
-    //  (
-    //    server: Server,
-    //    session: ClientSession | undefined,
-    //    callback: (e: Error, r: TResult) => void
-    //  ) => {
-    //    this.execute(server, session, callback as any);
-    //  }
-    //);
-
     this.readPreference = this.hasAspect(Aspect.WRITE_OPERATION)
       ? ReadPreference.primary
       : ReadPreference.fromOptions(options) ?? ReadPreference.primary;
@@ -118,7 +106,7 @@ export abstract class AbstractOperation<TResult = any> {
 }
 
 /** @internal */
-export abstract class AbstractCallbackOperation<TResult = any> extends AbstractOperation {
+export abstract class AbstractCallbackOperation<TResult> extends AbstractOperation<TResult> {
   constructor(options: OperationOptions = {}) {
     super(options);
   }

--- a/src/operations/options_operation.ts
+++ b/src/operations/options_operation.ts
@@ -4,10 +4,10 @@ import { MongoAPIError } from '../error';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
 import type { Callback } from '../utils';
-import { AbstractOperation, type OperationOptions } from './operation';
+import { AbstractCallbackOperation, type OperationOptions } from './operation';
 
 /** @internal */
-export class OptionsOperation extends AbstractOperation<Document> {
+export class OptionsOperation extends AbstractCallbackOperation<Document> {
   override options: OperationOptions;
   collection: Collection;
 
@@ -17,7 +17,7 @@ export class OptionsOperation extends AbstractOperation<Document> {
     this.collection = collection;
   }
 
-  override execute(
+  override executeCallback(
     server: Server,
     session: ClientSession | undefined,
     callback: Callback<Document>

--- a/src/operations/profiling_level.ts
+++ b/src/operations/profiling_level.ts
@@ -17,7 +17,7 @@ export class ProfilingLevelOperation extends CommandOperation<string> {
     this.options = options;
   }
 
-  override execute(
+  override executeCallback(
     server: Server,
     session: ClientSession | undefined,
     callback: Callback<string>

--- a/src/operations/remove_user.ts
+++ b/src/operations/remove_user.ts
@@ -19,7 +19,7 @@ export class RemoveUserOperation extends CommandOperation<boolean> {
     this.username = username;
   }
 
-  override execute(
+  override executeCallback(
     server: Server,
     session: ClientSession | undefined,
     callback: Callback<boolean>

--- a/src/operations/rename.ts
+++ b/src/operations/rename.ts
@@ -38,14 +38,14 @@ export class RenameOperation extends RunAdminCommandOperation {
     this.newName = newName;
   }
 
-  override execute(
+  override executeCallback(
     server: Server,
     session: ClientSession | undefined,
     callback: Callback<Collection>
   ): void {
     const coll = this.collection;
 
-    super.execute(server, session, (err, doc) => {
+    super.executeCallback(server, session, (err, doc) => {
       if (err) return callback(err);
       // We have an error
       if (doc?.errmsg) {

--- a/src/operations/run_command.ts
+++ b/src/operations/run_command.ts
@@ -55,7 +55,7 @@ export class RunCommandOperation<T = Document> extends CommandOperation<T> {
     this.command = command;
   }
 
-  override execute(
+  override executeCallback(
     server: Server,
     session: ClientSession | undefined,
     callback: Callback<T>

--- a/src/operations/search_indexes/create.ts
+++ b/src/operations/search_indexes/create.ts
@@ -4,7 +4,7 @@ import type { Collection } from '../../collection';
 import type { Server } from '../../sdam/server';
 import type { ClientSession } from '../../sessions';
 import type { Callback } from '../../utils';
-import { AbstractOperation } from '../operation';
+import { AbstractCallbackOperation } from '../operation';
 
 /**
  * @public
@@ -18,7 +18,7 @@ export interface SearchIndexDescription {
 }
 
 /** @internal */
-export class CreateSearchIndexesOperation extends AbstractOperation<string[]> {
+export class CreateSearchIndexesOperation extends AbstractCallbackOperation<string[]> {
   constructor(
     private readonly collection: Collection,
     private readonly descriptions: ReadonlyArray<SearchIndexDescription>
@@ -26,7 +26,11 @@ export class CreateSearchIndexesOperation extends AbstractOperation<string[]> {
     super();
   }
 
-  execute(server: Server, session: ClientSession | undefined, callback: Callback<string[]>): void {
+  executeCallback(
+    server: Server,
+    session: ClientSession | undefined,
+    callback: Callback<string[]>
+  ): void {
     const namespace = this.collection.fullNamespace;
     const command = {
       createSearchIndexes: namespace.collection,

--- a/src/operations/search_indexes/drop.ts
+++ b/src/operations/search_indexes/drop.ts
@@ -4,15 +4,19 @@ import type { Collection } from '../../collection';
 import type { Server } from '../../sdam/server';
 import type { ClientSession } from '../../sessions';
 import type { Callback } from '../../utils';
-import { AbstractOperation } from '../operation';
+import { AbstractCallbackOperation } from '../operation';
 
 /** @internal */
-export class DropSearchIndexOperation extends AbstractOperation<void> {
+export class DropSearchIndexOperation extends AbstractCallbackOperation<void> {
   constructor(private readonly collection: Collection, private readonly name: string) {
     super();
   }
 
-  execute(server: Server, session: ClientSession | undefined, callback: Callback<void>): void {
+  executeCallback(
+    server: Server,
+    session: ClientSession | undefined,
+    callback: Callback<void>
+  ): void {
     const namespace = this.collection.fullNamespace;
 
     const command: Document = {

--- a/src/operations/search_indexes/update.ts
+++ b/src/operations/search_indexes/update.ts
@@ -4,10 +4,10 @@ import type { Collection } from '../../collection';
 import type { Server } from '../../sdam/server';
 import type { ClientSession } from '../../sessions';
 import type { Callback } from '../../utils';
-import { AbstractOperation } from '../operation';
+import { AbstractCallbackOperation } from '../operation';
 
 /** @internal */
-export class UpdateSearchIndexOperation extends AbstractOperation<void> {
+export class UpdateSearchIndexOperation extends AbstractCallbackOperation<void> {
   constructor(
     private readonly collection: Collection,
     private readonly name: string,
@@ -16,7 +16,11 @@ export class UpdateSearchIndexOperation extends AbstractOperation<void> {
     super();
   }
 
-  execute(server: Server, session: ClientSession | undefined, callback: Callback<void>): void {
+  executeCallback(
+    server: Server,
+    session: ClientSession | undefined,
+    callback: Callback<void>
+  ): void {
     const namespace = this.collection.fullNamespace;
     const command = {
       updateSearchIndex: namespace.collection,

--- a/src/operations/set_profiling_level.ts
+++ b/src/operations/set_profiling_level.ts
@@ -48,7 +48,7 @@ export class SetProfilingLevelOperation extends CommandOperation<ProfilingLevel>
     this.level = level;
   }
 
-  override execute(
+  override executeCallback(
     server: Server,
     session: ClientSession | undefined,
     callback: Callback<ProfilingLevel>

--- a/src/operations/stats.ts
+++ b/src/operations/stats.ts
@@ -37,7 +37,7 @@ export class CollStatsOperation extends CommandOperation<Document> {
     this.collectionName = collection.collectionName;
   }
 
-  override execute(
+  override executeCallback(
     server: Server,
     session: ClientSession | undefined,
     callback: Callback<CollStats>
@@ -66,7 +66,7 @@ export class DbStatsOperation extends CommandOperation<Document> {
     this.options = options;
   }
 
-  override execute(
+  override executeCallback(
     server: Server,
     session: ClientSession | undefined,
     callback: Callback<Document>

--- a/src/operations/update.ts
+++ b/src/operations/update.ts
@@ -84,7 +84,7 @@ export class UpdateOperation extends CommandOperation<Document> {
     return this.statements.every(op => op.multi == null || op.multi === false);
   }
 
-  override execute(
+  override executeCallback(
     server: Server,
     session: ClientSession | undefined,
     callback: Callback<Document>
@@ -138,12 +138,12 @@ export class UpdateOneOperation extends UpdateOperation {
     }
   }
 
-  override execute(
+  override executeCallback(
     server: Server,
     session: ClientSession | undefined,
     callback: Callback<UpdateResult | Document>
   ): void {
-    super.execute(server, session, (err, res) => {
+    super.executeCallback(server, session, (err, res) => {
       if (err || !res) return callback(err);
       if (this.explain != null) return callback(undefined, res);
       if (res.code) return callback(new MongoServerError(res));
@@ -175,12 +175,12 @@ export class UpdateManyOperation extends UpdateOperation {
     }
   }
 
-  override execute(
+  override executeCallback(
     server: Server,
     session: ClientSession | undefined,
     callback: Callback<UpdateResult | Document>
   ): void {
-    super.execute(server, session, (err, res) => {
+    super.executeCallback(server, session, (err, res) => {
       if (err || !res) return callback(err);
       if (this.explain != null) return callback(undefined, res);
       if (res.code) return callback(new MongoServerError(res));
@@ -231,12 +231,12 @@ export class ReplaceOneOperation extends UpdateOperation {
     }
   }
 
-  override execute(
+  override executeCallback(
     server: Server,
     session: ClientSession | undefined,
     callback: Callback<UpdateResult | Document>
   ): void {
-    super.execute(server, session, (err, res) => {
+    super.executeCallback(server, session, (err, res) => {
       if (err || !res) return callback(err);
       if (this.explain != null) return callback(undefined, res);
       if (res.code) return callback(new MongoServerError(res));

--- a/src/operations/validate_collection.ts
+++ b/src/operations/validate_collection.ts
@@ -34,7 +34,7 @@ export class ValidateCollectionOperation extends CommandOperation<Document> {
     this.collectionName = collectionName;
   }
 
-  override execute(
+  override executeCallback(
     server: Server,
     session: ClientSession | undefined,
     callback: Callback<Document>

--- a/src/sdam/server.ts
+++ b/src/sdam/server.ts
@@ -1,3 +1,5 @@
+import { promisify } from 'util';
+
 import type { Document } from '../bson';
 import { type CommandOptions, Connection, type DestroyOptions } from '../cmap/connection';
 import {
@@ -116,6 +118,11 @@ export class Server extends TypedEventEmitter<ServerEvents> {
   pool: ConnectionPool;
   serverApi?: ServerApi;
   hello?: Document;
+  commandAsync: (
+    ns: MongoDBNamespace,
+    cmd: Document,
+    options: CommandOptions
+  ) => Promise<Document | undefined>;
   [kMonitor]: Monitor | null;
 
   /** @event */
@@ -138,6 +145,15 @@ export class Server extends TypedEventEmitter<ServerEvents> {
    */
   constructor(topology: Topology, description: ServerDescription, options: ServerOptions) {
     super();
+
+    this.commandAsync = promisify(
+      (
+        ns: MongoDBNamespace,
+        cmd: Document,
+        options: CommandOptions,
+        callback: Callback<Document>
+      ) => this.command(ns, cmd, options, callback as any)
+    );
 
     this.serverApi = options.serverApi;
 

--- a/test/integration/crud/explain.test.ts
+++ b/test/integration/crud/explain.test.ts
@@ -1,13 +1,7 @@
 import { expect } from 'chai';
 import { once } from 'events';
 
-import {
-  type Collection,
-  type CommandStartedEvent,
-  type Db,
-  type MongoClient,
-  MongoServerError
-} from '../../mongodb';
+import { type Collection, type Db, type MongoClient, MongoServerError } from '../../mongodb';
 
 const explain = [true, false, 'queryPlanner', 'allPlansExecution', 'executionStats', 'invalid'];
 

--- a/test/integration/crud/explain.test.ts
+++ b/test/integration/crud/explain.test.ts
@@ -74,7 +74,6 @@ describe('CRUD API explain option', function () {
   afterEach(async function () {
     await collection.drop();
     await client.close();
-    commandsStarted = [];
   });
 
   for (const explainValue of explain) {

--- a/test/integration/crud/explain.test.ts
+++ b/test/integration/crud/explain.test.ts
@@ -1,7 +1,13 @@
 import { expect } from 'chai';
 import { once } from 'events';
 
-import { type Collection, type Db, type MongoClient, MongoServerError } from '../../mongodb';
+import {
+  type Collection,
+  type CommandStartedEvent,
+  type Db,
+  type MongoClient,
+  MongoServerError
+} from '../../mongodb';
 
 const explain = [true, false, 'queryPlanner', 'allPlansExecution', 'executionStats', 'invalid'];
 

--- a/test/integration/crud/explain.test.ts
+++ b/test/integration/crud/explain.test.ts
@@ -74,6 +74,7 @@ describe('CRUD API explain option', function () {
   afterEach(async function () {
     await collection.drop();
     await client.close();
+    commandsStarted = [];
   });
 
   for (const explainValue of explain) {

--- a/test/unit/cmap/connection.test.ts
+++ b/test/unit/cmap/connection.test.ts
@@ -211,12 +211,16 @@ describe('new Connection()', function () {
       hostAddress: server.hostAddress()
     };
 
+    const serverSpy = sinon.spy(server, 'command');
     const connectAsync = promisify(connect);
     const connection: Connection = await connectAsync(options);
     const commandSpy = sinon.spy(connection, 'command');
 
-    connection.commandAsync(ns('dummy'), { ping: 1 }, {});
-    await expect(commandSpy).to.have.been.calledOnce;
+    await connection.commandAsync(ns('dummy'), { ping: 1 }, {});
+    expect(commandSpy).to.have.been.calledOnce;
+
+    await server.commandAsync(ns('dummy'), { ping: 1 }, {});
+    expect(serverSpy).to.have.been.calledOnce;
   });
 
   it('throws a network error with kBeforeHandshake set to true on timeout before handshake', function (done) {

--- a/test/unit/cmap/connection.test.ts
+++ b/test/unit/cmap/connection.test.ts
@@ -197,7 +197,7 @@ describe('new Connection()', function () {
     });
   });
 
-  it.only('calls the command function through commandAsync', async function () {
+  it('calls the command function through commandAsync', async function () {
     server.setMessageHandler(request => {
       const doc = request.document;
       if (isHello(doc)) {

--- a/test/unit/cmap/connection.test.ts
+++ b/test/unit/cmap/connection.test.ts
@@ -256,6 +256,22 @@ describe('new Connection()', function () {
         });
       });
 
+      context('when a connection is established', function () {
+        const inputStream = new InputStream();
+        let commandSpy;
+        let connection;
+
+        beforeEach(function () {
+          connection = new Connection(inputStream, connectionOptionsDefaults);
+          commandSpy = sinon.spy(connection, 'command');
+        });
+
+        it('calls the command function through commandAsync', function () {
+          connection.commandAsync();
+          expect(commandSpy).to.have.been.calledOnce;
+        });
+      });
+
       context('when requestId/responseTo do not match', function () {
         let callbackSpy;
         const document = { ok: 1 };

--- a/test/unit/cmap/connection.test.ts
+++ b/test/unit/cmap/connection.test.ts
@@ -3,7 +3,7 @@ import { EventEmitter, once } from 'events';
 import { Server } from 'http';
 import { Socket } from 'net';
 import * as sinon from 'sinon';
-import { Duplex, Readable } from 'stream';
+import { Readable } from 'stream';
 import { setTimeout } from 'timers';
 import { promisify } from 'util';
 
@@ -73,7 +73,7 @@ class FakeSocket extends EventEmitter {
   }
 }
 
-class InputStream extends Duplex {
+class InputStream extends Readable {
   writableEnded: boolean;
   timeout = 0;
 

--- a/test/unit/cmap/connection.test.ts
+++ b/test/unit/cmap/connection.test.ts
@@ -1,6 +1,5 @@
 import { expect } from 'chai';
 import { EventEmitter, once } from 'events';
-import { Server } from 'http';
 import { Socket } from 'net';
 import * as sinon from 'sinon';
 import { Readable } from 'stream';
@@ -86,16 +85,6 @@ class InputStream extends Readable {
     if (typeof cb === 'function') {
       process.nextTick(cb);
     }
-  }
-
-  write(
-    chunk: any,
-    encoding?: BufferEncoding | undefined,
-    cb?: ((error: Error | null | undefined) => void) | undefined
-  ): boolean;
-  write(chunk: any, cb?: ((error: Error | null | undefined) => void) | undefined): boolean;
-  write(chunk: unknown, encoding?: unknown, cb?: unknown): boolean {
-    this.push;
   }
 
   setTimeout(timeout) {

--- a/test/unit/cmap/connection.test.ts
+++ b/test/unit/cmap/connection.test.ts
@@ -211,16 +211,12 @@ describe('new Connection()', function () {
       hostAddress: server.hostAddress()
     };
 
-    const serverSpy = sinon.spy(server, 'command');
     const connectAsync = promisify(connect);
     const connection: Connection = await connectAsync(options);
     const commandSpy = sinon.spy(connection, 'command');
 
     await connection.commandAsync(ns('dummy'), { ping: 1 }, {});
     expect(commandSpy).to.have.been.calledOnce;
-
-    await server.commandAsync(ns('dummy'), { ping: 1 }, {});
-    expect(serverSpy).to.have.been.calledOnce;
   });
 
   it('throws a network error with kBeforeHandshake set to true on timeout before handshake', function (done) {

--- a/test/unit/operations/find.test.ts
+++ b/test/unit/operations/find.test.ts
@@ -1,6 +1,5 @@
 import { expect } from 'chai';
 import * as sinon from 'sinon';
-import { promisify } from 'util';
 
 import { FindOperation, ns, Server, ServerDescription } from '../../mongodb';
 import { topologyWithPlaceholderClient } from '../../tools/utils';
@@ -43,7 +42,7 @@ describe('FindOperation', function () {
       it('should build basic find command with filter', async () => {
         const findOperation = new FindOperation(undefined, namespace, filter);
         const stub = sinon.stub(server, 'command').yieldsRight();
-        await promisify(findOperation.executeCallback.bind(findOperation))(server, undefined);
+        await findOperation.execute.bind(findOperation)(server, undefined);
         expect(stub).to.have.been.calledOnceWith(namespace, {
           find: namespace.collection,
           filter
@@ -56,7 +55,7 @@ describe('FindOperation', function () {
         };
         const findOperation = new FindOperation(undefined, namespace, {}, options);
         const stub = sinon.stub(server, 'command').yieldsRight();
-        await promisify(findOperation.executeCallback.bind(findOperation))(server, undefined);
+        await findOperation.execute.bind(findOperation)(server, undefined);
         expect(stub).to.have.been.calledOnceWith(
           namespace,
           sinon.match.has('oplogReplay', options.oplogReplay)

--- a/test/unit/operations/find.test.ts
+++ b/test/unit/operations/find.test.ts
@@ -43,7 +43,7 @@ describe('FindOperation', function () {
       it('should build basic find command with filter', async () => {
         const findOperation = new FindOperation(undefined, namespace, filter);
         const stub = sinon.stub(server, 'command').yieldsRight();
-        await promisify(findOperation.execute.bind(findOperation))(server, undefined);
+        await promisify(findOperation.executeCallback.bind(findOperation))(server, undefined);
         expect(stub).to.have.been.calledOnceWith(namespace, {
           find: namespace.collection,
           filter
@@ -56,7 +56,7 @@ describe('FindOperation', function () {
         };
         const findOperation = new FindOperation(undefined, namespace, {}, options);
         const stub = sinon.stub(server, 'command').yieldsRight();
-        await promisify(findOperation.execute.bind(findOperation))(server, undefined);
+        await promisify(findOperation.executeCallback.bind(findOperation))(server, undefined);
         expect(stub).to.have.been.calledOnceWith(
           namespace,
           sinon.match.has('oplogReplay', options.oplogReplay)

--- a/test/unit/operations/find.test.ts
+++ b/test/unit/operations/find.test.ts
@@ -42,7 +42,7 @@ describe('FindOperation', function () {
       it('should build basic find command with filter', async () => {
         const findOperation = new FindOperation(undefined, namespace, filter);
         const stub = sinon.stub(server, 'command').yieldsRight();
-        await findOperation.execute.bind(findOperation)(server, undefined);
+        await findOperation.execute(server, undefined);
         expect(stub).to.have.been.calledOnceWith(namespace, {
           find: namespace.collection,
           filter
@@ -55,7 +55,7 @@ describe('FindOperation', function () {
         };
         const findOperation = new FindOperation(undefined, namespace, {}, options);
         const stub = sinon.stub(server, 'command').yieldsRight();
-        await findOperation.execute.bind(findOperation)(server, undefined);
+        await findOperation.execute(server, undefined);
         expect(stub).to.have.been.calledOnceWith(
           namespace,
           sinon.match.has('oplogReplay', options.oplogReplay)

--- a/test/unit/operations/get_more.test.ts
+++ b/test/unit/operations/get_more.test.ts
@@ -63,7 +63,7 @@ describe('GetMoreOperation', function () {
           maxTimeMS: 500
         };
 
-        await operation.execute.bind(operation)(server, undefined);
+        await operation.execute(server, undefined);
         expect(stub.calledOnce).to.be.true;
         const call = stub.getCall(0);
         expect(call.args[0]).to.equal(namespace);
@@ -108,7 +108,7 @@ describe('GetMoreOperation', function () {
       it('should build basic getMore command with cursorId and collection', async () => {
         const getMoreOperation = new GetMoreOperation(namespace, cursorId, server, {});
         const stub = sinon.stub(server, 'command').yieldsRight();
-        await getMoreOperation.execute.bind(getMoreOperation)(server, undefined);
+        await getMoreOperation.execute(server, undefined);
         expect(stub).to.have.been.calledOnceWith(namespace, {
           getMore: cursorId,
           collection: namespace.collection
@@ -121,7 +121,7 @@ describe('GetMoreOperation', function () {
         };
         const getMoreOperation = new GetMoreOperation(namespace, cursorId, server, options);
         const stub = sinon.stub(server, 'command').yieldsRight();
-        await getMoreOperation.execute.bind(getMoreOperation)(server, undefined);
+        await getMoreOperation.execute(server, undefined);
         expect(stub).to.have.been.calledOnceWith(
           namespace,
           sinon.match.has('batchSize', options.batchSize)
@@ -134,7 +134,7 @@ describe('GetMoreOperation', function () {
         };
         const getMoreOperation = new GetMoreOperation(namespace, cursorId, server, options);
         const stub = sinon.stub(server, 'command').yieldsRight();
-        await getMoreOperation.execute.bind(getMoreOperation)(server, undefined);
+        await getMoreOperation.execute(server, undefined);
         expect(stub).to.have.been.calledOnceWith(
           namespace,
           sinon.match.has('maxTimeMS', options.maxAwaitTimeMS)
@@ -192,7 +192,7 @@ describe('GetMoreOperation', function () {
             };
             const operation = new GetMoreOperation(namespace, cursorId, server, optionsWithComment);
             const stub = sinon.stub(server, 'command').yieldsRight();
-            await operation.execute.bind(operation)(server, undefined);
+            await operation.execute(server, undefined);
             expect(stub).to.have.been.calledOnceWith(namespace, getMore);
           });
         }
@@ -215,9 +215,7 @@ describe('GetMoreOperation', function () {
           server,
           options
         );
-        const error = await getMoreOperation.execute
-          .bind(getMoreOperation)(server, undefined)
-          .catch(error => error);
+        const error = await getMoreOperation.execute(server, undefined).catch(error => error);
         expect(error).to.be.instanceOf(MongoRuntimeError);
       });
 
@@ -228,9 +226,7 @@ describe('GetMoreOperation', function () {
           server,
           options
         );
-        const error = await getMoreOperation.execute
-          .bind(getMoreOperation)(server, undefined)
-          .catch(error => error);
+        const error = await getMoreOperation.execute(server, undefined).catch(error => error);
         expect(error).to.be.instanceOf(MongoRuntimeError);
       });
 
@@ -241,9 +237,7 @@ describe('GetMoreOperation', function () {
           server,
           options
         );
-        const error = await getMoreOperation.execute
-          .bind(getMoreOperation)(server, undefined)
-          .catch(error => error);
+        const error = await getMoreOperation.execute(server, undefined).catch(error => error);
         expect(error).to.be.instanceOf(MongoRuntimeError);
       });
     });

--- a/test/unit/operations/get_more.test.ts
+++ b/test/unit/operations/get_more.test.ts
@@ -1,6 +1,5 @@
 import { expect } from 'chai';
 import * as sinon from 'sinon';
-import { promisify } from 'util';
 
 import {
   Aspect,
@@ -64,7 +63,7 @@ describe('GetMoreOperation', function () {
           maxTimeMS: 500
         };
 
-        await promisify(operation.executeCallback.bind(operation))(server, undefined);
+        await operation.execute.bind(operation)(server, undefined);
         expect(stub.calledOnce).to.be.true;
         const call = stub.getCall(0);
         expect(call.args[0]).to.equal(namespace);
@@ -109,7 +108,7 @@ describe('GetMoreOperation', function () {
       it('should build basic getMore command with cursorId and collection', async () => {
         const getMoreOperation = new GetMoreOperation(namespace, cursorId, server, {});
         const stub = sinon.stub(server, 'command').yieldsRight();
-        await promisify(getMoreOperation.executeCallback.bind(getMoreOperation))(server, undefined);
+        await getMoreOperation.execute.bind(getMoreOperation)(server, undefined);
         expect(stub).to.have.been.calledOnceWith(namespace, {
           getMore: cursorId,
           collection: namespace.collection
@@ -122,7 +121,7 @@ describe('GetMoreOperation', function () {
         };
         const getMoreOperation = new GetMoreOperation(namespace, cursorId, server, options);
         const stub = sinon.stub(server, 'command').yieldsRight();
-        await promisify(getMoreOperation.executeCallback.bind(getMoreOperation))(server, undefined);
+        await getMoreOperation.execute.bind(getMoreOperation)(server, undefined);
         expect(stub).to.have.been.calledOnceWith(
           namespace,
           sinon.match.has('batchSize', options.batchSize)
@@ -135,7 +134,7 @@ describe('GetMoreOperation', function () {
         };
         const getMoreOperation = new GetMoreOperation(namespace, cursorId, server, options);
         const stub = sinon.stub(server, 'command').yieldsRight();
-        await promisify(getMoreOperation.executeCallback.bind(getMoreOperation))(server, undefined);
+        await getMoreOperation.execute.bind(getMoreOperation)(server, undefined);
         expect(stub).to.have.been.calledOnceWith(
           namespace,
           sinon.match.has('maxTimeMS', options.maxAwaitTimeMS)
@@ -193,7 +192,7 @@ describe('GetMoreOperation', function () {
             };
             const operation = new GetMoreOperation(namespace, cursorId, server, optionsWithComment);
             const stub = sinon.stub(server, 'command').yieldsRight();
-            await promisify(operation.executeCallback.bind(operation))(server, undefined);
+            await operation.execute.bind(operation)(server, undefined);
             expect(stub).to.have.been.calledOnceWith(namespace, getMore);
           });
         }
@@ -216,10 +215,9 @@ describe('GetMoreOperation', function () {
           server,
           options
         );
-        const error = await promisify(getMoreOperation.executeCallback.bind(getMoreOperation))(
-          server,
-          undefined
-        ).catch(error => error);
+        const error = await getMoreOperation.execute
+          .bind(getMoreOperation)(server, undefined)
+          .catch(error => error);
         expect(error).to.be.instanceOf(MongoRuntimeError);
       });
 
@@ -230,10 +228,9 @@ describe('GetMoreOperation', function () {
           server,
           options
         );
-        const error = await promisify(getMoreOperation.executeCallback.bind(getMoreOperation))(
-          server,
-          undefined
-        ).catch(error => error);
+        const error = await getMoreOperation.execute
+          .bind(getMoreOperation)(server, undefined)
+          .catch(error => error);
         expect(error).to.be.instanceOf(MongoRuntimeError);
       });
 
@@ -244,10 +241,9 @@ describe('GetMoreOperation', function () {
           server,
           options
         );
-        const error = await promisify(getMoreOperation.executeCallback.bind(getMoreOperation))(
-          server,
-          undefined
-        ).catch(error => error);
+        const error = await getMoreOperation.execute
+          .bind(getMoreOperation)(server, undefined)
+          .catch(error => error);
         expect(error).to.be.instanceOf(MongoRuntimeError);
       });
     });

--- a/test/unit/operations/get_more.test.ts
+++ b/test/unit/operations/get_more.test.ts
@@ -64,7 +64,7 @@ describe('GetMoreOperation', function () {
           maxTimeMS: 500
         };
 
-        await promisify(operation.execute.bind(operation))(server, undefined);
+        await promisify(operation.executeCallback.bind(operation))(server, undefined);
         expect(stub.calledOnce).to.be.true;
         const call = stub.getCall(0);
         expect(call.args[0]).to.equal(namespace);
@@ -93,7 +93,7 @@ describe('GetMoreOperation', function () {
           expect(error.message).to.equal('Getmore must run on the same server operation began on');
           done();
         };
-        operation.execute(server2, session, callback);
+        operation.executeCallback(server2, session, callback);
       });
     });
 
@@ -109,7 +109,7 @@ describe('GetMoreOperation', function () {
       it('should build basic getMore command with cursorId and collection', async () => {
         const getMoreOperation = new GetMoreOperation(namespace, cursorId, server, {});
         const stub = sinon.stub(server, 'command').yieldsRight();
-        await promisify(getMoreOperation.execute.bind(getMoreOperation))(server, undefined);
+        await promisify(getMoreOperation.executeCallback.bind(getMoreOperation))(server, undefined);
         expect(stub).to.have.been.calledOnceWith(namespace, {
           getMore: cursorId,
           collection: namespace.collection
@@ -122,7 +122,7 @@ describe('GetMoreOperation', function () {
         };
         const getMoreOperation = new GetMoreOperation(namespace, cursorId, server, options);
         const stub = sinon.stub(server, 'command').yieldsRight();
-        await promisify(getMoreOperation.execute.bind(getMoreOperation))(server, undefined);
+        await promisify(getMoreOperation.executeCallback.bind(getMoreOperation))(server, undefined);
         expect(stub).to.have.been.calledOnceWith(
           namespace,
           sinon.match.has('batchSize', options.batchSize)
@@ -135,7 +135,7 @@ describe('GetMoreOperation', function () {
         };
         const getMoreOperation = new GetMoreOperation(namespace, cursorId, server, options);
         const stub = sinon.stub(server, 'command').yieldsRight();
-        await promisify(getMoreOperation.execute.bind(getMoreOperation))(server, undefined);
+        await promisify(getMoreOperation.executeCallback.bind(getMoreOperation))(server, undefined);
         expect(stub).to.have.been.calledOnceWith(
           namespace,
           sinon.match.has('maxTimeMS', options.maxAwaitTimeMS)
@@ -193,7 +193,7 @@ describe('GetMoreOperation', function () {
             };
             const operation = new GetMoreOperation(namespace, cursorId, server, optionsWithComment);
             const stub = sinon.stub(server, 'command').yieldsRight();
-            await promisify(operation.execute.bind(operation))(server, undefined);
+            await promisify(operation.executeCallback.bind(operation))(server, undefined);
             expect(stub).to.have.been.calledOnceWith(namespace, getMore);
           });
         }
@@ -216,7 +216,7 @@ describe('GetMoreOperation', function () {
           server,
           options
         );
-        const error = await promisify(getMoreOperation.execute.bind(getMoreOperation))(
+        const error = await promisify(getMoreOperation.executeCallback.bind(getMoreOperation))(
           server,
           undefined
         ).catch(error => error);
@@ -230,7 +230,7 @@ describe('GetMoreOperation', function () {
           server,
           options
         );
-        const error = await promisify(getMoreOperation.execute.bind(getMoreOperation))(
+        const error = await promisify(getMoreOperation.executeCallback.bind(getMoreOperation))(
           server,
           undefined
         ).catch(error => error);
@@ -244,7 +244,7 @@ describe('GetMoreOperation', function () {
           server,
           options
         );
-        const error = await promisify(getMoreOperation.execute.bind(getMoreOperation))(
+        const error = await promisify(getMoreOperation.executeCallback.bind(getMoreOperation))(
           server,
           undefined
         ).catch(error => error);

--- a/test/unit/operations/kill_cursors.test.ts
+++ b/test/unit/operations/kill_cursors.test.ts
@@ -64,8 +64,8 @@ describe('class KillCursorsOperation', () => {
         options
       ) as any;
 
-      const error = await killCursorsOperation.execute
-        .bind(killCursorsOperation)(differentServer, undefined)
+      const error = await killCursorsOperation
+        .execute(differentServer, undefined)
         .catch(error => error);
 
       expect(error).to.be.instanceOf(MongoRuntimeError);
@@ -79,9 +79,7 @@ describe('class KillCursorsOperation', () => {
         options
       ) as any;
 
-      const error = await killCursorsOperation.execute
-        .bind(killCursorsOperation)(server, undefined)
-        .catch(error => error);
+      const error = await killCursorsOperation.execute(server, undefined).catch(error => error);
 
       expect(error).to.be.instanceOf(MongoRuntimeError);
     });
@@ -94,7 +92,7 @@ describe('class KillCursorsOperation', () => {
         options
       ) as any;
       const stub = sinon.stub(server, 'command').yieldsRight();
-      await killCursorsOperation.execute.bind(killCursorsOperation)(server, undefined);
+      await killCursorsOperation.execute(server, undefined);
       expect(stub).to.have.been.calledOnceWith(namespace, {
         killCursors: namespace.collection,
         cursors: [cursorId]

--- a/test/unit/operations/kill_cursors.test.ts
+++ b/test/unit/operations/kill_cursors.test.ts
@@ -1,6 +1,5 @@
 import { expect } from 'chai';
 import * as sinon from 'sinon';
-import { promisify } from 'util';
 
 import {
   KillCursorsOperation,
@@ -65,9 +64,9 @@ describe('class KillCursorsOperation', () => {
         options
       ) as any;
 
-      const error = await promisify(
-        killCursorsOperation.executeCallback.bind(killCursorsOperation)
-      )(differentServer, undefined).catch(error => error);
+      const error = await killCursorsOperation.execute
+        .bind(killCursorsOperation)(differentServer, undefined)
+        .catch(error => error);
 
       expect(error).to.be.instanceOf(MongoRuntimeError);
     });
@@ -80,9 +79,9 @@ describe('class KillCursorsOperation', () => {
         options
       ) as any;
 
-      const error = await promisify(
-        killCursorsOperation.executeCallback.bind(killCursorsOperation)
-      )(server, undefined).catch(error => error);
+      const error = await killCursorsOperation.execute
+        .bind(killCursorsOperation)(server, undefined)
+        .catch(error => error);
 
       expect(error).to.be.instanceOf(MongoRuntimeError);
     });
@@ -95,10 +94,7 @@ describe('class KillCursorsOperation', () => {
         options
       ) as any;
       const stub = sinon.stub(server, 'command').yieldsRight();
-      await promisify(killCursorsOperation.executeCallback.bind(killCursorsOperation))(
-        server,
-        undefined
-      );
+      await killCursorsOperation.execute.bind(killCursorsOperation)(server, undefined);
       expect(stub).to.have.been.calledOnceWith(namespace, {
         killCursors: namespace.collection,
         cursors: [cursorId]

--- a/test/unit/operations/kill_cursors.test.ts
+++ b/test/unit/operations/kill_cursors.test.ts
@@ -65,10 +65,9 @@ describe('class KillCursorsOperation', () => {
         options
       ) as any;
 
-      const error = await promisify(killCursorsOperation.execute.bind(killCursorsOperation))(
-        differentServer,
-        undefined
-      ).catch(error => error);
+      const error = await promisify(
+        killCursorsOperation.executeCallback.bind(killCursorsOperation)
+      )(differentServer, undefined).catch(error => error);
 
       expect(error).to.be.instanceOf(MongoRuntimeError);
     });
@@ -81,10 +80,9 @@ describe('class KillCursorsOperation', () => {
         options
       ) as any;
 
-      const error = await promisify(killCursorsOperation.execute.bind(killCursorsOperation))(
-        server,
-        undefined
-      ).catch(error => error);
+      const error = await promisify(
+        killCursorsOperation.executeCallback.bind(killCursorsOperation)
+      )(server, undefined).catch(error => error);
 
       expect(error).to.be.instanceOf(MongoRuntimeError);
     });
@@ -97,7 +95,10 @@ describe('class KillCursorsOperation', () => {
         options
       ) as any;
       const stub = sinon.stub(server, 'command').yieldsRight();
-      await promisify(killCursorsOperation.execute.bind(killCursorsOperation))(server, undefined);
+      await promisify(killCursorsOperation.executeCallback.bind(killCursorsOperation))(
+        server,
+        undefined
+      );
       expect(stub).to.have.been.calledOnceWith(namespace, {
         killCursors: namespace.collection,
         cursors: [cursorId]

--- a/test/unit/sdam/server.test.ts
+++ b/test/unit/sdam/server.test.ts
@@ -66,19 +66,9 @@ describe('Server', () => {
       );
     });
 
-    context.only('when a server is created', function () {
-      let serverSpy;
-      let server;
-      beforeEach(function () {
-        server = new Server(
-          topologyWithPlaceholderClient([], {}),
-          new ServerDescription('a:1'),
-          {} as any
-        );
-        serverSpy = sinon.spy(server, 'command');
-      });
-
+    context('when a server is created', function () {
       it('calls the command function through commandAsync', async function () {
+        const serverSpy = sinon.spy(server, 'command');
         await server.commandAsync(ns('dummy'), { ping: 1 }, {});
         expect(serverSpy).to.have.been.calledOnce;
       });

--- a/test/unit/sdam/server.test.ts
+++ b/test/unit/sdam/server.test.ts
@@ -64,6 +64,25 @@ describe('Server', () => {
         {} as any
       );
     });
+
+    context('when a server is created', function () {
+      let serverSpy;
+      let server;
+      beforeEach(function () {
+        server = new Server(
+          topologyWithPlaceholderClient([], {}),
+          new ServerDescription('a:1'),
+          {} as any
+        );
+        serverSpy = sinon.spy(server, 'command');
+      });
+
+      it('calls the command function through commandAsync', function () {
+        server.commandAsync();
+        expect(serverSpy).to.have.been.calledOnce;
+      });
+    });
+
     for (const loadBalanced of [true, false]) {
       const mode = loadBalanced ? 'loadBalanced' : 'non-loadBalanced';
       const contextSuffix = loadBalanced ? ' with connection provided' : '';

--- a/test/unit/sdam/server.test.ts
+++ b/test/unit/sdam/server.test.ts
@@ -77,8 +77,8 @@ describe('Server', () => {
         serverSpy = sinon.spy(server, 'command');
       });
 
-      it('calls the command function through commandAsync', function () {
-        server.commandAsync();
+      it('calls the command function through commandAsync', async function () {
+        await server.commandAsync();
         expect(serverSpy).to.have.been.calledOnce;
       });
     });

--- a/test/unit/sdam/server.test.ts
+++ b/test/unit/sdam/server.test.ts
@@ -9,6 +9,7 @@ import {
   MongoErrorLabel,
   MongoNetworkError,
   MongoNetworkTimeoutError,
+  ns,
   ObjectId,
   Server,
   ServerDescription,
@@ -65,7 +66,7 @@ describe('Server', () => {
       );
     });
 
-    context('when a server is created', function () {
+    context.only('when a server is created', function () {
       let serverSpy;
       let server;
       beforeEach(function () {
@@ -78,7 +79,7 @@ describe('Server', () => {
       });
 
       it('calls the command function through commandAsync', async function () {
-        await server.commandAsync();
+        await server.commandAsync(ns('dummy'), { ping: 1 }, {});
         expect(serverSpy).to.have.been.calledOnce;
       });
     });

--- a/test/unit/sdam/server.test.ts
+++ b/test/unit/sdam/server.test.ts
@@ -68,7 +68,7 @@ describe('Server', () => {
 
     context('when a server is created', function () {
       it('calls the command function through commandAsync', async function () {
-        const serverSpy = sinon.spy(server, 'command');
+        const serverSpy = sinon.stub(server, 'command').yieldsRight(undefined, { ok: 1 });
         await server.commandAsync(ns('dummy'), { ping: 1 }, {});
         expect(serverSpy).to.have.been.calledOnce;
       });


### PR DESCRIPTION
### Description

#### What is changing?
created callback
subclass of operation
and changed execute
##### Is there new documentation needed for these changes?
no
#### What is the motivation for this change?
first step in asyncifying the operations layer
<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
