### PR TITLE
refactor(NODE-5379): cursor internals to use async-await

### DIFF
--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -663,9 +663,11 @@ export abstract class AbstractCursor<
         this[kDocuments].push(state.response as TODO_NODE_3286);
       }
 
-      // the cursor is now initialized, even if an error occurred or it is dead
+      // the cursor is now initialized, even if it is dead
       this[kInitialized] = true;
     } catch (error) {
+      // the cursor is now initialized, even if an error occurred
+      this[kInitialized] = true;
       await cleanupCursor(this, { error });
       throw error;
     }

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -1,5 +1,4 @@
 import { Readable, Transform } from 'stream';
-import { promisify } from 'util';
 
 import { type BSONSerializeOptions, type Document, Long, pluckBSONSerializeOptions } from '../bson';
 import {
@@ -21,7 +20,7 @@ import { ReadConcern, type ReadConcernLike } from '../read_concern';
 import { ReadPreference, type ReadPreferenceLike } from '../read_preference';
 import type { Server } from '../sdam/server';
 import { ClientSession, maybeClearPinnedConnection } from '../sessions';
-import { type Callback, List, type MongoDBNamespace, ns } from '../utils';
+import { List, type MongoDBNamespace, ns } from '../utils';
 
 /** @internal */
 const kId = Symbol('id');
@@ -310,7 +309,7 @@ export abstract class AbstractCursor<
             const message =
               'Cursor returned a `null` document, but the cursor is not exhausted.  Mapping documents to `null` is not supported in the cursor transform.';
 
-            await cleanupCursorAsync(this, { needsToEmitClosed: true }).catch(() => null);
+            await cleanupCursor(this, { needsToEmitClosed: true }).catch(() => null);
 
             throw new MongoAPIError(message);
           }
@@ -419,7 +418,7 @@ export abstract class AbstractCursor<
   async close(): Promise<void> {
     const needsToEmitClosed = !this[kClosed];
     this[kClosed] = true;
-    await cleanupCursorAsync(this, { needsToEmitClosed });
+    await cleanupCursor(this, { needsToEmitClosed });
   }
 
   /**
@@ -613,13 +612,10 @@ export abstract class AbstractCursor<
   abstract clone(): AbstractCursor<TSchema>;
 
   /** @internal */
-  protected abstract _initialize(
-    session: ClientSession | undefined,
-    callback: Callback<ExecutionResult>
-  ): void;
+  protected abstract _initialize(session: ClientSession | undefined): Promise<ExecutionResult>;
 
   /** @internal */
