### PR TITLE
feat(NODE-2014)!: return executor result from withSession and withTransaction

### DIFF
--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -609,7 +609,7 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> {
    * The session will always be ended when the executor finishes.
    *
    * @param executor - An executor function that all operations using the provided session must be invoked in
-   * @param options - optional settings for the command
+   * @param options - optional settings for the session
    */
   async withSession<T = any>(executor: WithSessionCallback<T>): Promise<T>;
   async withSession<T = any>(

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -605,32 +605,30 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> {
   }
 
   /**
-   * Runs a given operation with an implicitly created session. The lifetime of the session
-   * will be handled without the need for user interaction.
+   * A convenience method for creating and handling the clean up of a ClientSession.
+   * The session will always be ended when the executor finishes.
    *
-   * NOTE: presently the operation MUST return a Promise (either explicit or implicitly as an async function)
-   *
-   * @param options - Optional settings for the command
-   * @param callback - An callback to execute with an implicitly created session
+   * @param executor - An executor function that all operations using the provided session must be invoked in
+   * @param options - optional settings for the command
    */
-  async withSession<T = any>(callback: WithSessionCallback<T>): Promise<T>;
+  async withSession<T = any>(executor: WithSessionCallback<T>): Promise<T>;
   async withSession<T = any>(
     options: ClientSessionOptions,
-    callback: WithSessionCallback<T>
+    executor: WithSessionCallback<T>
   ): Promise<T>;
   async withSession<T = any>(
-    optionsOrOperation: ClientSessionOptions | WithSessionCallback<T>,
-    callback?: WithSessionCallback<T>
+    optionsOrExecutor: ClientSessionOptions | WithSessionCallback<T>,
+    executor?: WithSessionCallback<T>
   ): Promise<T> {
     const options = {
       // Always define an owner
       owner: Symbol(),
       // If it's an object inherit the options
-      ...(typeof optionsOrOperation === 'object' ? optionsOrOperation : {})
+      ...(typeof optionsOrExecutor === 'object' ? optionsOrExecutor : {})
     };
 
     const withSessionCallback =
-      typeof optionsOrOperation === 'function' ? optionsOrOperation : callback;
+      typeof optionsOrExecutor === 'function' ? optionsOrExecutor : executor;
 
     if (withSessionCallback == null) {
       throw new MongoInvalidArgumentError('Missing required callback parameter');

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -256,7 +256,7 @@ export interface MongoClientOptions extends BSONSerializeOptions, SupportedNodeC
 }
 
 /** @public */
-export type WithSessionCallback = (session: ClientSession) => Promise<any>;
+export type WithSessionCallback<T = unknown> = (session: ClientSession) => Promise<T>;
 
 /** @internal */
 export interface MongoClientPrivate {
@@ -613,12 +613,15 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> {
    * @param options - Optional settings for the command
    * @param callback - An callback to execute with an implicitly created session
    */
-  async withSession(callback: WithSessionCallback): Promise<void>;
-  async withSession(options: ClientSessionOptions, callback: WithSessionCallback): Promise<void>;
-  async withSession(
-    optionsOrOperation: ClientSessionOptions | WithSessionCallback,
-    callback?: WithSessionCallback
-  ): Promise<void> {
+  async withSession<T = any>(callback: WithSessionCallback<T>): Promise<T>;
+  async withSession<T = any>(
+    options: ClientSessionOptions,
+    callback: WithSessionCallback<T>
+  ): Promise<T>;
+  async withSession<T = any>(
+    optionsOrOperation: ClientSessionOptions | WithSessionCallback<T>,
+    callback?: WithSessionCallback<T>
+  ): Promise<T> {
     const options = {
       // Always define an owner
       owner: Symbol(),
@@ -636,7 +639,7 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> {
     const session = this.startSession(options);
 
     try {
-      await withSessionCallback(session);
+      return await withSessionCallback(session);
     } finally {
       try {
         await session.endSession();

--- a/test/integration/sessions/sessions.test.ts
+++ b/test/integration/sessions/sessions.test.ts
@@ -81,6 +81,7 @@ describe('Sessions Spec', function () {
 
     describe('withSession', function () {
       let client: MongoClient;
+
       beforeEach(async function () {
         client = await this.configuration.newClient().connect();
       });
@@ -183,6 +184,13 @@ describe('Sessions Spec', function () {
 
         expect(client.s.sessionPool.sessions).to.have.length(1);
         expect(sessionWasEnded).to.be.true;
+      });
+
+      it('resolves with the value the callback returns', async () => {
+        const result = await client.withSession(async session => {
+          return client.db('test').collection('foo').find({}, { session }).toArray();
+        });
+        expect(result).to.be.an('array');
       });
     });
 

--- a/test/integration/transactions/transactions.test.ts
+++ b/test/integration/transactions/transactions.test.ts
@@ -91,7 +91,7 @@ describe('Transactions', function () {
           await client.close();
         });
 
-        it('should return undefined when transaction is aborted explicitly', async () => {
+        it('returns result of executor when transaction is aborted explicitly', async () => {
           const session = client.startSession();
 
           const withTransactionResult = await session
@@ -99,13 +99,14 @@ describe('Transactions', function () {
               await collection.insertOne({ a: 1 }, { session });
               await collection.findOne({ a: 1 }, { session });
               await session.abortTransaction();
+              return 'aborted!';
             })
             .finally(async () => await session.endSession());
 
-          expect(withTransactionResult).to.be.undefined;
+          expect(withTransactionResult).to.equal('aborted!');
         });
 
-        it('should return result of executor when transaction is successfully committed', async () => {
+        it('returns result of executor when transaction is successfully committed', async () => {
           const session = client.startSession();
 
           const withTransactionResult = await session
@@ -174,7 +175,8 @@ describe('Transactions', function () {
           })
           .finally(async () => await session.endSession());
 
-        expect(withTransactionResult).to.equal(counter);
+        expect(counter).to.equal(3);
+        expect(withTransactionResult).to.equal(3);
       });
     });
   });

--- a/test/integration/transactions/transactions.test.ts
+++ b/test/integration/transactions/transactions.test.ts
@@ -137,7 +137,7 @@ describe('Transactions', function () {
       }
     );
 
-    context('when retried', () => {
+    context('when retried', { requires: { mongodb: '>=4.2.0', topology: '!single' } }, () => {
       let client: MongoClient;
       let collection: Collection<{ a: number }>;
 

--- a/test/integration/transactions/transactions.test.ts
+++ b/test/integration/transactions/transactions.test.ts
@@ -104,19 +104,18 @@ describe('Transactions', function () {
           expect(withTransactionResult).to.be.undefined;
         });
 
-        it('should return raw command when transaction is successfully committed', async () => {
+        it('should return result of executor when transaction is successfully committed', async () => {
           const session = client.startSession();
 
           const withTransactionResult = await session
             .withTransaction(async session => {
               await collection.insertOne({ a: 1 }, { session });
               await collection.findOne({ a: 1 }, { session });
+              return 'committed!';
             })
             .finally(async () => await session.endSession());
 
-          expect(withTransactionResult).to.exist;
-          expect(withTransactionResult).to.be.an('object');
-          expect(withTransactionResult).to.have.property('ok', 1);
+          expect(withTransactionResult).to.equal('committed!');
         });
 
         it('should throw when transaction is aborted due to an error', async () => {

--- a/test/tools/unified-spec-runner/operations.ts
+++ b/test/tools/unified-spec-runner/operations.ts
@@ -593,18 +593,11 @@ operations.set('withTransaction', async ({ entities, operation, client, testConf
     maxCommitTimeMS: operation.arguments!.maxCommitTimeMS
   };
 
-  let errorFromOperations = null;
-  const result = await session.withTransaction(async () => {
-    errorFromOperations = await (async () => {
-      for (const callbackOperation of operation.arguments!.callback) {
-        await executeOperationAndCheck(callbackOperation, entities, client, testConfig);
-      }
-    })().catch(error => error);
+  await session.withTransaction(async () => {
+    for (const callbackOperation of operation.arguments!.callback) {
+      await executeOperationAndCheck(callbackOperation, entities, client, testConfig);
+    }
   }, options);
-
-  if (result == null || errorFromOperations) {
-    throw errorFromOperations ?? Error('transaction not committed');
-  }
 });
 
 operations.set('countDocuments', async ({ entities, operation }) => {

--- a/test/types/sessions.test-d.ts
+++ b/test/types/sessions.test-d.ts
@@ -15,3 +15,13 @@ expectType<ClientSession>(
   })
 );
 expectError(client.startSession({ defaultTransactionOptions: { readConcern: 1 } }));
+
+let something: any;
+expectType<number>(await client.withSession(async () => 2));
+expectType<string>(await client.withSession<string>(async () => something));
+const untypedFn: any = () => 2;
+expectType<any>(await client.withSession(untypedFn));
+const unknownFn: () => Promise<unknown> = async () => 2;
+expectType<unknown>(await client.withSession(unknownFn));
+// Not a promise returning function
+expectError(await client.withSession(() => null));


### PR DESCRIPTION
### Description

#### What is changing?

- `withSession` & `withTransaction` return the value returned by the provided functions

##### Is there new documentation needed for these changes?

Yes, API docs have been updated. Look for docs changes needed on the ticket

#### What is the motivation for this change?

See highlight.

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### `withSession` and `withTransaction` return the value returned by the provided function

The `await client.withSession(async session => {})` now returns the value that the provided function returns. Previously, this function returned `void` this is a feature to align with the following breaking change. 

The `await session.withTransaction(async () => {})` method now returns the value that the provided function returns. Previously, this function returned the server command response which is subject to change depending on the server version or type the driver is connected to. The return value got in the way of writing robust, reliable, consistent code no matter the backing database supporting the application. 

### ⚠️ **Attention! `withTransaction` breaking change**

When upgrading to this version of the driver audit the usages of `withTransaction` for `if` statements or other conditional checks on the return value of `withTransaction`. Previously, the return value was the command response if the transaction was committed, and `undefined` if it had been manually aborted. It would only throw if an operation or the author of the function threw an error. Since thus far there has not been the ability to get the result of the function passed to `withTransaction` we suspect most existing usages to return `void`, making `withTransaction` a `void` returning function in this major release. Take care to ensure that the return values of your function match the expectation of the code that follows the completion of `withTransaction`. 

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
- [x] Release Notes