### PR TITLE
feat(NODE-5243): add change stream split event

### DIFF
--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -163,6 +163,14 @@ export interface ChangeStreamDocumentKey<TSchema extends Document = Document> {
 }
 
 /** @public */
+export interface ChangeStreamSplitEvent {
+  /** Which fragment of the change this is. */
+  fragment: number;
+  /** The total number of fragments. */
+  of: number;
+}
+
+/** @public */
 export interface ChangeStreamDocumentCommon {
   /**
    * The id functions as an opaque token for use when resuming an interrupted
@@ -192,6 +200,13 @@ export interface ChangeStreamDocumentCommon {
    * Only present if the operation is part of a multi-document transaction.
    */
   lsid?: ServerSessionId;
+
+  /**
+   * When the change stream's backing aggregation pipeline contains the $changeStreamSplitLargeEvent
+   * stage, events larger than 16MB will be split into multiple events and contain the
+   * following information about which fragment the current event is.
+   */
+  splitEvent?: ChangeStreamSplitEvent;
 }
 
 /** @public */

--- a/src/index.ts
+++ b/src/index.ts
@@ -194,6 +194,7 @@ export type {
   ChangeStreamReplaceDocument,
   ChangeStreamReshardCollectionDocument,
   ChangeStreamShardCollectionDocument,
+  ChangeStreamSplitEvent,
   ChangeStreamUpdateDocument,
   OperationTime,
   ResumeOptions,

--- a/test/integration/change-streams/change_streams.prose.test.ts
+++ b/test/integration/change-streams/change_streams.prose.test.ts
@@ -976,6 +976,8 @@ describe('Change Stream prose tests', function () {
         // Collect two events from _S_.
         const eventOne = await changeStream.next();
         const eventTwo = await changeStream.next();
+        // Assert that the events collected have splitEvent fields { "fragment": 1, "of": 2 }
+        // and { "fragment": 2, "of": 2 }, in that order.
         expect(eventOne.splitEvent).to.deep.equal({ fragment: 1, of: 2 });
         expect(eventTwo.splitEvent).to.deep.equal({ fragment: 2, of: 2 });
       }

--- a/test/integration/change-streams/change_streams.prose.test.ts
+++ b/test/integration/change-streams/change_streams.prose.test.ts
@@ -1,8 +1,11 @@
 import { expect } from 'chai';
+import { once } from 'events';
 import * as sinon from 'sinon';
 import { setTimeout } from 'timers';
+import { promisify } from 'util';
 
 import {
+  AbstractCursor,
   type ChangeStream,
   type CommandFailedEvent,
   type CommandStartedEvent,
@@ -16,6 +19,7 @@ import {
   Timestamp
 } from '../../mongodb';
 import * as mock from '../../tools/mongodb-mock/index';
+import { getSymbolFrom } from '../../tools/utils';
 import { setupDatabase } from '../shared';
 
 /**
@@ -67,6 +71,14 @@ function triggerResumableError(
 
   triggerError();
 }
+
+const initIteratorMode = async (cs: ChangeStream) => {
+  const init = getSymbolFrom(AbstractCursor.prototype, 'kInit');
+  const initEvent = once(cs.cursor, 'init');
+  await promisify(cs.cursor[init].bind(cs.cursor))();
+  await initEvent;
+  return;
+};
 
 /** Waits for a change stream to start */
 function waitForStarted(changeStream, callback) {
@@ -961,7 +973,7 @@ describe('Change Stream prose tests', function () {
     });
 
     it('splits the event into multiple fragments', {
-      metadata: { requires: { topology: 'replicaset', mongodb: '>=7.0.0' } },
+      metadata: { requires: { topology: '!single', mongodb: '>=7.0.0' } },
       test: async function () {
         // Insert into _C_ a document at least 10mb in size, e.g. { "value": "q"*10*1024*1024 }
         await collection.insertOne({ value: 'q'.repeat(10 * 1024 * 1024) });
@@ -970,6 +982,7 @@ describe('Change Stream prose tests', function () {
         const changeStream = collection.watch([{ $changeStreamSplitLargeEvent: {} }], {
           fullDocumentBeforeChange: 'required'
         });
+        await initIteratorMode(changeStream);
         // Call updateOne on _C_ with an empty query and an update setting the field to a new
         // large value, e.g. { "$set": { "value": "z"*10*1024*1024 } }.
         await collection.updateOne({}, { $set: { value: 'z'.repeat(10 * 1024 * 1024) } });

--- a/test/integration/change-streams/change_streams.prose.test.ts
+++ b/test/integration/change-streams/change_streams.prose.test.ts
@@ -976,6 +976,7 @@ describe('Change Stream prose tests', function () {
         // Collect two events from _S_.
         const eventOne = await changeStream.next();
         const eventTwo = await changeStream.next();
+        await changeStream.close();
         // Assert that the events collected have splitEvent fields { "fragment": 1, "of": 2 }
         // and { "fragment": 2, "of": 2 }, in that order.
         expect(eventOne.splitEvent).to.deep.equal({ fragment: 1, of: 2 });


### PR DESCRIPTION
### Description

Adds support for change stream split events.

#### What is changing?

- Adds the new `ChangeStreamSplitEvent` type.
- Adds the `splitEvent` to the change stream common document type.
- Add the new prose test to test the event splitting. (see https://github.com/mongodb/specifications/tree/master/source/change-streams/tests#prose-tests #19)

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-5243

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

#### Support for change stream split events

When change stream documents exceed the max BSON size limit of 16MB, they can be split into multiple fragments in order to not error when sending events over the wire. In order to enable this functionality, the collection must be created with `changeStreamPreAndPostImages` enabled and the change stream itself must include an `$changeStreamSplitLargeEvent` aggregation stage. This feature requires a minimum server version of 7.0.0.

Example:

```typescript
await db.createCollection('test', { changeStreamPreAndPostImages: { enabled: true }});
const collection = db.collection('test');
const changeStream = collection.watch([{ $changeStreamSplitLargeEvent: {} ], {
  fullDocumentBeforeChange: 'required'
});

for await (const change of changeStream) {
  console.log(change.splitEvent); // If changes over 16MB: { fragment: n, of: n }
}
```

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
