### PR TITLE
feat(NODE-5319): mark search index api public

### DIFF
--- a/src/collection.ts
+++ b/src/collection.ts
@@ -1050,8 +1050,6 @@ export class Collection<TSchema extends Document = Document> {
   }
 
   /**
-   * @internal
-   *
    * Returns all search indexes for the current collection.
    *
    * @param options - The options for the list indexes operation.
@@ -1060,8 +1058,6 @@ export class Collection<TSchema extends Document = Document> {
    */
   listSearchIndexes(options?: ListSearchIndexesOptions): ListSearchIndexesCursor;
   /**
-   * @internal
-   *
    * Returns all search indexes for the current collection.
    *
    * @param name - The name of the index to search for.  Only indexes with matching index names will be returned.
@@ -1087,8 +1083,6 @@ export class Collection<TSchema extends Document = Document> {
   }
 
   /**
-   * @internal
-   *
    * Creates a single search index for the collection.
    *
    * @param description - The index description for the new search index.
@@ -1102,8 +1096,6 @@ export class Collection<TSchema extends Document = Document> {
   }
 
   /**
-   * @internal
-   *
    * Creates multiple search indexes for the current collection.
    *
    * @param descriptions - An array of `SearchIndexDescription`s for the new search indexes.
@@ -1120,8 +1112,6 @@ export class Collection<TSchema extends Document = Document> {
   }
 
   /**
-   * @internal
-   *
    * Deletes a search index by index name.
    *
    * @param name - The name of the search index to be deleted.
@@ -1136,8 +1126,6 @@ export class Collection<TSchema extends Document = Document> {
   }
 
   /**
-   * @internal
-   *
    * Updates a search index by replacing the existing index definition with the provided definition.
    *
    * @param name - The name of the search index to update.

--- a/src/cursor/list_search_indexes_cursor.ts
+++ b/src/cursor/list_search_indexes_cursor.ts
@@ -2,10 +2,10 @@ import type { Collection } from '../collection';
 import type { AggregateOptions } from '../operations/aggregate';
 import { AggregationCursor } from './aggregation_cursor';
 
-/** @internal */
+/** @public */
 export type ListSearchIndexesOptions = AggregateOptions;
 
-/** @internal */
+/** @public */
 export class ListSearchIndexesCursor extends AggregationCursor<{ name: string }> {
   /** @internal */
   constructor(

--- a/src/operations/search_indexes/create.ts
+++ b/src/operations/search_indexes/create.ts
@@ -6,13 +6,15 @@ import type { ClientSession } from '../../sessions';
 import type { Callback } from '../../utils';
 import { AbstractOperation } from '../operation';
 
-/** @internal */
+/**
+ * @public
+ */
 export interface SearchIndexDescription {
   /** The name of the index. */
   name?: string;
 
   /** The index definition. */
-  description: Document;
+  definition: Document;
 }
 
 /** @internal */


### PR DESCRIPTION
### Description

#### What is changing?

The search index API is marked public. 

Also, @lerouxb noticed that the definition for `SearchIndexModel` was incorrect, although the code path (and our unified tests) do assert on the correct value at runtime.  This PR fixes the type.

##### Is there new documentation needed for these changes?

Yes, docsp ticket.

#### What is the motivation for this change?


### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Programmatic management of search indexes

This PR adds support for managing search indexes (creating, updating, deleting and listing indexes).  The new methods are available on the `Collection` class.

```typescript
const indexes = await collection.listSearchIndexes().toArray(); // produces an array of search indexes
await collection.createSearchIndex({ name: 'my-index', definition: < index definition > } ); 
await collection.updateSearchIndex('my-index', < new definition >);
await collection.dropSearchIndex('my-index');
```

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
