### PR TITLE
fix(NODE-5412): drop aws sdk version to match node18 runtime

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,7 @@
         "saslprep": "^1.0.3"
       },
       "peerDependencies": {
-        "@aws-sdk/credential-providers": "^3.201.0",
+        "@aws-sdk/credential-providers": "^3.188.0",
         "@mongodb-js/zstd": "^1.1.0",
         "gcp-metadata": "^5.2.0",
         "kerberos": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "saslprep": "^1.0.3"
   },
   "peerDependencies": {
-    "@aws-sdk/credential-providers": "^3.201.0",
+    "@aws-sdk/credential-providers": "^3.188.0",
     "@mongodb-js/zstd": "^1.1.0",
     "gcp-metadata": "^5.2.0",
     "kerberos": "^2.0.1",


### PR DESCRIPTION
### Description

#### What is changing?

Change `@aws-sdk/credential-providers` version to 3.188.0 since this is the version that will get pulled in when users work with the driver in AWS Lambda

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

NODE-5412

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Lowered `aws-sdk` peer dependency version to 3.188.0

This release lowers the version of the `@aws-sdk/credential-providers` peer dependency to 3.188.0 as this is the version that will get pulled in when using the driver in AWS lambda environments in the Node 18 runtime.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [X] Ran `npm run check:lint` script
- [X] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [X] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
