### PR TITLE
feat!(NODE-5376): remove deprecated ssl options

### DIFF
--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -1096,50 +1096,6 @@ export const OPTIONS = {
     target: 'tls',
     type: 'boolean'
   },
-  sslCA: {
-    deprecated:
-      'sslCA is deprecated and will be removed in the next major version. Please use tlsCAFile instead.',
-    target: 'ca',
-    transform({ values: [value] }) {
-      return fs.readFileSync(String(value), { encoding: 'ascii' });
-    }
-  },
-  sslCRL: {
-    deprecated:
-      'sslCRL is deprecated and will be removed in the next major version. Please use tlsCertificateKeyFile instead.',
-    target: 'crl',
-    transform({ values: [value] }) {
-      return fs.readFileSync(String(value), { encoding: 'ascii' });
-    }
-  },
-  sslCert: {
-    deprecated:
-      'sslCert is deprecated and will be removed in the next major version. Please use tlsCertificateKeyFile instead.',
-    target: 'cert',
-    transform({ values: [value] }) {
-      return fs.readFileSync(String(value), { encoding: 'ascii' });
-    }
-  },
-  sslKey: {
-    deprecated:
-      'sslKey is deprecated and will be removed in the next major version. Please use tlsCertificateKeyFile instead.',
-    target: 'key',
-    transform({ values: [value] }) {
-      return fs.readFileSync(String(value), { encoding: 'ascii' });
-    }
-  },
-  sslPass: {
-    deprecated:
-      'sslPass is deprecated and will be removed in the next major version. Please use tlsCertificateKeyFilePassword instead.',
-    target: 'passphrase',
-    type: 'string'
-  },
-  sslValidate: {
-    deprecated:
-      'sslValidate is deprecated and will be removed in the next major version. Please use tlsAllowInvalidCertificates instead.',
-    target: 'rejectUnauthorized',
-    type: 'boolean'
-  },
   tls: {
     type: 'boolean'
   },
