### PR TITLE
chore: narrow the types for validatioLevel and validationAction in CreateCollectionOptions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -445,7 +445,9 @@ export type { CountDocumentsOptions } from './operations/count_documents';
 export type {
   ClusteredCollectionOptions,
   CreateCollectionOptions,
-  TimeSeriesCollectionOptions
+  TimeSeriesCollectionOptions,
+  ValidationAction,
+  ValidationLevel
 } from './operations/create_collection';
 export type { DeleteOptions, DeleteResult, DeleteStatement } from './operations/delete';
 export type { DistinctOptions } from './operations/distinct';

--- a/src/operations/create_collection.ts
+++ b/src/operations/create_collection.ts
@@ -60,6 +60,12 @@ export interface ClusteredCollectionOptions extends Document {
 }
 
 /** @public */
+export type ValidationLevel = 'off' | 'strict' | 'moderate';
+
+/** @public */
+export type ValidationAction = 'error' | 'warn';
+
+/** @public */
 export interface CreateCollectionOptions extends CommandOperationOptions {
   /** Create a capped collection */
   capped?: boolean;
@@ -76,9 +82,9 @@ export interface CreateCollectionOptions extends CommandOperationOptions {
   /** Allows users to specify validation rules or expressions for the collection. For more information, see Document Validation */
   validator?: Document;
   /** Determines how strictly MongoDB applies the validation rules to existing documents during an update */
-  validationLevel?: string;
+  validationLevel?: ValidationLevel;
   /** Determines whether to error on invalid documents or just warn about the violations but allow invalid documents to be inserted */
-  validationAction?: string;
+  validationAction?: ValidationAction;
   /** Allows users to specify a default configuration for indexes when creating a collection */
   indexOptionDefaults?: Document;
   /** The name of the source collection or view from which to create the view. The name is not the full namespace of the collection or view (i.e., does not include the database name and implies the same database as the view to create) */


### PR DESCRIPTION

### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
