### PR TITLE
fix(NODE-5489): set kerberos compatibility to ^1.0.0 || ^2.0.0

### DIFF
--- a/.evergreen/run-kerberos-tests.sh
+++ b/.evergreen/run-kerberos-tests.sh
@@ -21,7 +21,7 @@ echo "Running kinit"
 kinit -k -t "$(pwd)/.evergreen/drivers.keytab" -p ${KRB5_PRINCIPAL}
 
 set -o xtrace
-npm install kerberos@">=2.0.0-beta.0"
+npm install kerberos@2.0.1
 npm run check:kerberos
 
 if [ "$NODE_LTS_VERSION" != "latest" ] && [ $NODE_LTS_VERSION -lt 20 ]; then

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,7 @@
       "peerDependencies": {
         "@aws-sdk/credential-providers": "^3.201.0",
         "@mongodb-js/zstd": "^1.1.0",
-        "kerberos": "^2.0.1",
+        "kerberos": "^1.0.0 || ^2.0.0",
         "mongodb-client-encryption": ">=2.3.0 <3",
         "snappy": "^7.2.2"
       },

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "peerDependencies": {
     "@aws-sdk/credential-providers": "^3.201.0",
     "@mongodb-js/zstd": "^1.1.0",
-    "kerberos": "^2.0.1",
+    "kerberos": "^1.0.0 || ^2.0.0",
     "mongodb-client-encryption": ">=2.3.0 <3",
     "snappy": "^7.2.2"
   },


### PR DESCRIPTION
### Description

Changes kerberos dependency to `^1.0.0 || ^2.0.0`

#### What is changing?

Changes kerberos dependency back to `^1.0.0 || ^2.0.0` to reintroduce 1.x support.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-5489

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

#### Kerberos support for 1.x and 2.x

Moves the kerberos dependency back to `^1.0.0 || ^2.0.0` to indicate support for both 1.x and 2.x. Support for 1.x is removed in 6.0.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
