### PR TITLE
feat(NODE-4961)!: remove command result from commit and abort transaction APIs

### DIFF
--- a/test/integration/transactions/transactions.test.ts
+++ b/test/integration/transactions/transactions.test.ts
@@ -240,7 +240,7 @@ describe('Transactions', function () {
     });
 
     it(
-      'commitTransaction() resolve void',
+      'commitTransaction() resolves void',
       { requires: { mongodb: '>=4.2.0', topology: '!single' } },
       async () =>
         client.withSession(async session =>
@@ -251,7 +251,7 @@ describe('Transactions', function () {
     );
 
     it(
-      'abortTransaction() resolve void',
+      'abortTransaction() resolves void',
       { requires: { mongodb: '>=4.2.0', topology: '!single' } },
       async () =>
         client.withSession(async session =>

--- a/test/integration/transactions/transactions.test.ts
+++ b/test/integration/transactions/transactions.test.ts
@@ -10,6 +10,15 @@ import {
 } from '../../mongodb';
 
 describe('Transactions', function () {
+  let client: MongoClient;
+  beforeEach(async function () {
+    client = this.configuration.newClient();
+  });
+
+  afterEach(async function () {
+    await client.close();
+  });
+
   describe('withTransaction', function () {
     let session: ClientSession;
     let sessionPool: ServerSessionPool;
@@ -184,6 +193,32 @@ describe('Transactions', function () {
         });
       }
     });
+  });
+
+  context('commitTransaction()', () => {
+    it(
+      'returns void',
+      { requires: { topology: ['sharded', 'replicaset'], mongodb: '>=4.1.0' } },
+      async () =>
+        client.withSession(async session =>
+          session.withTransaction(async () => {
+            expect(await session.commitTransaction()).to.be.undefined;
+          })
+        )
+    );
+  });
+
+  context('abortTransaction()', () => {
+    it(
+      'returns void',
+      { requires: { topology: ['sharded', 'replicaset'], mongodb: '>=4.1.0' } },
+      async () =>
+        client.withSession(async session =>
+          session.withTransaction(async () => {
+            expect(await session.abortTransaction()).to.be.undefined;
+          })
+        )
+    );
   });
 
   describe('TransientTransactionError', function () {

--- a/test/integration/transactions/transactions.test.ts
+++ b/test/integration/transactions/transactions.test.ts
@@ -229,6 +229,39 @@ describe('Transactions', function () {
     });
   });
 
+  context('when completing a transaction', () => {
+    let client: MongoClient;
+    beforeEach(async function () {
+      client = this.configuration.newClient();
+    });
+
+    afterEach(async function () {
+      await client.close();
+    });
+
+    it(
+      'commitTransaction() resolve void',
+      { requires: { mongodb: '>=4.2.0', topology: '!single' } },
+      async () =>
+        client.withSession(async session =>
+          session.withTransaction(async session => {
+            expect(await session.commitTransaction()).to.be.undefined;
+          })
+        )
+    );
+
+    it(
+      'abortTransaction() resolve void',
+      { requires: { mongodb: '>=4.2.0', topology: '!single' } },
+      async () =>
+        client.withSession(async session =>
+          session.withTransaction(async session => {
+            expect(await session.abortTransaction()).to.be.undefined;
+          })
+        )
+    );
+  });
+
   describe('TransientTransactionError', function () {
     it('should have a TransientTransactionError label inside of a transaction', {
       metadata: { requires: { topology: 'replicaset', mongodb: '>=4.0.0' } },

--- a/test/tools/unified-spec-runner/operations.ts
+++ b/test/tools/unified-spec-runner/operations.ts
@@ -593,18 +593,11 @@ operations.set('withTransaction', async ({ entities, operation, client, testConf
     maxCommitTimeMS: operation.arguments!.maxCommitTimeMS
   };
 
-  let errorFromOperations = null;
-  const result = await session.withTransaction(async () => {
-    errorFromOperations = await (async () => {
-      for (const callbackOperation of operation.arguments!.callback) {
-        await executeOperationAndCheck(callbackOperation, entities, client, testConfig);
-      }
-    })().catch(error => error);
+  await session.withTransaction(async () => {
+    for (const callbackOperation of operation.arguments!.callback) {
+      await executeOperationAndCheck(callbackOperation, entities, client, testConfig);
+    }
   }, options);
-
-  if (result == null || errorFromOperations) {
-    throw errorFromOperations ?? Error('transaction not committed');
-  }
 });
 
 operations.set('countDocuments', async ({ entities, operation }) => {


### PR DESCRIPTION
### Description

#### What is changing?

- commit & abort transaction properly return void
- added a regression test

##### Is there new documentation needed for these changes?

The typescript has been updated.

#### What is the motivation for this change?

See notes

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### `session.commitTransaction()` and `session.abortTransaction()` return void

Each of these methods erroneously returned server command results that can be different depending on server version or type the driver is connected to. These methods return a promise that if resolved means the command (aborting or commiting) sucessfully completed and rejects otherwise. Viewing command responses is possible through the [command monitoring APIs](https://www.mongodb.com/docs/drivers/node/upcoming/fundamentals/monitoring/command-monitoring/) on the MongoClient.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
