### PR TITLE
chore: update release note generation formatting

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,11 +16,11 @@ If you haven't already, it would greatly help the team review this work in a tim
 You can do that here: https://jira.mongodb.org/projects/NODE
 -->
 
-#### Release Highlight
+### Release Highlight
 
 <!-- RELEASE_HIGHLIGHT_START -->
 
-## Fill in title or leave empty for no highlight
+### Fill in title or leave empty for no highlight
 
 <!-- RELEASE_HIGHLIGHT_END -->
 

--- a/.github/scripts/highlights.mjs
+++ b/.github/scripts/highlights.mjs
@@ -52,7 +52,7 @@ async function getPullRequestContent(pull_number) {
     return '';
   }
 
-  const start = body.indexOf('## ', body.indexOf(startIndicator));
+  const start = body.indexOf('### ', body.indexOf(startIndicator));
   const end = body.indexOf(endIndicator);
   const highlightSection = body.slice(start, end).trim();
 
@@ -67,6 +67,9 @@ async function pullRequestHighlights(prs) {
     const content = await getPullRequestContent(pr);
     highlights.push(content);
   }
+  if (!highlights.length) return '';
+
+  highlights.unshift['## Release Notes\n\n'];
   return highlights.join('');
 }
 

--- a/.github/scripts/highlights.mjs
+++ b/.github/scripts/highlights.mjs
@@ -69,7 +69,7 @@ async function pullRequestHighlights(prs) {
   }
   if (!highlights.length) return '';
 
-  highlights.unshift['## Release Notes\n\n'];
+  highlights.unshift('## Release Notes\n\n');
   return highlights.join('');
 }
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [5.7.0](https://github.com/mongodb/node-mongodb-native/compare/v5.6.0...v5.7.0) (2023-06-21)
+
+
+### Features
+
+* **NODE-4929:** Add OIDC Azure workflow ([#3670](https://github.com/mongodb/node-mongodb-native/issues/3670)) ([b3482f3](https://github.com/mongodb/node-mongodb-native/commit/b3482f32551ea5fcfefa861eca52961a99c82fe3))
+* **NODE-5008:** add zstd and kerberos to peer deps ([#3691](https://github.com/mongodb/node-mongodb-native/issues/3691)) ([9561f32](https://github.com/mongodb/node-mongodb-native/commit/9561f32a9dda6969be7f727c9bd1bd96980f5e95))
+* **NODE-5241:** add option to return modified document ([#3710](https://github.com/mongodb/node-mongodb-native/issues/3710)) ([d9c2600](https://github.com/mongodb/node-mongodb-native/commit/d9c2600daf3bb6c8106e0f3a27cb2f12b770c8eb))
+
+
+### Bug Fixes
+
+* **NODE-5289:** prevent scram auth from throwing TypeError if saslprep is not a function ([#3727](https://github.com/mongodb/node-mongodb-native/issues/3727)) ([e006347](https://github.com/mongodb/node-mongodb-native/commit/e0063477961bbd9c5ca34953e9afe554a1235581))
+
 ## [5.6.0](https://github.com/mongodb/node-mongodb-native/compare/v5.5.0...v5.6.0) (2023-06-01)
 
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,20 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-## [5.7.0](https://github.com/mongodb/node-mongodb-native/compare/v5.6.0...v5.7.0) (2023-06-21)
-
-
-### Features
-
-* **NODE-4929:** Add OIDC Azure workflow ([#3670](https://github.com/mongodb/node-mongodb-native/issues/3670)) ([b3482f3](https://github.com/mongodb/node-mongodb-native/commit/b3482f32551ea5fcfefa861eca52961a99c82fe3))
-* **NODE-5008:** add zstd and kerberos to peer deps ([#3691](https://github.com/mongodb/node-mongodb-native/issues/3691)) ([9561f32](https://github.com/mongodb/node-mongodb-native/commit/9561f32a9dda6969be7f727c9bd1bd96980f5e95))
-* **NODE-5241:** add option to return modified document ([#3710](https://github.com/mongodb/node-mongodb-native/issues/3710)) ([d9c2600](https://github.com/mongodb/node-mongodb-native/commit/d9c2600daf3bb6c8106e0f3a27cb2f12b770c8eb))
-
-
-### Bug Fixes
-
-* **NODE-5289:** prevent scram auth from throwing TypeError if saslprep is not a function ([#3727](https://github.com/mongodb/node-mongodb-native/issues/3727)) ([e006347](https://github.com/mongodb/node-mongodb-native/commit/e0063477961bbd9c5ca34953e9afe554a1235581))
-
 ## [5.6.0](https://github.com/mongodb/node-mongodb-native/compare/v5.5.0...v5.6.0) (2023-06-01)
 
 


### PR DESCRIPTION
### Description

#### What is changing?
Make relase-notes action and PR template format the highlights prettier.

##### Is there new documentation needed for these changes?
No

#### What is the motivation for this change?
Pretty release docs

### Double check the following

- [ ] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
