### PR TITLE
feat(NODE-5407): update bson to 5.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.6.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "bson": "^5.3.0",
+        "bson": "^5.4.0",
         "mongodb-connection-string-url": "^2.6.0",
         "socks": "^2.7.1"
       },
@@ -3478,9 +3478,9 @@
       }
     },
     "node_modules/bson": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-5.3.0.tgz",
-      "integrity": "sha512-ukmCZMneMlaC5ebPHXIkP8YJzNl5DC41N5MAIvKDqLggdao342t4McltoJBQfQya/nHBWAcSsYRqlXPoQkTJag==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-5.4.0.tgz",
+      "integrity": "sha512-WRZ5SQI5GfUuKnPTNmAYPiKIof3ORXAF4IRU5UcgmivNIon01rWQlw5RUH954dpu8yGL8T59YShVddIPaU/gFA==",
       "engines": {
         "node": ">=14.20.1"
       }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "email": "dbx-node@mongodb.com"
   },
   "dependencies": {
-    "bson": "^5.3.0",
+    "bson": "^5.4.0",
     "mongodb-connection-string-url": "^2.6.0",
     "socks": "^2.7.1"
   },


### PR DESCRIPTION
### Description

#### What is changing?

Updates BSON to latest 5.4.0

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

Keeps BSON up to date with next driver release

<!-- RELEASE_HIGHLIGHT_START -->

### BSON updated to v5.4.0

Take a look at the `bson` package's release notes!
- https://github.com/mongodb/js-bson/releases/tag/v5.4.0

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
