### PR TITLE
docs(NODE-5368): fix includeResultMetadata docs

### DIFF
--- a/src/operations/find_and_modify.ts
+++ b/src/operations/find_and_modify.ts
@@ -29,7 +29,10 @@ export interface FindOneAndDeleteOptions extends CommandOperationOptions {
   sort?: Sort;
   /** Map of parameter names and values that can be accessed using $$var (requires MongoDB 5.0). */
   let?: Document;
-  /** Return the ModifyResult instead of the modified document. Defaults to true. */
+  /**
+   * Return the ModifyResult instead of the modified document. Defaults to true
+   * but will default to false in the next major version.
+   */
   includeResultMetadata?: boolean;
 }
 
@@ -49,7 +52,10 @@ export interface FindOneAndReplaceOptions extends CommandOperationOptions {
   upsert?: boolean;
   /** Map of parameter names and values that can be accessed using $$var (requires MongoDB 5.0). */
   let?: Document;
-  /** Return the ModifyResult instead of the modified document. Defaults to true. */
+  /**
+   * Return the ModifyResult instead of the modified document. Defaults to true
+   * but will default to false in the next major version.
+   */
   includeResultMetadata?: boolean;
 }
 
@@ -71,7 +77,10 @@ export interface FindOneAndUpdateOptions extends CommandOperationOptions {
   upsert?: boolean;
   /** Map of parameter names and values that can be accessed using $$var (requires MongoDB 5.0). */
   let?: Document;
-  /** Return the ModifyResult instead of the modified document. Defaults to true. */
+  /**
+   * Return the ModifyResult instead of the modified document. Defaults to true
+   * but will default to false in the next major version.
+   */
   includeResultMetadata?: boolean;
 }
 

--- a/src/operations/find_and_modify.ts
+++ b/src/operations/find_and_modify.ts
@@ -29,7 +29,7 @@ export interface FindOneAndDeleteOptions extends CommandOperationOptions {
   sort?: Sort;
   /** Map of parameter names and values that can be accessed using $$var (requires MongoDB 5.0). */
   let?: Document;
-  /** Return the raw result document instead of the ModifyResult */
+  /** Return the ModifyResult instead of the modified document. Defaults to true. */
   includeResultMetadata?: boolean;
 }
 
@@ -49,7 +49,7 @@ export interface FindOneAndReplaceOptions extends CommandOperationOptions {
   upsert?: boolean;
   /** Map of parameter names and values that can be accessed using $$var (requires MongoDB 5.0). */
   let?: Document;
-  /** Return the raw result document instead of the ModifyResult */
+  /** Return the ModifyResult instead of the modified document. Defaults to true. */
   includeResultMetadata?: boolean;
 }
 
@@ -71,7 +71,7 @@ export interface FindOneAndUpdateOptions extends CommandOperationOptions {
   upsert?: boolean;
   /** Map of parameter names and values that can be accessed using $$var (requires MongoDB 5.0). */
   let?: Document;
-  /** Return the raw result document instead of the ModifyResult */
+  /** Return the ModifyResult instead of the modified document. Defaults to true. */
   includeResultMetadata?: boolean;
 }
 


### PR DESCRIPTION
### Description

Fixes the docs around the `includeResultMetadata` option.

#### What is changing?

Updates the docs on the options.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-5368

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

#### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

## findOneAndModify* helpers can now return only the affected document, not the server result

A new flag, `includeResultMetadata` has been added to `Collection.findOneAnd*` helpers.  This flag defaults to true.  When disabled, the collection helpers only return the modified document.  For example:

```typescript
const deletedDocument = collection.findOneAndDelete({ _id: <id> }, { includeResultMetadata: false });
// deletedDocument contains the deleted document from the server, not a `ModifyResult`
```

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
