### PR TITLE
chore(NODE-5433): add id-token permission to release workflow

### DIFF
--- a/.github/workflows/release-4.x.yml
+++ b/.github/workflows/release-4.x.yml
@@ -12,6 +12,8 @@ name: release-4x
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - id: release
         uses: google-github-actions/release-please-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ name: release
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - id: release
         uses: google-github-actions/release-please-action@v3


### PR DESCRIPTION
### Description

#### What is changing?

Adds id-token permission for releasing

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?


### Release Highlight


### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
