### PR TITLE
feat(NODE-5287): deprecate ssl options

### DIFF
--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -1097,35 +1097,46 @@ export const OPTIONS = {
     type: 'boolean'
   },
   sslCA: {
+    deprecated:
+      'sslCA is deprecated and will be removed in the next major version. Please use tlsCAFile instead.',
     target: 'ca',
     transform({ values: [value] }) {
       return fs.readFileSync(String(value), { encoding: 'ascii' });
     }
   },
   sslCRL: {
+    deprecated:
+      'sslCRL is deprecated and will be removed in the next major version. Please use tlsCertificateKeyFile instead.',
     target: 'crl',
     transform({ values: [value] }) {
       return fs.readFileSync(String(value), { encoding: 'ascii' });
     }
   },
   sslCert: {
+    deprecated:
+      'sslCert is deprecated and will be removed in the next major version. Please use tlsCertificateKeyFile instead.',
     target: 'cert',
     transform({ values: [value] }) {
       return fs.readFileSync(String(value), { encoding: 'ascii' });
     }
   },
   sslKey: {
+    deprecated:
+      'sslKey is deprecated and will be removed in the next major version. Please use tlsCertificateKeyFile instead.',
     target: 'key',
     transform({ values: [value] }) {
       return fs.readFileSync(String(value), { encoding: 'ascii' });
     }
   },
   sslPass: {
-    deprecated: true,
+    deprecated:
+      'sslPass is deprecated and will be removed in the next major version. Please use tlsCertificateKeyFilePassword instead.',
     target: 'passphrase',
     type: 'string'
   },
   sslValidate: {
+    deprecated:
+      'sslValidate is deprecated and will be removed in the next major version. Please use tlsAllowInvalidCertificates instead.',
     target: 'rejectUnauthorized',
     type: 'boolean'
   },
@@ -1153,6 +1164,8 @@ export const OPTIONS = {
     }
   },
   tlsCertificateFile: {
+    deprecated:
+      'tlsCertificateFile is deprecated and will be removed in the next major version. Please use tlsCertificateKeyFile instead.',
     target: 'cert',
     transform({ values: [value] }) {
       return fs.readFileSync(String(value), { encoding: 'ascii' });

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -108,7 +108,10 @@ export interface MongoClientOptions extends BSONSerializeOptions, SupportedNodeC
   tls?: boolean;
   /** A boolean to enable or disables TLS/SSL for the connection. (The ssl option is equivalent to the tls option.) */
   ssl?: boolean;
-  /** Specifies the location of a local TLS Certificate */
+  /**
+   * Specifies the location of a local TLS Certificate
+   * @deprecated Will be removed in the next major version. Please use tlsCertificateKeyFile instead.
+   */
   tlsCertificateFile?: string;
   /** Specifies the location of a local .pem file that contains either the client's TLS/SSL certificate and key or only the client's TLS/SSL key when tlsCertificateFile is used to provide the certificate. */
   tlsCertificateKeyFile?: string;
@@ -208,17 +211,35 @@ export interface MongoClientOptions extends BSONSerializeOptions, SupportedNodeC
    * @see https://www.mongodb.com/docs/manual/reference/write-concern/
    */
   writeConcern?: WriteConcern | WriteConcernSettings;
-  /** Validate mongod server certificate against Certificate Authority */
+  /**
+   * Validate mongod server certificate against Certificate Authority
+   * @deprecated Will be removed in the next major version. Please use tlsAllowInvalidCertificates instead.
+   */
   sslValidate?: boolean;
-  /** SSL Certificate file path. */
+  /**
+   * SSL Certificate file path.
+   * @deprecated Will be removed in the next major version. Please use tlsCAFile instead.
+   */
   sslCA?: string;
-  /** SSL Certificate file path. */
+  /**
+   * SSL Certificate file path.
+   * @deprecated Will be removed in the next major version. Please use tlsCertificateKeyFile instead.
+   */
   sslCert?: string;
-  /** SSL Key file file path. */
+  /**
+   * SSL Key file file path.
+   * @deprecated Will be removed in the next major version. Please use tlsCertificateKeyFile instead.
+   */
   sslKey?: string;
-  /** SSL Certificate pass phrase. */
+  /**
+   * SSL Certificate pass phrase.
+   * @deprecated Will be removed in the next major version. Please use tlsCertificateKeyFilePassword instead.
+   */
   sslPass?: string;
-  /** SSL Certificate revocation list file path. */
+  /**
+   * SSL Certificate revocation list file path.
+   * @deprecated Will be removed in the next major version. Please use tlsCertificateKeyFile instead.
+   */
   sslCRL?: string;
   /** TCP Connection no delay */
   noDelay?: boolean;


### PR DESCRIPTION
### Description

Deprecates duplicate SSL options in favour of spec compliant TLS options.

#### What is changing?

Deprecates:
- sslCA
- sslCRL
- sslCert
- sslKey
- sslPass
- sslValidate
- tlsCertificateFile


##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-5287

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
