### PR TITLE
ci(NODE-5361): use task groups for lambda

### DIFF
--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -1267,7 +1267,7 @@ tasks:
           working_dir: src
           binary: bash
           args:
-            - ${DRIVERS_TOOLS}/aws_lambda/run-deployed-lambda-aws-tests.sh
+            - ${DRIVERS_TOOLS}/.evergreen/aws_lambda/run-deployed-lambda-aws-tests.sh
           env:
             TEST_LAMBDA_DIRECTORY: ${PROJECT_DIRECTORY}/test/lambda
             DRIVERS_TOOLS: ${DRIVERS_TOOLS}

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -1431,7 +1431,7 @@ task_groups:
             LAMBDA_STACK_NAME: dbx-node-lambda
       - command: expansions.update
         params:
-          file: atlas-expansion.yml
+          file: src/atlas-expansion.yml
     teardown_group:
       - command: subprocess.exec
         params:

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -1404,7 +1404,7 @@ task_groups:
     tasks:
     - oidc-auth-test-azure-latest
 
-  - name: test_aws_lambda_task_group
+  - name: test_atlas_task_group
     setup_group:
       - func: fetch source
       - command: subprocess.exec
@@ -1413,7 +1413,7 @@ task_groups:
           binary: bash
           add_expansions_to_env: true
           args:
-            - ${DRIVERS_TOOLS}/.evergreen/aws_lambda/setup-atlas-cluster.sh
+            - ${DRIVERS_TOOLS}/.evergreen/atlas/setup-atlas-cluster.sh
       - command: expansions.update
         params:
           file: src/atlas-expansion.yml
@@ -1424,7 +1424,7 @@ task_groups:
           binary: bash
           add_expansions_to_env: true
           args:
-            - ${DRIVERS_TOOLS}/.evergreen/aws_lambda/teardown-atlas-cluster.sh
+            - ${DRIVERS_TOOLS}/.evergreen/atlas/teardown-atlas-cluster.sh
     setup_group_can_fail_task: true
     setup_group_timeout_secs: 1800
     tasks:

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -182,31 +182,6 @@ functions:
           PROJECT_DIRECTORY="${PROJECT_DIRECTORY}" \
             bash ${PROJECT_DIRECTORY}/.evergreen/run-oidc-tests.sh
 
-  "run deployed aws lambda tests":
-    - command: ec2.assume_role
-      params:
-        role_arn: ${LAMBDA_AWS_ROLE_ARN}
-        duration_seconds: 3600
-    - command: subprocess.exec
-      params:
-        working_dir: src
-        binary: bash
-        args:
-          - .evergreen/run-deployed-lambda-aws-tests.sh
-        env:
-          TEST_LAMBDA_DIRECTORY: ${PROJECT_DIRECTORY}/test/lambda
-          DRIVERS_TOOLS: ${DRIVERS_TOOLS}
-          DRIVERS_ATLAS_PUBLIC_API_KEY: ${DRIVERS_ATLAS_PUBLIC_API_KEY}
-          DRIVERS_ATLAS_PRIVATE_API_KEY: ${DRIVERS_ATLAS_PRIVATE_API_KEY}
-          DRIVERS_ATLAS_LAMBDA_USER: ${DRIVERS_ATLAS_LAMBDA_USER}
-          DRIVERS_ATLAS_LAMBDA_PASSWORD: ${DRIVERS_ATLAS_LAMBDA_PASSWORD}
-          DRIVERS_ATLAS_GROUP_ID: ${DRIVERS_ATLAS_GROUP_ID}
-          LAMBDA_STACK_NAME: dbx-node-lambda
-          AWS_REGION: us-east-1
-          AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
-          AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
-          AWS_SESSION_TOKEN: ${AWS_SESSION_TOKEN}
-
   "run tests":
     - command: shell.exec
       type: test
@@ -1280,6 +1255,33 @@ tasks:
           args:
           - .evergreen/run-oidc-tests-azure.sh
 
