### PR TITLE
refactor(NODE-5473): Remove Unused Callback Inheritance in Operations Layer

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -389,7 +389,6 @@ export type {
   CommandOperationOptions,
   OperationParent
 } from './operations/command';
-export type { CommandCallbackOperation } from './operations/command';
 export type { IndexInformationOptions } from './operations/common_functions';
 export type { CountOptions } from './operations/count';
 export type { CountDocumentsOptions } from './operations/count_documents';
@@ -421,12 +420,7 @@ export type {
 export type { InsertManyResult, InsertOneOptions, InsertOneResult } from './operations/insert';
 export type { CollectionInfo, ListCollectionsOptions } from './operations/list_collections';
 export type { ListDatabasesOptions, ListDatabasesResult } from './operations/list_databases';
-export type {
-  AbstractCallbackOperation,
-  AbstractOperation,
-  Hint,
-  OperationOptions
-} from './operations/operation';
+export type { AbstractOperation, Hint, OperationOptions } from './operations/operation';
 export type { ProfilingLevelOptions } from './operations/profiling_level';
 export type { RemoveUserOptions } from './operations/remove_user';
 export type { RenameOptions } from './operations/rename';

--- a/src/operations/aggregate.ts
+++ b/src/operations/aggregate.ts
@@ -3,7 +3,7 @@ import { MongoInvalidArgumentError } from '../error';
 import { type TODO_NODE_3286 } from '../mongo_types';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
-import { type Callback, maxWireVersion, type MongoDBNamespace } from '../utils';
+import { maxWireVersion, type MongoDBNamespace } from '../utils';
 import { WriteConcern } from '../write_concern';
 import { type CollationOptions, CommandOperation, type CommandOperationOptions } from './command';
 import { Aspect, defineAspects, type Hint } from './operation';
@@ -131,14 +131,6 @@ export class AggregateOperation<T = Document> extends CommandOperation<T> {
     }
 
     return super.executeCommand(server, session, command) as TODO_NODE_3286;
-  }
-
-  protected override executeCallback(
-    _server: Server,
-    _session: ClientSession | undefined,
-    _callback: Callback<T>
-  ): void {
-    throw new Error('Method not implemented.');
   }
 }
 

