### PR TITLE
chore(NODE-5428): add 5.x release automation

### DIFF
--- a/.github/workflows/release-5.x.yml
+++ b/.github/workflows/release-5.x.yml
@@ -1,0 +1,38 @@
+on:
+  push:
+    branches: [5.x]
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write
+
+name: release-5x
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - id: release
+        uses: google-github-actions/release-please-action@v3
+        with:
+          release-type: node
+          package-name: mongodb
+          # Example: chore(main): release 5.7.0 [skip-ci]
+          # ${scope} - parenthesis included, base branch name
+          pull-request-title-pattern: 'chore${scope}: release ${version} [skip-ci]'
+          pull-request-header: 'Please run the release_notes action before releasing to generate release highlights'
+          changelog-path: HISTORY.md
+          default-branch: 5.x
+
+      # If release-please created a release, publish to npm
+      - if: ${{ steps.release.outputs.release_created }}
+        uses: actions/checkout@v3
+      - if: ${{ steps.release.outputs.release_created }}
+        name: actions/setup
+        uses: ./.github/actions/setup
+      - if: ${{ steps.release.outputs.release_created }}
+        run: npm publish --provenance --tag=5x
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
### Description

#### What is changing?

Adds a 5.x release automation

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

- Merge robot PR === Release 5.x

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