+  - name: "test-aws-lambda-deployed"
+    commands:
+      - func: "install dependencies"
+      - command: ec2.assume_role
+        params:
+          role_arn: ${LAMBDA_AWS_ROLE_ARN}
+          duration_seconds: 3600
+      - command: subprocess.exec
+        params:
+          working_dir: src
+          binary: bash
+          args:
+            - ${DRIVERS_TOOLS}/aws_lambda/run-deployed-lambda-aws-tests.sh
+          env:
+            TEST_LAMBDA_DIRECTORY: ${PROJECT_DIRECTORY}/test/lambda
+            DRIVERS_TOOLS: ${DRIVERS_TOOLS}
+            DRIVERS_ATLAS_PUBLIC_API_KEY: ${DRIVERS_ATLAS_PUBLIC_API_KEY}
+            DRIVERS_ATLAS_PRIVATE_API_KEY: ${DRIVERS_ATLAS_PRIVATE_API_KEY}
+            DRIVERS_ATLAS_LAMBDA_USER: ${DRIVERS_ATLAS_LAMBDA_USER}
+            DRIVERS_ATLAS_LAMBDA_PASSWORD: ${DRIVERS_ATLAS_LAMBDA_PASSWORD}
+            DRIVERS_ATLAS_GROUP_ID: ${DRIVERS_ATLAS_GROUP_ID}
+            LAMBDA_STACK_NAME: dbx-node-lambda
+            AWS_REGION: us-east-1
+            AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+            AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+            AWS_SESSION_TOKEN: ${AWS_SESSION_TOKEN}
+
 task_groups:
   - name: serverless_task_group
     setup_group_can_fail_task: true
@@ -1410,6 +1412,39 @@ task_groups:
     setup_group_timeout_secs: 1800
     tasks:
     - oidc-auth-test-azure-latest
+
+  - name: test_aws_lambda_task_group
+    setup_group:
+      - func: fetch source
+      - command: subprocess.exec
+        params:
+          working_dir: src
+          binary: bash
+          args:
+            - ${DRIVERS_TOOLS}/aws_lambda/teardown-atlas-cluster.sh
+          env:
+            DRIVERS_TOOLS: ${DRIVERS_TOOLS}
+            DRIVERS_ATLAS_PUBLIC_API_KEY: ${DRIVERS_ATLAS_PUBLIC_API_KEY}
+            DRIVERS_ATLAS_PRIVATE_API_KEY: ${DRIVERS_ATLAS_PRIVATE_API_KEY}
+            DRIVERS_ATLAS_GROUP_ID: ${DRIVERS_ATLAS_GROUP_ID}
+            LAMBDA_STACK_NAME: dbx-node-lambda
+    teardown_group:
+      - command: subprocess.exec
+        params:
+          working_dir: src
+          binary: bash
+          args:
+            - ${DRIVERS_TOOLS}/aws_lambda/teardown-atlas-cluster.sh
+          env:
+            DRIVERS_TOOLS: ${DRIVERS_TOOLS}
+            DRIVERS_ATLAS_PUBLIC_API_KEY: ${DRIVERS_ATLAS_PUBLIC_API_KEY}
+            DRIVERS_ATLAS_PRIVATE_API_KEY: ${DRIVERS_ATLAS_PRIVATE_API_KEY}
+            DRIVERS_ATLAS_GROUP_ID: ${DRIVERS_ATLAS_GROUP_ID}
+            LAMBDA_STACK_NAME: dbx-node-lambda
+    setup_group_can_fail_task: true
+    setup_group_timeout_secs: 1800
+    tasks:
+      - test-aws-lambda-deployed
 
 pre:
   - func: "fetch source"

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -1421,7 +1421,7 @@ task_groups:
           working_dir: src
           binary: bash
           args:
-            - ${DRIVERS_TOOLS}/aws_lambda/teardown-atlas-cluster.sh
+            - ${DRIVERS_TOOLS}/.evergreen/aws_lambda/setup-atlas-cluster.sh
           env:
             DRIVERS_TOOLS: ${DRIVERS_TOOLS}
             DRIVERS_ATLAS_PUBLIC_API_KEY: ${DRIVERS_ATLAS_PUBLIC_API_KEY}
@@ -1434,7 +1434,7 @@ task_groups:
           working_dir: src
           binary: bash
           args:
-            - ${DRIVERS_TOOLS}/aws_lambda/teardown-atlas-cluster.sh
+            - ${DRIVERS_TOOLS}/.evergreen/aws_lambda/teardown-atlas-cluster.sh
           env:
             DRIVERS_TOOLS: ${DRIVERS_TOOLS}
             DRIVERS_ATLAS_PUBLIC_API_KEY: ${DRIVERS_ATLAS_PUBLIC_API_KEY}

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -1269,12 +1269,11 @@ tasks:
           args:
             - ${DRIVERS_TOOLS}/.evergreen/aws_lambda/run-deployed-lambda-aws-tests.sh
           env:
