### PR TITLE
chore(NODE-5382): add 4.x release workflow

### DIFF
--- a/.github/workflows/release-4.x.yml
+++ b/.github/workflows/release-4.x.yml
@@ -1,0 +1,37 @@
+on:
+  push:
+    branches: [4.x]
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+name: release
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - id: release
+        uses: google-github-actions/release-please-action@v3
+        with:
+          release-type: node
+          package-name: mongodb
+          # Example: chore(main): release 5.7.0 [skip-ci]
+          # ${scope} - parenthesis included, base branch name
+          pull-request-title-pattern: 'chore${scope}: release ${version} [skip-ci]'
+          pull-request-header: 'Please run the release_notes action before releasing to generate release highlights'
+          changelog-path: HISTORY.md
+          default-branch: 4.x
+
+      # If release-please created a release, publish to npm
+      - if: ${{ steps.release.outputs.release_created }}
+        uses: actions/checkout@v3
+      - if: ${{ steps.release.outputs.release_created }}
+        name: actions/setup
+        uses: ./.github/actions/setup
+      - if: ${{ steps.release.outputs.release_created }}
+        run: npm publish --provenance --tag=4x
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
### Description

#### What is changing?

- Copied the release from main workflow
- Changed the branch trigger to 4.x
- Changed default-branch to 4.x
- added npm tag "4x"

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

Automagic releases for 4.x

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->
<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [/] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [/] Changes are covered by tests
- [/] New TODOs have a related JIRA ticket