--- a/src/operations/command.ts
+++ b/src/operations/command.ts
@@ -7,7 +7,6 @@ import type { Server } from '../sdam/server';
 import { MIN_SECONDARY_WRITE_WIRE_VERSION } from '../sdam/server_selection';
 import type { ClientSession } from '../sessions';
 import {
-  type Callback,
   commandSupportsReadConcern,
   decorateWithExplain,
   maxWireVersion,
@@ -15,7 +14,7 @@ import {
 } from '../utils';
 import { WriteConcern, type WriteConcernOptions } from '../write_concern';
 import type { ReadConcernLike } from './../read_concern';
-import { AbstractCallbackOperation, Aspect, type OperationOptions } from './operation';
+import { AbstractOperation, Aspect, type OperationOptions } from './operation';
 
 /** @public */
 export interface CollationOptions {
@@ -68,7 +67,7 @@ export interface OperationParent {
 }
 
 /** @internal */
-export abstract class CommandOperation<T> extends AbstractCallbackOperation<T> {
+export abstract class CommandOperation<T> extends AbstractOperation<T> {
   override options: CommandOperationOptions;
   readConcern?: ReadConcern;
   writeConcern?: WriteConcern;
@@ -154,24 +153,5 @@ export abstract class CommandOperation<T> extends AbstractCallbackOperation<T> {
     }
 
     return server.commandAsync(this.ns, cmd, options);
-  }
-}
-
-/** @internal */
-export abstract class CommandCallbackOperation<T = any> extends CommandOperation<T> {
-  constructor(parent?: OperationParent, options?: CommandOperationOptions) {
-    super(parent, options);
-  }
-
-  executeCommandCallback(
-    server: Server,
-    session: ClientSession | undefined,
-    cmd: Document,
-    callback: Callback
-  ): void {
-    super.executeCommand(server, session, cmd).then(
-      res => callback(undefined, res),
-      err => callback(err, undefined)
-    );
   }
 }

--- a/src/operations/count.ts
+++ b/src/operations/count.ts
@@ -2,7 +2,7 @@ import type { Document } from '../bson';
 import type { Collection } from '../collection';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
-import type { Callback, MongoDBNamespace } from '../utils';
+import type { MongoDBNamespace } from '../utils';
 import { CommandOperation, type CommandOperationOptions } from './command';
 import { Aspect, defineAspects } from './operation';
 
@@ -57,14 +57,6 @@ export class CountOperation extends CommandOperation<number> {
 
     const result = await super.executeCommand(server, session, cmd);
     return result ? result.n : 0;
-  }
-
-  protected override executeCallback(
-    _server: Server,
-    _session: ClientSession | undefined,
-    _callback: Callback<number>
-  ): void {
-    throw new Error('Method not implemented.');
   }
 }
 

--- a/src/operations/create_collection.ts
+++ b/src/operations/create_collection.ts
@@ -9,7 +9,6 @@ import { MongoCompatibilityError } from '../error';
 import type { PkFactory } from '../mongo_client';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
-import { type Callback } from '../utils';
 import { CommandOperation, type CommandOperationOptions } from './command';
 import { CreateIndexOperation } from './indexes';
 import { Aspect, defineAspects } from './operation';
@@ -169,14 +168,6 @@ export class CreateCollectionOperation extends CommandOperation<Collection> {
     }
 
     return coll;
-  }
-
-  protected executeCallback(
-    _server: Server,
-    _session: ClientSession | undefined,
-    _callback: Callback<Collection>
-  ): void {
-    throw new Error('Method not implemented.');
   }
 
   private async executeWithoutEncryptedFieldsCheck(

--- a/src/operations/delete.ts
+++ b/src/operations/delete.ts
@@ -4,7 +4,7 @@ import { MongoCompatibilityError, MongoServerError } from '../error';
 import { type TODO_NODE_3286 } from '../mongo_types';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
-import type { Callback, MongoDBNamespace } from '../utils';
+import type { MongoDBNamespace } from '../utils';
 import type { WriteConcernOptions } from '../write_concern';
 import { type CollationOptions, CommandOperation, type CommandOperationOptions } from './command';
 import { Aspect, defineAspects, type Hint } from './operation';
@@ -92,14 +92,6 @@ export class DeleteOperation extends CommandOperation<DeleteResult> {
     }
 
     return super.executeCommand(server, session, command) as TODO_NODE_3286;
-  }
-
-  protected override executeCallback(
-    _server: Server,
-    _session: ClientSession | undefined,
-    _callback: Callback<DeleteResult>
-  ): void {
-    throw new Error('Method not implemented.');
   }
 }
 

--- a/src/operations/distinct.ts
+++ b/src/operations/distinct.ts
@@ -2,7 +2,7 @@ import type { Document } from '../bson';
 import type { Collection } from '../collection';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
-import { type Callback, decorateWithCollation, decorateWithReadConcern } from '../utils';
+import { decorateWithCollation, decorateWithReadConcern } from '../utils';
 import { CommandOperation, type CommandOperationOptions } from './command';
 import { Aspect, defineAspects } from './operation';
 
@@ -71,14 +71,6 @@ export class DistinctOperation extends CommandOperation<any[]> {
     const result = await super.executeCommand(server, session, cmd);
 
     return this.explain ? result : result.values;
-  }
-
-  protected override executeCallback(
-    _server: Server,
-    _session: ClientSession | undefined,
-    _callback: Callback<any[]>
-  ): void {
-    throw new Error('Method not implemented.');
   }
 }
 

--- a/src/operations/drop.ts
+++ b/src/operations/drop.ts
@@ -3,7 +3,6 @@ import type { Db } from '../db';
 import { MONGODB_ERROR_CODES, MongoServerError } from '../error';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
