### PR TITLE
feat(NODE-5186)!: remove duplicate BulkWriteResult accessors

### DIFF
--- a/src/bulk/common.ts
+++ b/src/bulk/common.ts
@@ -212,62 +212,6 @@ export class BulkWriteResult {
     return this.result.ok;
   }
 
-  /**
-   * The number of inserted documents
-   * @deprecated Use insertedCount instead.
-   */
-  get nInserted(): number {
-    return this.result.nInserted;
-  }
-
-  /**
-   * Number of upserted documents
-   * @deprecated User upsertedCount instead.
-   */
-  get nUpserted(): number {
-    return this.result.nUpserted;
-  }
-
-  /**
-   * Number of matched documents
-   * @deprecated Use matchedCount instead.
-   */
-  get nMatched(): number {
-    return this.result.nMatched;
-  }
-
-  /**
-   * Number of documents updated physically on disk
-   * @deprecated Use modifiedCount instead.
-   */
-  get nModified(): number {
-    return this.result.nModified;
-  }
-
-  /**
-   * Number of removed documents
-   * @deprecated Use deletedCount instead.
-   */
-  get nRemoved(): number {
-    return this.result.nRemoved;
-  }
-
-  /**
-   * Returns an array of all inserted ids
-   * @deprecated Use insertedIds instead.
-   */
-  getInsertedIds(): Document[] {
-    return this.result.insertedIds;
-  }
-
-  /**
-   * Returns an array of all upserted ids
-   * @deprecated Use upsertedIds instead.
-   */
-  getUpsertedIds(): Document[] {
-    return this.result.upserted;
-  }
-
   /** Returns the upserted id at the given index */
   getUpsertedIdAt(index: number): Document | undefined {
     return this.result.upserted[index];
@@ -864,11 +808,21 @@ export interface BulkOperationPrivate {
 
 /** @public */
 export interface BulkWriteOptions extends CommandOperationOptions {
-  /** Allow driver to bypass schema validation in MongoDB 3.2 or higher. */
+  /**
+   * Allow driver to bypass schema validation in MongoDB 3.2 or higher.
+   * @defaultValue `false` - documents will be validated by default
+   **/
   bypassDocumentValidation?: boolean;
-  /** If true, when an insert fails, don't execute the remaining writes. If false, continue with remaining inserts when one fails. */
+  /**
+   * If true, when an insert fails, don't execute the remaining writes.
+   * If false, continue with remaining inserts when one fails.
+   * @defaultValue `true` - inserts are ordered by default
+   */
   ordered?: boolean;
-  /** Force server to assign _id values instead of driver. */
+  /**
+   * Force server to assign _id values instead of driver.
+   * @defaultValue `false` - the driver generates `_id` fields by default
+   **/
   forceServerObjectId?: boolean;
   /** Map of parameter names and values that can be accessed using $$var (requires MongoDB 5.0). */
   let?: Document;

--- a/src/bulk/common.ts
+++ b/src/bulk/common.ts
@@ -809,7 +809,7 @@ export interface BulkOperationPrivate {
 /** @public */
 export interface BulkWriteOptions extends CommandOperationOptions {
   /**
-   * Allow driver to bypass schema validation in MongoDB 3.2 or higher.
+   * Allow driver to bypass schema validation.
    * @defaultValue `false` - documents will be validated by default
    **/
   bypassDocumentValidation?: boolean;

--- a/src/operations/aggregate.ts
+++ b/src/operations/aggregate.ts
@@ -21,7 +21,7 @@ export interface AggregateOptions extends CommandOperationOptions {
   allowDiskUse?: boolean;
   /** The number of documents to return per batch. See [aggregation documentation](https://www.mongodb.com/docs/manual/reference/command/aggregate). */
   batchSize?: number;
-  /** Allow driver to bypass schema validation in MongoDB 3.2 or higher. */
+  /** Allow driver to bypass schema validation. */
   bypassDocumentValidation?: boolean;
   /** Return the query as cursor, on 2.6 \> it returns as a real cursor on pre 2.6 it returns as an emulated cursor. */
   cursor?: Document;

--- a/src/operations/find_and_modify.ts
+++ b/src/operations/find_and_modify.ts
@@ -38,7 +38,7 @@ export interface FindOneAndDeleteOptions extends CommandOperationOptions {
 
 /** @public */
 export interface FindOneAndReplaceOptions extends CommandOperationOptions {
-  /** Allow driver to bypass schema validation in MongoDB 3.2 or higher. */
+  /** Allow driver to bypass schema validation. */
   bypassDocumentValidation?: boolean;
   /** An optional hint for query optimization. See the {@link https://www.mongodb.com/docs/manual/reference/command/update/#update-command-hint|update command} reference for more information.*/
   hint?: Document;
@@ -63,7 +63,7 @@ export interface FindOneAndReplaceOptions extends CommandOperationOptions {
 export interface FindOneAndUpdateOptions extends CommandOperationOptions {
   /** Optional list of array filters referenced in filtered positional operators */
   arrayFilters?: Document[];
-  /** Allow driver to bypass schema validation in MongoDB 3.2 or higher. */
+  /** Allow driver to bypass schema validation. */
   bypassDocumentValidation?: boolean;
   /** An optional hint for query optimization. See the {@link https://www.mongodb.com/docs/manual/reference/command/update/#update-command-hint|update command} reference for more information.*/
   hint?: Document;

--- a/src/operations/insert.ts
+++ b/src/operations/insert.ts
@@ -53,7 +53,7 @@ export class InsertOperation extends CommandCallbackOperation<Document> {
 
 /** @public */
 export interface InsertOneOptions extends CommandOperationOptions {
-  /** Allow driver to bypass schema validation in MongoDB 3.2 or higher. */
+  /** Allow driver to bypass schema validation. */
   bypassDocumentValidation?: boolean;
   /** Force server to assign _id values instead of driver. */
   forceServerObjectId?: boolean;


### PR DESCRIPTION
### Description

#### What is changing?

- remove duplicate BulkWriteResult accessors
- Add defaultValue documentation to BulkOptions
- Remove mention of non-supported server version on `bypassDocumentValidation` option.

##### Is there new documentation needed for these changes?

API docs will update in next release

#### What is the motivation for this change?

Removal of duplicate APIs so there is a single source of truth.

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### `BulkWriteResult` deprecated properties removed

The following deprecated properties have been removed as they duplicated the functionality provided by the common driver spec compliant properties. The list indicates what properties provide the correct migration:

- `BulkWriteResult.nInserted` -> `BulkWriteResult.insertedCount`
- `BulkWriteResult.nUpserted` -> `BulkWriteResult.upsertedCount`
- `BulkWriteResult.nMatched` -> `BulkWriteResult.matchedCount`
- `BulkWriteResult.nModified` -> `BulkWriteResult.modifiedCount`
- `BulkWriteResult.nRemoved` -> `BulkWriteResult.deletedCount`
- `BulkWriteResult.getUpsertedIds` -> `BulkWriteResult.upsertedIds` / `BulkWriteResult.getUpsertedIdAt(index: number)`
- `BulkWriteResult.getInsertedIds` -> `BulkWriteResult.insertedIds`

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
