### PR TITLE
refactor(NODE-5360): refactor CommandOperation to use async

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -388,6 +388,7 @@ export type {
   CommandOperationOptions,
   OperationParent
 } from './operations/command';
+export type { CommandCallbackOperation } from './operations/command';
 export type { IndexInformationOptions } from './operations/common_functions';
 export type { CountOptions } from './operations/count';
 export type { CountDocumentsOptions } from './operations/count_documents';

--- a/src/operations/add_user.ts
+++ b/src/operations/add_user.ts
@@ -6,7 +6,7 @@ import { MongoInvalidArgumentError } from '../error';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
 import { type Callback, emitWarningOnce, getTopology } from '../utils';
-import { CommandOperation, type CommandOperationOptions } from './command';
+import { CommandCallbackOperation, type CommandOperationOptions } from './command';
 import { Aspect, defineAspects } from './operation';
 
 /**
@@ -35,7 +35,7 @@ export interface AddUserOptions extends CommandOperationOptions {
 }
 
 /** @internal */
-export class AddUserOperation extends CommandOperation<Document> {
+export class AddUserOperation extends CommandCallbackOperation<Document> {
   override options: AddUserOptions;
   db: Db;
   username: string;
@@ -117,7 +117,7 @@ export class AddUserOperation extends CommandOperation<Document> {
       command.pwd = userPassword;
     }
 
-    super.executeCommand(server, session, command, callback);
+    super.executeCommandCallback(server, session, command, callback);
   }
 }
 

--- a/src/operations/aggregate.ts
+++ b/src/operations/aggregate.ts
@@ -4,7 +4,11 @@ import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
 import { type Callback, maxWireVersion, type MongoDBNamespace } from '../utils';
 import { WriteConcern } from '../write_concern';
-import { type CollationOptions, CommandOperation, type CommandOperationOptions } from './command';
+import {
+  type CollationOptions,
+  CommandCallbackOperation,
+  type CommandOperationOptions
+} from './command';
 import { Aspect, defineAspects, type Hint } from './operation';
 
 /** @internal */
@@ -36,7 +40,7 @@ export interface AggregateOptions extends CommandOperationOptions {
 }
 
 /** @internal */
-export class AggregateOperation<T = Document> extends CommandOperation<T> {
+export class AggregateOperation<T = Document> extends CommandCallbackOperation<T> {
   override options: AggregateOptions;
   target: string | typeof DB_AGGREGATE_COLLECTION;
   pipeline: Document[];
@@ -133,7 +137,7 @@ export class AggregateOperation<T = Document> extends CommandOperation<T> {
       command.cursor.batchSize = options.batchSize;
     }
 
-    super.executeCommand(server, session, command, callback);
+    super.executeCommandCallback(server, session, command, callback);
   }
 }
 

--- a/src/operations/command.ts
+++ b/src/operations/command.ts
@@ -157,6 +157,7 @@ export abstract class CommandOperation<T> extends AbstractCallbackOperation<T> {
   }
 }
 