+            MONGODB_URI: ${MONGODB_URI}
             TEST_LAMBDA_DIRECTORY: ${PROJECT_DIRECTORY}/test/lambda
             DRIVERS_TOOLS: ${DRIVERS_TOOLS}
             DRIVERS_ATLAS_PUBLIC_API_KEY: ${DRIVERS_ATLAS_PUBLIC_API_KEY}
             DRIVERS_ATLAS_PRIVATE_API_KEY: ${DRIVERS_ATLAS_PRIVATE_API_KEY}
-            DRIVERS_ATLAS_LAMBDA_USER: ${DRIVERS_ATLAS_LAMBDA_USER}
-            DRIVERS_ATLAS_LAMBDA_PASSWORD: ${DRIVERS_ATLAS_LAMBDA_PASSWORD}
             DRIVERS_ATLAS_GROUP_ID: ${DRIVERS_ATLAS_GROUP_ID}
             LAMBDA_STACK_NAME: dbx-node-lambda
             AWS_REGION: us-east-1
@@ -1427,7 +1426,12 @@ task_groups:
             DRIVERS_ATLAS_PUBLIC_API_KEY: ${DRIVERS_ATLAS_PUBLIC_API_KEY}
             DRIVERS_ATLAS_PRIVATE_API_KEY: ${DRIVERS_ATLAS_PRIVATE_API_KEY}
             DRIVERS_ATLAS_GROUP_ID: ${DRIVERS_ATLAS_GROUP_ID}
+            DRIVERS_ATLAS_LAMBDA_USER: ${DRIVERS_ATLAS_LAMBDA_USER}
+            DRIVERS_ATLAS_LAMBDA_PASSWORD: ${DRIVERS_ATLAS_LAMBDA_PASSWORD}
             LAMBDA_STACK_NAME: dbx-node-lambda
+      - command: expansions.update
+        params:
+          file: atlas-expansion.yml
     teardown_group:
       - command: subprocess.exec
         params:

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -1266,20 +1266,12 @@ tasks:
         params:
           working_dir: src
           binary: bash
+          add_expansions_to_env: true
           args:
             - ${DRIVERS_TOOLS}/.evergreen/aws_lambda/run-deployed-lambda-aws-tests.sh
           env:
-            MONGODB_URI: ${MONGODB_URI}
             TEST_LAMBDA_DIRECTORY: ${PROJECT_DIRECTORY}/test/lambda
-            DRIVERS_TOOLS: ${DRIVERS_TOOLS}
-            DRIVERS_ATLAS_PUBLIC_API_KEY: ${DRIVERS_ATLAS_PUBLIC_API_KEY}
-            DRIVERS_ATLAS_PRIVATE_API_KEY: ${DRIVERS_ATLAS_PRIVATE_API_KEY}
-            DRIVERS_ATLAS_GROUP_ID: ${DRIVERS_ATLAS_GROUP_ID}
-            LAMBDA_STACK_NAME: dbx-node-lambda
             AWS_REGION: us-east-1
-            AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
-            AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
-            AWS_SESSION_TOKEN: ${AWS_SESSION_TOKEN}
 
 task_groups:
   - name: serverless_task_group
@@ -1419,16 +1411,9 @@ task_groups:
         params:
           working_dir: src
           binary: bash
+          add_expansions_to_env: true
           args:
             - ${DRIVERS_TOOLS}/.evergreen/aws_lambda/setup-atlas-cluster.sh
-          env:
-            DRIVERS_TOOLS: ${DRIVERS_TOOLS}
-            DRIVERS_ATLAS_PUBLIC_API_KEY: ${DRIVERS_ATLAS_PUBLIC_API_KEY}
-            DRIVERS_ATLAS_PRIVATE_API_KEY: ${DRIVERS_ATLAS_PRIVATE_API_KEY}
-            DRIVERS_ATLAS_GROUP_ID: ${DRIVERS_ATLAS_GROUP_ID}
-            DRIVERS_ATLAS_LAMBDA_USER: ${DRIVERS_ATLAS_LAMBDA_USER}
-            DRIVERS_ATLAS_LAMBDA_PASSWORD: ${DRIVERS_ATLAS_LAMBDA_PASSWORD}
-            LAMBDA_STACK_NAME: dbx-node-lambda
       - command: expansions.update
         params:
           file: src/atlas-expansion.yml
@@ -1437,14 +1422,9 @@ task_groups:
         params:
           working_dir: src
           binary: bash
+          add_expansions_to_env: true
           args:
             - ${DRIVERS_TOOLS}/.evergreen/aws_lambda/teardown-atlas-cluster.sh
