### PR TITLE
docs(NODE-5523): add component support matrix to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The following table describes add-on compponent version compatibility for the No
 | kerberos                  | ^1.0.0      | ^1.0.0 \|\| ^2.0.0 | ^1.0.0 \|\| ^2.0.0 | ^2.0.0      |
 | mongodb-client-encryption | ^1.0.0      | ^1.0.0 \|\| ^2.0.0 | ^2.3.0             | ^6.0.0      |
 | mongodb-legacy            | N/A         | ^4.0.0             | ^5.0.0             | ^6.0.0      |
-| @mongodb-js/zstd          | N/A         | ^1.0.0             | ^1.0.0             | ^1.1.0      |
+| \@mongodb-js/zstd         | N/A         | ^1.0.0             | ^1.0.0             | ^1.1.0      |
 
 #### Typescript Version
 

--- a/README.md
+++ b/README.md
@@ -6,19 +6,19 @@ The official [MongoDB](https://www.mongodb.com/) driver for Node.js.
 
 ## Quick Links
 
-| Site                     | Link                                                                                                              |
-| -------------------------| ----------------------------------------------------------------------------------------------------------------- |
-| Documentation            | [www.mongodb.com/docs/drivers/node](https://www.mongodb.com/docs/drivers/node)                                    |
-| API Docs                 | [mongodb.github.io/node-mongodb-native](https://mongodb.github.io/node-mongodb-native)                            |
-| `npm` package            | [www.npmjs.com/package/mongodb](https://www.npmjs.com/package/mongodb)                                            |
-| MongoDB                  | [www.mongodb.com](https://www.mongodb.com)                                                                        |
-| MongoDB University       | [learn.mongodb.com](https://learn.mongodb.com/catalog?labels=%5B%22Language%22%5D&values=%5B%22Node.js%22%5D)     |
-| MongoDB Developer Center | [www.mongodb.com/developer](https://www.mongodb.com/developer/languages/javascript/)                              |
+| Site                     | Link                                                                                                                                  |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------- |
+| Documentation            | [www.mongodb.com/docs/drivers/node](https://www.mongodb.com/docs/drivers/node)                                                        |
+| API Docs                 | [mongodb.github.io/node-mongodb-native](https://mongodb.github.io/node-mongodb-native)                                                |
+| `npm` package            | [www.npmjs.com/package/mongodb](https://www.npmjs.com/package/mongodb)                                                                |
+| MongoDB                  | [www.mongodb.com](https://www.mongodb.com)                                                                                            |
+| MongoDB University       | [learn.mongodb.com](https://learn.mongodb.com/catalog?labels=%5B%22Language%22%5D&values=%5B%22Node.js%22%5D)                         |
+| MongoDB Developer Center | [www.mongodb.com/developer](https://www.mongodb.com/developer/languages/javascript/)                                                  |
 | Stack Overflow           | [stackoverflow.com](https://stackoverflow.com/search?q=%28%5Btypescript%5D+or+%5Bjavascript%5D+or+%5Bnode.js%5D%29+and+%5Bmongodb%5D) |
-| Source Code              | [github.com/mongodb/node-mongodb-native](https://github.com/mongodb/node-mongodb-native)                          |
-| Upgrade to v5            | [etc/notes/CHANGES_5.0.0.md](https://github.com/mongodb/node-mongodb-native/blob/HEAD/etc/notes/CHANGES_5.0.0.md) |
-| Contributing             | [CONTRIBUTING.md](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md)                       |
-| Changelog                | [HISTORY.md](https://github.com/mongodb/node-mongodb-native/blob/HEAD/HISTORY.md)                                 |
+| Source Code              | [github.com/mongodb/node-mongodb-native](https://github.com/mongodb/node-mongodb-native)                                              |
+| Upgrade to v5            | [etc/notes/CHANGES_5.0.0.md](https://github.com/mongodb/node-mongodb-native/blob/HEAD/etc/notes/CHANGES_5.0.0.md)                     |
+| Contributing             | [CONTRIBUTING.md](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md)                                           |
+| Changelog                | [HISTORY.md](https://github.com/mongodb/node-mongodb-native/blob/HEAD/HISTORY.md)                                                     |
 
 ### Bugs / Feature Requests
 
@@ -42,10 +42,23 @@ Change history can be found in [`HISTORY.md`](https://github.com/mongodb/node-mo
 
 ### Compatibility
 
-For version compatibility matrices, please refer to the following links:
+For server and runtime version compatibility matrices, please refer to the following links:
 
 - [MongoDB](https://www.mongodb.com/docs/drivers/node/current/compatibility/#mongodb-compatibility)
 - [NodeJS](https://www.mongodb.com/docs/drivers/node/current/compatibility/#language-compatibility)
+
+#### Component Support Matrix
+
+The following table describes add-on compponent version compatibility for the Node.js driver. Only packages with versions in these supported ranges are stable when used in combination.
+
+| Component                 | mongodb@3.x | mongodb@4.x        | mongodb@5.x        | mongodb@6.x |
+| ------------------------- | ----------- | ------------------ | ------------------ | ----------- |
+| bson                      | ^1.0.0      | ^2.0.0             | ^5.0.0             | ^6.0.0      |
+| bson-ext                  | ^1.0.0      | ^2.0.0             | N/A                | N/A         |
+| kerberos                  | ^1.0.0      | ^1.0.0 \|\| ^2.0.0 | ^1.0.0 \|\| ^2.0.0 | ^2.0.0      |
+| mongodb-client-encryption | ^1.0.0      | ^1.0.0 \|\| ^2.0.0 | ^2.3.0             | ^6.0.0      |
+| mongodb-legacy            | N/A         | ^4.0.0             | ^5.0.0             | ^6.0.0      |
+| @mongodb-js/zstd          | N/A         | ^1.0.0             | ^1.0.0             | ^1.1.0      |
 
 #### Typescript Version
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ For server and runtime version compatibility matrices, please refer to the follo
 
 #### Component Support Matrix
 
-The following table describes add-on compponent version compatibility for the Node.js driver. Only packages with versions in these supported ranges are stable when used in combination.
+The following table describes add-on component version compatibility for the Node.js driver. Only packages with versions in these supported ranges are stable when used in combination.
 
 | Component                                                                            | `mongodb@3.x`      | `mongodb@4.x`      | `mongodb@5.x`      | `mongodb@6.x` |
 | ------------------------------------------------------------------------------------ | ------------------ | ------------------ | ------------------ | ------------- |

--- a/README.md
+++ b/README.md
@@ -51,14 +51,14 @@ For server and runtime version compatibility matrices, please refer to the follo
 
 The following table describes add-on compponent version compatibility for the Node.js driver. Only packages with versions in these supported ranges are stable when used in combination.
 
-| Component                                                                            | `mongodb@3.x` | `mongodb@4.x`      | `mongodb@5.x`      | `mongodb@6.x` |
-| ------------------------------------------------------------------------------------ | ------------- | ------------------ | ------------------ | ------------- |
-| [bson](https://www.npmjs.com/package/bson)                                           | ^1.0.0        | ^2.0.0             | ^5.0.0             | ^6.0.0        |
-| [bson-ext](https://www.npmjs.com/package/bson-ext)                                   | ^1.0.0        | ^2.0.0             | N/A                | N/A           |
-| [kerberos](https://www.npmjs.com/package/kerberos)                                   | ^1.0.0        | ^1.0.0 \|\| ^2.0.0 | ^1.0.0 \|\| ^2.0.0 | ^2.0.1        |
-| [mongodb-client-encryption](https://www.npmjs.com/package/mongodb-client-encryption) | ^1.0.0        | ^1.0.0 \|\| ^2.0.0 | ^2.3.0             | ^6.0.0        |
-| [mongodb-legacy](https://www.npmjs.com/package/mongodb-legacy)                       | N/A           | ^4.0.0             | ^5.0.0             | ^6.0.0        |
-| [@mongodb-js/zstd](https://www.npmjs.com/package/@mongodb-js/zstd)                   | N/A           | ^1.0.0             | ^1.0.0             | ^1.1.0        |
+| Component                                                                            | `mongodb@3.x`      | `mongodb@4.x`      | `mongodb@5.x`      | `mongodb@6.x` |
+| ------------------------------------------------------------------------------------ | ------------------ | ------------------ | ------------------ | ------------- |
+| [bson](https://www.npmjs.com/package/bson)                                           | ^1.0.0             | ^4.0.0             | ^5.0.0             | ^6.0.0        |
+| [bson-ext](https://www.npmjs.com/package/bson-ext)                                   | ^1.0.0 \|\| ^2.0.0 | ^4.0.0             | N/A                | N/A           |
+| [kerberos](https://www.npmjs.com/package/kerberos)                                   | ^1.0.0             | ^1.0.0 \|\| ^2.0.0 | ^1.0.0 \|\| ^2.0.0 | ^2.0.1        |
+| [mongodb-client-encryption](https://www.npmjs.com/package/mongodb-client-encryption) | ^1.0.0             | ^1.0.0 \|\| ^2.0.0 | ^2.3.0             | ^6.0.0        |
+| [mongodb-legacy](https://www.npmjs.com/package/mongodb-legacy)                       | N/A                | ^4.0.0             | ^5.0.0             | ^6.0.0        |
+| [@mongodb-js/zstd](https://www.npmjs.com/package/@mongodb-js/zstd)                   | N/A                | ^1.0.0             | ^1.0.0             | ^1.1.0        |
 
 #### Typescript Version
 

--- a/README.md
+++ b/README.md
@@ -51,14 +51,14 @@ For server and runtime version compatibility matrices, please refer to the follo
 
 The following table describes add-on compponent version compatibility for the Node.js driver. Only packages with versions in these supported ranges are stable when used in combination.
 
-| Component                                                                            | mongodb\@3.x | mongodb\@4.x       | mongodb\@5.x       | mongodb\@6.x |
-| ------------------------------------------------------------------------------------ | ------------ | ------------------ | ------------------ | ------------ |
-| [bson](https://www.npmjs.com/package/bson)                                           | ^1.0.0       | ^2.0.0             | ^5.0.0             | ^6.0.0       |
-| [bson-ext](https://www.npmjs.com/package/bson-ext)                                   | ^1.0.0       | ^2.0.0             | N/A                | N/A          |
-| [kerberos](https://www.npmjs.com/package/kerberos)                                   | ^1.0.0       | ^1.0.0 \|\| ^2.0.0 | ^1.0.0 \|\| ^2.0.0 | ^2.0.0       |
-| [mongodb-client-encryption](https://www.npmjs.com/package/mongodb-client-encryption) | ^1.0.0       | ^1.0.0 \|\| ^2.0.0 | ^2.3.0             | ^6.0.0       |
-| [mongodb-legacy](https://www.npmjs.com/package/mongodb-legacy)                       | N/A          | ^4.0.0             | ^5.0.0             | ^6.0.0       |
-| [\@mongodb-js/zstd](https://www.npmjs.com/package/@mongodb-js/zstd)                  | N/A          | ^1.0.0             | ^1.0.0             | ^1.1.0       |
+| Component                                                                            | `mongodb@3.x` | `mongodb@4.x`      | `mongodb@5.x`      | `mongodb@6.x` |
+| ------------------------------------------------------------------------------------ | ------------- | ------------------ | ------------------ | ------------- |
+| [bson](https://www.npmjs.com/package/bson)                                           | ^1.0.0        | ^2.0.0             | ^5.0.0             | ^6.0.0        |
+| [bson-ext](https://www.npmjs.com/package/bson-ext)                                   | ^1.0.0        | ^2.0.0             | N/A                | N/A           |
+| [kerberos](https://www.npmjs.com/package/kerberos)                                   | ^1.0.0        | ^1.0.0 \|\| ^2.0.0 | ^1.0.0 \|\| ^2.0.0 | ^2.0.0        |
+| [mongodb-client-encryption](https://www.npmjs.com/package/mongodb-client-encryption) | ^1.0.0        | ^1.0.0 \|\| ^2.0.0 | ^2.3.0             | ^6.0.0        |
+| [mongodb-legacy](https://www.npmjs.com/package/mongodb-legacy)                       | N/A           | ^4.0.0             | ^5.0.0             | ^6.0.0        |
+| [@mongodb-js/zstd](https://www.npmjs.com/package/@mongodb-js/zstd)                   | N/A           | ^1.0.0             | ^1.0.0             | ^1.1.0        |
 
 #### Typescript Version
 

--- a/README.md
+++ b/README.md
@@ -51,14 +51,14 @@ For server and runtime version compatibility matrices, please refer to the follo
 
 The following table describes add-on compponent version compatibility for the Node.js driver. Only packages with versions in these supported ranges are stable when used in combination.
 
-| Component                                                                            | mongodb@3.x | mongodb@4.x        | mongodb@5.x        | mongodb@6.x |
-| ------------------------------------------------------------------------------------ | ----------- | ------------------ | ------------------ | ----------- |
-| [bson](https://www.npmjs.com/package/bson)                                           | ^1.0.0      | ^2.0.0             | ^5.0.0             | ^6.0.0      |
-| [bson-ext](https://www.npmjs.com/package/bson-ext)                                   | ^1.0.0      | ^2.0.0             | N/A                | N/A         |
-| [kerberos](https://www.npmjs.com/package/kerberos)                                   | ^1.0.0      | ^1.0.0 \|\| ^2.0.0 | ^1.0.0 \|\| ^2.0.0 | ^2.0.0      |
-| [mongodb-client-encryption](https://www.npmjs.com/package/mongodb-client-encryption) | ^1.0.0      | ^1.0.0 \|\| ^2.0.0 | ^2.3.0             | ^6.0.0      |
-| [mongodb-legacy](https://www.npmjs.com/package/mongodb-legacy)                       | N/A         | ^4.0.0             | ^5.0.0             | ^6.0.0      |
-| [\@mongodb-js/zstd](https://www.npmjs.com/package/@mongodb-js/zstd)                  | N/A         | ^1.0.0             | ^1.0.0             | ^1.1.0      |
+| Component                                                                            | mongodb\@3.x | mongodb\@4.x       | mongodb\@5.x       | mongodb\@6.x |
+| ------------------------------------------------------------------------------------ | ------------ | ------------------ | ------------------ | ------------ |
+| [bson](https://www.npmjs.com/package/bson)                                           | ^1.0.0       | ^2.0.0             | ^5.0.0             | ^6.0.0       |
+| [bson-ext](https://www.npmjs.com/package/bson-ext)                                   | ^1.0.0       | ^2.0.0             | N/A                | N/A          |
+| [kerberos](https://www.npmjs.com/package/kerberos)                                   | ^1.0.0       | ^1.0.0 \|\| ^2.0.0 | ^1.0.0 \|\| ^2.0.0 | ^2.0.0       |
+| [mongodb-client-encryption](https://www.npmjs.com/package/mongodb-client-encryption) | ^1.0.0       | ^1.0.0 \|\| ^2.0.0 | ^2.3.0             | ^6.0.0       |
+| [mongodb-legacy](https://www.npmjs.com/package/mongodb-legacy)                       | N/A          | ^4.0.0             | ^5.0.0             | ^6.0.0       |
+| [\@mongodb-js/zstd](https://www.npmjs.com/package/@mongodb-js/zstd)                  | N/A          | ^1.0.0             | ^1.0.0             | ^1.1.0       |
 
 #### Typescript Version
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The following table describes add-on compponent version compatibility for the No
 | ------------------------------------------------------------------------------------ | ------------- | ------------------ | ------------------ | ------------- |
 | [bson](https://www.npmjs.com/package/bson)                                           | ^1.0.0        | ^2.0.0             | ^5.0.0             | ^6.0.0        |
 | [bson-ext](https://www.npmjs.com/package/bson-ext)                                   | ^1.0.0        | ^2.0.0             | N/A                | N/A           |
-| [kerberos](https://www.npmjs.com/package/kerberos)                                   | ^1.0.0        | ^1.0.0 \|\| ^2.0.0 | ^1.0.0 \|\| ^2.0.0 | ^2.0.0        |
+| [kerberos](https://www.npmjs.com/package/kerberos)                                   | ^1.0.0        | ^1.0.0 \|\| ^2.0.0 | ^1.0.0 \|\| ^2.0.0 | ^2.0.1        |
 | [mongodb-client-encryption](https://www.npmjs.com/package/mongodb-client-encryption) | ^1.0.0        | ^1.0.0 \|\| ^2.0.0 | ^2.3.0             | ^6.0.0        |
 | [mongodb-legacy](https://www.npmjs.com/package/mongodb-legacy)                       | N/A           | ^4.0.0             | ^5.0.0             | ^6.0.0        |
 | [@mongodb-js/zstd](https://www.npmjs.com/package/@mongodb-js/zstd)                   | N/A           | ^1.0.0             | ^1.0.0             | ^1.1.0        |

--- a/README.md
+++ b/README.md
@@ -51,14 +51,14 @@ For server and runtime version compatibility matrices, please refer to the follo
 
 The following table describes add-on compponent version compatibility for the Node.js driver. Only packages with versions in these supported ranges are stable when used in combination.
 
-| Component                 | mongodb@3.x | mongodb@4.x        | mongodb@5.x        | mongodb@6.x |
-| ------------------------- | ----------- | ------------------ | ------------------ | ----------- |
-| bson                      | ^1.0.0      | ^2.0.0             | ^5.0.0             | ^6.0.0      |
-| bson-ext                  | ^1.0.0      | ^2.0.0             | N/A                | N/A         |
-| kerberos                  | ^1.0.0      | ^1.0.0 \|\| ^2.0.0 | ^1.0.0 \|\| ^2.0.0 | ^2.0.0      |
-| mongodb-client-encryption | ^1.0.0      | ^1.0.0 \|\| ^2.0.0 | ^2.3.0             | ^6.0.0      |
-| mongodb-legacy            | N/A         | ^4.0.0             | ^5.0.0             | ^6.0.0      |
-| \@mongodb-js/zstd         | N/A         | ^1.0.0             | ^1.0.0             | ^1.1.0      |
+| Component                                                                            | mongodb@3.x | mongodb@4.x        | mongodb@5.x        | mongodb@6.x |
+| ------------------------------------------------------------------------------------ | ----------- | ------------------ | ------------------ | ----------- |
+| [bson](https://www.npmjs.com/package/bson)                                           | ^1.0.0      | ^2.0.0             | ^5.0.0             | ^6.0.0      |
+| [bson-ext](https://www.npmjs.com/package/bson-ext)                                   | ^1.0.0      | ^2.0.0             | N/A                | N/A         |
+| [kerberos](https://www.npmjs.com/package/kerberos)                                   | ^1.0.0      | ^1.0.0 \|\| ^2.0.0 | ^1.0.0 \|\| ^2.0.0 | ^2.0.0      |
+| [mongodb-client-encryption](https://www.npmjs.com/package/mongodb-client-encryption) | ^1.0.0      | ^1.0.0 \|\| ^2.0.0 | ^2.3.0             | ^6.0.0      |
+| [mongodb-legacy](https://www.npmjs.com/package/mongodb-legacy)                       | N/A         | ^4.0.0             | ^5.0.0             | ^6.0.0      |
+| [\@mongodb-js/zstd](https://www.npmjs.com/package/@mongodb-js/zstd)                  | N/A         | ^1.0.0             | ^1.0.0             | ^1.1.0      |
 
 #### Typescript Version
 


### PR DESCRIPTION
### Description
NODE-5523

#### What is changing?
Added table with version compat info for add-on packages

##### Is there new documentation needed for these changes?
This is documentation

#### What is the motivation for this change?
Clarity about add-on compatibility

### Release Highlight - N/A

<!-- RELEASE_HIGHLIGHT_START -->

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [N/A] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [N/A] Changes are covered by tests
- [N/A] New TODOs have a related JIRA ticket
