### PR TITLE
chore(no-story): add script to display commands for a given evergreen task

### DIFF
--- a/etc/expand-tasks.mjs
+++ b/etc/expand-tasks.mjs
@@ -1,10 +1,18 @@
 // usage: node expand-task.js <task name>
 // must be run from root of the Node driver
+//
+// The output is pipeable: `node expand-task.js <task name> | jq '.'`
 
 import { readFileSync } from 'fs';
 import { load } from 'js-yaml';
+import { gte } from 'semver';
 import { Readable } from 'stream';
 import { inspect } from 'util';
+
+if (!gte(process.version, 16)) {
+  console.error('expand-tasks.mjs requires Node16+');
+  process.exit(1);
+}
 
 const config = load(readFileSync('.evergreen/config.yml'));
 const taskName = (process.argv[2] ?? '').trim();

--- a/etc/expand-tasks.mjs
+++ b/etc/expand-tasks.mjs
@@ -9,7 +9,7 @@ import { gte } from 'semver';
 import { Readable } from 'stream';
 import { inspect } from 'util';
 
-if (!gte(process.version, 16)) {
+if (!gte(process.version, '16.0.0')) {
   console.error('expand-tasks.mjs requires Node16+');
   process.exit(1);
 }

--- a/etc/expand-tasks.mjs
+++ b/etc/expand-tasks.mjs
@@ -1,0 +1,26 @@
+// usage: node expand-task.js <task name>
+// must be run from root of the Node driver
+
+import { readFileSync } from 'fs';
+import { load } from 'js-yaml';
+import { Readable } from 'stream';
+import { inspect } from 'util';
+
+const config = load(readFileSync('.evergreen/config.yml'));
+const taskName = (process.argv[2] ?? '').trim();
+
+const task = config.tasks.find(({ name }) => name === taskName);
+
+if (!task) {
+  process.exit();
+}
+
+const commands = task.commands.flatMap(({ func }) => config.functions[func]);
+
+if (process.stdout.isTTY) {
+  console.log(inspect(commands, { depth: Infinity, colors: true }));
+} else {
+  Readable.from(commands)
+    .map(command => JSON.stringify(command))
+    .pipe(process.stdout);
+}


### PR DESCRIPTION
### Description

#### What is changing?

This script parses the evergreen config and will print all the commands that get executed in CI for that task.  This is useful when you need to answer the question: "What happens in CI for a particular task?"

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
