### PR TITLE
feat(NODE-5409)!: allow socks to be installed optionally

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "bson": "^5.4.0",
-        "mongodb-connection-string-url": "^2.6.0",
-        "socks": "^2.7.1"
+        "mongodb-connection-string-url": "^2.6.0"
       },
       "devDependencies": {
         "@iarna/toml": "^2.2.5",
@@ -55,6 +54,7 @@
         "sinon": "^15.0.4",
         "sinon-chai": "^3.7.0",
         "snappy": "^7.2.2",
+        "socks": "^2.7.1",
         "source-map-support": "^0.5.21",
         "ts-node": "^10.9.1",
         "tsd": "^0.28.1",
@@ -75,7 +75,8 @@
         "gcp-metadata": "^5.2.0",
         "kerberos": "^2.0.1",
         "mongodb-client-encryption": ">=6.0.0-alpha.0 <7",
-        "snappy": "^7.2.2"
+        "snappy": "^7.2.2",
+        "socks": "^2.7.1"
       },
       "peerDependenciesMeta": {
         "@aws-sdk/credential-providers": {
@@ -94,6 +95,9 @@
           "optional": true
         },
         "snappy": {
+          "optional": true
+        },
+        "socks": {
           "optional": true
         }
       }
@@ -5593,7 +5597,8 @@
     "node_modules/ip": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
-      "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
+      "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==",
+      "dev": true
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -8099,6 +8104,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
@@ -8136,6 +8142,7 @@
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
       "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
+      "dev": true,
       "dependencies": {
         "ip": "^2.0.0",
         "smart-buffer": "^4.2.0"

--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
   },
   "dependencies": {
     "bson": "^5.4.0",
-    "mongodb-connection-string-url": "^2.6.0",
-    "socks": "^2.7.1"
+    "mongodb-connection-string-url": "^2.6.0"
   },
   "optionalDependencies": {
     "saslprep": "^1.0.3"
@@ -38,7 +37,8 @@
     "gcp-metadata": "^5.2.0",
     "kerberos": "^2.0.1",
     "mongodb-client-encryption": ">=6.0.0-alpha.0 <7",
-    "snappy": "^7.2.2"
+    "snappy": "^7.2.2",
+    "socks": "^2.7.1"
   },
   "peerDependenciesMeta": {
     "@aws-sdk/credential-providers": {
@@ -57,6 +57,9 @@
       "optional": true
     },
     "gcp-metadata": {
+      "optional": true
+    },
+    "socks": {
       "optional": true
     }
   },
@@ -102,6 +105,7 @@
     "sinon": "^15.0.4",
     "sinon-chai": "^3.7.0",
     "snappy": "^7.2.2",
+    "socks": "^2.7.1",
     "source-map-support": "^0.5.21",
     "ts-node": "^10.9.1",
     "tsd": "^0.28.1",

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 import type { Document } from './bson';
+import { type Stream } from './cmap/connect';
 import type { ProxyOptions } from './cmap/connection';
 import { MongoMissingDependencyError } from './error';
 import type { MongoClient } from './mongo_client';
@@ -151,6 +152,40 @@ export function getSnappy(): SnappyLib | { kModuleError: MongoMissingDependencyE
   } catch (cause) {
     const kModuleError = new MongoMissingDependencyError(
       'Optional module `snappy` not found. Please install it to enable snappy compression',
+      { cause }
+    );
+    return { kModuleError };
+  }
+}
+
+export type SocksLib = {
+  SocksClient: {
+    createConnection(options: {
+      command: 'connect';
+      destination: { host: string; port: number };
+      proxy: {
+        /** host and port are ignored because we pass existing_socket */
+        host: 'iLoveJavaScript';
+        port: 0;
+        type: 5;
+        userId?: string;
+        password?: string;
+      };
+      timeout?: number;
+      /** We always create our own socket, and pass it to this API for proxy negotiation */
+      existing_socket: Stream;
+    }): Promise<{ socket: Stream }>;
+  };
+};
+
+export function getSocks(): SocksLib | { kModuleError: MongoMissingDependencyError } {
+  try {
+    // Ensure you always wrap an optional require in the try block NODE-3199
+    const value = require('socks');
+    return value;
+  } catch (cause) {
+    const kModuleError = new MongoMissingDependencyError(
+      'Optional module `socks` not found. Please install it to connections over a SOCKS5 proxy',
       { cause }
     );
     return { kModuleError };

--- a/test/action/dependency.test.ts
+++ b/test/action/dependency.test.ts
@@ -7,14 +7,15 @@ import { expect } from 'chai';
 import { dependencies, peerDependencies, peerDependenciesMeta } from '../../package.json';
 import { itInNodeProcess } from '../tools/utils';
 
-const EXPECTED_DEPENDENCIES = ['bson', 'mongodb-connection-string-url', 'socks'];
+const EXPECTED_DEPENDENCIES = ['bson', 'mongodb-connection-string-url'];
 const EXPECTED_PEER_DEPENDENCIES = [
   '@aws-sdk/credential-providers',
   '@mongodb-js/zstd',
   'kerberos',
   'snappy',
   'mongodb-client-encryption',
-  'gcp-metadata'
+  'gcp-metadata',
+  'socks'
 ];
 
 describe('package.json', function () {
@@ -119,10 +120,7 @@ describe('package.json', function () {
     'mongodb-connection-string-url',
     'whatwg-url',
     'webidl-conversions',
-    'tr46',
-    'socks',
-    'ip',
-    'smart-buffer'
+    'tr46'
   ];
 
   describe('mongodb imports', () => {


### PR DESCRIPTION
### Description

#### What is changing?

- Add getSocks method to deps
- update dependencies test for socks, and general imports

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

See highlight

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Allow socks to be installed optionally

The driver uses the `socks` dependency to connect to `mongod` or `mongos` through a [SOCKS5 proxy](https://en.wikipedia.org/wiki/SOCKS).  `socks` used to be a required dependency of the driver and was installed automatically.  Now, `socks` is a `peerDependency` that must be installed to enable `socks` proxy support. 

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
