### PR TITLE
fix(NODE-5228)!: remove unneeded fields from ConnectionPoolCreatedEvent.options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,7 @@
         "yargs": "^17.7.2"
       },
       "engines": {
-        "node": ">=14.20.1"
+        "node": ">=16.20.1"
       },
       "optionalDependencies": {
         "saslprep": "^1.0.3"

--- a/src/cmap/connection_pool_events.ts
+++ b/src/cmap/connection_pool_events.ts
@@ -54,14 +54,19 @@ export abstract class ConnectionPoolMonitoringEvent {
  */
 export class ConnectionPoolCreatedEvent extends ConnectionPoolMonitoringEvent {
   /** The options used to create this connection pool */
-  options?: ConnectionPoolOptions;
+  options?: Pick<
+    ConnectionPoolOptions,
+    'maxPoolSize' | 'minPoolSize' | 'maxConnecting' | 'maxIdleTimeMS' | 'waitQueueTimeoutMS'
+  >;
   /** @internal */
   name = CONNECTION_POOL_CREATED;
 
   /** @internal */
   constructor(pool: ConnectionPool) {
     super(pool);
-    this.options = pool.options;
+    const { maxConnecting, maxPoolSize, minPoolSize, maxIdleTimeMS, waitQueueTimeoutMS } =
+      pool.options;
+    this.options = { maxConnecting, maxPoolSize, minPoolSize, maxIdleTimeMS, waitQueueTimeoutMS };
   }
 }
 

--- a/src/cmap/connection_pool_events.ts
+++ b/src/cmap/connection_pool_events.ts
@@ -54,7 +54,7 @@ export abstract class ConnectionPoolMonitoringEvent {
  */
 export class ConnectionPoolCreatedEvent extends ConnectionPoolMonitoringEvent {
   /** The options used to create this connection pool */
-  options?: Pick<
+  options: Pick<
     ConnectionPoolOptions,
     'maxPoolSize' | 'minPoolSize' | 'maxConnecting' | 'maxIdleTimeMS' | 'waitQueueTimeoutMS'
   >;

--- a/test/integration/connection-monitoring-and-pooling/connection_pool.test.ts
+++ b/test/integration/connection-monitoring-and-pooling/connection_pool.test.ts
@@ -2,12 +2,7 @@ import { once } from 'node:events';
 
 import { expect } from 'chai';
 
-import {
-  type ConnectionPoolCreatedEvent,
-  type Db,
-  type MongoClient,
-  type MongoClientOptions
-} from '../../mongodb';
+import { type ConnectionPoolCreatedEvent, type Db, type MongoClient } from '../../mongodb';
 
 describe('Connection Pool', function () {
   let client: MongoClient;
@@ -64,37 +59,6 @@ describe('Connection Pool', function () {
 
         it('the options field only contains keys and values matching the non-default options', function () {
           expect(connectionPoolCreated).to.have.deep.property('options', options);
-        });
-      });
-
-      context('when non connection pool options are passed in', function () {
-        let pConnectionPoolCreated: Promise<ConnectionPoolCreatedEvent[]>;
-        let connectionPoolCreated: ConnectionPoolCreatedEvent;
-        const options: MongoClientOptions = {
-          waitQueueTimeoutMS: 2000,
-          maxIdleTimeMS: 1,
-          maxConnecting: 3,
-          minPoolSize: 1,
-          maxPoolSize: 101,
-          tls: true
-        };
-        const optionsNoMetadata = {
-          waitQueueTimeoutMS: 2000,
-          maxIdleTimeMS: 1,
-          maxConnecting: 3,
-          minPoolSize: 1,
-          maxPoolSize: 101
-        };
-        beforeEach(async function () {
-          client = this.configuration.newClient({}, options);
-          pConnectionPoolCreated = once(client, 'connectionPoolCreated');
-          await client.connect();
-
-          connectionPoolCreated = (await pConnectionPoolCreated)[0];
-        });
-
-        it('the options field only contains keys and values associated with connection pool', function () {
-          expect(connectionPoolCreated).to.have.deep.property('options', optionsNoMetadata);
         });
       });
     });

--- a/test/integration/connection-monitoring-and-pooling/connection_pool.test.ts
+++ b/test/integration/connection-monitoring-and-pooling/connection_pool.test.ts
@@ -3,7 +3,7 @@ import { once } from 'node:events';
 import { expect } from 'chai';
 
 import {
-  ConnectionPoolCreatedEvent,
+  type ConnectionPoolCreatedEvent,
   type Db,
   type MongoClient,
   type MongoClientOptions
@@ -22,14 +22,6 @@ describe('Connection Pool', function () {
   });
   describe('Events', function () {
     describe('ConnectionPoolCreatedEvent', function () {
-      it('is emitted on client connect', async function () {
-        client = this.configuration.newClient();
-        const pConnectionPoolCreated = once(client, 'connectionPoolCreated');
-        await client.connect();
-
-        expect((await pConnectionPoolCreated)[0]).to.be.instanceOf(ConnectionPoolCreatedEvent);
-      });
-
       context('when no connection pool options are passed in', function () {
         let pConnectionPoolCreated: Promise<ConnectionPoolCreatedEvent[]>;
         let connectionPoolCreated: ConnectionPoolCreatedEvent;

--- a/test/integration/connection-monitoring-and-pooling/connection_pool.test.ts
+++ b/test/integration/connection-monitoring-and-pooling/connection_pool.test.ts
@@ -1,0 +1,110 @@
+import { once } from 'node:events';
+
+import { expect } from 'chai';
+
+import {
+  ConnectionPoolCreatedEvent,
+  type Db,
+  type MongoClient,
+  type MongoClientOptions
+} from '../../mongodb';
+
+describe('Connection Pool', function () {
+  let client: MongoClient;
+  let db: Db;
+  afterEach(async function () {
+    if (client) {
+      if (db) {
+        await db.dropDatabase();
+      }
+      await client.close();
+    }
+  });
+  describe('Events', function () {
+    describe('ConnectionPoolCreatedEvent', function () {
+      it('is emitted on client connect', async function () {
+        client = this.configuration.newClient();
+        const pConnectionPoolCreated = once(client, 'connectionPoolCreated');
+        await client.connect();
+
+        expect((await pConnectionPoolCreated)[0]).to.be.instanceOf(ConnectionPoolCreatedEvent);
+      });
+
+      context('when no connection pool options are passed in', function () {
+        let pConnectionPoolCreated: Promise<ConnectionPoolCreatedEvent[]>;
+        let connectionPoolCreated: ConnectionPoolCreatedEvent;
+        beforeEach(async function () {
+          client = this.configuration.newClient({}, {});
+          pConnectionPoolCreated = once(client, 'connectionPoolCreated');
+          await client.connect();
+
+          connectionPoolCreated = (await pConnectionPoolCreated)[0];
+        });
+
+        it('the options field matches the default options', function () {
+          expect(connectionPoolCreated).to.have.deep.property('options', {
+            waitQueueTimeoutMS: 0,
+            maxIdleTimeMS: 0,
+            maxConnecting: 2,
+            minPoolSize: 0,
+            maxPoolSize: 100
+          });
+        });
+      });
+
+      context('when valid non-default connection pool options are passed in', function () {
+        let pConnectionPoolCreated: Promise<ConnectionPoolCreatedEvent[]>;
+        let connectionPoolCreated: ConnectionPoolCreatedEvent;
+        const options = {
+          waitQueueTimeoutMS: 2000,
+          maxIdleTimeMS: 1,
+          maxConnecting: 3,
+          minPoolSize: 1,
+          maxPoolSize: 101
+        };
+        beforeEach(async function () {
+          client = this.configuration.newClient({}, options);
+          pConnectionPoolCreated = once(client, 'connectionPoolCreated');
+          await client.connect();
+
+          connectionPoolCreated = (await pConnectionPoolCreated)[0];
+        });
+
+        it('the options field only contains keys and values matching the non-default options', function () {
+          expect(connectionPoolCreated).to.have.deep.property('options', options);
+        });
+      });
+
+      context('when non connection pool options are passed in', function () {
+        let pConnectionPoolCreated: Promise<ConnectionPoolCreatedEvent[]>;
+        let connectionPoolCreated: ConnectionPoolCreatedEvent;
+        const options: MongoClientOptions = {
+          waitQueueTimeoutMS: 2000,
+          maxIdleTimeMS: 1,
+          maxConnecting: 3,
+          minPoolSize: 1,
+          maxPoolSize: 101,
+          tls: true
+        };
+        const optionsNoMetadata = {
+          waitQueueTimeoutMS: 2000,
+          maxIdleTimeMS: 1,
+          maxConnecting: 3,
+          minPoolSize: 1,
+          maxPoolSize: 101
+        };
+        beforeEach(async function () {
+          client = this.configuration.newClient({}, options);
+          pConnectionPoolCreated = once(client, 'connectionPoolCreated');
+          await client.connect();
+
+          connectionPoolCreated = (await pConnectionPoolCreated)[0];
+        });
+
+        it('the options field only contains keys and values associated with connection pool', function () {
+          expect(connectionPoolCreated).to.have.deep.property('options', optionsNoMetadata);
+        });
+      });
+    });
+  });
+});

--- a/test/types/connection_pool_events.test-d.ts
+++ b/test/types/connection_pool_events.test-d.ts
@@ -1,0 +1,20 @@
+import { once } from 'events';
+import { expectType } from 'tsd';
+
+import type { ConnectionPoolCreatedEvent } from '../mongodb';
+import { MongoClient } from '../mongodb';
+
+const client: MongoClient = new MongoClient('');
+const p = once(client, 'connectionPoolCreated');
+await client.connect();
+
+const ev: ConnectionPoolCreatedEvent = (await p)[0];
+expectType<ConnectionPoolCreatedEvent>(ev);
+
+expectType<{
+  maxPoolSize: number;
+  minPoolSize: number;
+  maxConnecting: number;
+  maxIdleTimeMS: number;
+  waitQueueTimeoutMS: number;
+}>(ev.options);

--- a/test/unit/cmap/connection_pool_events.test.ts
+++ b/test/unit/cmap/connection_pool_events.test.ts
@@ -1,25 +1,17 @@
 import { expect } from 'chai';
-import { ConnectionPool, ConnectionPoolCreatedEvent } from '../../../mongodb';
 
+import { type ConnectionPool, ConnectionPoolCreatedEvent } from '../../mongodb';
 
-describe('Connection Pool Events', function() {
+describe('Connection Pool Events', function () {
   const connectionPoolMock = {
     address: 'localhost:9000',
-    time: new Date(),
+    time: new Date()
   };
 
-  const allowedFields = [
-    'waitQueueTimeoutMS',
-    'maxIdleTimeMS',
-    'maxConnecting',
-    'minPoolSize',
-    'maxPoolSize'
-
-  ];
-  describe('ConnectionPoolCreatedEvent', function() {
-    describe('constructor', function() {
-      context('when provided expected option fields', function() {
-        it(`Sets the allowed fields appropriately`, function() {
+  describe('ConnectionPoolCreatedEvent', function () {
+    describe('constructor', function () {
+      context('when provided expected option fields', function () {
+        it(`Sets the allowed fields appropriately`, function () {
           const options = {
             maxIdleTimeMS: 0,
             maxConnecting: 2,
@@ -27,13 +19,16 @@ describe('Connection Pool Events', function() {
             maxPoolSize: 100,
             waitQueueTimeoutMS: 1000
           };
-          const event = new ConnectionPoolCreatedEvent({ ...connectionPoolMock, options } as unknown as ConnectionPool);
+          const event = new ConnectionPoolCreatedEvent({
+            ...connectionPoolMock,
+            options
+          } as unknown as ConnectionPool);
 
           expect(event).to.have.deep.property('options', options);
         });
       });
-      context('when provided unallowed fields', function() {
-        it('only stores expected fields', function() {
+      context('when provided unallowed fields', function () {
+        it('only stores expected fields', function () {
           const options = {
             maxIdleTimeMS: 0,
             maxConnecting: 2,
@@ -47,14 +42,17 @@ describe('Connection Pool Events', function() {
             foo: 'foo',
             hello: 'world'
           };
-          const event = new ConnectionPoolCreatedEvent({ ...connectionPoolMock, options } as unknown as ConnectionPool);
+          const event = new ConnectionPoolCreatedEvent({
+            ...connectionPoolMock,
+            options
+          } as unknown as ConnectionPool);
 
           expect(event).to.have.deep.property('options', {
             maxIdleTimeMS: 0,
             maxConnecting: 2,
             minPoolSize: 0,
             maxPoolSize: 100,
-            waitQueueTimeoutMS: 1000,
+            waitQueueTimeoutMS: 1000
           });
         });
       });

--- a/test/unit/cmap/connection_pool_events.test.ts
+++ b/test/unit/cmap/connection_pool_events.test.ts
@@ -1,0 +1,63 @@
+import { expect } from 'chai';
+import { ConnectionPool, ConnectionPoolCreatedEvent } from '../../../mongodb';
+
+
+describe('Connection Pool Events', function() {
+  const connectionPoolMock = {
+    address: 'localhost:9000',
+    time: new Date(),
+  };
+
+  const allowedFields = [
+    'waitQueueTimeoutMS',
+    'maxIdleTimeMS',
+    'maxConnecting',
+    'minPoolSize',
+    'maxPoolSize'
+
+  ];
+  describe('ConnectionPoolCreatedEvent', function() {
+    describe('constructor', function() {
+      context('when provided expected option fields', function() {
+        it(`Sets the allowed fields appropriately`, function() {
+          const options = {
+            maxIdleTimeMS: 0,
+            maxConnecting: 2,
+            minPoolSize: 0,
+            maxPoolSize: 100,
+            waitQueueTimeoutMS: 1000
+          };
+          const event = new ConnectionPoolCreatedEvent({ ...connectionPoolMock, options } as unknown as ConnectionPool);
+
+          expect(event).to.have.deep.property('options', options);
+        });
+      });
+      context('when provided unallowed fields', function() {
+        it('only stores expected fields', function() {
+          const options = {
+            maxIdleTimeMS: 0,
+            maxConnecting: 2,
+            minPoolSize: 0,
+            maxPoolSize: 100,
+            waitQueueTimeoutMS: 1000,
+            credentials: {
+              user: 'user',
+              pass: 'pass'
+            },
+            foo: 'foo',
+            hello: 'world'
+          };
+          const event = new ConnectionPoolCreatedEvent({ ...connectionPoolMock, options } as unknown as ConnectionPool);
+
+          expect(event).to.have.deep.property('options', {
+            maxIdleTimeMS: 0,
+            maxConnecting: 2,
+            minPoolSize: 0,
+            maxPoolSize: 100,
+            waitQueueTimeoutMS: 1000,
+          });
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
### Description

#### What is changing?
- Remove unneeded fields from `ConnectionPoolCraetedEvent.options`
- Made `ConnectionPoolCreatedEvent.options` field required

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Removed unneeded fields from `ConnectionPoolCreatedEvent.options`

The `options` field of `ConnectionPoolCreatedEvent` now has the following shape:

```ts
{
	maxPoolSize: number,
	minPoolSize: number,
	maxConnecting: number,
	maxIdleTimeMS: number,
	waitQueueTimeoutMS: number
}
```

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