-          env:
-            DRIVERS_TOOLS: ${DRIVERS_TOOLS}
-            DRIVERS_ATLAS_PUBLIC_API_KEY: ${DRIVERS_ATLAS_PUBLIC_API_KEY}
-            DRIVERS_ATLAS_PRIVATE_API_KEY: ${DRIVERS_ATLAS_PRIVATE_API_KEY}
-            DRIVERS_ATLAS_GROUP_ID: ${DRIVERS_ATLAS_GROUP_ID}
-            LAMBDA_STACK_NAME: dbx-node-lambda
     setup_group_can_fail_task: true
     setup_group_timeout_secs: 1800
     tasks:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -3484,7 +3484,7 @@ task_groups:
             LAMBDA_STACK_NAME: dbx-node-lambda
       - command: expansions.update
         params:
-          file: atlas-expansion.yml
+          file: src/atlas-expansion.yml
     teardown_group:
       - command: subprocess.exec
         params:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -3457,7 +3457,7 @@ task_groups:
     setup_group_timeout_secs: 1800
     tasks:
       - oidc-auth-test-azure-latest
-  - name: test_aws_lambda_task_group
+  - name: test_atlas_task_group
     setup_group:
       - func: fetch source
       - command: subprocess.exec
@@ -3466,7 +3466,7 @@ task_groups:
           binary: bash
           add_expansions_to_env: true
           args:
-            - ${DRIVERS_TOOLS}/.evergreen/aws_lambda/setup-atlas-cluster.sh
+            - ${DRIVERS_TOOLS}/.evergreen/atlas/setup-atlas-cluster.sh
       - command: expansions.update
         params:
           file: src/atlas-expansion.yml
@@ -3477,7 +3477,7 @@ task_groups:
           binary: bash
           add_expansions_to_env: true
           args:
-            - ${DRIVERS_TOOLS}/.evergreen/aws_lambda/teardown-atlas-cluster.sh
+            - ${DRIVERS_TOOLS}/.evergreen/atlas/teardown-atlas-cluster.sh
     setup_group_can_fail_task: true
     setup_group_timeout_secs: 1800
     tasks:
@@ -4066,12 +4066,12 @@ buildvariants:
     batchtime: 20160
     tasks:
       - testazureoidc_task_group
-  - name: rhel8-test-aws-lambda
-    display_name: AWS Lambda Deployed Tests
+  - name: rhel8-test-atlas
+    display_name: Atlas Cluster Tests
     run_on: rhel80-large
     batchtime: 20160
     tasks:
-      - test_aws_lambda_task_group
+      - test_atlas_task_group
   - name: rhel8-no-auth-tests
     display_name: No Auth Tests
     run_on: rhel80-large

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1193,12 +1193,11 @@ tasks:
           args:
             - ${DRIVERS_TOOLS}/.evergreen/aws_lambda/run-deployed-lambda-aws-tests.sh
           env:
+            MONGODB_URI: ${MONGODB_URI}
             TEST_LAMBDA_DIRECTORY: ${PROJECT_DIRECTORY}/test/lambda
             DRIVERS_TOOLS: ${DRIVERS_TOOLS}
             DRIVERS_ATLAS_PUBLIC_API_KEY: ${DRIVERS_ATLAS_PUBLIC_API_KEY}
             DRIVERS_ATLAS_PRIVATE_API_KEY: ${DRIVERS_ATLAS_PRIVATE_API_KEY}
-            DRIVERS_ATLAS_LAMBDA_USER: ${DRIVERS_ATLAS_LAMBDA_USER}
-            DRIVERS_ATLAS_LAMBDA_PASSWORD: ${DRIVERS_ATLAS_LAMBDA_PASSWORD}
             DRIVERS_ATLAS_GROUP_ID: ${DRIVERS_ATLAS_GROUP_ID}
             LAMBDA_STACK_NAME: dbx-node-lambda
             AWS_REGION: us-east-1
@@ -3480,7 +3479,12 @@ task_groups:
             DRIVERS_ATLAS_PUBLIC_API_KEY: ${DRIVERS_ATLAS_PUBLIC_API_KEY}
             DRIVERS_ATLAS_PRIVATE_API_KEY: ${DRIVERS_ATLAS_PRIVATE_API_KEY}
             DRIVERS_ATLAS_GROUP_ID: ${DRIVERS_ATLAS_GROUP_ID}
