### PR TITLE
ci(NODE-5424): add CI testing for FLE 6.0 with driver latest

### DIFF
--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -352,6 +352,13 @@ functions:
           SKIP_DEPS=${SKIP_DEPS|1} \
             bash ${PROJECT_DIRECTORY}/.evergreen/run-tests.sh
 
+  "install package":
+    - command: shell.exec
+      params:
+        working_dir: src
+        script: |
+          npm install --force ${PACKAGE}
+
   "run lint checks":
     - command: subprocess.exec
       type: test

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -316,6 +316,12 @@ functions:
           COMPRESSOR="${COMPRESSOR}" \
           SKIP_DEPS=${SKIP_DEPS|1} \
             bash ${PROJECT_DIRECTORY}/.evergreen/run-tests.sh
+  install package:
+    - command: shell.exec
+      params:
+        working_dir: src
+        script: |
+          npm install --force ${PACKAGE}
   run lint checks:
     - command: subprocess.exec
       type: test
@@ -2745,6 +2751,22 @@ tasks:
       - func: run custom csfle tests
         vars:
           CSFLE_GIT_REF: master
+  - name: test-latest-driver-mongodb-client-encryption-6.0.0
+    tags:
+      - run-custom-dependency-tests
+    commands:
+      - func: install dependencies
+        vars:
+          NODE_LTS_VERSION: 16
+      - func: bootstrap mongo-orchestration
+        vars:
+          VERSION: '7.0'
+          TOPOLOGY: replica_set
+      - func: bootstrap kms servers
+      - func: install package
+        vars:
+          PACKAGE: mongodb-client-encryption@6.0.0-alpha.1
+      - func: run tests
   - name: test-latest-server-noauth
     tags:
       - latest
@@ -3676,6 +3698,7 @@ buildvariants:
       - test-auth-ldap
       - test-auth-oidc
       - test-socks5
+      - test-socks5-csfle
       - test-socks5-tls
       - test-tls-support-latest
       - test-tls-support-6.0
@@ -3726,6 +3749,7 @@ buildvariants:
       - test-auth-ldap
       - test-auth-oidc
       - test-socks5
+      - test-socks5-csfle
       - test-socks5-tls
       - test-tls-support-latest
       - test-tls-support-6.0
@@ -4015,6 +4039,7 @@ buildvariants:
       - run-custom-csfle-tests-rapid-master
       - run-custom-csfle-tests-latest-pinned-commit
       - run-custom-csfle-tests-latest-master
+      - test-latest-driver-mongodb-client-encryption-6.0.0
   - name: rhel8-test-serverless
     display_name: Serverless Test
     run_on: rhel80-large

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2765,7 +2765,7 @@ tasks:
       - func: bootstrap kms servers
       - func: install package
         vars:
-          PACKAGE: mongodb-client-encryption@6.0.0-alpha.1
+          PACKAGE: mongodb-client-encryption@6.0.0-alpha.3
       - func: run tests
         vars:
           CLIENT_ENCRYPTION: true

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2767,6 +2767,8 @@ tasks:
         vars:
           PACKAGE: mongodb-client-encryption@6.0.0-alpha.1
       - func: run tests
+        vars:
+          CLIENT_ENCRYPTION: true
   - name: test-latest-server-noauth
     tags:
       - latest

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -703,7 +703,10 @@ oneOffFuncAsTasks.push({
       }
     },
     {
-      func: 'run tests'
+      func: 'run tests',
+      vars: {
+        CLIENT_ENCRYPTION: true
+      }
     }
   ]
 });

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -677,6 +677,37 @@ for (const version of ['5.0', 'rapid', 'latest']) {
   }
 }
 
