### PR TITLE
feat(NODE-5415)!: bump minimum Node.js version to v16.20.1

### DIFF
--- a/.evergreen/ci_matrix_constants.js
+++ b/.evergreen/ci_matrix_constants.js
@@ -1,6 +1,5 @@
 const MONGODB_VERSIONS = ['latest', 'rapid', '7.0', '6.0', '5.0', '4.4', '4.2', '4.0', '3.6'];
 const versions = [
-  { codeName: 'fermium', versionNumber: 14 },
   { codeName: 'gallium', versionNumber: 16 },
   { codeName: 'hydrogen', versionNumber: 18 },
   { codeName: 'iron', versionNumber: 20 }

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2584,7 +2584,7 @@ tasks:
     commands:
       - func: install dependencies
         vars:
-          NODE_LTS_VERSION: 14
+          NODE_LTS_VERSION: 16
       - func: run unit tests
   - name: run-lint-checks
     tags:
@@ -2592,7 +2592,7 @@ tasks:
     commands:
       - func: install dependencies
         vars:
-          NODE_LTS_VERSION: 14
+          NODE_LTS_VERSION: 16
       - func: run lint checks
   - name: check-types-typescript-next
     tags:
@@ -2600,7 +2600,7 @@ tasks:
     commands:
       - func: install dependencies
         vars:
-          NODE_LTS_VERSION: 14
+          NODE_LTS_VERSION: 16
       - func: check types
         vars:
           TS_VERSION: next
@@ -2610,7 +2610,7 @@ tasks:
     commands:
       - func: install dependencies
         vars:
-          NODE_LTS_VERSION: 14
+          NODE_LTS_VERSION: 16
       - func: compile driver
         vars:
           TS_VERSION: current
@@ -2620,7 +2620,7 @@ tasks:
     commands:
       - func: install dependencies
         vars:
-          NODE_LTS_VERSION: 14
+          NODE_LTS_VERSION: 16
       - func: check types
         vars:
           TS_VERSION: current
@@ -2630,7 +2630,7 @@ tasks:
     commands:
       - func: install dependencies
         vars:
-          NODE_LTS_VERSION: 14
+          NODE_LTS_VERSION: 16
       - func: check types
         vars:
           TS_VERSION: 4.1.6
@@ -2660,7 +2660,7 @@ tasks:
     commands:
       - func: install dependencies
         vars:
-          NODE_LTS_VERSION: 14
+          NODE_LTS_VERSION: 16
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '5.0'
@@ -2675,7 +2675,7 @@ tasks:
     commands:
       - func: install dependencies
         vars:
-          NODE_LTS_VERSION: 14
+          NODE_LTS_VERSION: 16
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '5.0'
@@ -2690,7 +2690,7 @@ tasks:
     commands:
       - func: install dependencies
         vars:
-          NODE_LTS_VERSION: 14
+          NODE_LTS_VERSION: 16
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: rapid
@@ -2705,7 +2705,7 @@ tasks:
     commands:
       - func: install dependencies
         vars:
-          NODE_LTS_VERSION: 14
+          NODE_LTS_VERSION: 16
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: rapid
@@ -2720,7 +2720,7 @@ tasks:
     commands:
       - func: install dependencies
         vars:
-          NODE_LTS_VERSION: 14
+          NODE_LTS_VERSION: 16
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: latest
@@ -2735,7 +2735,7 @@ tasks:
     commands:
       - func: install dependencies
         vars:
-          NODE_LTS_VERSION: 14
+          NODE_LTS_VERSION: 16
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: latest
@@ -3500,59 +3500,6 @@ buildvariants:
     run_on: rhel90-dbx-perf-large
     tasks:
       - run-spec-benchmark-tests-node-18-server-6.0
-  - name: rhel80-large-fermium
-    display_name: rhel8 Node14
-    run_on: rhel80-large
-    expansions:
-      NODE_LTS_VERSION: 14
-      CLIENT_ENCRYPTION: true
-    tasks:
-      - test-latest-server
-      - test-latest-replica_set
-      - test-latest-sharded_cluster
-      - test-rapid-server
-      - test-rapid-replica_set
-      - test-rapid-sharded_cluster
-      - test-7.0-server
-      - test-7.0-replica_set
-      - test-7.0-sharded_cluster
-      - test-6.0-server
-      - test-6.0-replica_set
-      - test-6.0-sharded_cluster
-      - test-5.0-server
-      - test-5.0-replica_set
-      - test-5.0-sharded_cluster
-      - test-4.4-server
-      - test-4.4-replica_set
-      - test-4.4-sharded_cluster
-      - test-4.2-server
-      - test-4.2-replica_set
-      - test-4.2-sharded_cluster
-      - test-4.0-server
-      - test-4.0-replica_set
-      - test-4.0-sharded_cluster
-      - test-3.6-server
-      - test-3.6-replica_set
-      - test-3.6-sharded_cluster
-      - test-latest-server-v1-api
-      - test-atlas-connectivity
-      - test-atlas-data-lake
-      - test-5.0-load-balanced
-      - test-6.0-load-balanced
-      - test-latest-load-balanced
-      - test-auth-kerberos
-      - test-auth-ldap
-      - test-auth-oidc
-      - test-socks5
-      - test-socks5-csfle
-      - test-socks5-tls
-      - test-zstd-compression
-      - test-snappy-compression
-      - test-tls-support-latest
-      - test-tls-support-6.0
-      - test-tls-support-5.0
-      - test-tls-support-4.4
-      - test-tls-support-4.2
   - name: rhel80-large-gallium
     display_name: rhel8 Node16
     run_on: rhel80-large
@@ -3883,13 +3830,13 @@ buildvariants:
       - test-tls-support-5.0
       - test-tls-support-4.4
       - test-tls-support-4.2
-  - name: rhel8-node14-test-csfle-mongocryptd
-    display_name: rhel 8 Node14 test mongocryptd
+  - name: rhel8-node16-test-csfle-mongocryptd
+    display_name: rhel 8 Node16 test mongocryptd
     run_on: rhel80-large
     expansions:
       CLIENT_ENCRYPTION: true
       RUN_WITH_MONGOCRYPTD: true
-      NODE_LTS_VERSION: 14
+      NODE_LTS_VERSION: 16
     tasks:
       - test-latest-csfle-mongocryptd
       - test-rapid-csfle-mongocryptd
@@ -3904,7 +3851,7 @@ buildvariants:
     expansions:
       CLIENT_ENCRYPTION: true
       RUN_WITH_MONGOCRYPTD: true
-      NODE_LTS_VERSION: 14
+      NODE_LTS_VERSION: 16
     tasks:
       - test-latest-csfle-mongocryptd
       - test-rapid-csfle-mongocryptd
@@ -3952,7 +3899,7 @@ buildvariants:
     display_name: MONGODB-AWS Auth test
     run_on: ubuntu1804-large
     expansions:
-      NODE_LTS_VERSION: 14
+      NODE_LTS_VERSION: 16
     tasks:
       - aws-latest-auth-test-run-aws-auth-test-with-regular-aws-credentials
       - aws-latest-auth-test-run-aws-auth-test-with-assume-role-credentials
@@ -4044,7 +3991,7 @@ buildvariants:
     display_name: Serverless Test
     run_on: rhel80-large
     expansions:
-      NODE_LTS_VERSION: 14
+      NODE_LTS_VERSION: 16
     tasks:
       - serverless_task_group
   - name: rhel8-test-gcp-kms

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -426,8 +426,6 @@ for (const {
   });
 
   for (const NODE_LTS_VERSION of testedNodeVersions) {
-    if (NODE_LTS_VERSION === 14 && os.match(/^windows/)) continue;
-
     const nodeLTSCodeName = versions.find(({ versionNumber }) => versionNumber === NODE_LTS_VERSION).codeName;
     const nodeLtsDisplayName = `Node${NODE_LTS_VERSION}`;
     const name = `${osName}-${NODE_LTS_VERSION >= 20 ? nodeLtsDisplayName : nodeLTSCodeName}`;

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -o errexit  # Exit the script with error if any of the commands fail
 
-NODE_LTS_VERSION=${NODE_LTS_VERSION:-14}
+NODE_LTS_VERSION=${NODE_LTS_VERSION:-16}
 
 source "${PROJECT_DIRECTORY}/.evergreen/init-node-and-npm-env.sh"
 

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=14.20.1"
+    "node": ">=16.20.1"
   },
   "bugs": {
     "url": "https://jira.mongodb.org/projects/NODE/issues/"

--- a/test/integration/node-specific/errors.test.ts
+++ b/test/integration/node-specific/errors.test.ts
@@ -16,20 +16,16 @@ describe('Error (Integration)', function () {
         message: 'message 1, message 2'
       }
     ]) {
-      it(
-        `constructs the message properly with an array of ${errors.length} errors`,
-        { requires: { nodejs: '>=16' } },
-        () => {
-          const error = new AggregateError(errors);
-          const mongoError = new MongoError(error);
+      it(`constructs the message properly with an array of ${errors.length} errors`, () => {
+        const error = new AggregateError(errors);
+        const mongoError = new MongoError(error);
 
-          expect(mongoError.message).to.equal(message);
-        }
-      );
+        expect(mongoError.message).to.equal(message);
+      });
     }
 
     context('when the message on the AggregateError is non-empty', () => {
-      it(`uses the AggregateError's message`, { requires: { nodejs: '>=16' } }, () => {
+      it(`uses the AggregateError's message`, () => {
         const error = new AggregateError([new Error('non-empty')]);
         error.message = 'custom error message';
         const mongoError = new MongoError(error);
@@ -37,7 +33,7 @@ describe('Error (Integration)', function () {
       });
     });
 
-    it('sets the AggregateError to the cause property', { requires: { nodejs: '>=16' } }, () => {
+    it('sets the AggregateError to the cause property', () => {
       const error = new AggregateError([new Error('error 1')]);
       const mongoError = new MongoError(error);
       expect(mongoError.cause).to.equal(error);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,12 +4,12 @@
     "checkJs": false,
     "strict": true,
     "alwaysStrict": true,
-    "target": "ES2020",
+    "target": "ES2021",
     "module": "commonJS",
     "moduleResolution": "node",
     "skipLibCheck": true,
     "lib": [
-      "es2020"
+      "es2021"
     ],
     // We don't make use of tslib helpers, all syntax used is supported by target engine
     "importHelpers": false,


### PR DESCRIPTION
### Description

#### What is changing?

- Dropping testing & support for Node.js 14
- Update engine field to >=16.20.1
- Update tsconfig target & lib to es2021

##### Is there new documentation needed for these changes?

Update to the compat table will follow the release of v6

#### What is the motivation for this change?

Removing support for EOL node versions helps us keep our tooling and testing up to date and modern. 

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Minimum Node.js version is now v16.20.1

The minimum supported Node.js  version is now v16.20.1. We strive to keep our minimum supported Node.js version in sync with the runtime's [release cadence](https://nodejs.dev/en/about/releases/) to keep up with the latest security updates and modern language features.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