+            DRIVERS_ATLAS_LAMBDA_USER: ${DRIVERS_ATLAS_LAMBDA_USER}
+            DRIVERS_ATLAS_LAMBDA_PASSWORD: ${DRIVERS_ATLAS_LAMBDA_PASSWORD}
             LAMBDA_STACK_NAME: dbx-node-lambda
+      - command: expansions.update
+        params:
+          file: atlas-expansion.yml
     teardown_group:
       - command: subprocess.exec
         params:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -4069,7 +4069,6 @@ buildvariants:
   - name: rhel8-test-atlas
     display_name: Atlas Cluster Tests
     run_on: rhel80-large
-    batchtime: 20160
     tasks:
       - test_atlas_task_group
   - name: rhel8-no-auth-tests

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1191,7 +1191,7 @@ tasks:
           working_dir: src
           binary: bash
           args:
-            - ${DRIVERS_TOOLS}/aws_lambda/run-deployed-lambda-aws-tests.sh
+            - ${DRIVERS_TOOLS}/.evergreen/aws_lambda/run-deployed-lambda-aws-tests.sh
           env:
             TEST_LAMBDA_DIRECTORY: ${PROJECT_DIRECTORY}/test/lambda
             DRIVERS_TOOLS: ${DRIVERS_TOOLS}

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1190,20 +1190,12 @@ tasks:
         params:
           working_dir: src
           binary: bash
+          add_expansions_to_env: true
           args:
             - ${DRIVERS_TOOLS}/.evergreen/aws_lambda/run-deployed-lambda-aws-tests.sh
           env:
-            MONGODB_URI: ${MONGODB_URI}
             TEST_LAMBDA_DIRECTORY: ${PROJECT_DIRECTORY}/test/lambda
-            DRIVERS_TOOLS: ${DRIVERS_TOOLS}
-            DRIVERS_ATLAS_PUBLIC_API_KEY: ${DRIVERS_ATLAS_PUBLIC_API_KEY}
-            DRIVERS_ATLAS_PRIVATE_API_KEY: ${DRIVERS_ATLAS_PRIVATE_API_KEY}
-            DRIVERS_ATLAS_GROUP_ID: ${DRIVERS_ATLAS_GROUP_ID}
-            LAMBDA_STACK_NAME: dbx-node-lambda
             AWS_REGION: us-east-1
-            AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
-            AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
-            AWS_SESSION_TOKEN: ${AWS_SESSION_TOKEN}
   - name: test-latest-server
     tags:
       - latest
@@ -3472,16 +3464,9 @@ task_groups:
         params:
           working_dir: src
           binary: bash
+          add_expansions_to_env: true
           args:
             - ${DRIVERS_TOOLS}/.evergreen/aws_lambda/setup-atlas-cluster.sh
-          env:
-            DRIVERS_TOOLS: ${DRIVERS_TOOLS}
-            DRIVERS_ATLAS_PUBLIC_API_KEY: ${DRIVERS_ATLAS_PUBLIC_API_KEY}
-            DRIVERS_ATLAS_PRIVATE_API_KEY: ${DRIVERS_ATLAS_PRIVATE_API_KEY}
-            DRIVERS_ATLAS_GROUP_ID: ${DRIVERS_ATLAS_GROUP_ID}
-            DRIVERS_ATLAS_LAMBDA_USER: ${DRIVERS_ATLAS_LAMBDA_USER}
-            DRIVERS_ATLAS_LAMBDA_PASSWORD: ${DRIVERS_ATLAS_LAMBDA_PASSWORD}
-            LAMBDA_STACK_NAME: dbx-node-lambda
       - command: expansions.update
         params:
           file: src/atlas-expansion.yml
@@ -3490,14 +3475,9 @@ task_groups:
         params:
           working_dir: src
           binary: bash
+          add_expansions_to_env: true
           args:
             - ${DRIVERS_TOOLS}/.evergreen/aws_lambda/teardown-atlas-cluster.sh
-          env:
-            DRIVERS_TOOLS: ${DRIVERS_TOOLS}
-            DRIVERS_ATLAS_PUBLIC_API_KEY: ${DRIVERS_ATLAS_PUBLIC_API_KEY}
-            DRIVERS_ATLAS_PRIVATE_API_KEY: ${DRIVERS_ATLAS_PRIVATE_API_KEY}
-            DRIVERS_ATLAS_GROUP_ID: ${DRIVERS_ATLAS_GROUP_ID}
-            LAMBDA_STACK_NAME: dbx-node-lambda
     setup_group_can_fail_task: true
     setup_group_timeout_secs: 1800
     tasks:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -151,30 +151,6 @@ functions:
           AWS_WEB_IDENTITY_TOKEN_FILE="/tmp/tokens/test_user1" \
           PROJECT_DIRECTORY="${PROJECT_DIRECTORY}" \
             bash ${PROJECT_DIRECTORY}/.evergreen/run-oidc-tests.sh
