### PR TITLE
chore: pin dependencies check mongodb-client-encryption test to install alpha

### DIFF
--- a/test/action/dependency.test.ts
+++ b/test/action/dependency.test.ts
@@ -83,7 +83,11 @@ describe('package.json', function () {
       });
 
       context(`when ${depName} is installed`, () => {
-        beforeEach(async () => {
+        beforeEach(async function () {
+          if (depName === 'mongodb-client-encryption') {
+            execSync(`npm install --no-save "${depName}"@alpha`);
+            return;
+          }
           execSync(`npm install --no-save "${depName}"@"${depMajor}"`);
         });
 


### PR DESCRIPTION
### Description

#### What is changing?

- use alpha version instead of major for check:dependencies test

##### Is there new documentation needed for these changes?

No.

#### What is the motivation for this change?

Prevent inbox spam 

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