@@ -1159,14 +1115,6 @@ export const OPTIONS = {
   },
   tlsCAFile: {
     target: 'ca',
-    transform({ values: [value] }) {
-      return fs.readFileSync(String(value), { encoding: 'ascii' });
-    }
-  },
-  tlsCertificateFile: {
-    deprecated:
-      'tlsCertificateFile is deprecated and will be removed in the next major version. Please use tlsCertificateKeyFile instead.',
-    target: 'cert',
     transform({ values: [value] }) {
       return fs.readFileSync(String(value), { encoding: 'ascii' });
     }

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -108,11 +108,6 @@ export interface MongoClientOptions extends BSONSerializeOptions, SupportedNodeC
   tls?: boolean;
   /** A boolean to enable or disables TLS/SSL for the connection. (The ssl option is equivalent to the tls option.) */
   ssl?: boolean;
-  /**
-   * Specifies the location of a local TLS Certificate
-   * @deprecated Will be removed in the next major version. Please use tlsCertificateKeyFile instead.
-   */
-  tlsCertificateFile?: string;
   /** Specifies the location of a local .pem file that contains either the client's TLS/SSL certificate and key or only the client's TLS/SSL key when tlsCertificateFile is used to provide the certificate. */
   tlsCertificateKeyFile?: string;
   /** Specifies the password to de-crypt the tlsCertificateKeyFile. */
@@ -211,36 +206,6 @@ export interface MongoClientOptions extends BSONSerializeOptions, SupportedNodeC
    * @see https://www.mongodb.com/docs/manual/reference/write-concern/
    */
   writeConcern?: WriteConcern | WriteConcernSettings;
-  /**
-   * Validate mongod server certificate against Certificate Authority
-   * @deprecated Will be removed in the next major version. Please use tlsAllowInvalidCertificates instead.
-   */
-  sslValidate?: boolean;
-  /**
-   * SSL Certificate file path.
-   * @deprecated Will be removed in the next major version. Please use tlsCAFile instead.
-   */
-  sslCA?: string;
-  /**
-   * SSL Certificate file path.
-   * @deprecated Will be removed in the next major version. Please use tlsCertificateKeyFile instead.
-   */
-  sslCert?: string;
-  /**
-   * SSL Key file file path.
-   * @deprecated Will be removed in the next major version. Please use tlsCertificateKeyFile instead.
-   */
-  sslKey?: string;
-  /**
-   * SSL Certificate pass phrase.
-   * @deprecated Will be removed in the next major version. Please use tlsCertificateKeyFilePassword instead.
-   */
-  sslPass?: string;
-  /**
-   * SSL Certificate revocation list file path.
-   * @deprecated Will be removed in the next major version. Please use tlsCertificateKeyFile instead.
-   */
-  sslCRL?: string;
   /** TCP Connection no delay */
   noDelay?: boolean;
   /** @deprecated TCP Connection keep alive enabled. Will not be able to turn off in the future. */
@@ -805,16 +770,16 @@ export interface MongoOptions
    *
    * ### Additional options:
    *
-   * | nodejs native option  | driver spec compliant option name             | legacy option name | driver option type |
-   * |:----------------------|:----------------------------------------------|:-------------------|:-------------------|
-   * | `ca`                  | `tlsCAFile`                                   | `sslCA`            | `string`           |
-   * | `crl`                 | N/A                                           | `sslCRL`           | `string`           |
-   * | `cert`                | `tlsCertificateFile`, `tlsCertificateKeyFile` | `sslCert`          | `string`           |
-   * | `key`                 | `tlsCertificateKeyFile`                       | `sslKey`           | `string`           |
-   * | `passphrase`          | `tlsCertificateKeyFilePassword`               | `sslPass`          | `string`           |
-   * | `rejectUnauthorized`  | `tlsAllowInvalidCertificates`                 | `sslValidate`      | `boolean`          |
-   * | `checkServerIdentity` | `tlsAllowInvalidHostnames`                    | N/A                | `boolean`          |
-   * | see note below        | `tlsInsecure`                                 | N/A                | `boolean`          |
+   * | nodejs native option  | driver spec compliant option name             | driver option type |
+   * |:----------------------|:----------------------------------------------|:-------------------|
+   * | `ca`                  | `tlsCAFile`                                   | `string`           |
+   * | `crl`                 | N/A                                           | `string`           |
+   * | `cert`                | `tlsCertificateKeyFile`                       | `string`           |
+   * | `key`                 | `tlsCertificateKeyFile`                       | `string`           |
+   * | `passphrase`          | `tlsCertificateKeyFilePassword`               | `string`           |
+   * | `rejectUnauthorized`  | `tlsAllowInvalidCertificates`                 | `boolean`          |
+   * | `checkServerIdentity` | `tlsAllowInvalidHostnames`                    | `boolean`          |
+   * | see note below        | `tlsInsecure`                                 | `boolean`          |
    *
    * If `tlsInsecure` is set to `true`, then it will set the node native options `checkServerIdentity`
    * to a no-op and `rejectUnauthorized` to `false`.

--- a/test/integration/node-specific/bson-options/ignore_undefined.test.js
+++ b/test/integration/node-specific/bson-options/ignore_undefined.test.js
@@ -56,8 +56,7 @@ describe('Ignore Undefined', function () {
         const client = configuration.newClient(
           {},
           {
-            ignoreUndefined: true,
-            sslValidate: false
+            ignoreUndefined: true
           }
         );
 

--- a/test/types/community/changes_from_36.test-d.ts
+++ b/test/types/community/changes_from_36.test-d.ts
@@ -25,16 +25,6 @@ expectNotType<boolean>(options.readPreference);
 expectNotType<{}>(options.pkFactory);
 // .checkServerIdentity cannot be `true`
 expectNotType<true>(options.checkServerIdentity);
-// .sslCA cannot be string[]
-expectNotType<string[]>(options.sslCA);
-// .sslCRL cannot be string[]
-expectNotType<string[]>(options.sslCRL);
-// .sslCert cannot be a Buffer
-expectNotType<Buffer>(options.sslCert);
-// .sslKey cannot be a Buffer
-expectNotType<Buffer>(options.sslKey);
-// .sslPass cannot be a Buffer
-expectNotType<Buffer>(options.sslPass);
 
 // Legacy option kept
 expectType<PropExists<MongoClientOptions, 'w'>>(true);
@@ -60,7 +50,6 @@ expectType<ReadPreferenceMode | ReadPreference | undefined>(options.readPreferen
 expectType<boolean | undefined>(options.promoteValues);
 expectType<number | undefined>(options.family);
 expectType<boolean | undefined>(options.ssl);
-expectType<boolean | undefined>(options.sslValidate);
 expectAssignable<((host: string, cert: PeerCertificate) => Error | undefined) | undefined>(
   options.checkServerIdentity
 );

--- a/test/types/community/client.test-d.ts
+++ b/test/types/community/client.test-d.ts
@@ -25,7 +25,7 @@ const options: MongoClientOptions = {
   maxPoolSize: 1,
   family: 4,
   ssl: true,
-  sslValidate: false,
+  tlsAllowInvalidCertificates: false,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   checkServerIdentity(host, cert) {
     return undefined;

--- a/test/unit/mongo_client.test.js
+++ b/test/unit/mongo_client.test.js
@@ -36,9 +36,7 @@ describe('MongoOptions', function () {
       tlsCertificateKeyFile: filename,
       tlsCertificateFile: filename,
       tlsCAFile: filename,
-      sslCRL: filename,
-      tlsCertificateKeyFilePassword: 'tlsCertificateKeyFilePassword',
-      sslValidate: false
+      tlsCertificateKeyFilePassword: 'tlsCertificateKeyFilePassword'
     });
     fs.unlinkSync(filename);
 
@@ -47,19 +45,20 @@ describe('MongoOptions', function () {
      *
      * ### Additional options:
      *
-     * |    nodejs option     | MongoDB equivalent                                 | type                                   |
-     * |:---------------------|----------------------------------------------------|:---------------------------------------|
-     * | `ca`                 | sslCA, tlsCAFile                                   | `string \| Buffer \| Buffer[]`         |
-     * | `crl`                | sslCRL                                             | `string \| Buffer \| Buffer[]`         |
-     * | `cert`               | sslCert, tlsCertificateFile                        | `string \| Buffer \| Buffer[]`         |
-     * | `key`                | sslKey, tlsCertificateKeyFile                      | `string \| Buffer \| KeyObject[]`      |
-     * | `passphrase`         | sslPass, tlsCertificateKeyFilePassword             | `string`                               |
-     * | `rejectUnauthorized` | sslValidate                                        | `boolean`                              |
+     * | nodejs native option  | driver spec compliant option name             | driver option type |
+     * |:----------------------|:----------------------------------------------|:-------------------|
+     * | `ca`                  | `tlsCAFile`                                   | `string`           |
+     * | `crl`                 | N/A                                           | `string`           |
+     * | `cert`                | `tlsCertificateKeyFile`                       | `string`           |
+     * | `key`                 | `tlsCertificateKeyFile`                       | `string`           |
+     * | `passphrase`          | `tlsCertificateKeyFilePassword`               | `string`           |
+     * | `rejectUnauthorized`  | `tlsAllowInvalidCertificates`                 | `boolean`          |
+     * | `checkServerIdentity` | `tlsAllowInvalidHostnames`                    | `boolean`          |
+     * | see note below        | `tlsInsecure`                                 | `boolean`          |
      *
      */
     expect(options).to.not.have.property('tlsCertificateKeyFile');
     expect(options).to.not.have.property('tlsCAFile');
-    expect(options).to.not.have.property('sslCRL');
     expect(options).to.not.have.property('tlsCertificateKeyFilePassword');
     expect(options).has.property('ca', '');
     expect(options).has.property('crl', '');
@@ -126,8 +125,6 @@ describe('MongoOptions', function () {
     serverApi: { version: '1' },
     socketTimeoutMS: 3,
     ssl: true,
-    sslPass: 'pass',
-    sslValidate: true,
     tls: true,
     tlsAllowInvalidCertificates: true,
     tlsAllowInvalidHostnames: true,


### PR DESCRIPTION
### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