+oneOffFuncAsTasks.push({
+  name: `test-latest-driver-mongodb-client-encryption-6.0.0`,
+  tags: ['run-custom-dependency-tests'],
+  commands: [
+    {
+      func: 'install dependencies',
+      vars: {
+        NODE_LTS_VERSION: LOWEST_LTS
+      }
+    },
+    {
+      func: 'bootstrap mongo-orchestration',
+      vars: {
+        VERSION: '7.0',
+        TOPOLOGY: 'replica_set'
+      }
+    },
+    { func: 'bootstrap kms servers' },
+    {
+      func: 'install package',
+      vars: {
+        // TODO: update the package version here
+        PACKAGE: 'mongodb-client-encryption@6.0.0-alpha.1'
+      }
+    },
+    {
+      func: 'run tests'
+    }
+  ]
+});
+
 const coverageTask = {
   name: 'download and merge coverage'.split(' ').join('-'),
   tags: [],
@@ -779,13 +810,6 @@ for (const variant of BUILD_VARIANTS.filter(
   variant => variant.expansions && ['latest'].includes(variant.expansions.NODE_LTS_VERSION)
 )) {
   variant.tasks = variant.tasks.filter(name => !['test-socks5'].includes(name));
-}
-
-// TODO(NODE-5283): fix socks5 fle tests on node 20+
-for (const variant of BUILD_VARIANTS.filter(
-  variant => variant.expansions && [20].includes(variant.expansions.NODE_LTS_VERSION)
-) ) {
-  variant.tasks = variant.tasks.filter(name => !['test-socks5-csfle'].includes(name));
 }
 
 const fileData = yaml.load(fs.readFileSync(`${__dirname}/config.in.yml`, 'utf8'));

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -698,8 +698,7 @@ oneOffFuncAsTasks.push({
     {
       func: 'install package',
       vars: {
-        // TODO: update the package version here
-        PACKAGE: 'mongodb-client-encryption@6.0.0-alpha.1'
+        PACKAGE: 'mongodb-client-encryption@6.0.0-alpha.3'
       }
     },
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "js-yaml": "^4.1.0",
         "mocha": "^10.2.0",
         "mocha-sinon": "^2.1.2",
-        "mongodb-client-encryption": "6.0.0-alpha.1",
+        "mongodb-client-encryption": "6.0.0-alpha.3",
         "mongodb-legacy": "^5.0.0",
         "nyc": "^15.1.0",
         "prettier": "^2.8.8",
@@ -75,7 +75,7 @@
         "@mongodb-js/zstd": "^1.1.0",
         "gcp-metadata": "^5.2.0",
         "kerberos": "^2.0.1",
-        "mongodb-client-encryption": ">=6.0.0-alpha.1 <7",
+        "mongodb-client-encryption": ">=6.0.0-alpha.3 <7",
         "snappy": "^7.2.2",
         "socks": "^2.7.1"
       },
@@ -6629,9 +6629,9 @@
       }
     },
     "node_modules/mongodb-client-encryption": {
-      "version": "6.0.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-6.0.0-alpha.1.tgz",
-      "integrity": "sha512-SaYli844l5TN8oog4nJW8KKWpSPwSx2auojv30JtDQv8hgWV979Bnc4bwF2pf+R9fquqgoLr27CWxganGY0Zfg==",
+      "version": "6.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-6.0.0-alpha.3.tgz",
+      "integrity": "sha512-4mMs1SHfeE7c69xzqzXEC8psx8mh1o+6DOuXgft83RkBAIaI/YwfnHAHKxYH1KtwEmq60CK3tE3fai+JZjh8BA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6629,9 +6629,9 @@
       }
     },
     "node_modules/mongodb-client-encryption": {
-      "version": "6.0.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-6.0.0-alpha.2.tgz",
-      "integrity": "sha512-MTIKpTN7MIbsPqXr2wWUs91yFIXMpXSvosnEi2qvsquD3OVtue/zMCiKCqSZH4ulBLiKnEESOsOPyqzfwgS1ow==",
+      "version": "6.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-6.0.0-alpha.1.tgz",
+      "integrity": "sha512-SaYli844l5TN8oog4nJW8KKWpSPwSx2auojv30JtDQv8hgWV979Bnc4bwF2pf+R9fquqgoLr27CWxganGY0Zfg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6629,9 +6629,9 @@
       }
     },
     "node_modules/mongodb-client-encryption": {
-      "version": "6.0.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-6.0.0-alpha.1.tgz",
-      "integrity": "sha512-SaYli844l5TN8oog4nJW8KKWpSPwSx2auojv30JtDQv8hgWV979Bnc4bwF2pf+R9fquqgoLr27CWxganGY0Zfg==",
+      "version": "6.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-6.0.0-alpha.2.tgz",
+      "integrity": "sha512-MTIKpTN7MIbsPqXr2wWUs91yFIXMpXSvosnEi2qvsquD3OVtue/zMCiKCqSZH4ulBLiKnEESOsOPyqzfwgS1ow==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@mongodb-js/zstd": "^1.1.0",
     "gcp-metadata": "^5.2.0",
     "kerberos": "^2.0.1",
-    "mongodb-client-encryption": ">=6.0.0-alpha.1 <7",
+    "mongodb-client-encryption": ">=6.0.0-alpha.3 <7",
     "snappy": "^7.2.2",
     "socks": "^2.7.1"
   },