-import { type Callback } from '../utils';
 import { CommandOperation, type CommandOperationOptions } from './command';
 import { Aspect, defineAspects } from './operation';
 
@@ -69,14 +68,6 @@ export class DropCollectionOperation extends CommandOperation<boolean> {
     return this.executeWithoutEncryptedFieldsCheck(server, session);
   }
 
-  protected executeCallback(
-    _server: Server,
-    _session: ClientSession | undefined,
-    _callback: Callback<boolean>
-  ): void {
-    throw new Error('Method not implemented.');
-  }
-
   private async executeWithoutEncryptedFieldsCheck(
     server: Server,
     session: ClientSession | undefined
@@ -100,14 +91,6 @@ export class DropDatabaseOperation extends CommandOperation<boolean> {
   override async execute(server: Server, session: ClientSession | undefined): Promise<boolean> {
     await super.executeCommand(server, session, { dropDatabase: 1 });
     return true;
-  }
-
-  protected executeCallback(
-    _server: Server,
-    _session: ClientSession | undefined,
-    _callback: Callback<boolean>
-  ): void {
-    throw new Error('Method not implemented.');
   }
 }
 

--- a/src/operations/estimated_document_count.ts
+++ b/src/operations/estimated_document_count.ts
@@ -2,7 +2,6 @@ import type { Document } from '../bson';
 import type { Collection } from '../collection';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
-import type { Callback } from '../utils';
 import { CommandOperation, type CommandOperationOptions } from './command';
 import { Aspect, defineAspects } from './operation';
 
@@ -43,14 +42,6 @@ export class EstimatedDocumentCountOperation extends CommandOperation<number> {
     const response = await super.executeCommand(server, session, cmd);
 
     return response?.n || 0;
-  }
-
-  protected override executeCallback(
-    _server: Server,
-    _session: ClientSession | undefined,
-    _callback: Callback<number>
-  ): void {
-    throw new Error('Method not implemented.');
   }
 }
 

--- a/src/operations/find.ts
+++ b/src/operations/find.ts
@@ -5,12 +5,7 @@ import { ReadConcern } from '../read_concern';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
 import { formatSort, type Sort } from '../sort';
-import {
-  type Callback,
-  decorateWithExplain,
-  type MongoDBNamespace,
-  normalizeHintField
-} from '../utils';
+import { decorateWithExplain, type MongoDBNamespace, normalizeHintField } from '../utils';
 import { type CollationOptions, CommandOperation, type CommandOperationOptions } from './command';
 import { Aspect, defineAspects, type Hint } from './operation';
 
@@ -118,14 +113,6 @@ export class FindOperation extends CommandOperation<Document> {
       documentsReturnedIn: 'firstBatch',
       session
     });
-  }
-
-  protected executeCallback(
-    _server: Server,
-    _session: ClientSession | undefined,
-    _callback: Callback<Document>
-  ): void {
-    throw new Error('Method not implemented.');
   }
 }
 

--- a/src/operations/find_and_modify.ts
+++ b/src/operations/find_and_modify.ts
@@ -5,7 +5,7 @@ import { ReadPreference } from '../read_preference';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
 import { formatSort, type Sort, type SortForCmd } from '../sort';
-import { type Callback, decorateWithCollation, hasAtomicOperators, maxWireVersion } from '../utils';
+import { decorateWithCollation, hasAtomicOperators, maxWireVersion } from '../utils';
 import type { WriteConcern, WriteConcernSettings } from '../write_concern';
 import { CommandOperation, type CommandOperationOptions } from './command';
 import { Aspect, defineAspects } from './operation';
@@ -214,14 +214,6 @@ class FindAndModifyOperation extends CommandOperation<Document> {
     // Execute the command
     const result = await super.executeCommand(server, session, cmd);
     return options.includeResultMetadata ? result : result.value ?? null;
-  }
-
-  protected override executeCallback(
-    _server: Server,
-    _session: ClientSession | undefined,
-    _callback: Callback<Document>
-  ): void {
-    throw new Error('Method not implemented.');
   }
 }
 

