### PR TITLE
fix(NODE-5355): prevent error when saslprep is not a function

### DIFF
--- a/lib/core/auth/scram.js
+++ b/lib/core/auth/scram.js
@@ -258,11 +258,17 @@ function xor(a, b) {
 }
 
 function H(method, text) {
-  return crypto.createHash(method).update(text).digest();
+  return crypto
+    .createHash(method)
+    .update(text)
+    .digest();
 }
 
 function HMAC(method, key, text) {
-  return crypto.createHmac(method, key).update(text).digest();
+  return crypto
+    .createHmac(method, key)
+    .update(text)
+    .digest();
 }
 
 let _hiCache = {};

--- a/lib/core/auth/scram.js
+++ b/lib/core/auth/scram.js
@@ -25,7 +25,7 @@ class ScramSHA extends AuthProvider {
 
   prepare(handshakeDoc, authContext, callback) {
     const cryptoMethod = this.cryptoMethod;
-    if (cryptoMethod === 'sha256' && saslprep == null) {
+    if (cryptoMethod === 'sha256' && typeof saslprep !== 'function') {
       emitWarningOnce('Warning: no saslprep library specified. Passwords will not be sanitized');
     }
 
@@ -125,7 +125,7 @@ function continueScramConversation(cryptoMethod, response, authContext, callback
 
   let processedPassword;
   if (cryptoMethod === 'sha256') {
-    processedPassword = saslprep ? saslprep(password) : password;
+    processedPassword = typeof saslprep === 'function' ? saslprep(password) : password;
   } else {
     try {
       processedPassword = passwordDigest(username, password);
@@ -258,17 +258,11 @@ function xor(a, b) {
 }
 
 function H(method, text) {
-  return crypto
-    .createHash(method)
-    .update(text)
-    .digest();
+  return crypto.createHash(method).update(text).digest();
 }
 
 function HMAC(method, key, text) {
-  return crypto
-    .createHmac(method, key)
-    .update(text)
-    .digest();
+  return crypto.createHmac(method, key).update(text).digest();
 }
 
 let _hiCache = {};


### PR DESCRIPTION
### Description

#### What is changing?

Prevents an error when `saslprep` is not a function.

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