@@ -101,7 +101,7 @@
     "js-yaml": "^4.1.0",
     "mocha": "^10.2.0",
     "mocha-sinon": "^2.1.2",
-    "mongodb-client-encryption": "6.0.0-alpha.1",
+    "mongodb-client-encryption": "6.0.0-alpha.3",
     "mongodb-legacy": "^5.0.0",
     "nyc": "^15.1.0",
     "prettier": "^2.8.8",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,9 @@
     "snappy": "^7.2.2",
     "socks": "^2.7.1"
   },
+  "overrides": {
+    "node-gyp": "9.4.0"
+  },
   "peerDependenciesMeta": {
     "@aws-sdk/credential-providers": {
       "optional": true

--- a/package.json
+++ b/package.json
@@ -40,9 +40,6 @@
     "snappy": "^7.2.2",
     "socks": "^2.7.1"
   },
-  "overrides": {
-    "node-gyp": "9.4.0"
-  },
   "peerDependenciesMeta": {
     "@aws-sdk/credential-providers": {
       "optional": true

--- a/test/tools/runner/filters/client_encryption_filter.js
+++ b/test/tools/runner/filters/client_encryption_filter.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { readFileSync } = require('fs');
+const { resolve } = require('path');
 const process = require('process');
 
 /**
@@ -25,13 +27,20 @@ class ClientSideEncryptionFilter {
       }
     }
 
+    const { version } = JSON.parse(
+      readFileSync(
+        resolve(__dirname, '../../../../node_modules/mongodb-client-encryption', 'package.json')
+      )
+    );
+
     this.enabled = !!(CSFLE_KMS_PROVIDERS && mongodbClientEncryption);
 
     // Adds these fields onto the context so that they can be reused by tests
     context.clientSideEncryption = {
       enabled: this.enabled,
       mongodbClientEncryption,
-      CSFLE_KMS_PROVIDERS
+      CSFLE_KMS_PROVIDERS,
+      version
     };
 
     callback();

--- a/test/tools/runner/hooks/configuration.js
+++ b/test/tools/runner/hooks/configuration.js
@@ -156,7 +156,10 @@ const testConfigBeforeHook = async function () {
     serverless: process.env.SERVERLESS === '1',
     auth: process.env.AUTH === 'auth',
     tls: process.env.SSL === 'ssl',
-    csfle: this.configuration.clientSideEncryption.enabled,
+    csfle: {
+      enabled: this.configuration.clientSideEncryption.enabled,
+      version: this.configuration.clientSideEncryption.version
+    },
     serverApi: MONGODB_API_VERSION,
     atlas: process.env.ATLAS_CONNECTIVITY != null,
     aws: MONGODB_URI.includes('authMechanism=MONGODB-AWS'),


### PR DESCRIPTION
### Description

#### What is changing?

To prepare for the 6.0 release and the compatabilty matrix between mongodb-client-encryption and the driver, I added a task to our CI that tests the latest driver changes against mongodb-client-encryption@6.0.0.  This task runs for all regular CI runs as a part of the custom csfle tests.

I also pulled in the latest alpha of mongodb-client-encryption for all CI runs except the new variant.

To confirm that the new task was running against the correct version of `mongodb-client-encryption`, I added the version of mongodb-client-encryption used (if it's available) to the printout before mocha CI runs.  This affects all CI runs but I believe this is a useful improvement.  Here is an example: https://parsley.mongodb.com/evergreen/mongo_node_driver_next_rhel80_large_Node20_test_4.4_sharded_cluster_patch_51a573fe99506b81c7ab808898eb9eb63f58f600_64d3af041e2d171079fd9bc0_23_08_09_15_21_41/0/task?bookmarks=0,7369&shareLine=545


##### Is there new documentation needed for these changes?

No.

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