-  _getMore(batchSize: number, callback: Callback<Document>): void {
+  async getMore(batchSize: number): Promise<Document | null> {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const getMoreOperation = new GetMoreOperation(this[kNamespace], this[kId]!, this[kServer]!, {
       ...this[kOptions],
@@ -627,7 +623,7 @@ export abstract class AbstractCursor<
       batchSize
     });
 
-    executeOperation(this[kClient], getMoreOperation, callback);
+    return executeOperation(this[kClient], getMoreOperation);
   }
 
   /**
@@ -637,51 +633,48 @@ export abstract class AbstractCursor<
    * operation.  We cannot refactor to use the abstract _initialize method without
    * a significant refactor.
    */
-  [kInit](callback: Callback<TSchema | null>): void {
-    this._initialize(this[kSession], (error, state) => {
-      if (state) {
-        const response = state.response;
-        this[kServer] = state.server;
+  async [kInit](): Promise<void> {
+    try {
+      const state = await this._initialize(this[kSession]);
+      const response = state.response;
+      this[kServer] = state.server;
+      if (response.cursor) {
+        // TODO(NODE-2674): Preserve int64 sent from MongoDB
+        this[kId] =
+          typeof response.cursor.id === 'number'
+            ? Long.fromNumber(response.cursor.id)
+            : typeof response.cursor.id === 'bigint'
+            ? Long.fromBigInt(response.cursor.id)
+            : response.cursor.id;
 
-        if (response.cursor) {
-          // TODO(NODE-2674): Preserve int64 sent from MongoDB
-          this[kId] =
-            typeof response.cursor.id === 'number'
-              ? Long.fromNumber(response.cursor.id)
-              : typeof response.cursor.id === 'bigint'
-              ? Long.fromBigInt(response.cursor.id)
-              : response.cursor.id;
-
-          if (response.cursor.ns) {
-            this[kNamespace] = ns(response.cursor.ns);
-          }
-
-          this[kDocuments].pushMany(response.cursor.firstBatch);
+        if (response.cursor.ns) {
+          this[kNamespace] = ns(response.cursor.ns);
         }
 
-        // When server responses return without a cursor document, we close this cursor
-        // and return the raw server response. This is often the case for explain commands
-        // for example
-        if (this[kId] == null) {
-          this[kId] = Long.ZERO;
-          // TODO(NODE-3286): ExecutionResult needs to accept a generic parameter
-          this[kDocuments].push(state.response as TODO_NODE_3286);
-        }
+        this[kDocuments].pushMany(response.cursor.firstBatch);
+      }
+
+      // When server responses return without a cursor document, we close this cursor
+      // and return the raw server response. This is often the case for explain commands
+      // for example
+      if (this[kId] == null) {
+        this[kId] = Long.ZERO;
+        // TODO(NODE-3286): ExecutionResult needs to accept a generic parameter
+        this[kDocuments].push(state.response as TODO_NODE_3286);
       }
 
       // the cursor is now initialized, even if an error occurred or it is dead
       this[kInitialized] = true;
+    } catch (error) {
+      await cleanupCursor(this, { error });
+      throw error;
+    }
 
-      if (error) {
-        return cleanupCursor(this, { error }, () => callback(error, undefined));
-      }
+    if (this.isDead) {
+      await cleanupCursor(this, undefined);
+    }
 
-      if (this.isDead) {
-        return cleanupCursor(this, undefined, () => callback());
-      }
-
-      callback();
-    });
+    return;
   }
 }
 
@@ -713,7 +706,7 @@ async function next<T>(
   do {
     if (cursor[kId] == null) {
       // All cursors must operate within a session, one must be made implicitly if not explicitly provided
-      await promisify(cursor[kInit].bind(cursor))();
+      await cursor[kInit]();
     }
 
     if (cursor[kDocuments].length !== 0) {
@@ -725,7 +718,7 @@ async function next<T>(
         } catch (error) {
           // `cleanupCursorAsync` should never throw, but if it does we want to throw the original
           // error instead.
-          await cleanupCursorAsync(cursor, { error, needsToEmitClosed: true }).catch(() => null);
+          await cleanupCursor(cursor, { error, needsToEmitClosed: true }).catch(() => null);
           throw error;
         }
       }
@@ -737,7 +730,7 @@ async function next<T>(
       // if the cursor is dead, we clean it up
       // cleanupCursorAsync should never throw, but if it does it indicates a bug in the driver
       // and we should surface the error
-      await cleanupCursorAsync(cursor, {});
+      await cleanupCursor(cursor, {});
       return null;
     }
 
@@ -745,7 +738,7 @@ async function next<T>(
     const batchSize = cursor[kOptions].batchSize || 1000;
 
     try {
-      const response = await promisify(cursor._getMore.bind(cursor))(batchSize);
+      const response = await cursor.getMore(batchSize);
 
       if (response) {
         const cursorId =
@@ -761,7 +754,7 @@ async function next<T>(
     } catch (error) {
       // `cleanupCursorAsync` should never throw, but if it does we want to throw the original
       // error instead.
-      await cleanupCursorAsync(cursor, { error }).catch(() => null);
+      await cleanupCursor(cursor, { error }).catch(() => null);
       throw error;
     }
 
@@ -773,7 +766,7 @@ async function next<T>(
       //
       // cleanupCursorAsync should never throw, but if it does it indicates a bug in the driver
       // and we should surface the error
-      await cleanupCursorAsync(cursor, {});
+      await cleanupCursor(cursor, {});
     }
 
     if (cursor[kDocuments].length === 0 && blocking === false) {
@@ -784,13 +777,10 @@ async function next<T>(
   return null;
 }
 
-const cleanupCursorAsync = promisify(cleanupCursor);
-
-function cleanupCursor(
+async function cleanupCursor(
   cursor: AbstractCursor,
-  options: { error?: AnyError | undefined; needsToEmitClosed?: boolean } | undefined,
-  callback: Callback
-): void {
+  options: { error?: AnyError | undefined; needsToEmitClosed?: boolean } | undefined
+): Promise<void> {
   const cursorId = cursor[kId];
   const cursorNs = cursor[kNamespace];
   const server = cursor[kServer];
@@ -817,9 +807,7 @@ function cleanupCursor(
 
     if (session) {
       if (session.owner === cursor) {
-        session.endSession({ error }).finally(() => {
-          callback();
-        });
+        await session.endSession({ error });
         return;
       }
 
@@ -828,16 +816,17 @@ function cleanupCursor(
       }
     }
 
-    return callback();
+    return;
   }
 
-  function completeCleanup() {
+  async function completeCleanup() {
     if (session) {
       if (session.owner === cursor) {
-        session.endSession({ error }).finally(() => {
+        try {
+          await session.endSession({ error });
+        } finally {
           cursor.emit(AbstractCursor.CLOSE);
-          callback();
-        });
+        }
         return;
       }
 
@@ -847,7 +836,7 @@ function cleanupCursor(
     }
 
     cursor.emit(AbstractCursor.CLOSE);
-    return callback();
+    return;
   }
 
   cursor[kKilled] = true;
@@ -856,12 +845,14 @@ function cleanupCursor(
     return completeCleanup();
   }
 
-  executeOperation(
-    cursor[kClient],
-    new KillCursorsOperation(cursorId, cursorNs, server, { session })
-  )
-    .catch(() => null)
-    .finally(completeCleanup);
+  try {
+    await executeOperation(
+      cursor[kClient],
+      new KillCursorsOperation(cursorId, cursorNs, server, { session })
+    ).catch(() => null);
+  } finally {
+    await completeCleanup();
+  }
 }
 
 /** @internal */

--- a/src/cursor/find_cursor.ts
+++ b/src/cursor/find_cursor.ts
@@ -87,6 +87,7 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
   override async getMore(batchSize: number): Promise<Document | null> {
     const numReturned = this[kNumReturned];
     if (numReturned) {
+      // TODO(DRIVERS-1448): Remove logic to enforce `limit` in the driver
       const limit = this[kBuiltOptions].limit;
       batchSize =
         limit && limit > 0 && numReturned + batchSize > limit ? limit - numReturned : batchSize;

--- a/src/cursor/find_cursor.ts
+++ b/src/cursor/find_cursor.ts
@@ -1,6 +1,6 @@
 import { type Document, Long } from '../bson';
 import { MongoInvalidArgumentError, MongoTailableCursorError } from '../error';
-import type { ExplainVerbosityLike } from '../explain';
+import { Explain, type ExplainVerbosityLike } from '../explain';
 import type { MongoClient } from '../mongo_client';
 import type { CollationOptions } from '../operations/command';
 import { CountOperation, type CountOptions } from '../operations/count';
@@ -77,7 +77,9 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
 
     const response = await executeOperation(this.client, findOperation);
 
-    this[kNumReturned] = response.cursor.firstBatch.length;
+    if (!Explain.fromOptions(this[kBuiltOptions])) {
+      this[kNumReturned] = response.cursor.firstBatch.length;
+    }
 
     // TODO: NODE-2882
     return { server: findOperation.server, session, response };

--- a/src/cursor/find_cursor.ts
+++ b/src/cursor/find_cursor.ts
@@ -1,6 +1,6 @@
 import { type Document, Long } from '../bson';
 import { MongoInvalidArgumentError, MongoTailableCursorError } from '../error';
-import { Explain, type ExplainVerbosityLike } from '../explain';
+import { type ExplainVerbosityLike } from '../explain';
 import type { MongoClient } from '../mongo_client';
 import type { CollationOptions } from '../operations/command';
 import { CountOperation, type CountOptions } from '../operations/count';
@@ -77,9 +77,8 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
 
     const response = await executeOperation(this.client, findOperation);
 
-    if (!Explain.fromOptions(this[kBuiltOptions])) {
-      this[kNumReturned] = response.cursor.firstBatch.length;
-    }
+    // the response is not a cursor when `explain` is enabled
+    this[kNumReturned] = response.cursor?.firstBatch?.length;
 
     // TODO: NODE-2882
     return { server: findOperation.server, session, response };

--- a/src/cursor/list_collections_cursor.ts
+++ b/src/cursor/list_collections_cursor.ts
@@ -7,7 +7,6 @@ import {
   type ListCollectionsOptions
 } from '../operations/list_collections';
 import type { ClientSession } from '../sessions';
-import type { Callback } from '../utils';
 import { AbstractCursor } from './abstract_cursor';
 
 /** @public */
@@ -35,18 +34,16 @@ export class ListCollectionsCursor<
   }
 
   /** @internal */
-  _initialize(session: ClientSession | undefined, callback: Callback<ExecutionResult>): void {
+  async _initialize(session: ClientSession | undefined): Promise<ExecutionResult> {
     const operation = new ListCollectionsOperation(this.parent, this.filter, {
       ...this.cursorOptions,
       ...this.options,
       session
     });
 
-    executeOperation(this.parent.client, operation, (err, response) => {
-      if (err || response == null) return callback(err);
+    const response = await executeOperation(this.parent.client, operation);
 
-      // TODO: NODE-2882
-      callback(undefined, { server: operation.server, session, response });
-    });
+    // TODO: NODE-2882
+    return { server: operation.server, session, response };
   }
 }

--- a/src/cursor/list_indexes_cursor.ts
+++ b/src/cursor/list_indexes_cursor.ts
@@ -2,7 +2,6 @@ import type { Collection } from '../collection';
 import { executeOperation, type ExecutionResult } from '../operations/execute_operation';
 import { ListIndexesOperation, type ListIndexesOptions } from '../operations/indexes';
 import type { ClientSession } from '../sessions';
-import type { Callback } from '../utils';
 import { AbstractCursor } from './abstract_cursor';
 
 /** @public */
@@ -24,18 +23,16 @@ export class ListIndexesCursor extends AbstractCursor {
   }
 
   /** @internal */
-  _initialize(session: ClientSession | undefined, callback: Callback<ExecutionResult>): void {
+  async _initialize(session: ClientSession | undefined): Promise<ExecutionResult> {
     const operation = new ListIndexesOperation(this.parent, {
       ...this.cursorOptions,
       ...this.options,
       session
     });
 
-    executeOperation(this.parent.client, operation, (err, response) => {
-      if (err || response == null) return callback(err);
+    const response = await executeOperation(this.parent.client, operation);
 
-      // TODO: NODE-2882
-      callback(undefined, { server: operation.server, session, response });
-    });
+    // TODO: NODE-2882
+    return { server: operation.server, session, response };
   }
 }

--- a/test/integration/change-streams/change_stream.test.ts
+++ b/test/integration/change-streams/change_stream.test.ts
@@ -5,7 +5,6 @@ import { gte, lt } from 'semver';
 import * as sinon from 'sinon';
 import { PassThrough } from 'stream';
 import { setTimeout } from 'timers';
-import { promisify } from 'util';
 
 import {
   AbstractCursor,
@@ -34,9 +33,9 @@ import {
 import { delay, filterForCommands } from '../shared';
 
 const initIteratorMode = async (cs: ChangeStream) => {
-  const init = getSymbolFrom(AbstractCursor.prototype, 'kInit');
+  const kInit = getSymbolFrom(AbstractCursor.prototype, 'kInit');
   const initEvent = once(cs.cursor, 'init');
-  await promisify(cs.cursor[init].bind(cs.cursor))();
+  await cs.cursor[kInit]();
   await initEvent;
   return;
 };
@@ -1981,14 +1980,12 @@ describe('ChangeStream resumability', function () {
             await collection.insertOne({ name: 'bailey' });
             await changeStream.next();
 
-            const mock = sinon
-              .stub(changeStream.cursor, '_getMore')
-              .callsFake((_batchSize, callback) => {
-                mock.restore();
-                const error = new MongoServerError({ message: message });
-                error.code = code;
-                callback(error);
-              });
+            const mock = sinon.stub(changeStream.cursor, 'getMore').callsFake(async _batchSize => {
+              mock.restore();
+              const error = new MongoServerError({ message: message });
+              error.code = code;
+              throw error;
+            });
 
             await collection.insertOne({ name: 'bailey' });
 
@@ -2147,14 +2144,12 @@ describe('ChangeStream resumability', function () {
             await collection.insertOne({ name: 'bailey' });
             await changeStream.next();
 
-            const mock = sinon
-              .stub(changeStream.cursor, '_getMore')
-              .callsFake((_batchSize, callback) => {
-                mock.restore();
-                const error = new MongoServerError({ message: message });
-                error.code = code;
-                callback(error);
-              });
+            const mock = sinon.stub(changeStream.cursor, 'getMore').callsFake(async _batchSize => {
+              mock.restore();
+              const error = new MongoServerError({ message: message });
+              error.code = code;
+              throw error;
+            });
 
             await collection.insertOne({ name: 'bailey' });
 
@@ -2320,14 +2315,12 @@ describe('ChangeStream resumability', function () {
             await collection.insertOne({ name: 'bailey' });
             await changeStream.next();
 
-            const mock = sinon
-              .stub(changeStream.cursor, '_getMore')
-              .callsFake((_batchSize, callback) => {
-                mock.restore();
-                const error = new MongoServerError({ message: message });
-                error.code = code;
-                callback(error);
-              });
+            const mock = sinon.stub(changeStream.cursor, 'getMore').callsFake(async _batchSize => {
+              mock.restore();
+              const error = new MongoServerError({ message: message });
+              error.code = code;
+              throw error;
+            });
 
             try {
               // tryNext is not blocking and on sharded clusters we don't have control of when
@@ -2464,14 +2457,12 @@ describe('ChangeStream resumability', function () {
             await collection.insertOne({ city: 'New York City' });
             await changeStreamIterator.next();
 
-            const mock = sinon
-              .stub(changeStream.cursor, '_getMore')
-              .callsFake((_batchSize, callback) => {
-                mock.restore();
-                const error = new MongoServerError({ message });
-                error.code = code;
-                callback(error);
-              });
+            const mock = sinon.stub(changeStream.cursor, 'getMore').callsFake(async _batchSize => {
+              mock.restore();
+              const error = new MongoServerError({ message });
+              error.code = code;
+              throw error;
+            });
 
             const docs = [{ city: 'Seattle' }, { city: 'Boston' }];
             await collection.insertMany(docs);

--- a/test/integration/change-streams/change_streams.prose.test.ts
+++ b/test/integration/change-streams/change_streams.prose.test.ts
@@ -2,7 +2,6 @@ import { expect } from 'chai';
 import { once } from 'events';
 import * as sinon from 'sinon';
 import { setTimeout } from 'timers';
-import { promisify } from 'util';
 
 import {
   AbstractCursor,
@@ -73,9 +72,9 @@ function triggerResumableError(
 }
 
 const initIteratorMode = async (cs: ChangeStream) => {
-  const init = getSymbolFrom(AbstractCursor.prototype, 'kInit');
+  const kInit = getSymbolFrom(AbstractCursor.prototype, 'kInit');
   const initEvent = once(cs.cursor, 'init');
-  await promisify(cs.cursor[init].bind(cs.cursor))();
+  await cs.cursor[kInit]();
   await initEvent;
   return;
 };

--- a/test/integration/crud/explain.test.ts
+++ b/test/integration/crud/explain.test.ts
@@ -12,7 +12,7 @@ import {
 
 const explain = [true, false, 'queryPlanner', 'allPlansExecution', 'executionStats', 'invalid'];
 
-describe.only('CRUD API explain option', function () {
+describe('CRUD API explain option', function () {
   let client: MongoClient;
   let db: Db;
   let collection: Collection;

--- a/test/integration/crud/explain.test.ts
+++ b/test/integration/crud/explain.test.ts
@@ -12,7 +12,7 @@ import {
 
 const explain = [true, false, 'queryPlanner', 'allPlansExecution', 'executionStats', 'invalid'];
 
-describe('CRUD API explain option', function () {
+describe.only('CRUD API explain option', function () {
   let client: MongoClient;
   let db: Db;
   let collection: Collection;
@@ -47,7 +47,9 @@ describe('CRUD API explain option', function () {
     },
     {
       name: 'findOne',
-      op: async (explain: boolean | string) => await collection.findOne({ a: 1 }, { explain })
+      op: async (explain: boolean | string) => {
+        return await collection.findOne({ a: 1 }, { explain });
+      }
     },
     { name: 'find', op: (explain: boolean | string) => collection.find({ a: 1 }).explain(explain) },
     {

--- a/test/tools/unified-spec-runner/operations.ts
+++ b/test/tools/unified-spec-runner/operations.ts
@@ -241,14 +241,9 @@ operations.set('createChangeStream', async ({ entities, operation }) => {
 
   const { pipeline, ...args } = operation.arguments!;
   const changeStream = watchable.watch(pipeline, args);
-
-  return new Promise((resolve, reject) => {
-    const init = getSymbolFrom(AbstractCursor.prototype, 'kInit');
-    changeStream.cursor[init](err => {
-      if (err) return reject(err);
-      resolve(changeStream);
-    });
-  });
+  const kInit = getSymbolFrom(AbstractCursor.prototype, 'kInit');
+  await changeStream.cursor[kInit]();
+  return changeStream;
 });
 
 operations.set('createCollection', async ({ entities, operation }) => {


### PR DESCRIPTION
### Description
refactored cursor internals to use async-await syntax instead of callbacks

#### What is changing?
getMore, _initialize, cleanupCursor, and [kInit] now use async-await syntax
all classes that inherit from AbstractCursor now use async-await

##### Is there new documentation needed for these changes?
None

#### What is the motivation for this change?
further converting the driver to async-await

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