-  run deployed aws lambda tests:
-    - command: ec2.assume_role
-      params:
-        role_arn: ${LAMBDA_AWS_ROLE_ARN}
-        duration_seconds: 3600
-    - command: subprocess.exec
-      params:
-        working_dir: src
-        binary: bash
-        args:
-          - .evergreen/run-deployed-lambda-aws-tests.sh
-        env:
-          TEST_LAMBDA_DIRECTORY: ${PROJECT_DIRECTORY}/test/lambda
-          DRIVERS_TOOLS: ${DRIVERS_TOOLS}
-          DRIVERS_ATLAS_PUBLIC_API_KEY: ${DRIVERS_ATLAS_PUBLIC_API_KEY}
-          DRIVERS_ATLAS_PRIVATE_API_KEY: ${DRIVERS_ATLAS_PRIVATE_API_KEY}
-          DRIVERS_ATLAS_LAMBDA_USER: ${DRIVERS_ATLAS_LAMBDA_USER}
-          DRIVERS_ATLAS_LAMBDA_PASSWORD: ${DRIVERS_ATLAS_LAMBDA_PASSWORD}
-          DRIVERS_ATLAS_GROUP_ID: ${DRIVERS_ATLAS_GROUP_ID}
-          LAMBDA_STACK_NAME: dbx-node-lambda
-          AWS_REGION: us-east-1
-          AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
-          AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
-          AWS_SESSION_TOKEN: ${AWS_SESSION_TOKEN}
   run tests:
     - command: shell.exec
       type: test
@@ -1203,6 +1179,32 @@ tasks:
             PROVIDER_NAME: azure
           args:
             - .evergreen/run-oidc-tests-azure.sh
+  - name: test-aws-lambda-deployed
+    commands:
+      - func: install dependencies
+      - command: ec2.assume_role
+        params:
+          role_arn: ${LAMBDA_AWS_ROLE_ARN}
+          duration_seconds: 3600
+      - command: subprocess.exec
+        params:
+          working_dir: src
+          binary: bash
+          args:
+            - ${DRIVERS_TOOLS}/aws_lambda/run-deployed-lambda-aws-tests.sh
+          env:
+            TEST_LAMBDA_DIRECTORY: ${PROJECT_DIRECTORY}/test/lambda
+            DRIVERS_TOOLS: ${DRIVERS_TOOLS}
+            DRIVERS_ATLAS_PUBLIC_API_KEY: ${DRIVERS_ATLAS_PUBLIC_API_KEY}
+            DRIVERS_ATLAS_PRIVATE_API_KEY: ${DRIVERS_ATLAS_PRIVATE_API_KEY}
+            DRIVERS_ATLAS_LAMBDA_USER: ${DRIVERS_ATLAS_LAMBDA_USER}
+            DRIVERS_ATLAS_LAMBDA_PASSWORD: ${DRIVERS_ATLAS_LAMBDA_PASSWORD}
+            DRIVERS_ATLAS_GROUP_ID: ${DRIVERS_ATLAS_GROUP_ID}
+            LAMBDA_STACK_NAME: dbx-node-lambda
+            AWS_REGION: us-east-1
+            AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+            AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+            AWS_SESSION_TOKEN: ${AWS_SESSION_TOKEN}
   - name: test-latest-server
     tags:
       - latest
@@ -3140,13 +3142,6 @@ tasks:
           VERSION: rapid
           TOPOLOGY: server
       - func: run lambda handler example tests
-  - name: test-deployed-lambda
-    tags:
-      - latest
-      - lambda
-    commands:
-      - func: install dependencies
-      - func: run deployed aws lambda tests
   - name: test-lambda-aws-auth-example
     tags:
       - latest
@@ -3471,6 +3466,38 @@ task_groups:
     setup_group_timeout_secs: 1800
     tasks:
       - oidc-auth-test-azure-latest