--- a/src/operations/indexes.ts
+++ b/src/operations/indexes.ts
@@ -6,7 +6,7 @@ import { type OneOrMore } from '../mongo_types';
 import { ReadPreference } from '../read_preference';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
-import { type Callback, isObject, maxWireVersion, type MongoDBNamespace } from '../utils';
+import { isObject, maxWireVersion, type MongoDBNamespace } from '../utils';
 import {
   type CollationOptions,
   CommandOperation,
@@ -260,14 +260,6 @@ export class CreateIndexesOperation<
     const indexNames = indexes.map(index => index.name || '');
     return indexNames as T;
   }
-
-  protected executeCallback(
-    _server: Server,
-    _session: ClientSession | undefined,
-    _callback: Callback<T>
-  ): void {
-    throw new Error('Method not implemented.');
-  }
 }
 
 /** @internal */
@@ -340,14 +332,6 @@ export class DropIndexOperation extends CommandOperation<Document> {
     const cmd = { dropIndexes: this.collection.collectionName, index: this.indexName };
     return super.executeCommand(server, session, cmd);
   }
-
-  protected executeCallback(
-    _server: Server,
-    _session: ClientSession | undefined,
-    _callback: Callback<Document>
-  ): void {
-    throw new Error('Method not implemented.');
-  }
 }
 
 /** @public */
@@ -390,14 +374,6 @@ export class ListIndexesOperation extends CommandOperation<Document> {
     }
 
     return super.executeCommand(server, session, command);
-  }
-
-  protected executeCallback(
-    _server: Server,
-    _session: ClientSession | undefined,
-    _callback: Callback<Document>
-  ): void {
-    throw new Error('Method not implemented.');
   }
 }
 

--- a/src/operations/insert.ts
+++ b/src/operations/insert.ts
@@ -5,7 +5,7 @@ import { MongoInvalidArgumentError, MongoServerError } from '../error';
 import type { InferIdType } from '../mongo_types';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
-import type { Callback, MongoDBNamespace } from '../utils';
+import type { MongoDBNamespace } from '../utils';
 import { WriteConcern } from '../write_concern';
 import { BulkWriteOperation } from './bulk_write';
 import { CommandOperation, type CommandOperationOptions } from './command';
@@ -44,14 +44,6 @@ export class InsertOperation extends CommandOperation<Document> {
     }
 
     return super.executeCommand(server, session, command);
-  }
-
-  protected override executeCallback(
-    _server: Server,
-    _session: ClientSession | undefined,
-    _callback: Callback<Document>
-  ): void {
-    throw new Error('Method not implemented.');
   }
 }
 

--- a/src/operations/list_collections.ts
+++ b/src/operations/list_collections.ts
@@ -2,7 +2,7 @@ import type { Binary, Document } from '../bson';
 import type { Db } from '../db';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
-import { type Callback, maxWireVersion } from '../utils';
+import { maxWireVersion } from '../utils';
 import { CommandOperation, type CommandOperationOptions } from './command';
 import { Aspect, defineAspects } from './operation';
 
@@ -49,14 +49,6 @@ export class ListCollectionsOperation extends CommandOperation<Document> {
 
   override async execute(server: Server, session: ClientSession | undefined): Promise<Document> {
     return super.executeCommand(server, session, this.generateCommand(maxWireVersion(server)));
-  }
-
-  protected executeCallback(
-    _server: Server,
-    _session: ClientSession | undefined,
-    _callback: Callback<Document>
-  ): void {
-    throw new Error('Method not implemented.');
   }
 
   /* This is here for the purpose of unit testing the final command that gets sent. */

--- a/src/operations/list_databases.ts
+++ b/src/operations/list_databases.ts
@@ -3,7 +3,7 @@ import type { Db } from '../db';
 import { type TODO_NODE_3286 } from '../mongo_types';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
-import { type Callback, maxWireVersion, MongoDBNamespace } from '../utils';
+import { maxWireVersion, MongoDBNamespace } from '../utils';
 import { CommandOperation, type CommandOperationOptions } from './command';
 import { Aspect, defineAspects } from './operation';
 
@@ -60,14 +60,6 @@ export class ListDatabasesOperation extends CommandOperation<ListDatabasesResult
     }
 
     return super.executeCommand(server, session, cmd) as TODO_NODE_3286;
