### PR TITLE
fix(NODE-4788)!: use implementer Writable methods for GridFSBucketWriteStream 

### DIFF
--- a/src/gridfs/upload.ts
+++ b/src/gridfs/upload.ts
@@ -138,7 +138,9 @@ export class GridFSBucketWriteStream extends Writable {
   }
 
   /**
-   * The stream is considered constructed when the indexes ßare done being created
+   * @internal
+   *
+   * The stream is considered constructed when the indexes are done being created
    */
   override _construct(callback: (error?: Error | null) => void): void {
     if (this.bucket.s.checkedIndexes) {
@@ -148,12 +150,12 @@ export class GridFSBucketWriteStream extends Writable {
   }
 
   /**
+   * @internal
    * Write a buffer to the stream.
    *
    * @param chunk - Buffer to write
-   * @param encodingOrCallback - Optional encoding for the buffer
+   * @param encoding - Optional encoding for the buffer
    * @param callback - Function to call when the chunk was added to the buffer, or if the entire chunk was persisted to MongoDB if this chunk caused a flush.
-   * @returns False if this write required flushing a chunk to MongoDB. True otherwise.
    */
   override _write(
     chunk: Buffer | string,
@@ -163,6 +165,7 @@ export class GridFSBucketWriteStream extends Writable {
     doWrite(this, chunk, encoding, callback);
   }
 
+  /** @internal */
   override _final(callback: (error?: Error | null) => void): void {
     if (this.state.streamEnd) {
       return process.nextTick(callback);

--- a/src/gridfs/upload.ts
+++ b/src/gridfs/upload.ts
@@ -3,7 +3,7 @@ import { Writable } from 'stream';
 import type { Document } from '../bson';
 import { ObjectId } from '../bson';
 import type { Collection } from '../collection';
-import { type AnyError, MongoAPIError, MONGODB_ERROR_CODES, MongoError } from '../error';
+import { MongoAPIError, MONGODB_ERROR_CODES, MongoError } from '../error';
 import type { Callback } from '../utils';
 import type { WriteConcernOptions } from '../write_concern';
 import { WriteConcern } from './../write_concern';
@@ -38,7 +38,7 @@ export interface GridFSBucketWriteStreamOptions extends WriteConcernOptions {
  * Do not instantiate this class directly. Use `openUploadStream()` instead.
  * @public
  */
-export class GridFSBucketWriteStream extends Writable implements NodeJS.WritableStream {
+export class GridFSBucketWriteStream extends Writable {
   bucket: GridFSBucket;
   chunks: Collection<GridFSChunk>;
   filename: string;
@@ -59,15 +59,7 @@ export class GridFSBucketWriteStream extends Writable implements NodeJS.Writable
   };
   writeConcern?: WriteConcern;
 
-  /** @event */
-  static readonly CLOSE = 'close';
-  /** @event */
-  static readonly ERROR = 'error';
-  /**
-   * `end()` was called and the write stream successfully wrote the file metadata and all the chunks to MongoDB.
-   * @event
-   */
-  static readonly FINISH = 'finish';
+  fileMetadata: GridFSFile | null = null;
 
   /**
    * @param bucket - Handle for this stream's corresponding bucket
@@ -116,6 +108,16 @@ export class GridFSBucketWriteStream extends Writable implements NodeJS.Writable
   }
 
   /**
+   * The stream is considered constructed when the indexes ßare done being created
+   */
+  override _construct(callback: (error?: Error | null) => void): void {
+    if (this.bucket.s.checkedIndexes) {
+      return process.nextTick(callback);
+    }
+    this.bucket.once('index', callback);
+  }
+
+  /**
    * Write a buffer to the stream.
    *
    * @param chunk - Buffer to write
@@ -123,22 +125,20 @@ export class GridFSBucketWriteStream extends Writable implements NodeJS.Writable
    * @param callback - Function to call when the chunk was added to the buffer, or if the entire chunk was persisted to MongoDB if this chunk caused a flush.
    * @returns False if this write required flushing a chunk to MongoDB. True otherwise.
    */
-  override write(chunk: Buffer | string): boolean;
-  override write(chunk: Buffer | string, callback: Callback<void>): boolean;
-  override write(chunk: Buffer | string, encoding: BufferEncoding | undefined): boolean;
-  override write(
+  override _write(
     chunk: Buffer | string,
-    encoding: BufferEncoding | undefined,
+    encoding: BufferEncoding,
     callback: Callback<void>
-  ): boolean;
-  override write(
-    chunk: Buffer | string,
-    encodingOrCallback?: Callback<void> | BufferEncoding,
-    callback?: Callback<void>
-  ): boolean {
-    const encoding = typeof encodingOrCallback === 'function' ? undefined : encodingOrCallback;
-    callback = typeof encodingOrCallback === 'function' ? encodingOrCallback : callback;
-    return waitForIndexes(this, () => doWrite(this, chunk, encoding, callback));
+  ): void {
+    doWrite(this, chunk, encoding, callback);
+  }
+
+  override _final(callback: (error?: Error | null) => void): void {
+    if (this.state.streamEnd) {
+      return process.nextTick(callback);
+    }
+    this.state.streamEnd = true;
+    writeRemnant(this, callback);
   }
 
   /**
@@ -159,76 +159,15 @@ export class GridFSBucketWriteStream extends Writable implements NodeJS.Writable
     this.state.aborted = true;
     await this.chunks.deleteMany({ files_id: this.id });
   }
-
-  /**
-   * Tells the stream that no more data will be coming in. The stream will
-   * persist the remaining data to MongoDB, write the files document, and
-   * then emit a 'finish' event.
-   *
-   * @param chunk - Buffer to write
-   * @param encoding - Optional encoding for the buffer
-   * @param callback - Function to call when all files and chunks have been persisted to MongoDB
-   */
-  override end(): this;
-  override end(chunk: Buffer): this;
-  override end(callback: Callback<GridFSFile | void>): this;
-  override end(chunk: Buffer, callback: Callback<GridFSFile | void>): this;
-  override end(chunk: Buffer, encoding: BufferEncoding): this;
-  override end(
-    chunk: Buffer,
-    encoding: BufferEncoding | undefined,
-    callback: Callback<GridFSFile | void>
-  ): this;
-  override end(
-    chunkOrCallback?: Buffer | Callback<GridFSFile | void>,
-    encodingOrCallback?: BufferEncoding | Callback<GridFSFile | void>,
-    callback?: Callback<GridFSFile | void>
-  ): this {
-    const chunk = typeof chunkOrCallback === 'function' ? undefined : chunkOrCallback;
-    const encoding = typeof encodingOrCallback === 'function' ? undefined : encodingOrCallback;
-    callback =
-      typeof chunkOrCallback === 'function'
-        ? chunkOrCallback
-        : typeof encodingOrCallback === 'function'
-        ? encodingOrCallback
-        : callback;
-
-    if (this.state.streamEnd || checkAborted(this, callback)) return this;
-
-    this.state.streamEnd = true;
-
-    if (callback) {
-      this.once(GridFSBucketWriteStream.FINISH, (result: GridFSFile) => {
-        if (callback) callback(undefined, result);
-      });
-    }
-
-    if (!chunk) {
-      waitForIndexes(this, () => !!writeRemnant(this));
-      return this;
-    }
-
-    this.write(chunk, encoding, () => {
-      writeRemnant(this);
-    });
-
-    return this;
-  }
 }
 
-function __handleError(
-  stream: GridFSBucketWriteStream,
-  error: AnyError,
-  callback?: Callback
-): void {
+function handleError(stream: GridFSBucketWriteStream, error: Error, callback: Callback): void {
   if (stream.state.errored) {
+    process.nextTick(callback);
     return;
   }
   stream.state.errored = true;
-  if (callback) {
-    return callback(error);
-  }
-  stream.emit(GridFSBucketWriteStream.ERROR, error);
+  process.nextTick(callback, error);
 }
 
 function createChunkDoc(filesId: ObjectId, n: number, data: Buffer): GridFSChunk {
@@ -271,13 +210,16 @@ async function checkChunksIndex(stream: GridFSBucketWriteStream): Promise<void> 
   }
 }
 
-function checkDone(stream: GridFSBucketWriteStream, callback?: Callback): boolean {
-  if (stream.done) return true;
+function checkDone(stream: GridFSBucketWriteStream, callback: Callback): void {
+  if (stream.done) {
+    return process.nextTick(callback);
+  }
+
   if (stream.state.streamEnd && stream.state.outstandingRequests === 0 && !stream.state.errored) {
     // Set done so we do not trigger duplicate createFilesDoc
     stream.done = true;
     // Create a new files doc
-    const filesDoc = createFilesDoc(
+    const fileMetadata = createFilesDoc(
       stream.id,
       stream.length,
       stream.chunkSizeBytes,
@@ -287,24 +229,21 @@ function checkDone(stream: GridFSBucketWriteStream, callback?: Callback): boolea
       stream.options.metadata
     );
 
-    if (checkAborted(stream, callback)) {
-      return false;
+    if (isAborted(stream, callback)) {
+      return;
     }
 
-    stream.files.insertOne(filesDoc, { writeConcern: stream.writeConcern }).then(
+    stream.files.insertOne(fileMetadata, { writeConcern: stream.writeConcern }).then(
       () => {
-        stream.emit(GridFSBucketWriteStream.FINISH, filesDoc);
-        stream.emit(GridFSBucketWriteStream.CLOSE);
+        stream.fileMetadata = fileMetadata;
+        callback();
       },
-      error => {
-        return __handleError(stream, error, callback);
-      }
+      error => handleError(stream, error, callback)
     );
-
-    return true;
+    return;
   }
 
-  return false;
+  process.nextTick(callback);
 }
 
 async function checkIndexes(stream: GridFSBucketWriteStream): Promise<void> {
@@ -377,11 +316,11 @@ function createFilesDoc(
 function doWrite(
   stream: GridFSBucketWriteStream,
   chunk: Buffer | string,
-  encoding?: BufferEncoding,
-  callback?: Callback<void>
-): boolean {
-  if (checkAborted(stream, callback)) {
-    return false;
+  encoding: BufferEncoding,
+  callback: Callback<void>
+): void {
+  if (isAborted(stream, callback)) {
+    return;
   }
 
   const inputBuf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk, encoding);
@@ -392,13 +331,8 @@ function doWrite(
   if (stream.pos + inputBuf.length < stream.chunkSizeBytes) {
     inputBuf.copy(stream.bufToStore, stream.pos);
     stream.pos += inputBuf.length;
-
-    callback && callback();
-
-    // Note that we reverse the typical semantics of write's return value
-    // to be compatible with node's `.pipe()` function.
-    // True means client can keep writing.
-    return true;
+    process.nextTick(callback);
+    return;
   }
 
   // Otherwise, buffer is too big for current chunk, so we need to flush
@@ -418,8 +352,8 @@ function doWrite(
       ++stream.state.outstandingRequests;
       ++outstandingRequests;
 
-      if (checkAborted(stream, callback)) {
-        return false;
+      if (isAborted(stream, callback)) {
+        return;
       }
 
       stream.chunks.insertOne(doc, { writeConcern: stream.writeConcern }).then(
@@ -429,13 +363,10 @@ function doWrite(
 
           if (!outstandingRequests) {
             stream.emit('drain', doc);
-            callback && callback();
-            checkDone(stream);
+            checkDone(stream, callback);
           }
         },
-        error => {
-          return __handleError(stream, error);
-        }
+        error => handleError(stream, error, callback)
       );
 
       spaceRemaining = stream.chunkSizeBytes;
@@ -445,29 +376,9 @@ function doWrite(
     inputBufRemaining -= numToCopy;
     numToCopy = Math.min(spaceRemaining, inputBufRemaining);
   }
-
-  // Note that we reverse the typical semantics of write's return value
-  // to be compatible with node's `.pipe()` function.
-  // False means the client should wait for the 'drain' event.
-  return false;
 }
 
-function waitForIndexes(
-  stream: GridFSBucketWriteStream,
-  callback: (res: boolean) => boolean
-): boolean {
-  if (stream.bucket.s.checkedIndexes) {
-    return callback(false);
-  }
-
-  stream.bucket.once('index', () => {
-    callback(true);
-  });
-
-  return true;
-}
-
-function writeRemnant(stream: GridFSBucketWriteStream, callback?: Callback): boolean {
+function writeRemnant(stream: GridFSBucketWriteStream, callback: Callback): void {
   // Buffer is empty, so don't bother to insert
   if (stream.pos === 0) {
     return checkDone(stream, callback);
@@ -482,28 +393,22 @@ function writeRemnant(stream: GridFSBucketWriteStream, callback?: Callback): boo
   const doc = createChunkDoc(stream.id, stream.n, remnant);
 
   // If the stream was aborted, do not write remnant
-  if (checkAborted(stream, callback)) {
-    return false;
+  if (isAborted(stream, callback)) {
+    return;
   }
 
   stream.chunks.insertOne(doc, { writeConcern: stream.writeConcern }).then(
     () => {
       --stream.state.outstandingRequests;
-      checkDone(stream);
+      checkDone(stream, callback);
     },
-    error => {
-      return __handleError(stream, error);
-    }
+    error => handleError(stream, error, callback)
   );
-  return true;
 }
 
-function checkAborted(stream: GridFSBucketWriteStream, callback?: Callback<void>): boolean {
+function isAborted(stream: GridFSBucketWriteStream, callback: Callback<void>): boolean {
   if (stream.state.aborted) {
-    if (typeof callback === 'function') {
-      // TODO(NODE-3485): Replace with MongoGridFSStreamClosedError
-      callback(new MongoAPIError('Stream has been aborted'));
-    }
+    process.nextTick(callback, new MongoAPIError('Stream has been aborted'));
     return true;
   }
   return false;

--- a/test/integration/gridfs/gridfs_stream.test.js
+++ b/test/integration/gridfs/gridfs_stream.test.js
@@ -4,17 +4,20 @@ const { Double } = require('bson');
 const stream = require('stream');
 const fs = require('fs');
 const { expect } = require('chai');
-const { GridFSBucket, ObjectId } = require('../../mongodb');
-const sinon = require('sinon');
-const { sleep } = require('../../tools/utils');
+const { promisify } = require('node:util');
+const { once } = require('node:events');
+const { GridFSBucket, ObjectId, MongoAPIError } = require('../../mongodb');
 
 describe('GridFS Stream', function () {
   let client;
+  let db;
   beforeEach(async function () {
     client = this.configuration.newClient();
+    db = client.db('gridfs_stream_tests');
   });
 
   afterEach(async function () {
+    await db.dropDatabase().catch(() => null);
     await client.close();
   });
 
@@ -432,106 +435,32 @@ describe('GridFS Stream', function () {
     }
   });
 
-  /**
-   * Aborting an upload
-   *
-   * @example-class GridFSBucketWriteStream
-   * @example-method abort
-   */
   it('Aborting an upload', {
     metadata: { requires: { topology: ['single'] } },
 
-    test(done) {
-      const configuration = this.configuration;
-      const client = configuration.newClient(configuration.writeConcernMax(), { maxPoolSize: 1 });
-      client.connect(function (err, client) {
-        const db = client.db(configuration.db);
-        const bucket = new GridFSBucket(db, { bucketName: 'gridfsabort', chunkSizeBytes: 1 });
-        const CHUNKS_COLL = 'gridfsabort.chunks';
-        const uploadStream = bucket.openUploadStream('test.dat');
+    async test() {
+      const bucket = new GridFSBucket(db, { bucketName: 'gridfsabort', chunkSizeBytes: 1 });
+      const chunks = db.collection('gridfsabort.chunks');
+      const uploadStream = bucket.openUploadStream('test.dat');
 
-        const id = uploadStream.id;
-        const query = { files_id: id };
-        uploadStream.write('a', 'utf8', function (error) {
-          expect(error).to.not.exist;
+      const willError = once(uploadStream, 'error');
 
-          db.collection(CHUNKS_COLL).count(query, function (error, c) {
-            expect(error).to.not.exist;
-            expect(c).to.equal(1);
-            uploadStream.abort(function (error) {
-              expect(error).to.not.exist;
-              db.collection(CHUNKS_COLL).count(query, function (error, c) {
-                expect(error).to.not.exist;
-                expect(c).to.equal(0);
-                uploadStream.write('b', 'utf8', function (error) {
-                  expect(error.toString()).to.equal('MongoAPIError: Stream has been aborted');
-                  uploadStream.end('c', 'utf8', function (error) {
-                    expect(error.toString()).to.equal('MongoAPIError: Stream has been aborted');
-                    // Fail if user tries to abort an aborted stream
-                    uploadStream.abort().then(null, function (error) {
-                      expect(error.toString()).to.equal(
-                        // TODO(NODE-3485): Replace with MongoGridFSStreamClosedError
-                        'MongoAPIError: Cannot call abort() on a stream twice'
-                      );
-                      client.close(done);
-                    });
-                  });
-                });
-              });
-            });
-          });
-        });
-      });
-    }
-  });
+      const id = uploadStream.id;
+      const query = { files_id: id };
 
-  /**
-   * Aborting an upload
-   */
-  it('Destroy an upload', {
-    metadata: { requires: { topology: ['single'] } },
+      const writeAsync = promisify(uploadStream.write.bind(uploadStream));
 
-    test(done) {
-      const configuration = this.configuration;
-      const client = configuration.newClient(configuration.writeConcernMax(), { maxPoolSize: 1 });
-      client.connect(function (err, client) {
-        const db = client.db(configuration.db);
-        const bucket = new GridFSBucket(db, { bucketName: 'gridfsabort', chunkSizeBytes: 1 });
-        const CHUNKS_COLL = 'gridfsabort.chunks';
-        const uploadStream = bucket.openUploadStream('test.dat');
+      await writeAsync('a', 'utf8');
 
-        const id = uploadStream.id;
-        const query = { files_id: id };
-        uploadStream.write('a', 'utf8', function (error) {
-          expect(error).to.not.exist;
+      expect(await chunks.countDocuments(query)).to.equal(1);
 
-          db.collection(CHUNKS_COLL).count(query, function (error, c) {
-            expect(error).to.not.exist;
-            expect(c).to.equal(1);
-            uploadStream.abort(function (error) {
-              expect(error).to.not.exist;
-              db.collection(CHUNKS_COLL).count(query, function (error, c) {
-                expect(error).to.not.exist;
-                expect(c).to.equal(0);
-                uploadStream.write('b', 'utf8', function (error) {
-                  expect(error.toString()).to.equal('MongoAPIError: Stream has been aborted');
-                  uploadStream.end('c', 'utf8', function (error) {
-                    expect(error.toString()).to.equal('MongoAPIError: Stream has been aborted');
-                    // Fail if user tries to abort an aborted stream
-                    uploadStream.abort().then(null, function (error) {
-                      expect(error.toString()).to.equal(
-                        // TODO(NODE-3485): Replace with MongoGridFSStreamClosedError
-                        'MongoAPIError: Cannot call abort() on a stream twice'
-                      );
-                      client.close(done);
-                    });
-                  });
-                });
-              });
-            });
-          });
-        });
-      });
+      await uploadStream.abort();
+
+      expect(await chunks.countDocuments(query)).to.equal(0);
+
+      expect(await writeAsync('b', 'utf8').catch(e => e)).to.be.instanceOf(MongoAPIError);
+      expect(await uploadStream.abort().catch(e => e)).to.be.instanceOf(MongoAPIError);
+      expect((await willError)[0]).to.be.instanceOf(MongoAPIError);
     }
   });
 
@@ -545,51 +474,46 @@ describe('GridFS Stream', function () {
     metadata: { requires: { topology: ['single'], apiVersion: false } },
 
     test(done) {
-      const configuration = this.configuration;
-      const client = configuration.newClient(configuration.writeConcernMax(), { maxPoolSize: 1 });
-      client.connect(function (err, client) {
-        const db = client.db(configuration.db);
-        const bucket = new GridFSBucket(db, { bucketName: 'gridfsdestroy', chunkSizeBytes: 10 });
-        const readStream = fs.createReadStream('./LICENSE.md');
-        const uploadStream = bucket.openUploadStream('test.dat');
+      const bucket = new GridFSBucket(db, { bucketName: 'gridfsdestroy', chunkSizeBytes: 10 });
+      const readStream = fs.createReadStream('./LICENSE.md');
+      const uploadStream = bucket.openUploadStream('test.dat');
 
-        // Wait for stream to finish
-        uploadStream.once('finish', function () {
-          const id = uploadStream.id;
-          const downloadStream = bucket.openDownloadStream(id);
-          const finished = {};
-          downloadStream.on('data', function () {
-            expect.fail('Should be unreachable');
-          });
-
-          downloadStream.on('error', function () {
-            expect.fail('Should be unreachable');
-          });
-
-          downloadStream.on('end', function () {
-            expect(downloadStream.s.cursor).to.not.exist;
-            if (finished.close) {
-              client.close(done);
-              return;
-            }
-            finished.end = true;
-          });
-
-          downloadStream.on('close', function () {
-            if (finished.end) {
-              client.close(done);
-              return;
-            }
-            finished.close = true;
-          });
-
-          downloadStream.abort(function (error) {
-            expect(error).to.not.exist;
-          });
+      // Wait for stream to finish
+      uploadStream.once('finish', function () {
+        const id = uploadStream.id;
+        const downloadStream = bucket.openDownloadStream(id);
+        const finished = {};
+        downloadStream.on('data', function () {
+          expect.fail('Should be unreachable');
         });
 
-        readStream.pipe(uploadStream);
+        downloadStream.on('error', function () {
+          expect.fail('Should be unreachable');
+        });
+
+        downloadStream.on('end', function () {
+          expect(downloadStream.s.cursor).to.not.exist;
+          if (finished.close) {
+            client.close(done);
+            return;
+          }
+          finished.end = true;
+        });
+
+        downloadStream.on('close', function () {
+          if (finished.end) {
+            client.close(done);
+            return;
+          }
+          finished.close = true;
+        });
+
+        downloadStream.abort(function (error) {
+          expect(error).to.not.exist;
+        });
       });
+
+      readStream.pipe(uploadStream);
     }
   });
 
@@ -872,134 +796,6 @@ describe('GridFS Stream', function () {
         });
       });
     }
-  });
-
-  /**
-   * NODE-822 GridFSBucketWriteStream end method does not handle optional parameters
-   */
-  it('should correctly handle calling end function with only a callback', {
-    metadata: { requires: { topology: ['single'] } },
-
-    test(done) {
-      const configuration = this.configuration;
-      const client = configuration.newClient(configuration.writeConcernMax(), { maxPoolSize: 1 });
-      client.connect(function (err, client) {
-        const db = client.db(configuration.db);
-        const bucket = new GridFSBucket(db, { bucketName: 'gridfsabort', chunkSizeBytes: 1 });
-        const CHUNKS_COLL = 'gridfsabort.chunks';
-        const uploadStream = bucket.openUploadStream('test.dat');
-
-        const id = uploadStream.id;
-        const query = { files_id: id };
-        uploadStream.write('a', 'utf8', function (error) {
-          expect(error).to.not.exist;
-
-          db.collection(CHUNKS_COLL).count(query, function (error, c) {
-            expect(error).to.not.exist;
-            expect(c).to.equal(1);
-
-            uploadStream.abort(function (error) {
-              expect(error).to.not.exist;
-
-              db.collection(CHUNKS_COLL).count(query, function (error, c) {
-                expect(error).to.not.exist;
-                expect(c).to.equal(0);
-
-                uploadStream.write('b', 'utf8', function (error) {
-                  expect(error.toString()).to.equal('MongoAPIError: Stream has been aborted');
-
-                  uploadStream.end(function (error) {
-                    expect(error.toString()).to.equal('MongoAPIError: Stream has been aborted');
-
-                    // Fail if user tries to abort an aborted stream
-                    uploadStream.abort().then(null, function (error) {
-                      expect(error.toString()).to.equal(
-                        // TODO(NODE-3485): Replace with MongoGridFSStreamClosedError
-                        'MongoAPIError: Cannot call abort() on a stream twice'
-                      );
-                      client.close(done);
-                    });
-                  });
-                });
-              });
-            });
-          });
-        });
-      });
-    }
-  });
-
-  describe('upload stream end()', () => {
-    let client, db;
-
-    afterEach(async () => {
-      sinon.restore();
-      await client.close();
-    });
-
-    it('should not call the callback on repeat calls to end', {
-      metadata: { requires: { topology: ['single'] } },
-
-      async test() {
-        const configuration = this.configuration;
-        client = configuration.newClient(configuration.writeConcernMax(), {
-          maxPoolSize: 1
-        });
-        await client.connect();
-        db = client.db(configuration.db);
-        const bucket = new GridFSBucket(db, { bucketName: 'gridfsabort', chunkSizeBytes: 1 });
-        const uploadStream = bucket.openUploadStream('test.dat');
-
-        const endPromise = new Promise(resolve => {
-          uploadStream.end('1', resolve);
-        });
-
-        const endPromise2 = new Promise((resolve, reject) => {
-          uploadStream.end('2', () => {
-            reject(new Error('Expected callback to not be called on duplicate end'));
-          });
-        });
-
-        await endPromise;
-        // in the fail case, the callback would be called when the actual write is finished,
-        // so we need to give it a moment
-        await Promise.race([endPromise2, sleep(100)]);
-      }
-    });
-
-    it('should not write a chunk on repeat calls to end', {
-      metadata: { requires: { topology: ['single'] } },
-
-      async test() {
-        const configuration = this.configuration;
-        client = configuration.newClient(configuration.writeConcernMax(), {
-          maxPoolSize: 1
-        });
-        await client.connect();
-        db = client.db(this.configuration.db);
-        const bucket = new GridFSBucket(db, { bucketName: 'gridfsabort', chunkSizeBytes: 1 });
-        const uploadStream = bucket.openUploadStream('test.dat');
-        const spy = sinon.spy(uploadStream, 'write');
-
-        const endPromise = new Promise(resolve => {
-          uploadStream.end('1', resolve);
-        });
-
-        await endPromise;
-        expect(spy).to.have.been.calledWith('1');
-
-        uploadStream.end('2');
-
-        // wait for potential async calls to happen before we close the client
-        // so that we don't get a client not connected failure in the afterEach
-        // in the failure case since it would be confusing and unnecessary
-        // given the assertions we already have for this case
-        await sleep(100);
-
-        expect(spy).not.to.have.been.calledWith('2');
-        expect(spy.calledOnce).to.be.true;
-      }
-    });
   });
 
   it('should return only end - start bytes when the end is within a chunk', {

--- a/test/tools/unified-spec-runner/operations.ts
+++ b/test/tools/unified-spec-runner/operations.ts
@@ -427,7 +427,7 @@ operations.set('upload', async ({ entities, operation }) => {
   stream.end(data);
   await willFinish;
 
-  return stream.fileMetadata?._id;
+  return stream.gridFSFile?._id;
 });
 
 operations.set('wait', async ({ operation }) => {


### PR DESCRIPTION
### Description

#### What is changing?

- Remove overrides of stream methods
- Add overrides of _X stream methods that control the underlying implmentations
- Remove manual event emitting
- Ensure callback is always invoked asynchronously (nextTick)

##### Is there new documentation needed for these changes?

- TBD

#### What is the motivation for this change?

Node.js Streams are supposed to be implemented with the _X methods, the write & end functions are maintained by Node.js, the _ methods define the implementation of a stream.

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Corrected `GridFSBucketWriteStream`'s `Writable` method overrides and event emission

Our implementation of a writeable stream for GridFSBucketWriteStream mistakenly overrode the `write()` and `end()` methods, as well as, manually emitted `'close'`, `'drain'`, `'finish'` events. Per Node.js documentation, these methods and events are intended for the Node.js stream implementation to provide, and an author of a stream implementation is supposed to override `_write`, `_final`, and allow Node.js to manage event emitting. 

Since the API is still a `Writable` stream most usages will continue to work with no changes, the `.write()` and `.end()` methods are still available and take the same arguments. The breaking change relates to the improper manually emitted event listeners that are now handled by Node.js. **The `'finish'` and `'drain'` events will no longer receive the `GridFSFile` document as an argument** (this is the document inserted to the bucket's files collection after all chunks have been inserted). Instead, it will be available on the stream itself as a property: `gridFSFile`. 

```ts
// If our event handler is declared as a `function` "this" is bound to the stream.
fs.createReadStream('./file.txt')
  .pipe(bucket.openUploadStream('file.txt'))
  .on('finish', function () {
    console.log(this.gridFSFile)
  })

// If our event handler is declared using big arrow notation,
// the property is accessible on a scoped variable
const uploadStream = bucket.openUploadStream('file.txt')
fs.createReadStream('./file.txt')
  .pipe(uploadStream)
  .on('finish', () => console.log(uploadStream.gridFSFile))
```

Since the class no longer emits its own events: static constants `GridFSBucketWriteStream.ERROR`, `GridFSBucketWriteStream.FINISH`, `GridFSBucketWriteStream.CLOSE` have been removed to avoid confusion about the source of the events and the arguments their listeners accept.

### Fix manually emitted events from `GridFSBucketReadStream`

The `GridFSBucketReadStream` internals have also been corrected to no longer emit events that are handled by Node's stream logic. Since the class no longer emits its own events: static constants `GridFSBucketReadStream.ERROR`, `GridFSBucketReadStream.DATA`, `GridFSBucketReadStream.CLOSE`, and `GridFSBucketReadStream.END` have been removed to avoid confusion about the source of the events and the arguments their listeners accept.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
