### PR TITLE
feat(NODE-5429): deprecate the `AutoEncrypter` interface

### DIFF
--- a/src/deps.ts
+++ b/src/deps.ts
@@ -396,7 +396,10 @@ export interface AutoEncryptionOptions {
   };
 }
 
-/** @public */
+/**
+ * @public
+ * @deprecated This interface will be removed in the next major version.
+ */
 export interface AutoEncrypter {
   // eslint-disable-next-line @typescript-eslint/no-misused-new
   new (client: MongoClient, options: AutoEncryptionOptions): AutoEncrypter;

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -417,6 +417,9 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> {
     this[kOptions].monitorCommands = value;
   }
 
+  /**
+   * @deprecated This method will be removed in the next major version.
+   */
   get autoEncrypter(): AutoEncrypter | undefined {
     return this[kOptions].autoEncrypter;
   }
@@ -780,6 +783,9 @@ export interface MongoOptions
   writeConcern: WriteConcern;
   dbName: string;
   metadata: ClientMetadata;
+  /**
+   * @deprecated This option will be removed in the next major version.
+   */
   autoEncrypter?: AutoEncrypter;
   proxyHost?: string;
   proxyPort?: number;


### PR DESCRIPTION
### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