+/** @internal */
 export abstract class CommandCallbackOperation<T = any> extends CommandOperation<T> {
   constructor(parent?: OperationParent, options?: CommandOperationOptions) {
     super(parent, options);

--- a/src/operations/command.ts
+++ b/src/operations/command.ts
@@ -1,5 +1,3 @@
-import { promisify } from 'util';
-
 import type { BSONSerializeOptions, Document } from '../bson';
 import { MongoInvalidArgumentError } from '../error';
 import { Explain, type ExplainOptions } from '../explain';
@@ -162,16 +160,6 @@ export abstract class CommandOperation<T> extends AbstractCallbackOperation<T> {
 export abstract class CommandCallbackOperation<T = any> extends CommandOperation<T> {
   constructor(parent?: OperationParent, options?: CommandOperationOptions) {
     super(parent, options);
-  }
-
-  override executeCommand(
-    server: Server,
-    session: ClientSession | undefined,
-    cmd: Document
-  ): Promise<any> {
-    return promisify((callback: (e: Error, r: T) => void) => {
-      this.executeCommandCallback(server, session, cmd, callback as any);
-    })();
   }
 
   protected executeCommandCallback(

--- a/src/operations/command.ts
+++ b/src/operations/command.ts
@@ -163,7 +163,7 @@ export abstract class CommandCallbackOperation<T = any> extends CommandOperation
     super(parent, options);
   }
 
-  protected executeCommandCallback(
+  executeCommandCallback(
     server: Server,
     session: ClientSession | undefined,
     cmd: Document,

--- a/src/operations/command.ts
+++ b/src/operations/command.ts
@@ -109,10 +109,10 @@ export abstract class CommandOperation<T> extends AbstractCallbackOperation<T> {
     return true;
   }
 
-  executeCommand(
+  async executeCommand(
     server: Server,
     session: ClientSession | undefined,
-    cmd: Document,
+    cmd: Document
   ): Promise<any> {
     // TODO: consider making this a non-enumerable property
     this.server = server;
@@ -159,12 +159,12 @@ export abstract class CommandOperation<T> extends AbstractCallbackOperation<T> {
   }
 }
 
-export abstract class CommandCallbackOperation<T = any> extends AbstractCallbackOperation<T> {
+export abstract class CommandCallbackOperation<T = any> extends CommandOperation<T> {
   constructor(parent?: OperationParent, options?: CommandOperationOptions) {
     super(parent, options);
   }
 
-  async executeCommand(
+  override executeCommand(
     server: Server,
     session: ClientSession | undefined,
     cmd: Document
@@ -174,12 +174,12 @@ export abstract class CommandCallbackOperation<T = any> extends AbstractCallback
     })();
   }
 
-  protected abstract executeCommandCallback(
+  protected executeCommandCallback(
     server: Server,
     session: ClientSession | undefined,
     cmd: Document,
     callback: Callback
-  ): void; {
+  ): void {
     this.server = server;
 
     const options = {

--- a/src/operations/count.ts
+++ b/src/operations/count.ts
@@ -3,7 +3,7 @@ import type { Collection } from '../collection';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
 import type { Callback, MongoDBNamespace } from '../utils';
-import { CommandOperation, type CommandOperationOptions } from './command';
+import { CommandCallbackOperation, type CommandOperationOptions } from './command';
 import { Aspect, defineAspects } from './operation';
 
 /** @public */
@@ -19,7 +19,7 @@ export interface CountOptions extends CommandOperationOptions {
 }
 
 /** @internal */
-export class CountOperation extends CommandOperation<number> {
+export class CountOperation extends CommandCallbackOperation<number> {
   override options: CountOptions;
   collectionName?: string;
   query: Document;
@@ -59,7 +59,7 @@ export class CountOperation extends CommandOperation<number> {
       cmd.maxTimeMS = options.maxTimeMS;
     }
 
-    super.executeCommand(server, session, cmd, (err, result) => {
+    super.executeCommandCallback(server, session, cmd, (err, result) => {
       callback(err, result ? result.n : 0);
     });
   }

--- a/src/operations/create_collection.ts
+++ b/src/operations/create_collection.ts
@@ -10,7 +10,7 @@ import type { PkFactory } from '../mongo_client';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
 import type { Callback } from '../utils';
-import { CommandOperation, type CommandOperationOptions } from './command';
+import { CommandCallbackOperation, type CommandOperationOptions } from './command';
 import { CreateIndexOperation } from './indexes';
 import { Aspect, defineAspects } from './operation';
 
@@ -108,7 +108,7 @@ const INVALID_QE_VERSION =
   'Driver support of Queryable Encryption is incompatible with server. Upgrade server to use Queryable Encryption.';
 
 /** @internal */
-export class CreateCollectionOperation extends CommandOperation<Collection> {
+export class CreateCollectionOperation extends CommandCallbackOperation<Collection> {
   override options: CreateCollectionOptions;
   db: Db;
   name: string;
@@ -209,7 +209,7 @@ export class CreateCollectionOperation extends CommandOperation<Collection> {
       }
 
       // otherwise just execute the command
-      super.executeCommand(server, session, cmd, done);
+      super.executeCommandCallback(server, session, cmd, done);
     });
   }
 }

--- a/src/operations/delete.ts
+++ b/src/operations/delete.ts
@@ -5,7 +5,11 @@ import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
 import type { Callback, MongoDBNamespace } from '../utils';
 import type { WriteConcernOptions } from '../write_concern';
-import { type CollationOptions, CommandOperation, type CommandOperationOptions } from './command';
+import {
+  type CollationOptions,
+  CommandCallbackOperation,
+  type CommandOperationOptions
+} from './command';
 import { Aspect, defineAspects, type Hint } from './operation';
 
 /** @public */
@@ -41,7 +45,7 @@ export interface DeleteStatement {
 }
 
 /** @internal */
-export class DeleteOperation extends CommandOperation<DeleteResult> {
+export class DeleteOperation extends CommandCallbackOperation<DeleteResult> {
   override options: DeleteOptions;
   statements: DeleteStatement[];
 
@@ -92,7 +96,7 @@ export class DeleteOperation extends CommandOperation<DeleteResult> {
       }
     }
 
-    super.executeCommand(server, session, command, callback);
+    super.executeCommandCallback(server, session, command, callback);
   }
 }
 

--- a/src/operations/distinct.ts
+++ b/src/operations/distinct.ts
@@ -3,7 +3,7 @@ import type { Collection } from '../collection';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
 import { type Callback, decorateWithCollation, decorateWithReadConcern } from '../utils';
-import { CommandOperation, type CommandOperationOptions } from './command';
+import { CommandCallbackOperation, type CommandOperationOptions } from './command';
 import { Aspect, defineAspects } from './operation';
 
 /** @public */
@@ -13,7 +13,7 @@ export type DistinctOptions = CommandOperationOptions;
  * Return a list of distinct values for the given key across a collection.
  * @internal
  */
-export class DistinctOperation extends CommandOperation<any[]> {
+export class DistinctOperation extends CommandCallbackOperation<any[]> {
   override options: DistinctOptions;
   collection: Collection;
   /** Field of the document to find distinct values for. */
@@ -76,7 +76,7 @@ export class DistinctOperation extends CommandOperation<any[]> {
       return callback(err);
     }
 
-    super.executeCommand(server, session, cmd, (err, result) => {
+    super.executeCommandCallback(server, session, cmd, (err, result) => {
       if (err) {
         callback(err);
         return;

--- a/src/operations/drop.ts
+++ b/src/operations/drop.ts
@@ -4,7 +4,7 @@ import { MONGODB_ERROR_CODES, MongoServerError } from '../error';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
 import type { Callback } from '../utils';
-import { CommandOperation, type CommandOperationOptions } from './command';
+import { CommandCallbackOperation, type CommandOperationOptions } from './command';
 import { Aspect, defineAspects } from './operation';
 
 /** @public */
@@ -14,7 +14,7 @@ export interface DropCollectionOptions extends CommandOperationOptions {
 }
 
 /** @internal */
-export class DropCollectionOperation extends CommandOperation<boolean> {
+export class DropCollectionOperation extends CommandCallbackOperation<boolean> {
   override options: DropCollectionOptions;
   db: Db;
   name: string;
@@ -83,7 +83,7 @@ export class DropCollectionOperation extends CommandOperation<boolean> {
     session: ClientSession | undefined
   ): Promise<boolean> {
     return new Promise<boolean>((resolve, reject) => {
-      super.executeCommand(server, session, { drop: this.name }, (err, result) => {
+      super.executeCommandCallback(server, session, { drop: this.name }, (err, result) => {
         if (err) return reject(err);
         resolve(!!result.ok);
       });
@@ -95,7 +95,7 @@ export class DropCollectionOperation extends CommandOperation<boolean> {
 export type DropDatabaseOptions = CommandOperationOptions;
 
 /** @internal */
-export class DropDatabaseOperation extends CommandOperation<boolean> {
+export class DropDatabaseOperation extends CommandCallbackOperation<boolean> {
   override options: DropDatabaseOptions;
 
   constructor(db: Db, options: DropDatabaseOptions) {
@@ -107,7 +107,7 @@ export class DropDatabaseOperation extends CommandOperation<boolean> {
     session: ClientSession | undefined,
     callback: Callback<boolean>
   ): void {
-    super.executeCommand(server, session, { dropDatabase: 1 }, (err, result) => {
+    super.executeCommandCallback(server, session, { dropDatabase: 1 }, (err, result) => {
       if (err) return callback(err);
       if (result.ok) return callback(undefined, true);
       callback(undefined, false);

--- a/src/operations/estimated_document_count.ts
+++ b/src/operations/estimated_document_count.ts
@@ -3,7 +3,7 @@ import type { Collection } from '../collection';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
 import type { Callback } from '../utils';
-import { CommandOperation, type CommandOperationOptions } from './command';
+import { CommandCallbackOperation, type CommandOperationOptions } from './command';
 import { Aspect, defineAspects } from './operation';
 
 /** @public */
@@ -17,7 +17,7 @@ export interface EstimatedDocumentCountOptions extends CommandOperationOptions {
 }
 
 /** @internal */
-export class EstimatedDocumentCountOperation extends CommandOperation<number> {
+export class EstimatedDocumentCountOperation extends CommandCallbackOperation<number> {
   override options: EstimatedDocumentCountOptions;
   collectionName: string;
 
@@ -44,7 +44,7 @@ export class EstimatedDocumentCountOperation extends CommandOperation<number> {
       cmd.comment = this.options.comment;
     }
 
-    super.executeCommand(server, session, cmd, (err, response) => {
+    super.executeCommandCallback(server, session, cmd, (err, response) => {
       if (err) {
         callback(err);
         return;

--- a/src/operations/eval.ts
+++ b/src/operations/eval.ts
@@ -6,7 +6,7 @@ import { ReadPreference } from '../read_preference';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
 import type { Callback } from '../utils';
-import { CommandOperation, type CommandOperationOptions } from './command';
+import { CommandCallbackOperation, type CommandOperationOptions } from './command';
 
 /** @public */
 export interface EvalOptions extends CommandOperationOptions {
@@ -14,7 +14,7 @@ export interface EvalOptions extends CommandOperationOptions {
 }
 
 /** @internal */
-export class EvalOperation extends CommandOperation<Document> {
+export class EvalOperation extends CommandCallbackOperation<Document> {
   override options: EvalOptions;
   code: Code;
   parameters?: Document | Document[];
@@ -65,7 +65,7 @@ export class EvalOperation extends CommandOperation<Document> {
     }
 
     // Execute the command
-    super.executeCommand(server, session, cmd, (err, result) => {
+    super.executeCommandCallback(server, session, cmd, (err, result) => {
       if (err) return callback(err);
       if (result && result.ok === 1) {
         return callback(undefined, result.retval);

--- a/src/operations/find.ts
+++ b/src/operations/find.ts
@@ -11,7 +11,11 @@ import {
   type MongoDBNamespace,
   normalizeHintField
 } from '../utils';
-import { type CollationOptions, CommandOperation, type CommandOperationOptions } from './command';
+import {
+  type CollationOptions,
+  CommandCallbackOperation,
+  type CommandOperationOptions
+} from './command';
 import { Aspect, defineAspects, type Hint } from './operation';
 
 /**
@@ -71,7 +75,7 @@ export interface FindOptions<TSchema extends Document = Document>
 }
 
 /** @internal */
-export class FindOperation extends CommandOperation<Document> {
+export class FindOperation extends CommandCallbackOperation<Document> {
   /**
    * @remarks WriteConcern can still be present on the options because
    * we inherit options from the client/db/collection.  The

--- a/src/operations/find_and_modify.ts
+++ b/src/operations/find_and_modify.ts
@@ -7,7 +7,7 @@ import type { ClientSession } from '../sessions';
 import { formatSort, type Sort, type SortForCmd } from '../sort';
 import { type Callback, decorateWithCollation, hasAtomicOperators, maxWireVersion } from '../utils';
 import type { WriteConcern, WriteConcernSettings } from '../write_concern';
-import { CommandOperation, type CommandOperationOptions } from './command';
+import { CommandCallbackOperation, type CommandOperationOptions } from './command';
 import { Aspect, defineAspects } from './operation';
 
 /** @public */
@@ -122,7 +122,7 @@ function configureFindAndModifyCmdBaseUpdateOpts(
 }
 
 /** @internal */
-class FindAndModifyOperation extends CommandOperation<Document> {
+class FindAndModifyOperation extends CommandCallbackOperation<Document> {
   override options: FindOneAndReplaceOptions | FindOneAndUpdateOptions | FindOneAndDeleteOptions;
   cmdBase: FindAndModifyCmdBase;
   collection: Collection;
@@ -220,7 +220,7 @@ class FindAndModifyOperation extends CommandOperation<Document> {
     }
 
     // Execute the command
-    super.executeCommand(server, session, cmd, (err, result) => {
+    super.executeCommandCallback(server, session, cmd, (err, result) => {
       if (err) return callback(err);
       return callback(undefined, options.includeResultMetadata ? result : result.value ?? null);
     });

--- a/src/operations/indexes.ts
+++ b/src/operations/indexes.ts
@@ -9,7 +9,7 @@ import type { ClientSession } from '../sessions';
 import { type Callback, isObject, maxWireVersion, type MongoDBNamespace } from '../utils';
 import {
   type CollationOptions,
-  CommandOperation,
+  CommandCallbackOperation,
   type CommandOperationOptions,
   type OperationParent
 } from './command';
@@ -206,7 +206,7 @@ export class IndexesOperation extends AbstractCallbackOperation<Document[]> {
 /** @internal */
 export class CreateIndexesOperation<
   T extends string | string[] = string[]
-> extends CommandOperation<T> {
+> extends CommandCallbackOperation<T> {
   override options: CreateIndexesOptions;
   collectionName: string;
   indexes: ReadonlyArray<Omit<IndexDescription, 'key'> & { key: Map<string, IndexDirection> }>;
@@ -266,7 +266,7 @@ export class CreateIndexesOperation<
     // collation is set on each index, it should not be defined at the root
     this.options.collation = undefined;
 
-    super.executeCommand(server, session, cmd, err => {
+    super.executeCommandCallback(server, session, cmd, err => {
       if (err) {
         callback(err);
         return;
@@ -348,7 +348,7 @@ export class EnsureIndexOperation extends CreateIndexOperation {
 export type DropIndexesOptions = CommandOperationOptions;
 
 /** @internal */
-export class DropIndexOperation extends CommandOperation<Document> {
+export class DropIndexOperation extends CommandCallbackOperation<Document> {
   override options: DropIndexesOptions;
   collection: Collection;
   indexName: string;
@@ -367,7 +367,7 @@ export class DropIndexOperation extends CommandOperation<Document> {
     callback: Callback<Document>
   ): void {
     const cmd = { dropIndexes: this.collection.collectionName, index: this.indexName };
-    super.executeCommand(server, session, cmd, callback);
+    super.executeCommandCallback(server, session, cmd, callback);
   }
 }
 
@@ -396,7 +396,7 @@ export interface ListIndexesOptions extends Omit<CommandOperationOptions, 'write
 }
 
 /** @internal */
-export class ListIndexesOperation extends CommandOperation<Document> {
+export class ListIndexesOperation extends CommandCallbackOperation<Document> {
   /**
    * @remarks WriteConcern can still be present on the options because
    * we inherit options from the client/db/collection.  The
@@ -432,7 +432,7 @@ export class ListIndexesOperation extends CommandOperation<Document> {
       command.comment = this.options.comment;
     }
 
-    super.executeCommand(server, session, command, callback);
+    super.executeCommandCallback(server, session, command, callback);
   }
 }
 

--- a/src/operations/insert.ts
+++ b/src/operations/insert.ts
@@ -8,12 +8,12 @@ import type { ClientSession } from '../sessions';
 import type { Callback, MongoDBNamespace } from '../utils';
 import { WriteConcern } from '../write_concern';
 import { BulkWriteOperation } from './bulk_write';
-import { CommandOperation, type CommandOperationOptions } from './command';
+import { CommandCallbackOperation, type CommandOperationOptions } from './command';
 import { prepareDocs } from './common_functions';
 import { AbstractCallbackOperation, Aspect, defineAspects } from './operation';
 
 /** @internal */
-export class InsertOperation extends CommandOperation<Document> {
+export class InsertOperation extends CommandCallbackOperation<Document> {
   override options: BulkWriteOptions;
   documents: Document[];
 
@@ -47,7 +47,7 @@ export class InsertOperation extends CommandOperation<Document> {
       command.comment = options.comment;
     }
 
-    super.executeCommand(server, session, command, callback);
+    super.executeCommandCallback(server, session, command, callback);
   }
 }
 

--- a/src/operations/list_collections.ts
+++ b/src/operations/list_collections.ts
@@ -3,7 +3,7 @@ import type { Db } from '../db';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
 import { type Callback, maxWireVersion } from '../utils';
-import { CommandOperation, type CommandOperationOptions } from './command';
+import { CommandCallbackOperation, type CommandOperationOptions } from './command';
 import { Aspect, defineAspects } from './operation';
 
 /** @public */
@@ -17,7 +17,7 @@ export interface ListCollectionsOptions extends Omit<CommandOperationOptions, 'w
 }
 
 /** @internal */
-export class ListCollectionsOperation extends CommandOperation<string[]> {
+export class ListCollectionsOperation extends CommandCallbackOperation<string[]> {
   /**
    * @remarks WriteConcern can still be present on the options because
    * we inherit options from the client/db/collection.  The
@@ -52,7 +52,7 @@ export class ListCollectionsOperation extends CommandOperation<string[]> {
     session: ClientSession | undefined,
     callback: Callback<string[]>
   ): void {
-    return super.executeCommand(
+    return super.executeCommandCallback(
       server,
       session,
       this.generateCommand(maxWireVersion(server)),

--- a/src/operations/list_databases.ts
+++ b/src/operations/list_databases.ts
@@ -3,7 +3,7 @@ import type { Db } from '../db';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
 import { type Callback, maxWireVersion, MongoDBNamespace } from '../utils';
-import { CommandOperation, type CommandOperationOptions } from './command';
+import { CommandCallbackOperation, type CommandOperationOptions } from './command';
 import { Aspect, defineAspects } from './operation';
 
 /** @public */
@@ -25,7 +25,7 @@ export interface ListDatabasesOptions extends CommandOperationOptions {
 }
 
 /** @internal */
-export class ListDatabasesOperation extends CommandOperation<ListDatabasesResult> {
+export class ListDatabasesOperation extends CommandCallbackOperation<ListDatabasesResult> {
   override options: ListDatabasesOptions;
 
   constructor(db: Db, options?: ListDatabasesOptions) {
@@ -59,7 +59,7 @@ export class ListDatabasesOperation extends CommandOperation<ListDatabasesResult
       cmd.comment = this.options.comment;
     }
 
-    super.executeCommand(server, session, cmd, callback);
+    super.executeCommandCallback(server, session, cmd, callback);
   }
 }
 

--- a/src/operations/profiling_level.ts
+++ b/src/operations/profiling_level.ts
@@ -3,13 +3,13 @@ import { MongoRuntimeError } from '../error';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
 import type { Callback } from '../utils';
-import { CommandOperation, type CommandOperationOptions } from './command';
+import { CommandCallbackOperation, type CommandOperationOptions } from './command';
 
 /** @public */
 export type ProfilingLevelOptions = CommandOperationOptions;
 
 /** @internal */
-export class ProfilingLevelOperation extends CommandOperation<string> {
+export class ProfilingLevelOperation extends CommandCallbackOperation<string> {
   override options: ProfilingLevelOptions;
 
   constructor(db: Db, options: ProfilingLevelOptions) {
@@ -22,7 +22,7 @@ export class ProfilingLevelOperation extends CommandOperation<string> {
     session: ClientSession | undefined,
     callback: Callback<string>
   ): void {
-    super.executeCommand(server, session, { profile: -1 }, (err, doc) => {
+    super.executeCommandCallback(server, session, { profile: -1 }, (err, doc) => {
       if (err == null && doc.ok === 1) {
         const was = doc.was;
         if (was === 0) return callback(undefined, 'off');

--- a/src/operations/remove_user.ts
+++ b/src/operations/remove_user.ts
@@ -2,14 +2,14 @@ import type { Db } from '../db';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
 import type { Callback } from '../utils';
-import { CommandOperation, type CommandOperationOptions } from './command';
+import { CommandCallbackOperation, type CommandOperationOptions } from './command';
 import { Aspect, defineAspects } from './operation';
 
 /** @public */
 export type RemoveUserOptions = CommandOperationOptions;
 
 /** @internal */
-export class RemoveUserOperation extends CommandOperation<boolean> {
+export class RemoveUserOperation extends CommandCallbackOperation<boolean> {
   override options: RemoveUserOptions;
   username: string;
 
@@ -24,7 +24,7 @@ export class RemoveUserOperation extends CommandOperation<boolean> {
     session: ClientSession | undefined,
     callback: Callback<boolean>
   ): void {
-    super.executeCommand(server, session, { dropUser: this.username }, err => {
+    super.executeCommandCallback(server, session, { dropUser: this.username }, err => {
       callback(err, err ? false : true);
     });
   }

--- a/src/operations/run_command.ts
+++ b/src/operations/run_command.ts
@@ -3,7 +3,7 @@ import type { ReadPreferenceLike } from '../read_preference';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
 import { type Callback, MongoDBNamespace } from '../utils';
-import { CommandOperation, type OperationParent } from './command';
+import { CommandCallbackOperation, type OperationParent } from './command';
 
 /** @public */
 export type RunCommandOptions = {
@@ -45,7 +45,7 @@ export type RunCommandOptions = {
 } & BSONSerializeOptions;
 
 /** @internal */
-export class RunCommandOperation<T = Document> extends CommandOperation<T> {
+export class RunCommandOperation<T = Document> extends CommandCallbackOperation<T> {
   override options: RunCommandOptions;
   command: Document;
 
@@ -61,7 +61,7 @@ export class RunCommandOperation<T = Document> extends CommandOperation<T> {
     callback: Callback<T>
   ): void {
     const command = this.command;
-    this.executeCommand(server, session, command, callback);
+    this.executeCommandCallback(server, session, command, callback);
   }
 }
 

--- a/src/operations/set_profiling_level.ts
+++ b/src/operations/set_profiling_level.ts
@@ -4,7 +4,7 @@ import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
 import type { Callback } from '../utils';
 import { enumToString } from '../utils';
-import { CommandOperation, type CommandOperationOptions } from './command';
+import { CommandCallbackOperation, type CommandOperationOptions } from './command';
 
 const levelValues = new Set(['off', 'slow_only', 'all']);
 
@@ -22,7 +22,7 @@ export type ProfilingLevel = (typeof ProfilingLevel)[keyof typeof ProfilingLevel
 export type SetProfilingLevelOptions = CommandOperationOptions;
 
 /** @internal */
-export class SetProfilingLevelOperation extends CommandOperation<ProfilingLevel> {
+export class SetProfilingLevelOperation extends CommandCallbackOperation<ProfilingLevel> {
   override options: SetProfilingLevelOptions;
   level: ProfilingLevel;
   profile: 0 | 1 | 2;
@@ -64,7 +64,7 @@ export class SetProfilingLevelOperation extends CommandOperation<ProfilingLevel>
     }
 
     // TODO(NODE-3483): Determine error to put here
-    super.executeCommand(server, session, { profile: this.profile }, (err, doc) => {
+    super.executeCommandCallback(server, session, { profile: this.profile }, (err, doc) => {
       if (err == null && doc.ok === 1) return callback(undefined, level);
       return err != null
         ? callback(err)

--- a/src/operations/stats.ts
+++ b/src/operations/stats.ts
@@ -4,7 +4,7 @@ import type { Db } from '../db';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
 import type { Callback } from '../utils';
-import { CommandOperation, type CommandOperationOptions } from './command';
+import { CommandCallbackOperation, type CommandOperationOptions } from './command';
 import { Aspect, defineAspects } from './operation';
 
 /**
@@ -21,7 +21,7 @@ export interface CollStatsOptions extends CommandOperationOptions {
  * Get all the collection statistics.
  * @internal
  */
-export class CollStatsOperation extends CommandOperation<Document> {
+export class CollStatsOperation extends CommandCallbackOperation<Document> {
   override options: CollStatsOptions;
   collectionName: string;
 
@@ -47,7 +47,7 @@ export class CollStatsOperation extends CommandOperation<Document> {
       command.scale = this.options.scale;
     }
 
-    super.executeCommand(server, session, command, callback);
+    super.executeCommandCallback(server, session, command, callback);
   }
 }
 
@@ -58,7 +58,7 @@ export interface DbStatsOptions extends CommandOperationOptions {
 }
 
 /** @internal */
-export class DbStatsOperation extends CommandOperation<Document> {
+export class DbStatsOperation extends CommandCallbackOperation<Document> {
   override options: DbStatsOptions;
 
   constructor(db: Db, options: DbStatsOptions) {
@@ -76,7 +76,7 @@ export class DbStatsOperation extends CommandOperation<Document> {
       command.scale = this.options.scale;
     }
 
-    super.executeCommand(server, session, command, callback);
+    super.executeCommandCallback(server, session, command, callback);
   }
 }
 

--- a/src/operations/update.ts
+++ b/src/operations/update.ts
@@ -5,7 +5,11 @@ import type { InferIdType } from '../mongo_types';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
 import { type Callback, hasAtomicOperators, type MongoDBNamespace } from '../utils';
-import { type CollationOptions, CommandOperation, type CommandOperationOptions } from './command';
+import {
+  type CollationOptions,
+  CommandCallbackOperation,
+  type CommandOperationOptions
+} from './command';
 import { Aspect, defineAspects, type Hint } from './operation';
 
 /** @public */
@@ -60,7 +64,7 @@ export interface UpdateStatement {
 }
 
 /** @internal */
-export class UpdateOperation extends CommandOperation<Document> {
+export class UpdateOperation extends CommandCallbackOperation<Document> {
   override options: UpdateOptions & { ordered?: boolean };
   statements: UpdateStatement[];
 
@@ -120,7 +124,7 @@ export class UpdateOperation extends CommandOperation<Document> {
       }
     }
 
-    super.executeCommand(server, session, command, callback);
+    super.executeCommandCallback(server, session, command, callback);
   }
 }
 

--- a/src/operations/validate_collection.ts
+++ b/src/operations/validate_collection.ts
@@ -4,7 +4,7 @@ import { MongoRuntimeError } from '../error';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
 import type { Callback } from '../utils';
-import { CommandOperation, type CommandOperationOptions } from './command';
+import { CommandCallbackOperation, type CommandOperationOptions } from './command';
 
 /** @public */
 export interface ValidateCollectionOptions extends CommandOperationOptions {
@@ -13,7 +13,7 @@ export interface ValidateCollectionOptions extends CommandOperationOptions {
 }
 
 /** @internal */
-export class ValidateCollectionOperation extends CommandOperation<Document> {
+export class ValidateCollectionOperation extends CommandCallbackOperation<Document> {
   override options: ValidateCollectionOptions;
   collectionName: string;
   command: Document;
@@ -41,7 +41,7 @@ export class ValidateCollectionOperation extends CommandOperation<Document> {
   ): void {
     const collectionName = this.collectionName;
 
-    super.executeCommand(server, session, this.command, (err, doc) => {
+    super.executeCommandCallback(server, session, this.command, (err, doc) => {
       if (err != null) return callback(err);
 
       // TODO(NODE-3483): Replace these with MongoUnexpectedServerResponseError

--- a/src/sdam/server.ts
+++ b/src/sdam/server.ts
@@ -118,11 +118,7 @@ export class Server extends TypedEventEmitter<ServerEvents> {
   pool: ConnectionPool;
   serverApi?: ServerApi;
   hello?: Document;
-  commandAsync: (
-    ns: MongoDBNamespace,
-    cmd: Document,
-    options: CommandOptions
-  ) => Promise<Document | undefined>;
+  commandAsync: (ns: MongoDBNamespace, cmd: Document, options: CommandOptions) => Promise<Document>;
   [kMonitor]: Monitor | null;
 
   /** @event */
@@ -151,7 +147,8 @@ export class Server extends TypedEventEmitter<ServerEvents> {
         ns: MongoDBNamespace,
         cmd: Document,
         options: CommandOptions,
-        callback: Callback<Document>
+        // callback type defines Document result because result is never nullish when it succeeds, otherwise promise rejects
+        callback: (error: Error | undefined, result: Document) => void
       ) => this.command(ns, cmd, options, callback as any)
     );
 

--- a/test/integration/crud/explain.test.ts
+++ b/test/integration/crud/explain.test.ts
@@ -1,13 +1,7 @@
 import { expect } from 'chai';
 import { once } from 'events';
 
-import {
-  type Collection,
-  type CommandStartedEvent,
-  type Db,
-  type MongoClient,
-  MongoServerError
-} from '../../mongodb';
+import { type Collection, type Db, type MongoClient, MongoServerError } from '../../mongodb';
 
 const explain = [true, false, 'queryPlanner', 'allPlansExecution', 'executionStats', 'invalid'];
 

--- a/test/integration/crud/explain.test.ts
+++ b/test/integration/crud/explain.test.ts
@@ -74,7 +74,6 @@ describe('CRUD API explain option', function () {
   afterEach(async function () {
     await collection.drop();
     await client.close();
-    commandsStarted = [];
   });
 
   for (const explainValue of explain) {

--- a/test/integration/crud/explain.test.ts
+++ b/test/integration/crud/explain.test.ts
@@ -11,7 +11,7 @@ import {
 
 const explain = [true, false, 'queryPlanner', 'allPlansExecution', 'executionStats', 'invalid'];
 
-describe('CRUD API explain option', function () {
+describe.only('CRUD API explain option', function () {
   let client: MongoClient;
   let db: Db;
   let collection: Collection;

--- a/test/integration/crud/explain.test.ts
+++ b/test/integration/crud/explain.test.ts
@@ -1,7 +1,13 @@
 import { expect } from 'chai';
 import { once } from 'events';
 
-import { type Collection, type Db, type MongoClient, MongoServerError } from '../../mongodb';
+import {
+  type Collection,
+  type CommandStartedEvent,
+  type Db,
+  type MongoClient,
+  MongoServerError
+} from '../../mongodb';
 
 const explain = [true, false, 'queryPlanner', 'allPlansExecution', 'executionStats', 'invalid'];
 

--- a/test/integration/crud/explain.test.ts
+++ b/test/integration/crud/explain.test.ts
@@ -74,6 +74,7 @@ describe('CRUD API explain option', function () {
   afterEach(async function () {
     await collection.drop();
     await client.close();
+    commandsStarted = [];
   });
 
   for (const explainValue of explain) {

--- a/test/integration/crud/explain.test.ts
+++ b/test/integration/crud/explain.test.ts
@@ -11,7 +11,7 @@ import {
 
 const explain = [true, false, 'queryPlanner', 'allPlansExecution', 'executionStats', 'invalid'];
 
-describe.only('CRUD API explain option', function () {
+describe('CRUD API explain option', function () {
   let client: MongoClient;
   let db: Db;
   let collection: Collection;

--- a/test/unit/operations/abstract_command.test.ts
+++ b/test/unit/operations/abstract_command.test.ts
@@ -31,7 +31,10 @@ class ConcreteCommand<T> extends CommandOperation<T> {
     session: ClientSession | undefined,
     callback: Callback<any>
   ) {
-    return [server, session, callback];
+    super.execute(server, session).then(
+      res => callback(undefined, res),
+      err => callback(err, undefined)
+    );
   }
 }
 
@@ -50,7 +53,7 @@ describe('class CommandOperation', () => {
       const operation = new ConcreteCommand<any>();
       const serverSpy = sinon.stub(server, 'commandAsync');
       const commandPromise = operation.executeCommand(server, undefined, { ping: 1 });
-      expect(commandPromise).to.be.instanceOf(Promise<any>);
+      expect(commandPromise).to.be.instanceOf(Promise);
       await commandPromise;
       expect(serverSpy).to.have.been.calledOnce;
     });

--- a/test/unit/operations/abstract_command.test.ts
+++ b/test/unit/operations/abstract_command.test.ts
@@ -1,0 +1,58 @@
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+
+import {
+  type Callback,
+  type ClientSession,
+  CommandOperation,
+  type CommandOperationOptions,
+type Document,
+  type OperationParent,
+  Server,
+  ServerDescription
+} from '../../mongodb';
+import { topologyWithPlaceholderClient } from '../../tools/utils';
+
+class ConcreteCommand<T> extends CommandOperation<T> {
+  constructor(parent?: OperationParent, options?: CommandOperationOptions) {
+    super(parent, options);
+  }
+
+  async executeCommand(
+    server: Server,
+    session: ClientSession | undefined,
+    cmd: Document
+  ): Promise<any> {
+    return super.executeCommand(server, session, cmd);
+  }
+
+  protected executeCallback(
+    server: Server,
+    session: ClientSession | undefined,
+    callback: Callback<any>
+  ) {
+    return [server, session, callback];
+  }
+}
+
+describe('class CommandOperation', () => {
+  let server: Server;
+  beforeEach(() => {
+    server = new Server(
+      topologyWithPlaceholderClient([], {} as any),
+      new ServerDescription('a:1'),
+      {} as any
+    );
+  });
+
+  context('when a server is created', () => {
+    it('calls server.commandAsync when executeCommand is invoked', async () => {
+      const operation = new ConcreteCommand<any>();
+      const serverSpy = sinon.stub(server, 'commandAsync');
+      const commandPromise = operation.executeCommand(server, undefined, { ping: 1 });
+      expect(commandPromise).to.be.instanceOf(Promise<any>);
+      await commandPromise;
+      expect(serverSpy).to.have.been.calledOnce;
+    });
+  });
+});

--- a/test/unit/operations/abstract_command.test.ts
+++ b/test/unit/operations/abstract_command.test.ts
@@ -6,7 +6,7 @@ import {
   type ClientSession,
   CommandOperation,
   type CommandOperationOptions,
-type Document,
+  type Document,
   type OperationParent,
   Server,
   ServerDescription

--- a/test/unit/operations/abstract_command.test.ts
+++ b/test/unit/operations/abstract_command.test.ts
@@ -4,7 +4,7 @@ import * as sinon from 'sinon';
 import {
   type Callback,
   type ClientSession,
-  CommandOperation,
+  CommandCallbackOperation,
   type CommandOperationOptions,
   type Document,
   type OperationParent,
@@ -13,7 +13,7 @@ import {
 } from '../../mongodb';
 import { topologyWithPlaceholderClient } from '../../tools/utils';
 
-class ConcreteCommand<T> extends CommandOperation<T> {
+class ConcreteCommand<T> extends CommandCallbackOperation<T> {
   constructor(parent?: OperationParent, options?: CommandOperationOptions) {
     super(parent, options);
   }
@@ -49,12 +49,12 @@ describe('class CommandOperation', () => {
   });
 
   context('when a server is created', () => {
-    it('calls server.commandAsync when executeCommand is invoked', async () => {
+    it('calls executeCommand, which calls server.commandAsync, when executeCommandCallback is invoked', async () => {
       const operation = new ConcreteCommand<any>();
       const serverSpy = sinon.stub(server, 'commandAsync');
-      const commandPromise = operation.executeCommand(server, undefined, { ping: 1 });
-      expect(commandPromise).to.be.instanceOf(Promise);
-      await commandPromise;
+      operation.executeCommandCallback(server, undefined, { ping: 1 }, (err, res) => {
+        err ? err : res;
+      });
       expect(serverSpy).to.have.been.calledOnce;
     });
   });


### PR DESCRIPTION
### Description
refactored CommandOperation class to use async
modified all calls to CommandOperation to call CommandCallbackOperation instead

#### What is changing?
new class CommandCallbackOperation
operations now subclass CommandCallbackOperation
new tests

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?
refactoring operations layer to use async/await

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
