### PR TITLE
feat(NODE-5274): deprecate write concern options

### DIFF
--- a/src/gridfs/upload.ts
+++ b/src/gridfs/upload.ts
@@ -458,8 +458,8 @@ function getWriteOptions(stream: GridFSBucketWriteStream): WriteConcernOptions {
   if (stream.writeConcern) {
     obj.writeConcern = {
       w: stream.writeConcern.w,
-      wtimeout: stream.writeConcern.wtimeout,
-      j: stream.writeConcern.j
+      wtimeout: stream.writeConcern.wtimeoutMS,
+      j: stream.writeConcern.journal
     };
   }
   return obj;

--- a/src/operations/aggregate.ts
+++ b/src/operations/aggregate.ts
@@ -3,6 +3,7 @@ import { MongoInvalidArgumentError } from '../error';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
 import { type Callback, maxWireVersion, type MongoDBNamespace } from '../utils';
+import { WriteConcern } from '../write_concern';
 import { type CollationOptions, CommandOperation, type CommandOperationOptions } from './command';
 import { Aspect, defineAspects, type Hint } from './operation';
 
@@ -102,7 +103,7 @@ export class AggregateOperation<T = Document> extends CommandOperation<T> {
     }
 
     if (this.hasWriteStage && this.writeConcern) {
-      Object.assign(command, { writeConcern: this.writeConcern });
+      WriteConcern.apply(command, this.writeConcern);
     }
 
     if (options.bypassDocumentValidation === true) {

--- a/src/operations/command.ts
+++ b/src/operations/command.ts
@@ -135,7 +135,7 @@ export abstract class CommandOperation<T> extends AbstractCallbackOperation<T> {
     }
 
     if (this.writeConcern && this.hasAspect(Aspect.WRITE_OPERATION) && !inTransaction) {
-      Object.assign(cmd, { writeConcern: this.writeConcern });
+      WriteConcern.apply(cmd, this.writeConcern);
     }
 
     if (

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -698,7 +698,7 @@ function endTransaction(
   // apply a writeConcern if specified
   let writeConcern;
   if (session.transaction.options.writeConcern) {
-    writeConcern = WriteConcern.apply({}, session.transaction.options.writeConcern);
+    writeConcern = Object.assign({}, session.transaction.options.writeConcern);
   } else if (session.clientOptions && session.clientOptions.writeConcern) {
     writeConcern = { w: session.clientOptions.writeConcern.w };
   }
@@ -708,9 +708,10 @@ function endTransaction(
   }
 
   if (writeConcern) {
-    Object.assign(command, { writeConcern });
+    WriteConcern.apply(command, writeConcern);
   }
 
+  console.log(command);
   if (commandName === 'commitTransaction' && session.transaction.options.maxTimeMS) {
     Object.assign(command, { maxTimeMS: session.transaction.options.maxTimeMS });
   }

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -773,9 +773,9 @@ function endTransaction(
 
           WriteConcern.apply(
             command,
-            Object.assign({ wtimeoutMS: 10000 }, command.writeConcern, {
-              w: 'majority'
-            })
+            WriteConcern.fromOptions(
+              Object.assign({ wtimeout: 10000 }, command.writeConcern, { w: 'majority' })
+            ) || {}
           );
         }
 

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -45,6 +45,7 @@ import {
   now,
   uuidV4
 } from './utils';
+import { WriteConcern } from './write_concern';
 
 const minWireVersionForShardedTransactions = 8;
 
@@ -697,7 +698,7 @@ function endTransaction(
   // apply a writeConcern if specified
   let writeConcern;
   if (session.transaction.options.writeConcern) {
-    writeConcern = Object.assign({}, session.transaction.options.writeConcern);
+    writeConcern = WriteConcern.apply({}, session.transaction.options.writeConcern);
   } else if (session.clientOptions && session.clientOptions.writeConcern) {
     writeConcern = { w: session.clientOptions.writeConcern.w };
   }

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -773,7 +773,7 @@ function endTransaction(
 
           WriteConcern.apply(
             command,
-            Object.assign({ wtimeout: 10000 }, command.writeConcern, {
+            Object.assign({ wtimeoutMS: 10000 }, command.writeConcern, {
               w: 'majority'
             })
           );

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -704,14 +704,13 @@ function endTransaction(
   }
 
   if (txnState === TxnState.TRANSACTION_COMMITTED) {
-    writeConcern = Object.assign({ wtimeout: 10000 }, writeConcern, { w: 'majority' });
+    writeConcern = Object.assign({ wtimeoutMS: 10000 }, writeConcern, { w: 'majority' });
   }
 
   if (writeConcern) {
     WriteConcern.apply(command, writeConcern);
   }
 
-  console.log(command);
   if (commandName === 'commitTransaction' && session.transaction.options.maxTimeMS) {
     Object.assign(command, { maxTimeMS: session.transaction.options.maxTimeMS });
   }

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -771,9 +771,12 @@ function endTransaction(
           // per txns spec, must unpin session in this case
           session.unpin({ force: true });
 
-          command.writeConcern = Object.assign({ wtimeout: 10000 }, command.writeConcern, {
-            w: 'majority'
-          });
+          WriteConcern.apply(
+            command,
+            Object.assign({ wtimeout: 10000 }, command.writeConcern, {
+              w: 'majority'
+            })
+          );
         }
 
         return executeOperation(

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -771,12 +771,9 @@ function endTransaction(
           // per txns spec, must unpin session in this case
           session.unpin({ force: true });
 
-          WriteConcern.apply(
-            command,
-            WriteConcern.fromOptions(
-              Object.assign({ wtimeout: 10000 }, command.writeConcern, { w: 'majority' })
-            ) || {}
-          );
+          command.writeConcern = Object.assign({ wtimeout: 10000 }, command.writeConcern, {
+            w: 'majority'
+          });
         }
 
         return executeOperation(

--- a/src/write_concern.ts
+++ b/src/write_concern.ts
@@ -1,3 +1,5 @@
+import { Document } from "bson";
+
 /** @public */
 export type W = number | 'majority';
 
@@ -17,15 +19,35 @@ export interface WriteConcernSettings {
   journal?: boolean;
 
   // legacy options
-  /** The journal write concern */
+  /**
+   * The journal write concern.
+   * @deprecated Will be removed in the next major version. Please use the journal option.
+   */
   j?: boolean;
-  /** The write concern timeout */
+  /**
+   * The write concern timeout.
+   * @deprecated Will be removed in the next major version. Please use the wtimeoutMS option.
+   */
   wtimeout?: number;
-  /** The file sync write concern */
+  /**
+   * The file sync write concern.
+   * @deprecated Will be removed in the next major version. Please use the journal option.
+   */
   fsync?: boolean | 1;
 }
 
 export const WRITE_CONCERN_KEYS = ['w', 'wtimeout', 'j', 'journal', 'fsync'];
+
+interface CommandWriteConcernOptions {
+  /** The write concern */
+  w?: W;
+  /** The journal write concern. */
+  j?: boolean;
+  /** The write concern timeout. */
+  wtimeout?: number;
+  /** The file sync write concern. */
+  fsync?: boolean | 1;
+}
 
 /**
  * A MongoDB WriteConcern, which describes the level of acknowledgement
@@ -35,23 +57,36 @@ export const WRITE_CONCERN_KEYS = ['w', 'wtimeout', 'j', 'journal', 'fsync'];
  * @see https://www.mongodb.com/docs/manual/reference/write-concern/
  */
 export class WriteConcern {
-  /** request acknowledgment that the write operation has propagated to a specified number of mongod instances or to mongod instances with specified tags. */
-  w?: W;
-  /** specify a time limit to prevent write operations from blocking indefinitely */
+  /** Request acknowledgment that the write operation has propagated to a specified number of mongod instances or to mongod instances with specified tags. */
+  readonly w?: W;
+  /** Request acknowledgment that the write operation has been written to the on-disk journal */
+  readonly journal?: boolean;
+  /** Specify a time limit to prevent write operations from blocking indefinitely */
+  readonly wtimeoutMS?: number;
+  /**
+   * Specify a time limit to prevent write operations from blocking indefinitely.
+   * @deprecated Will be removed in the next major version. Please use wtimeoutMS.
+   */
   wtimeout?: number;
-  /** request acknowledgment that the write operation has been written to the on-disk journal */
+  /**
+   * Request acknowledgment that the write operation has been written to the on-disk journal.
+   * @deprecated Will be removed in the next major version. Please use journal.
+   */
   j?: boolean;
-  /** equivalent to the j option */
+  /**
+   * Equivalent to the j option.
+   * @deprecated Will be removed in the next major version. Please use journal.
+   */
   fsync?: boolean | 1;
 
   /**
    * Constructs a WriteConcern from the write concern properties.
    * @param w - request acknowledgment that the write operation has propagated to a specified number of mongod instances or to mongod instances with specified tags.
-   * @param wtimeout - specify a time limit to prevent write operations from blocking indefinitely
-   * @param j - request acknowledgment that the write operation has been written to the on-disk journal
+   * @param wtimeoutMS - specify a time limit to prevent write operations from blocking indefinitely
+   * @param journal - request acknowledgment that the write operation has been written to the on-disk journal
    * @param fsync - equivalent to the j option
    */
-  constructor(w?: W, wtimeout?: number, j?: boolean, fsync?: boolean | 1) {
+  constructor(w?: W, wtimeoutMS?: number, journal?: boolean, fsync?: boolean | 1) {
     if (w != null) {
       if (!Number.isNaN(Number(w))) {
         this.w = Number(w);
@@ -59,15 +94,27 @@ export class WriteConcern {
         this.w = w;
       }
     }
-    if (wtimeout != null) {
-      this.wtimeout = wtimeout;
+    if (wtimeoutMS != null) {
+      this.wtimeoutMS = this.wtimeout = wtimeoutMS;
     }
-    if (j != null) {
-      this.j = j;
+    if (journal != null) {
+      this.journal = this.j = journal;
     }
     if (fsync != null) {
-      this.fsync = fsync;
+      this.journal = this.j = fsync ? true : false;
     }
+  }
+
+  /**
+   * Apply a write concern to a command document.
+   */
+  static apply(command: Document, writeConcern: WriteConcern): Document {
+    const wc: CommandWriteConcernOptions = {};
+    // The write concern document sent to the server has w/wtimeout/j fields.
+    if (writeConcern.w != null) wc.w = writeConcern.w;
+    if (writeConcern.wtimeoutMS != null) wc.wtimeout = writeConcern.wtimeoutMS;
+    if (writeConcern.journal != null) wc.j = writeConcern.j;
+    return Object.assign(command, { writeConcern: wc });
   }
 
   /** Construct a WriteConcern given an options object. */

--- a/src/write_concern.ts
+++ b/src/write_concern.ts
@@ -1,4 +1,4 @@
-import { Document } from "bson";
+import { type Document } from 'bson';
 
 /** @public */
 export type W = number | 'majority';

--- a/src/write_concern.ts
+++ b/src/write_concern.ts
@@ -38,6 +38,7 @@ export interface WriteConcernSettings {
 
 export const WRITE_CONCERN_KEYS = ['w', 'wtimeout', 'j', 'journal', 'fsync'];
 
+/** The write concern options that decorate the server command. */
 interface CommandWriteConcernOptions {
   /** The write concern */
   w?: W;
@@ -45,8 +46,6 @@ interface CommandWriteConcernOptions {
   j?: boolean;
   /** The write concern timeout. */
   wtimeout?: number;
-  /** The file sync write concern. */
-  fsync?: boolean | 1;
 }
 
 /**

--- a/src/write_concern.ts
+++ b/src/write_concern.ts
@@ -83,7 +83,7 @@ export class WriteConcern {
    * @param w - request acknowledgment that the write operation has propagated to a specified number of mongod instances or to mongod instances with specified tags.
    * @param wtimeoutMS - specify a time limit to prevent write operations from blocking indefinitely
    * @param journal - request acknowledgment that the write operation has been written to the on-disk journal
-   * @param fsync - equivalent to the j option
+   * @param fsync - equivalent to the j option. Is deprecated and will be removed in the next major version.
    */
   constructor(w?: W, wtimeoutMS?: number, journal?: boolean, fsync?: boolean | 1) {
     if (w != null) {

--- a/src/write_concern.ts
+++ b/src/write_concern.ts
@@ -1,4 +1,4 @@
-import { type Document } from 'bson';
+import { type Document } from './bson';
 
 /** @public */
 export type W = number | 'majority';
@@ -105,7 +105,7 @@ export class WriteConcern {
   }
 
   /**
-   * Apply a write concern to a command document.
+   * Apply a write concern to a command document. Will modify and return the command.
    */
   static apply(command: Document, writeConcern: WriteConcern): Document {
     const wc: CommandWriteConcernOptions = {};
@@ -113,7 +113,8 @@ export class WriteConcern {
     if (writeConcern.w != null) wc.w = writeConcern.w;
     if (writeConcern.wtimeoutMS != null) wc.wtimeout = writeConcern.wtimeoutMS;
     if (writeConcern.journal != null) wc.j = writeConcern.j;
-    return Object.assign(command, { writeConcern: wc });
+    command.writeConcern = wc;
+    return command;
   }
 
   /** Construct a WriteConcern given an options object. */

--- a/test/integration/crud/find_and_modify.test.ts
+++ b/test/integration/crud/find_and_modify.test.ts
@@ -119,8 +119,8 @@ describe('Collection (#findOneAnd...)', function () {
         });
 
         it('passes through the writeConcern', async function () {
-          await collection.findOneAndDelete({}, { writeConcern: { fsync: 1 } });
-          expect(started[0].command.writeConcern).to.deep.equal({ fsync: 1 });
+          await collection.findOneAndDelete({}, { writeConcern: { j: 1 } });
+          expect(started[0].command.writeConcern).to.deep.equal({ j: 1 });
         });
       });
 
@@ -128,27 +128,27 @@ describe('Collection (#findOneAnd...)', function () {
         beforeEach(async function () {
           collection = client
             .db('test')
-            .collection('findAndModifyTest', { writeConcern: { fsync: 1 } });
+            .collection('findAndModifyTest', { writeConcern: { j: 1 } });
           await collection.insertMany([{ a: 1, b: 1 }], { writeConcern: { w: 1 } });
         });
 
         it('passes through the writeConcern', async function () {
           await collection.findOneAndDelete({});
-          expect(started[0].command.writeConcern).to.deep.equal({ fsync: 1 });
+          expect(started[0].command.writeConcern).to.deep.equal({ j: 1 });
         });
       });
 
       context('when provided at the db level', function () {
         beforeEach(async function () {
           collection = client
-            .db('test', { writeConcern: { fsync: 1 } })
+            .db('test', { writeConcern: { j: 1 } })
             .collection('findAndModifyTest');
           await collection.insertMany([{ a: 1, b: 1 }], { writeConcern: { w: 1 } });
         });
 
         it('passes through the writeConcern', async function () {
           await collection.findOneAndDelete({});
-          expect(started[0].command.writeConcern).to.deep.equal({ fsync: 1 });
+          expect(started[0].command.writeConcern).to.deep.equal({ j: 1 });
         });
       });
     });
@@ -297,8 +297,8 @@ describe('Collection (#findOneAnd...)', function () {
         });
 
         it('passes through the writeConcern', async function () {
-          await collection.findOneAndUpdate({}, { $set: { a: 1 } }, { writeConcern: { fsync: 1 } });
-          expect(started[0].command.writeConcern).to.deep.equal({ fsync: 1 });
+          await collection.findOneAndUpdate({}, { $set: { a: 1 } }, { writeConcern: { j: 1 } });
+          expect(started[0].command.writeConcern).to.deep.equal({ j: 1 });
         });
       });
 
@@ -306,27 +306,27 @@ describe('Collection (#findOneAnd...)', function () {
         beforeEach(async function () {
           collection = client
             .db('test')
-            .collection('findAndModifyTest', { writeConcern: { fsync: 1 } });
+            .collection('findAndModifyTest', { writeConcern: { j: 1 } });
           await collection.insertMany([{ a: 1, b: 1 }], { writeConcern: { w: 1 } });
         });
 
         it('passes through the writeConcern', async function () {
           await collection.findOneAndUpdate({}, { $set: { a: 1 } });
-          expect(started[0].command.writeConcern).to.deep.equal({ fsync: 1 });
+          expect(started[0].command.writeConcern).to.deep.equal({ j: 1 });
         });
       });
 
       context('when provided at the db level', function () {
         beforeEach(async function () {
           collection = client
-            .db('test', { writeConcern: { fsync: 1 } })
+            .db('test', { writeConcern: { j: 1 } })
             .collection('findAndModifyTest');
           await collection.insertMany([{ a: 1, b: 1 }], { writeConcern: { w: 1 } });
         });
 
         it('passes through the writeConcern', async function () {
           await collection.findOneAndUpdate({}, { $set: { a: 1 } });
-          expect(started[0].command.writeConcern).to.deep.equal({ fsync: 1 });
+          expect(started[0].command.writeConcern).to.deep.equal({ j: 1 });
         });
       });
     });
@@ -468,8 +468,8 @@ describe('Collection (#findOneAnd...)', function () {
         });
 
         it('passes through the writeConcern', async function () {
-          await collection.findOneAndReplace({}, { b: 1 }, { writeConcern: { fsync: 1 } });
-          expect(started[0].command.writeConcern).to.deep.equal({ fsync: 1 });
+          await collection.findOneAndReplace({}, { b: 1 }, { writeConcern: { j: 1 } });
+          expect(started[0].command.writeConcern).to.deep.equal({ j: 1 });
         });
       });
 

--- a/test/integration/node-specific/mongo_client.test.ts
+++ b/test/integration/node-specific/mongo_client.test.ts
@@ -52,9 +52,8 @@ describe('class MongoClient', function () {
 
         expect(db).to.have.property('writeConcern');
         expect(db.writeConcern).to.have.property('w', 1);
-        expect(db.writeConcern).to.have.property('wtimeout', 1000);
-        expect(db.writeConcern).to.have.property('fsync', true);
-        expect(db.writeConcern).to.have.property('j', true);
+        expect(db.writeConcern).to.have.property('wtimeoutMS', 1000);
+        expect(db.writeConcern).to.have.property('journal', true);
 
         expect(db).to.have.property('s');
         expect(db.s).to.have.property('readPreference');

--- a/test/integration/transactions/transactions.spec.test.js
+++ b/test/integration/transactions/transactions.spec.test.js
@@ -93,7 +93,7 @@ const SKIP_TESTS = [
   'Client side error when transaction is in progress'
 ];
 
-describe('Transactions Spec Legacy Tests', function () {
+describe.only('Transactions Spec Legacy Tests', function () {
   const testContext = new TransactionsRunnerContext();
   if (process.env.SERVERLESS) {
     // TODO(NODE-3550): these tests should pass on serverless but currently fail

--- a/test/integration/transactions/transactions.spec.test.js
+++ b/test/integration/transactions/transactions.spec.test.js
@@ -93,7 +93,7 @@ const SKIP_TESTS = [
   'Client side error when transaction is in progress'
 ];
 
-describe.only('Transactions Spec Legacy Tests', function () {
+describe('Transactions Spec Legacy Tests', function () {
   const testContext = new TransactionsRunnerContext();
   if (process.env.SERVERLESS) {
     // TODO(NODE-3550): these tests should pass on serverless but currently fail

--- a/test/integration/uri-options/uri.test.js
+++ b/test/integration/uri-options/uri.test.js
@@ -66,7 +66,7 @@ describe('URI', function () {
       const client = this.configuration.newClient('mongodb://127.0.0.1:27017/?fsync=true');
       client.connect((err, client) => {
         var db = client.db(this.configuration.db);
-        expect(db.writeConcern.fsync).to.be.true;
+        expect(db.writeConcern.journal).to.be.true;
         client.close(done);
       });
     }

--- a/test/unit/write_concern.test.ts
+++ b/test/unit/write_concern.test.ts
@@ -27,7 +27,7 @@ describe('WriteConcern', function () {
         it('sets the w property to the string', function () {
           expect(writeConcern.w).to.equal('majority');
         });
-      })
+      });
     });
 
     context('when wtimeoutMS is provided', function () {

--- a/test/unit/write_concern.test.ts
+++ b/test/unit/write_concern.test.ts
@@ -5,11 +5,29 @@ import { WriteConcern } from '../mongodb';
 describe('WriteConcern', function () {
   describe('#constructor', function () {
     context('when w is provided', function () {
-      const writeConcern = new WriteConcern(1);
+      context('when w is a number', function () {
+        const writeConcern = new WriteConcern(1);
 
-      it('sets the w property', function () {
-        expect(writeConcern.w).to.equal(1);
+        it('sets the w property', function () {
+          expect(writeConcern.w).to.equal(1);
+        });
       });
+
+      context('when w is a string number', function () {
+        const writeConcern = new WriteConcern('10');
+
+        it('sets the w property to a number', function () {
+          expect(writeConcern.w).to.equal(10);
+        });
+      });
+
+      context('when w is a string', function () {
+        const writeConcern = new WriteConcern('majority');
+
+        it('sets the w property to the string', function () {
+          expect(writeConcern.w).to.equal('majority');
+        });
+      })
     });
 
     context('when wtimeoutMS is provided', function () {

--- a/test/unit/write_concern.test.ts
+++ b/test/unit/write_concern.test.ts
@@ -114,7 +114,7 @@ describe('WriteConcern', function () {
       const document = {};
       const writeConcern = new WriteConcern(2, 30, true, false);
 
-      it('overrites j to the write concern document', function () {
+      it('overwrites j to the write concern document', function () {
         expect(WriteConcern.apply(document, writeConcern)).to.deep.equal({
           writeConcern: { w: 2, wtimeout: 30, j: false }
         });

--- a/test/unit/write_concern.test.ts
+++ b/test/unit/write_concern.test.ts
@@ -1,0 +1,106 @@
+import { expect } from 'chai';
+
+import { WriteConcern } from '../mongodb';
+
+describe('WriteConcern', function () {
+  describe('#constructor', function () {
+    context('when w is provided', function () {
+      const writeConcern = new WriteConcern(1);
+
+      it('sets the w property', function () {
+        expect(writeConcern.w).to.equal(1);
+      });
+    });
+
+    context('when wtimeoutMS is provided', function () {
+      const writeConcern = new WriteConcern(1, 50);
+
+      it('sets the wtimeoutMS property', function () {
+        expect(writeConcern.wtimeoutMS).to.equal(50);
+      });
+
+      it('sets the wtimeout property', function () {
+        expect(writeConcern.wtimeout).to.equal(50);
+      });
+    });
+
+    context('when journal is provided', function () {
+      const writeConcern = new WriteConcern(1, 50, true);
+
+      it('sets the journal property', function () {
+        expect(writeConcern.journal).to.be.true;
+      });
+
+      it('sets the j property', function () {
+        expect(writeConcern.j).to.be.true;
+      });
+    });
+
+    context('when fsync is provided', function () {
+      const writeConcern = new WriteConcern(1, 50, false, true);
+
+      it('sets the journal property', function () {
+        expect(writeConcern.journal).to.be.true;
+      });
+
+      it('sets the j property', function () {
+        expect(writeConcern.j).to.be.true;
+      });
+    });
+  });
+
+  describe('.apply', function () {
+    context('when no options are set', function () {
+      const document = {};
+      const writeConcern = new WriteConcern();
+
+      it('returns an empty write concern', function () {
+        expect(WriteConcern.apply(document, writeConcern)).to.deep.equal({ writeConcern: {} });
+      });
+    });
+
+    context('when w is in the write concern', function () {
+      const document = {};
+      const writeConcern = new WriteConcern(2);
+
+      it('adds w to the write concern document', function () {
+        expect(WriteConcern.apply(document, writeConcern)).to.deep.equal({
+          writeConcern: { w: 2 }
+        });
+      });
+    });
+
+    context('when wtimeoutMS is in the write concern', function () {
+      const document = {};
+      const writeConcern = new WriteConcern(2, 30);
+
+      it('adds wtimeout to the write concern document', function () {
+        expect(WriteConcern.apply(document, writeConcern)).to.deep.equal({
+          writeConcern: { w: 2, wtimeout: 30 }
+        });
+      });
+    });
+
+    context('when journal is in the write concern', function () {
+      const document = {};
+      const writeConcern = new WriteConcern(2, 30, true);
+
+      it('adds j to the write concern document', function () {
+        expect(WriteConcern.apply(document, writeConcern)).to.deep.equal({
+          writeConcern: { w: 2, wtimeout: 30, j: true }
+        });
+      });
+    });
+
+    context('when fsync is in the write concern', function () {
+      const document = {};
+      const writeConcern = new WriteConcern(2, 30, true, false);
+
+      it('overrites j to the write concern document', function () {
+        expect(WriteConcern.apply(document, writeConcern)).to.deep.equal({
+          writeConcern: { w: 2, wtimeout: 30, j: false }
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
### Description

Deprecates old write concern options.

#### What is changing?
- Deprecates `wtimeout`, `j`, and `fsync` options.
- Adds new `WriteConcern.apply()` method to add a write concern to a command.
- Updates instances of adding write concern to commands to use the new apply method.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-5274

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

#### Write Concern legacy options deprecated

`wtimeout`, `j`, and `fsync` options have been deprecated, please use `wtimeoutMS` and `journal` instead.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
