### PR TITLE
chore: put check-remote script back to fix docs build

### DIFF
--- a/etc/check-remote.sh
+++ b/etc/check-remote.sh
@@ -1,0 +1,6 @@
+#! /bin/bash
+
+if git remote get-url --push origin | grep -qv "github.com:mongodb\|github.com/mongodb"; then
+    echo "git remote does not match node-mongodb-native.  are you working off of a fork?"
+    exit 1
+fi


### PR DESCRIPTION
### Description

#### What is changing?
Restoring the check-remote script that turned out to be used in our docs build.

##### Is there new documentation needed for these changes?
No

#### What is the motivation for this change?

Fix the docs build

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
