### PR TITLE
refactor(NODE-5437): admin operations to use async syntax

### DIFF
--- a/src/operations/add_user.ts
+++ b/src/operations/add_user.ts
@@ -6,7 +6,7 @@ import { MongoInvalidArgumentError } from '../error';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
 import { type Callback, emitWarningOnce, getTopology } from '../utils';
-import { CommandCallbackOperation, type CommandOperationOptions } from './command';
+import { CommandOperation, type CommandOperationOptions } from './command';
 import { Aspect, defineAspects } from './operation';
 
 /**
@@ -35,7 +35,7 @@ export interface AddUserOptions extends CommandOperationOptions {
 }
 
 /** @internal */
-export class AddUserOperation extends CommandCallbackOperation<Document> {
+export class AddUserOperation extends CommandOperation<Document> {
   override options: AddUserOptions;
   db: Db;
   username: string;
@@ -50,11 +50,7 @@ export class AddUserOperation extends CommandCallbackOperation<Document> {
     this.options = options ?? {};
   }
 
-  override executeCallback(
-    server: Server,
-    session: ClientSession | undefined,
-    callback: Callback<Document>
-  ): void {
+  override execute(server: Server, session: ClientSession | undefined): Promise<Document> {
     const db = this.db;
     const username = this.username;
     const password = this.password;
@@ -64,7 +60,7 @@ export class AddUserOperation extends CommandCallbackOperation<Document> {
     // v5 removed the digestPassword option from AddUserOptions but we still want to throw
     // an error when digestPassword is provided.
     if ('digestPassword' in options && options.digestPassword != null) {
-      return callback(
+      return Promise.reject(
         new MongoInvalidArgumentError(
           'Option "digestPassword" not supported via addUser, use db.command(...) instead'
         )
@@ -89,7 +85,7 @@ export class AddUserOperation extends CommandCallbackOperation<Document> {
     try {
       topology = getTopology(db);
     } catch (error) {
-      return callback(error);
+      return Promise.reject(error);
     }
 
     const digestPassword = topology.lastHello().maxWireVersion >= 7;
@@ -117,7 +113,11 @@ export class AddUserOperation extends CommandCallbackOperation<Document> {
       command.pwd = userPassword;
     }
 
-    super.executeCommandCallback(server, session, command, callback);
+    return super.executeCommand(server, session, command);
+  }
+
+  executeCallback(_server: Server, _session: ClientSession | undefined, _callback: Callback): void {
+    throw new Error('Method not implemented');
   }
 }
 

--- a/src/operations/add_user.ts
+++ b/src/operations/add_user.ts
@@ -60,10 +60,8 @@ export class AddUserOperation extends CommandOperation<Document> {
     // v5 removed the digestPassword option from AddUserOptions but we still want to throw
     // an error when digestPassword is provided.
     if ('digestPassword' in options && options.digestPassword != null) {
-      return Promise.reject(
-        new MongoInvalidArgumentError(
-          'Option "digestPassword" not supported via addUser, use db.command(...) instead'
-        )
+      throw new MongoInvalidArgumentError(
+        'Option "digestPassword" not supported via addUser, use db.command(...) instead'
       );
     }
 
@@ -81,12 +79,7 @@ export class AddUserOperation extends CommandOperation<Document> {
       roles = Array.isArray(options.roles) ? options.roles : [options.roles];
     }
 
-    let topology;
-    try {
-      topology = getTopology(db);
-    } catch (error) {
-      return Promise.reject(error);
-    }
+    const topology = getTopology(db);
 
     const digestPassword = topology.lastHello().maxWireVersion >= 7;
 

--- a/src/operations/create_collection.ts
+++ b/src/operations/create_collection.ts
@@ -1,5 +1,3 @@
-import { type Callback } from 'mongodb-legacy';
-
 import type { Document } from '../bson';
 import {
   MIN_SUPPORTED_QE_SERVER_VERSION,
@@ -11,6 +9,7 @@ import { MongoCompatibilityError } from '../error';
 import type { PkFactory } from '../mongo_client';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
+import { type Callback } from '../utils';
 import { CommandOperation, type CommandOperationOptions } from './command';
 import { CreateIndexOperation } from './indexes';
 import { Aspect, defineAspects } from './operation';

--- a/src/operations/drop.ts
+++ b/src/operations/drop.ts
@@ -1,10 +1,9 @@
-import { type Callback } from 'mongodb-legacy';
-
 import type { Document } from '../bson';
 import type { Db } from '../db';
 import { MONGODB_ERROR_CODES, MongoServerError } from '../error';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
+import { type Callback } from '../utils';
 import { CommandOperation, type CommandOperationOptions } from './command';
 import { Aspect, defineAspects } from './operation';
 

--- a/src/operations/drop.ts
+++ b/src/operations/drop.ts
@@ -1,10 +1,11 @@
+import { type Callback } from 'mongodb-legacy';
+
 import type { Document } from '../bson';
 import type { Db } from '../db';
 import { MONGODB_ERROR_CODES, MongoServerError } from '../error';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
-import type { Callback } from '../utils';
-import { CommandCallbackOperation, type CommandOperationOptions } from './command';
+import { CommandOperation, type CommandOperationOptions } from './command';
 import { Aspect, defineAspects } from './operation';
 
 /** @public */
@@ -14,7 +15,7 @@ export interface DropCollectionOptions extends CommandOperationOptions {
 }
 
 /** @internal */
-export class DropCollectionOperation extends CommandCallbackOperation<boolean> {
+export class DropCollectionOperation extends CommandOperation<boolean> {
   override options: DropCollectionOptions;
   db: Db;
   name: string;
@@ -26,68 +27,63 @@ export class DropCollectionOperation extends CommandCallbackOperation<boolean> {
     this.name = name;
   }
 
-  override executeCallback(
-    server: Server,
-    session: ClientSession | undefined,
-    callback: Callback<boolean>
-  ): void {
-    (async () => {
-      const db = this.db;
-      const options = this.options;
-      const name = this.name;
+  override async execute(server: Server, session: ClientSession | undefined): Promise<boolean> {
+    const db = this.db;
+    const options = this.options;
+    const name = this.name;
 
-      const encryptedFieldsMap = db.client.options.autoEncryption?.encryptedFieldsMap;
-      let encryptedFields: Document | undefined =
-        options.encryptedFields ?? encryptedFieldsMap?.[`${db.databaseName}.${name}`];
+    const encryptedFieldsMap = db.client.options.autoEncryption?.encryptedFieldsMap;
+    let encryptedFields: Document | undefined =
+      options.encryptedFields ?? encryptedFieldsMap?.[`${db.databaseName}.${name}`];
 
-      if (!encryptedFields && encryptedFieldsMap) {
-        // If the MongoClient was configured with an encryptedFieldsMap,
-        // and no encryptedFields config was available in it or explicitly
-        // passed as an argument, the spec tells us to look one up using
-        // listCollections().
-        const listCollectionsResult = await db
-          .listCollections({ name }, { nameOnly: false })
-          .toArray();
-        encryptedFields = listCollectionsResult?.[0]?.options?.encryptedFields;
-      }
+    if (!encryptedFields && encryptedFieldsMap) {
+      // If the MongoClient was configured with an encryptedFieldsMap,
+      // and no encryptedFields config was available in it or explicitly
+      // passed as an argument, the spec tells us to look one up using
+      // listCollections().
+      const listCollectionsResult = await db
+        .listCollections({ name }, { nameOnly: false })
+        .toArray();
+      encryptedFields = listCollectionsResult?.[0]?.options?.encryptedFields;
+    }
 
-      if (encryptedFields) {
-        const escCollection = encryptedFields.escCollection || `enxcol_.${name}.esc`;
-        const ecocCollection = encryptedFields.ecocCollection || `enxcol_.${name}.ecoc`;
+    if (encryptedFields) {
+      const escCollection = encryptedFields.escCollection || `enxcol_.${name}.esc`;
+      const ecocCollection = encryptedFields.ecocCollection || `enxcol_.${name}.ecoc`;
 
-        for (const collectionName of [escCollection, ecocCollection]) {
-          // Drop auxilliary collections, ignoring potential NamespaceNotFound errors.
-          const dropOp = new DropCollectionOperation(db, collectionName);
-          try {
-            await dropOp.executeWithoutEncryptedFieldsCheck(server, session);
-          } catch (err) {
-            if (
-              !(err instanceof MongoServerError) ||
-              err.code !== MONGODB_ERROR_CODES.NamespaceNotFound
-            ) {
-              throw err;
-            }
+      for (const collectionName of [escCollection, ecocCollection]) {
+        // Drop auxilliary collections, ignoring potential NamespaceNotFound errors.
+        const dropOp = new DropCollectionOperation(db, collectionName);
+        try {
+          await dropOp.executeWithoutEncryptedFieldsCheck(server, session);
+        } catch (err) {
+          if (
+            !(err instanceof MongoServerError) ||
+            err.code !== MONGODB_ERROR_CODES.NamespaceNotFound
+          ) {
+            throw err;
           }
         }
       }
+    }
 
-      return this.executeWithoutEncryptedFieldsCheck(server, session);
-    })().then(
-      result => callback(undefined, result),
-      err => callback(err)
-    );
+    return this.executeWithoutEncryptedFieldsCheck(server, session);
   }
 
-  private executeWithoutEncryptedFieldsCheck(
+  protected executeCallback(
+    _server: Server,
+    _session: ClientSession | undefined,
+    _callback: Callback<boolean>
+  ): void {
+    throw new Error('Method not implemented.');
+  }
+
+  private async executeWithoutEncryptedFieldsCheck(
     server: Server,
     session: ClientSession | undefined
   ): Promise<boolean> {
-    return new Promise<boolean>((resolve, reject) => {
-      super.executeCommandCallback(server, session, { drop: this.name }, (err, result) => {
-        if (err) return reject(err);
-        resolve(!!result.ok);
-      });
-    });
+    await super.executeCommand(server, session, { drop: this.name });
+    return true;
   }
 }
 
@@ -95,23 +91,24 @@ export class DropCollectionOperation extends CommandCallbackOperation<boolean> {
 export type DropDatabaseOptions = CommandOperationOptions;
 
 /** @internal */
-export class DropDatabaseOperation extends CommandCallbackOperation<boolean> {
+export class DropDatabaseOperation extends CommandOperation<boolean> {
   override options: DropDatabaseOptions;
 
   constructor(db: Db, options: DropDatabaseOptions) {
     super(db, options);
     this.options = options;
   }
-  override executeCallback(
-    server: Server,
-    session: ClientSession | undefined,
-    callback: Callback<boolean>
+  override async execute(server: Server, session: ClientSession | undefined): Promise<boolean> {
+    await super.executeCommand(server, session, { dropDatabase: 1 });
+    return true;
+  }
+
+  protected executeCallback(
+    _server: Server,
+    _session: ClientSession | undefined,
+    _callback: Callback<boolean>
   ): void {
-    super.executeCommandCallback(server, session, { dropDatabase: 1 }, (err, result) => {
-      if (err) return callback(err);
-      if (result.ok) return callback(undefined, true);
-      callback(undefined, false);
-    });
+    throw new Error('Method not implemented.');
   }
 }
 

--- a/src/operations/is_capped.ts
+++ b/src/operations/is_capped.ts
@@ -26,6 +26,6 @@ export class IsCappedOperation extends AbstractOperation<boolean> {
     if (collection == null || collection.options == null) {
       throw new MongoAPIError(`collection ${coll.namespace} not found`);
     }
-    return collection.options?.capped;
+    return !!collection.options?.capped;
   }
 }

--- a/src/operations/is_capped.ts
+++ b/src/operations/is_capped.ts
@@ -2,11 +2,10 @@ import type { Collection } from '../collection';
 import { MongoAPIError } from '../error';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
-import type { Callback } from '../utils';
-import { AbstractCallbackOperation, type OperationOptions } from './operation';
+import { AbstractOperation, type OperationOptions } from './operation';
 
 /** @internal */
-export class IsCappedOperation extends AbstractCallbackOperation<boolean> {
+export class IsCappedOperation extends AbstractOperation<boolean> {
   override options: OperationOptions;
   collection: Collection;
 
@@ -16,29 +15,17 @@ export class IsCappedOperation extends AbstractCallbackOperation<boolean> {
     this.collection = collection;
   }
 
-  override executeCallback(
-    server: Server,
-    session: ClientSession | undefined,
-    callback: Callback<boolean>
-  ): void {
+  override async execute(server: Server, session: ClientSession | undefined): Promise<boolean> {
     const coll = this.collection;
-
-    coll.s.db
+    const [collection] = await coll.s.db
       .listCollections(
         { name: coll.collectionName },
         { ...this.options, nameOnly: false, readPreference: this.readPreference, session }
       )
-      .toArray()
-      .then(
-        collections => {
-          if (collections.length === 0) {
-            // TODO(NODE-3485)
-            return callback(new MongoAPIError(`collection ${coll.namespace} not found`));
-          }
-
-          callback(undefined, !!collections[0].options?.capped);
-        },
-        error => callback(error)
-      );
+      .toArray();
+    if (collection == null || collection.options == null) {
+      throw new MongoAPIError(`collection ${coll.namespace} not found`);
+    }
+    return collection.options?.capped;
   }
 }

--- a/src/operations/profiling_level.ts
+++ b/src/operations/profiling_level.ts
@@ -24,10 +24,8 @@ export class ProfilingLevelOperation extends CommandOperation<string> {
       if (was === 0) return 'off';
       if (was === 1) return 'slow_only';
       if (was === 2) return 'all';
-      // TODO(NODE-3483)
       throw new MongoUnexpectedServerResponseError(`Illegal profiling level value ${was}`);
     } else {
-      // TODO(NODE-3483): Consider MongoUnexpectedServerResponseError
       throw new MongoUnexpectedServerResponseError('Error with profile command');
     }
   }

--- a/src/operations/profiling_level.ts
+++ b/src/operations/profiling_level.ts
@@ -1,8 +1,8 @@
-import { type Callback, MongoUnexpectedServerResponseError } from 'mongodb-legacy';
-
 import type { Db } from '../db';
+import { MongoUnexpectedServerResponseError } from '../error';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
+import { type Callback } from '../utils';
 import { CommandOperation, type CommandOperationOptions } from './command';
 
 /** @public */

--- a/src/operations/remove_user.ts
+++ b/src/operations/remove_user.ts
@@ -1,15 +1,16 @@
+import { type Callback } from 'mongodb-legacy';
+
 import type { Db } from '../db';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
-import type { Callback } from '../utils';
-import { CommandCallbackOperation, type CommandOperationOptions } from './command';
+import { CommandOperation, type CommandOperationOptions } from './command';
 import { Aspect, defineAspects } from './operation';
 
 /** @public */
 export type RemoveUserOptions = CommandOperationOptions;
 
 /** @internal */
-export class RemoveUserOperation extends CommandCallbackOperation<boolean> {
+export class RemoveUserOperation extends CommandOperation<boolean> {
   override options: RemoveUserOptions;
   username: string;
 
@@ -19,14 +20,17 @@ export class RemoveUserOperation extends CommandCallbackOperation<boolean> {
     this.username = username;
   }
 
-  override executeCallback(
-    server: Server,
-    session: ClientSession | undefined,
-    callback: Callback<boolean>
+  override async execute(server: Server, session: ClientSession | undefined): Promise<boolean> {
+    await super.executeCommand(server, session, { dropUser: this.username });
+    return true;
+  }
+
+  protected executeCallback(
+    _server: Server,
+    _session: ClientSession | undefined,
+    _callback: Callback<boolean>
   ): void {
-    super.executeCommandCallback(server, session, { dropUser: this.username }, err => {
-      callback(err, err ? false : true);
-    });
+    throw new Error('Method not implemented.');
   }
 }
 

--- a/src/operations/remove_user.ts
+++ b/src/operations/remove_user.ts
@@ -1,8 +1,7 @@
-import { type Callback } from 'mongodb-legacy';
-
 import type { Db } from '../db';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
+import { type Callback } from '../utils';
 import { CommandOperation, type CommandOperationOptions } from './command';
 import { Aspect, defineAspects } from './operation';
 

--- a/src/operations/rename.ts
+++ b/src/operations/rename.ts
@@ -47,12 +47,7 @@ export class RenameOperation extends RunAdminCommandOperation {
       throw new MongoServerError(doc);
     }
 
-    let newColl: Collection<Document>;
-    try {
-      newColl = new Collection(coll.s.db, this.newName, coll.s.options);
-    } catch (err) {
-      return err;
-    }
+    const newColl: Collection<Document> = new Collection(coll.s.db, this.newName, coll.s.options);
 
     return newColl;
   }

--- a/src/operations/rename.ts
+++ b/src/operations/rename.ts
@@ -3,7 +3,7 @@ import { Collection } from '../collection';
 import { MongoServerError } from '../error';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
-import { type Callback, checkCollectionName } from '../utils';
+import { checkCollectionName } from '../utils';
 import type { CommandOperationOptions } from './command';
 import { Aspect, defineAspects } from './operation';
 import { RunAdminCommandOperation } from './run_command';
@@ -38,29 +38,23 @@ export class RenameOperation extends RunAdminCommandOperation {
     this.newName = newName;
   }
 
-  override executeCallback(
-    server: Server,
-    session: ClientSession | undefined,
-    callback: Callback<Collection>
-  ): void {
+  override async execute(server: Server, session: ClientSession | undefined): Promise<Collection> {
     const coll = this.collection;
 
-    super.executeCallback(server, session, (err, doc) => {
-      if (err) return callback(err);
-      // We have an error
-      if (doc?.errmsg) {
-        return callback(new MongoServerError(doc));
-      }
+    const doc = await super.execute(server, session);
+    // We have an error
+    if (doc?.errmsg) {
+      throw new MongoServerError(doc);
+    }
 
-      let newColl: Collection<Document>;
-      try {
-        newColl = new Collection(coll.s.db, this.newName, coll.s.options);
-      } catch (err) {
-        return callback(err);
-      }
+    let newColl: Collection<Document>;
+    try {
+      newColl = new Collection(coll.s.db, this.newName, coll.s.options);
+    } catch (err) {
+      return err;
+    }
 
-      return callback(undefined, newColl);
-    });
+    return newColl;
   }
 }
 

--- a/src/operations/stats.ts
+++ b/src/operations/stats.ts
@@ -4,7 +4,11 @@ import type { Db } from '../db';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
 import type { Callback } from '../utils';
-import { CommandCallbackOperation, type CommandOperationOptions } from './command';
+import {
+  CommandCallbackOperation,
+  CommandOperation,
+  type CommandOperationOptions
+} from './command';
 import { Aspect, defineAspects } from './operation';
 
 /**
@@ -58,7 +62,7 @@ export interface DbStatsOptions extends CommandOperationOptions {
 }
 
 /** @internal */
-export class DbStatsOperation extends CommandCallbackOperation<Document> {
+export class DbStatsOperation extends CommandOperation<Document> {
   override options: DbStatsOptions;
 
   constructor(db: Db, options: DbStatsOptions) {
@@ -66,17 +70,21 @@ export class DbStatsOperation extends CommandCallbackOperation<Document> {
     this.options = options;
   }
 
-  override executeCallback(
-    server: Server,
-    session: ClientSession | undefined,
-    callback: Callback<Document>
-  ): void {
+  override async execute(server: Server, session: ClientSession | undefined): Promise<Document> {
     const command: Document = { dbStats: true };
     if (this.options.scale != null) {
       command.scale = this.options.scale;
     }
 
-    super.executeCommandCallback(server, session, command, callback);
+    return super.executeCommand(server, session, command);
+  }
+
+  protected executeCallback(
+    _server: Server,
+    _session: ClientSession | undefined,
+    _callback: Callback<Document>
+  ): void {
+    throw new Error('Method not implemented.');
   }
 }
 

--- a/src/operations/validate_collection.ts
+++ b/src/operations/validate_collection.ts
@@ -1,9 +1,9 @@
-import { type Callback, MongoUnexpectedServerResponseError } from 'mongodb-legacy';
-
 import type { Admin } from '../admin';
 import type { Document } from '../bson';
+import { MongoUnexpectedServerResponseError } from '../error';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
+import { type Callback } from '../utils';
 import { CommandOperation, type CommandOperationOptions } from './command';
 
 /** @public */

--- a/src/operations/validate_collection.ts
+++ b/src/operations/validate_collection.ts
@@ -38,7 +38,6 @@ export class ValidateCollectionOperation extends CommandOperation<Document> {
     const collectionName = this.collectionName;
 
     const doc = await super.executeCommand(server, session, this.command);
-    // TODO(NODE-3483): Replace these with MongoUnexpectedServerResponseError
     if (doc.result != null && typeof doc.result !== 'string')
       throw new MongoUnexpectedServerResponseError('Error with validation data');
     if (doc.result != null && doc.result.match(/exception|corrupt/) != null)

--- a/src/operations/validate_collection.ts
+++ b/src/operations/validate_collection.ts
@@ -1,10 +1,10 @@
+import { type Callback, MongoUnexpectedServerResponseError } from 'mongodb-legacy';
+
 import type { Admin } from '../admin';
 import type { Document } from '../bson';
-import { MongoRuntimeError } from '../error';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
-import type { Callback } from '../utils';
-import { CommandCallbackOperation, type CommandOperationOptions } from './command';
+import { CommandOperation, type CommandOperationOptions } from './command';
 
 /** @public */
 export interface ValidateCollectionOptions extends CommandOperationOptions {
@@ -13,7 +13,7 @@ export interface ValidateCollectionOptions extends CommandOperationOptions {
 }
 
 /** @internal */
-export class ValidateCollectionOperation extends CommandCallbackOperation<Document> {
+export class ValidateCollectionOperation extends CommandOperation<Document> {
   override options: ValidateCollectionOptions;
   collectionName: string;
   command: Document;
@@ -34,26 +34,26 @@ export class ValidateCollectionOperation extends CommandCallbackOperation<Docume
     this.collectionName = collectionName;
   }
 
-  override executeCallback(
-    server: Server,
-    session: ClientSession | undefined,
-    callback: Callback<Document>
-  ): void {
+  override async execute(server: Server, session: ClientSession | undefined): Promise<Document> {
     const collectionName = this.collectionName;
 
-    super.executeCommandCallback(server, session, this.command, (err, doc) => {
-      if (err != null) return callback(err);
+    const doc = await super.executeCommand(server, session, this.command);
+    // TODO(NODE-3483): Replace these with MongoUnexpectedServerResponseError
+    if (doc.result != null && typeof doc.result !== 'string')
+      throw new MongoUnexpectedServerResponseError('Error with validation data');
+    if (doc.result != null && doc.result.match(/exception|corrupt/) != null)
+      throw new MongoUnexpectedServerResponseError(`Invalid collection ${collectionName}`);
+    if (doc.valid != null && !doc.valid)
+      throw new MongoUnexpectedServerResponseError(`Invalid collection ${collectionName}`);
 
-      // TODO(NODE-3483): Replace these with MongoUnexpectedServerResponseError
-      if (doc.ok === 0) return callback(new MongoRuntimeError('Error with validate command'));
-      if (doc.result != null && typeof doc.result !== 'string')
-        return callback(new MongoRuntimeError('Error with validation data'));
-      if (doc.result != null && doc.result.match(/exception|corrupt/) != null)
-        return callback(new MongoRuntimeError(`Invalid collection ${collectionName}`));
-      if (doc.valid != null && !doc.valid)
-        return callback(new MongoRuntimeError(`Invalid collection ${collectionName}`));
+    return doc;
+  }
 
-      return callback(undefined, doc);
-    });
+  protected executeCallback(
+    _server: Server,
+    _session: ClientSession | undefined,
+    _callback: Callback<Document>
+  ): void {
+    throw new Error('Method not implemented.');
   }
 }


### PR DESCRIPTION
### Description
admin operations were converted from callback to async/await format

#### What is changing?
executeCallback changed to execute and now returns a promise
because of inheritance from AbstractCallbackOperation, there is also an implementation of executeCallback

##### Is there new documentation needed for these changes?
No

#### What is the motivation for this change?
further converting the driver from callbacks to async/await


### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