-  }
-
-  protected executeCallback(
-    _server: Server,
-    _session: ClientSession | undefined,
-    _callback: Callback<ListDatabasesResult>
-  ): void {
-    throw new Error('Method not implemented.');
   }
 }
 

--- a/src/operations/operation.ts
+++ b/src/operations/operation.ts
@@ -1,10 +1,8 @@
-import { promisify } from 'util';
-
 import { type BSONSerializeOptions, type Document, resolveBSONOptions } from '../bson';
 import { ReadPreference, type ReadPreferenceLike } from '../read_preference';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
-import type { Callback, MongoDBNamespace } from '../utils';
+import type { MongoDBNamespace } from '../utils';
 
 export const Aspect = {
   READ_OPERATION: Symbol('READ_OPERATION'),
@@ -102,25 +100,6 @@ export abstract class AbstractOperation<TResult = any> {
   get canRetryWrite(): boolean {
     return true;
   }
-}
-
-/** @internal */
-export abstract class AbstractCallbackOperation<TResult = any> extends AbstractOperation {
-  constructor(options: OperationOptions = {}) {
-    super(options);
-  }
-
-  execute(server: Server, session: ClientSession | undefined): Promise<TResult> {
-    return promisify((callback: (e: Error, r: TResult) => void) => {
-      this.executeCallback(server, session, callback as any);
-    })();
-  }
-
-  protected abstract executeCallback(
-    server: Server,
-    session: ClientSession | undefined,
-    callback: Callback<TResult>
-  ): void;
 }
 
 export function defineAspects(

--- a/src/operations/profiling_level.ts
+++ b/src/operations/profiling_level.ts
@@ -2,7 +2,6 @@ import type { Db } from '../db';
 import { MongoUnexpectedServerResponseError } from '../error';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
-import { type Callback } from '../utils';
 import { CommandOperation, type CommandOperationOptions } from './command';
 
 /** @public */
@@ -28,13 +27,5 @@ export class ProfilingLevelOperation extends CommandOperation<string> {
     } else {
       throw new MongoUnexpectedServerResponseError('Error with profile command');
     }
-  }
-
-  protected executeCallback(
-    _server: Server,
-    _session: ClientSession | undefined,
-    _callback: Callback<string>
-  ): void {
-    throw new Error('Method not implemented.');
   }
 }

--- a/src/operations/remove_user.ts
+++ b/src/operations/remove_user.ts
@@ -1,7 +1,6 @@
 import type { Db } from '../db';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
-import { type Callback } from '../utils';
 import { CommandOperation, type CommandOperationOptions } from './command';
 import { Aspect, defineAspects } from './operation';
 
@@ -22,14 +21,6 @@ export class RemoveUserOperation extends CommandOperation<boolean> {
   override async execute(server: Server, session: ClientSession | undefined): Promise<boolean> {
     await super.executeCommand(server, session, { dropUser: this.username });
     return true;
-  }
-
-  protected executeCallback(
-    _server: Server,
-    _session: ClientSession | undefined,
-    _callback: Callback<boolean>
-  ): void {
-    throw new Error('Method not implemented.');
   }
 }
 

--- a/src/operations/rename.ts
+++ b/src/operations/rename.ts
@@ -42,10 +42,6 @@ export class RenameOperation extends CommandOperation<Document> {
     await super.executeCommand(server, session, command);
     return new Collection(this.collection.s.db, this.newName, this.collection.s.options);
   }
