### PR TITLE
refactor(NODE-5480): search index operations to use async syntax

### DIFF
--- a/src/operations/search_indexes/drop.ts
+++ b/src/operations/search_indexes/drop.ts
@@ -3,20 +3,15 @@ import type { Document } from 'bson';
 import type { Collection } from '../../collection';
 import type { Server } from '../../sdam/server';
 import type { ClientSession } from '../../sessions';
-import type { Callback } from '../../utils';
-import { AbstractCallbackOperation } from '../operation';
+import { AbstractOperation } from '../operation';
 
 /** @internal */
-export class DropSearchIndexOperation extends AbstractCallbackOperation<void> {
+export class DropSearchIndexOperation extends AbstractOperation<void> {
   constructor(private readonly collection: Collection, private readonly name: string) {
     super();
   }
 
-  executeCallback(
-    server: Server,
-    session: ClientSession | undefined,
-    callback: Callback<void>
-  ): void {
+  override async execute(server: Server, session: ClientSession | undefined): Promise<void> {
     const namespace = this.collection.fullNamespace;
 
     const command: Document = {
@@ -27,13 +22,7 @@ export class DropSearchIndexOperation extends AbstractCallbackOperation<void> {
       command.name = this.name;
     }
 
-    server.command(namespace, command, { session }, err => {
-      if (err) {
-        callback(err);
-        return;
-      }
-
-      callback();
-    });
+    await server.commandAsync(namespace, command, { session });
+    return;
   }
 }

--- a/src/operations/search_indexes/update.ts
+++ b/src/operations/search_indexes/update.ts
@@ -3,11 +3,10 @@ import type { Document } from 'bson';
 import type { Collection } from '../../collection';
 import type { Server } from '../../sdam/server';
 import type { ClientSession } from '../../sessions';
-import type { Callback } from '../../utils';
-import { AbstractCallbackOperation } from '../operation';
+import { AbstractOperation } from '../operation';
 
 /** @internal */
-export class UpdateSearchIndexOperation extends AbstractCallbackOperation<void> {
+export class UpdateSearchIndexOperation extends AbstractOperation<void> {
   constructor(
     private readonly collection: Collection,
     private readonly name: string,
@@ -16,11 +15,7 @@ export class UpdateSearchIndexOperation extends AbstractCallbackOperation<void> 
     super();
   }
 
-  executeCallback(
-    server: Server,
-    session: ClientSession | undefined,
-    callback: Callback<void>
-  ): void {
+  override async execute(server: Server, session: ClientSession | undefined): Promise<void> {
     const namespace = this.collection.fullNamespace;
     const command = {
       updateSearchIndex: namespace.collection,
@@ -28,13 +23,7 @@ export class UpdateSearchIndexOperation extends AbstractCallbackOperation<void> 
       definition: this.definition
     };
 
-    server.command(namespace, command, { session }, err => {
-      if (err) {
-        callback(err);
-        return;
-      }
-
-      callback();
-    });
+    await server.commandAsync(namespace, command, { session });
+    return;
   }
 }


### PR DESCRIPTION
### Description
search index operations now use async/await syntax

#### What is changing?
each search index operation inherits from AbstractOperation and calls server.commandAsync

##### Is there new documentation needed for these changes?
None

#### What is the motivation for this change?

further converting the driver to use async syntax

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