+  - name: test_aws_lambda_task_group
+    setup_group:
+      - func: fetch source
+      - command: subprocess.exec
+        params:
+          working_dir: src
+          binary: bash
+          args:
+            - ${DRIVERS_TOOLS}/aws_lambda/teardown-atlas-cluster.sh
+          env:
+            DRIVERS_TOOLS: ${DRIVERS_TOOLS}
+            DRIVERS_ATLAS_PUBLIC_API_KEY: ${DRIVERS_ATLAS_PUBLIC_API_KEY}
+            DRIVERS_ATLAS_PRIVATE_API_KEY: ${DRIVERS_ATLAS_PRIVATE_API_KEY}
+            DRIVERS_ATLAS_GROUP_ID: ${DRIVERS_ATLAS_GROUP_ID}
+            LAMBDA_STACK_NAME: dbx-node-lambda
+    teardown_group:
+      - command: subprocess.exec
+        params:
+          working_dir: src
+          binary: bash
+          args:
+            - ${DRIVERS_TOOLS}/aws_lambda/teardown-atlas-cluster.sh
+          env:
+            DRIVERS_TOOLS: ${DRIVERS_TOOLS}
+            DRIVERS_ATLAS_PUBLIC_API_KEY: ${DRIVERS_ATLAS_PUBLIC_API_KEY}
+            DRIVERS_ATLAS_PRIVATE_API_KEY: ${DRIVERS_ATLAS_PRIVATE_API_KEY}
+            DRIVERS_ATLAS_GROUP_ID: ${DRIVERS_ATLAS_GROUP_ID}
+            LAMBDA_STACK_NAME: dbx-node-lambda
+    setup_group_can_fail_task: true
+    setup_group_timeout_secs: 1800
+    tasks:
+      - test-aws-lambda-deployed
 pre:
   - func: fetch source
   - func: windows fix
@@ -4055,6 +4082,12 @@ buildvariants:
     batchtime: 20160
     tasks:
       - testazureoidc_task_group
+  - name: rhel8-test-aws-lambda
+    display_name: AWS Lambda Deployed Tests
+    run_on: rhel80-large
+    batchtime: 20160
+    tasks:
+      - test_aws_lambda_task_group
   - name: rhel8-no-auth-tests
     display_name: No Auth Tests
     run_on: rhel80-large
@@ -4094,7 +4127,6 @@ buildvariants:
     tasks:
       - test-lambda-example
       - test-lambda-aws-auth-example
-      - test-deployed-lambda
   - name: rhel8-test-seach-index-management-helpers
     display_name: Search Index Management Helpers Tests
     run_on: rhel80-large

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -3474,7 +3474,7 @@ task_groups:
           working_dir: src
           binary: bash
           args:
-            - ${DRIVERS_TOOLS}/aws_lambda/teardown-atlas-cluster.sh
+            - ${DRIVERS_TOOLS}/.evergreen/aws_lambda/setup-atlas-cluster.sh
           env:
             DRIVERS_TOOLS: ${DRIVERS_TOOLS}
             DRIVERS_ATLAS_PUBLIC_API_KEY: ${DRIVERS_ATLAS_PUBLIC_API_KEY}
@@ -3487,7 +3487,7 @@ task_groups:
           working_dir: src
           binary: bash
           args:
-            - ${DRIVERS_TOOLS}/aws_lambda/teardown-atlas-cluster.sh
+            - ${DRIVERS_TOOLS}/.evergreen/aws_lambda/teardown-atlas-cluster.sh
           env:
             DRIVERS_TOOLS: ${DRIVERS_TOOLS}
             DRIVERS_ATLAS_PUBLIC_API_KEY: ${DRIVERS_ATLAS_PUBLIC_API_KEY}

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -754,11 +754,11 @@ BUILD_VARIANTS.push({
 });
 
 BUILD_VARIANTS.push({
-  name: 'rhel8-test-aws-lambda',
-  display_name: 'AWS Lambda Deployed Tests',
+  name: 'rhel8-test-atlas',
+  display_name: 'Atlas Cluster Tests',
   run_on: DEFAULT_OS,
   batchtime: 20160,
-  tasks: ['test_aws_lambda_task_group']
+  tasks: ['test_atlas_task_group']
 });
 
 BUILD_VARIANTS.push({

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -302,16 +302,6 @@ AWS_LAMBDA_HANDLER_TASKS.push({
   ]
 });
 
-// Add the deployed lambda function tests.
-AWS_LAMBDA_HANDLER_TASKS.push({
-  name: 'test-deployed-lambda',
-  tags: ['latest', 'lambda'],
-  commands: [
-    { func: 'install dependencies' },
-    { func: 'run deployed aws lambda tests' }
-  ]
-});
-
 // Add task for testing lambda example with aws auth.
 AWS_LAMBDA_HANDLER_TASKS.push({
   name: 'test-lambda-aws-auth-example',
@@ -764,6 +754,14 @@ BUILD_VARIANTS.push({
 });
 
 BUILD_VARIANTS.push({
+  name: 'rhel8-test-aws-lambda',
+  display_name: 'AWS Lambda Deployed Tests',
+  run_on: DEFAULT_OS,
+  batchtime: 20160,
+  tasks: ['test_aws_lambda_task_group']
+});
+
+BUILD_VARIANTS.push({
   name: 'rhel8-no-auth-tests',
   display_name: 'No Auth Tests',
   run_on: DEFAULT_OS,
@@ -777,7 +775,7 @@ BUILD_VARIANTS.push({
   name: 'rhel8-test-lambda',
   display_name: 'AWS Lambda handler tests',
   run_on: DEFAULT_OS,
-  tasks: ['test-lambda-example', 'test-lambda-aws-auth-example', 'test-deployed-lambda']
+  tasks: ['test-lambda-example', 'test-lambda-aws-auth-example']
 });
 
 BUILD_VARIANTS.push({

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -757,7 +757,6 @@ BUILD_VARIANTS.push({
   name: 'rhel8-test-atlas',
   display_name: 'Atlas Cluster Tests',
   run_on: DEFAULT_OS,
-  batchtime: 20160,
   tasks: ['test_atlas_task_group']
 });
 

--- a/.evergreen/prepare-shell.sh
+++ b/.evergreen/prepare-shell.sh
@@ -31,7 +31,7 @@ export PATH="$MONGODB_BINARIES:$PATH"
 
 if [ ! -d "$DRIVERS_TOOLS" ]; then
   # Only clone driver tools if it does not exist
-  git clone --depth=1 --branch NODE-5361 "https://github.com/mongodb-labs/drivers-evergreen-tools.git" "${DRIVERS_TOOLS}"
+  git clone --depth=1 --branch DRIVERS-2657 "https://github.com/mongodb-labs/drivers-evergreen-tools.git" "${DRIVERS_TOOLS}"
 fi
 
 echo "installed DRIVERS_EVERGREEN_TOOLS from commit $(git -C $DRIVERS_EVERGREEN_TOOLS rev-parse HEAD)"

--- a/.evergreen/prepare-shell.sh
+++ b/.evergreen/prepare-shell.sh
@@ -31,7 +31,7 @@ export PATH="$MONGODB_BINARIES:$PATH"
 
 if [ ! -d "$DRIVERS_TOOLS" ]; then
   # Only clone driver tools if it does not exist
-  git clone --depth=1 "https://github.com/mongodb-labs/drivers-evergreen-tools.git" "${DRIVERS_TOOLS}"
+  git clone --depth=1 --branch NODE-5361 "https://github.com/mongodb-labs/drivers-evergreen-tools.git" "${DRIVERS_TOOLS}"
 fi
 
 echo "installed DRIVERS_EVERGREEN_TOOLS from commit $(git -C $DRIVERS_EVERGREEN_TOOLS rev-parse HEAD)"

--- a/.evergreen/prepare-shell.sh
+++ b/.evergreen/prepare-shell.sh
@@ -31,7 +31,7 @@ export PATH="$MONGODB_BINARIES:$PATH"
 
 if [ ! -d "$DRIVERS_TOOLS" ]; then
   # Only clone driver tools if it does not exist
-  git clone --depth=1 --branch DRIVERS-2657 "https://github.com/mongodb-labs/drivers-evergreen-tools.git" "${DRIVERS_TOOLS}"
+  git clone --depth=1 "https://github.com/mongodb-labs/drivers-evergreen-tools.git" "${DRIVERS_TOOLS}"
 fi
 
 echo "installed DRIVERS_EVERGREEN_TOOLS from commit $(git -C $DRIVERS_EVERGREEN_TOOLS rev-parse HEAD)"


### PR DESCRIPTION
### Description

Switches the deployed AWS Lambda tests to use task groups for more consistent setup and teardown.

#### What is changing?

- Removes the one-shot lambda test.
- Updates the Evergreen config to use task groups with a setup and teardown script provided in drivers tools. (https://github.com/mongodb-labs/drivers-evergreen-tools/pull/325)
- Spec changes: https://github.com/mongodb/specifications/pull/1438

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-5361/DRIVERS-2657 and not losing money on orphaned Atlas clusters.

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
