### PR TITLE
docs(NODE-5438): Improve naming in code example for documentation

### DIFF
--- a/test/integration/node-specific/examples/change_streams.test.js
+++ b/test/integration/node-specific/examples/change_streams.test.js
@@ -71,13 +71,30 @@ maybeDescribe('examples(change-stream):', function () {
       });
       // End Changestream Example 1
 
-      // Start Changestream Example 1 Alternative
       const changeStreamIterator = collection.watch();
       const next = await changeStreamIterator.next();
-      // End Changestream Example 1 Alternative
 
       await changeStream.close();
       await changeStreamIterator.close();
+      await looper.stop();
+
+      expect(next).to.have.property('operationType').that.equals('insert');
+    }
+  });
+
+  it('Open A Change Stream and use iteration methods', {
+    metadata: { requires: { topology: ['replicaset'], mongodb: '>=3.6.0' } },
+    test: async function () {
+      const looper = new Looper(() => db.collection('inventory').insertOne({ a: 1 }));
+      looper.run();
+
+      // Start Changestream Example 1 Alternative
+      const collection = db.collection('inventory');
+      const changeStream = collection.watch();
+      const next = await changeStream.next();
+      // End Changestream Example 1 Alternative
+
+      await changeStream.close();
       await looper.stop();
 
       expect(next).to.have.property('operationType').that.equals('insert');


### PR DESCRIPTION
### Description

#### What is changing?

The Server documentation has a ticket (DOCSP-29813) to improve the code example naming, which is generated from this test file.

##### Is there new documentation needed for these changes?

The corresponding documentation ticket mentioned above tracks these changes.

#### What is the motivation for this change?

There was a discussion in NODE-2307 about confusion related to how to use change streams. Updating this example was an action item from that discussion that is intended to help relieve some of that confusion.

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
