### PR TITLE
feat(NODE-5490)!: bump kerberos compatibility to ^2.0.1

### DIFF
--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -774,13 +774,6 @@ for (const variant of BUILD_VARIANTS.filter(
   );
 }
 
-// TODO(NODE-5021): Drop support for Kerberos 1.x on in 6.0.0
-for (const variant of BUILD_VARIANTS.filter(
-  variant => variant.expansions && ['latest'].includes(variant.expansions.NODE_LTS_VERSION)
-)) {
-  variant.tasks = variant.tasks.filter(name => !['test-auth-kerberos'].includes(name));
-}
-
 // TODO(NODE-4897): Debug socks5 tests on node latest
 for (const variant of BUILD_VARIANTS.filter(
   variant => variant.expansions && ['latest'].includes(variant.expansions.NODE_LTS_VERSION)

--- a/.evergreen/run-kerberos-tests.sh
+++ b/.evergreen/run-kerberos-tests.sh
@@ -21,7 +21,7 @@ echo "Running kinit"
 kinit -k -t "$(pwd)/.evergreen/drivers.keytab" -p ${KRB5_PRINCIPAL}
 
 set -o xtrace
-npm install kerberos@">=2.0.0-beta.0"
+npm install kerberos@2.0.1
 npm run check:kerberos
 
 set +o xtrace


### PR DESCRIPTION
### Description

Updates kerberos dependency to ^2.0.1

#### What is changing?

The optional peer dependency has already changed, this updates the test script to install it instead of the beta. There were no specific tests targeting kerberos 1.x and the filter in the evergreen generation script was removed even though it was no longer actually doing anything.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-5490

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

#### Kerberos optional peer dependency minimum version raised to 2.0.1

This was done in https://github.com/mongodb/node-mongodb-native/pull/3691/commits/5fcdf93df573739904f405177413fb327a5015d6 (https://github.com/mongodb/node-mongodb-native/pull/3691)

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
