### PR TITLE
chore(NODE-5474): move id-token permission to workflow

### DIFF
--- a/.github/workflows/release-4.x.yml
+++ b/.github/workflows/release-4.x.yml
@@ -6,14 +6,13 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 name: release-4x
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
     steps:
       - id: release
         uses: google-github-actions/release-please-action@v3

--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -8,13 +8,14 @@ on:
         required: true
         type: string
 
+permissions:
+  id-token: write
+
 name: release-alpha
 
 jobs:
   release-alpha:
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
     steps:
       - shell: bash
         run: |

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -11,13 +11,15 @@ on:
   # As long as the commit hash has changed on main a release will be published
   workflow_dispatch: {}
 
+permissions:
+  id-token: write
+
 name: release-nightly
 
 jobs:
   release-nightly:
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
+
     steps:
       - uses: actions/checkout@v3
       - name: actions/setup

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -19,7 +19,6 @@ name: release-nightly
 jobs:
   release-nightly:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v3
       - name: actions/setup

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,14 +6,13 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 name: release
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
     steps:
       - id: release
         uses: google-github-actions/release-please-action@v3


### PR DESCRIPTION
### Description

#### What is changing?

Move permissions, make release work again

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