-
-  protected executeCallback(_server: any, _session: any, _callback: any): void {
-    throw new Error('Method not implemented.');
-  }
 }
 
 defineAspects(RenameOperation, [Aspect.WRITE_OPERATION]);

--- a/src/operations/set_profiling_level.ts
+++ b/src/operations/set_profiling_level.ts
@@ -2,7 +2,7 @@ import type { Db } from '../db';
 import { MongoInvalidArgumentError } from '../error';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
-import { type Callback, enumToString } from '../utils';
+import { enumToString } from '../utils';
 import { CommandOperation, type CommandOperationOptions } from './command';
 
 const levelValues = new Set(['off', 'slow_only', 'all']);
@@ -62,13 +62,5 @@ export class SetProfilingLevelOperation extends CommandOperation<ProfilingLevel>
     // TODO(NODE-3483): Determine error to put here
     await super.executeCommand(server, session, { profile: this.profile });
     return level;
-  }
-
-  protected executeCallback(
-    _server: Server,
-    _session: ClientSession | undefined,
-    _callback: Callback<ProfilingLevel>
-  ): void {
-    throw new Error('Method not implemented.');
   }
 }

--- a/src/operations/stats.ts
+++ b/src/operations/stats.ts
@@ -2,7 +2,6 @@ import type { Document } from '../bson';
 import type { Db } from '../db';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
-import type { Callback } from '../utils';
 import { CommandOperation, type CommandOperationOptions } from './command';
 import { Aspect, defineAspects } from './operation';
 
@@ -28,14 +27,6 @@ export class DbStatsOperation extends CommandOperation<Document> {
     }
 
     return super.executeCommand(server, session, command);
-  }
-
-  protected executeCallback(
-    _server: Server,
-    _session: ClientSession | undefined,
-    _callback: Callback<Document>
-  ): void {
-    throw new Error('Method not implemented.');
   }
 }
 

--- a/src/operations/update.ts
+++ b/src/operations/update.ts
@@ -4,7 +4,7 @@ import { MongoCompatibilityError, MongoInvalidArgumentError, MongoServerError } 
 import type { InferIdType, TODO_NODE_3286 } from '../mongo_types';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
-import { type Callback, hasAtomicOperators, type MongoDBNamespace } from '../utils';
+import { hasAtomicOperators, type MongoDBNamespace } from '../utils';
 import { type CollationOptions, CommandOperation, type CommandOperationOptions } from './command';
 import { Aspect, defineAspects, type Hint } from './operation';
 
@@ -119,14 +119,6 @@ export class UpdateOperation extends CommandOperation<Document> {
     }
 
     return super.executeCommand(server, session, command);
-  }
-
-  protected override executeCallback(
-    _server: Server,
-    _session: ClientSession | undefined,
-    _callback: Callback<Document>
-  ): void {
-    throw new Error('Method not implemented.');
   }
 }
 

--- a/src/operations/validate_collection.ts
+++ b/src/operations/validate_collection.ts
@@ -3,7 +3,6 @@ import type { Document } from '../bson';
 import { MongoUnexpectedServerResponseError } from '../error';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
-import { type Callback } from '../utils';
 import { CommandOperation, type CommandOperationOptions } from './command';
 
 /** @public */
@@ -46,13 +45,5 @@ export class ValidateCollectionOperation extends CommandOperation<Document> {
       throw new MongoUnexpectedServerResponseError(`Invalid collection ${collectionName}`);
 
     return doc;
-  }
-
-  protected executeCallback(
-    _server: Server,
-    _session: ClientSession | undefined,
-    _callback: Callback<Document>
-  ): void {
-    throw new Error('Method not implemented.');
   }
 }


### PR DESCRIPTION
### Description
removed unused callback inheritance in all operation files

#### What is changing?
asyncified eval.ts
removed unimplemented executeCallback method from all operation files
removed callback classes from AbstractOperation and CommandOperation

##### Is there new documentation needed for these changes?
None

#### What is the motivation for this change?
further asyncifying the driver

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
