### PR TITLE
fix(NODE-5495): do not emit deprecation warning when tlsCertificateKeyFile is specified and tlsCertificateFile is not

### DIFF
--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -347,10 +347,10 @@ export function parseOptions(
     allProvidedOptions.set(key, values);
   }
 
-  if (
+  const didMapTLSCertificateFile =
     allProvidedOptions.has('tlsCertificateKeyFile') &&
-    !allProvidedOptions.has('tlsCertificateFile')
-  ) {
+    !allProvidedOptions.has('tlsCertificateFile');
+  if (didMapTLSCertificateFile) {
     allProvidedOptions.set('tlsCertificateFile', allProvidedOptions.get('tlsCertificateKeyFile'));
   }
 
@@ -387,7 +387,9 @@ export function parseOptions(
       }
     } else {
       const { deprecated } = descriptor;
-      if (deprecated) {
+      const shouldEmitTLSCertificateFileDeprecation =
+        didMapTLSCertificateFile && key === 'tlsCertificateFile';
+      if (deprecated && !shouldEmitTLSCertificateFileDeprecation) {
         const deprecatedMsg = typeof deprecated === 'string' ? `: ${deprecated}` : '';
         emitWarning(`${key} is a deprecated option${deprecatedMsg}`);
       }

--- a/test/unit/mongo_client.test.js
+++ b/test/unit/mongo_client.test.js
@@ -12,8 +12,6 @@ const { MongoClient, MongoParseError, ServerApiVersion } = require('../mongodb')
 const { MongoLogger } = require('../mongodb');
 const sinon = require('sinon');
 const { Writable } = require('stream');
-const { once } = require('events');
-const { setTimeout } = require('timers/promises');
 
 describe('MongoOptions', function () {
   it('MongoClient should always freeze public options', function () {

--- a/test/unit/mongo_client.test.js
+++ b/test/unit/mongo_client.test.js
@@ -12,6 +12,8 @@ const { MongoClient, MongoParseError, ServerApiVersion } = require('../mongodb')
 const { MongoLogger } = require('../mongodb');
 const sinon = require('sinon');
 const { Writable } = require('stream');
+const { once } = require('events');
+const { setTimeout } = require('timers/promises');
 
 describe('MongoOptions', function () {
   it('MongoClient should always freeze public options', function () {
@@ -29,46 +31,60 @@ describe('MongoOptions', function () {
     expect(options.prototype).to.not.exist;
   });
 
-  it('should rename tls options correctly', function () {
-    const filename = `${os.tmpdir()}/tmp.pem`;
-    fs.closeSync(fs.openSync(filename, 'w'));
-    const options = parseOptions('mongodb://localhost:27017/?ssl=true', {
-      tlsCertificateKeyFile: filename,
-      tlsCertificateFile: filename,
-      tlsCAFile: filename,
-      sslCRL: filename,
-      tlsCertificateKeyFilePassword: 'tlsCertificateKeyFilePassword',
-      sslValidate: false
+  describe('tls options', () => {
+    let filename;
+    before(() => {
+      filename = `${os.tmpdir()}/tmp.pem`;
+      fs.closeSync(fs.openSync(filename, 'w'));
     });
-    fs.unlinkSync(filename);
+    after(() => {
+      fs.unlinkSync(filename);
+    });
+    it('should rename tls options correctly', function () {
+      const options = parseOptions('mongodb://localhost:27017/?ssl=true', {
+        tlsCertificateKeyFile: filename,
+        tlsCertificateFile: filename,
+        tlsCAFile: filename,
+        sslCRL: filename,
+        tlsCertificateKeyFilePassword: 'tlsCertificateKeyFilePassword',
+        sslValidate: false
+      });
 
-    /*
-     * If set TLS enabled, equivalent to setting the ssl option.
-     *
-     * ### Additional options:
-     *
-     * |    nodejs option     | MongoDB equivalent                                 | type                                   |
-     * |:---------------------|----------------------------------------------------|:---------------------------------------|
-     * | `ca`                 | sslCA, tlsCAFile                                   | `string \| Buffer \| Buffer[]`         |
-     * | `crl`                | sslCRL                                             | `string \| Buffer \| Buffer[]`         |
-     * | `cert`               | sslCert, tlsCertificateFile                        | `string \| Buffer \| Buffer[]`         |
-     * | `key`                | sslKey, tlsCertificateKeyFile                      | `string \| Buffer \| KeyObject[]`      |
-     * | `passphrase`         | sslPass, tlsCertificateKeyFilePassword             | `string`                               |
-     * | `rejectUnauthorized` | sslValidate                                        | `boolean`                              |
-     *
-     */
-    expect(options).to.not.have.property('tlsCertificateKeyFile');
-    expect(options).to.not.have.property('tlsCAFile');
-    expect(options).to.not.have.property('sslCRL');
-    expect(options).to.not.have.property('tlsCertificateKeyFilePassword');
-    expect(options).has.property('ca', '');
-    expect(options).has.property('crl', '');
-    expect(options).has.property('cert', '');
-    expect(options).has.property('key');
-    expect(options.key).has.length(0);
-    expect(options).has.property('passphrase', 'tlsCertificateKeyFilePassword');
-    expect(options).has.property('rejectUnauthorized', false);
-    expect(options).has.property('tls', true);
+      /*
+       * If set TLS enabled, equivalent to setting the ssl option.
+       *
+       * ### Additional options:
+       *
+       * |    nodejs option     | MongoDB equivalent                                 | type                                   |
+       * |:---------------------|----------------------------------------------------|:---------------------------------------|
+       * | `ca`                 | sslCA, tlsCAFile                                   | `string \| Buffer \| Buffer[]`         |
+       * | `crl`                | sslCRL                                             | `string \| Buffer \| Buffer[]`         |
+       * | `cert`               | sslCert, tlsCertificateFile                        | `string \| Buffer \| Buffer[]`         |
+       * | `key`                | sslKey, tlsCertificateKeyFile                      | `string \| Buffer \| KeyObject[]`      |
+       * | `passphrase`         | sslPass, tlsCertificateKeyFilePassword             | `string`                               |
+       * | `rejectUnauthorized` | sslValidate                                        | `boolean`                              |
+       *
+       */
+      expect(options).to.not.have.property('tlsCertificateKeyFile');
+      expect(options).to.not.have.property('tlsCAFile');
+      expect(options).to.not.have.property('sslCRL');
+      expect(options).to.not.have.property('tlsCertificateKeyFilePassword');
+      expect(options).has.property('ca', '');
+      expect(options).has.property('crl', '');
+      expect(options).has.property('cert', '');
+      expect(options).has.property('key');
+      expect(options.key).has.length(0);
+      expect(options).has.property('passphrase', 'tlsCertificateKeyFilePassword');
+      expect(options).has.property('rejectUnauthorized', false);
+      expect(options).has.property('tls', true);
+    });
+
+    it('should not emit a deprecation warning for `tlsCertificateKeyFile` when `tlsCaFile` is specified', () => {
+      const promiseSpy = sinon.spy(process, 'emitWarning');
+      new MongoClient(`mongodb://localhost:27017/my_db?tlsCertificateKeyFile=${filename}`);
+
+      expect(promiseSpy).not.to.have.been.called;
+    });
   });
 
   const ALL_OPTIONS = {


### PR DESCRIPTION
### Description

#### What is changing?

This PR prevents the driver from emitting a deprecation warning when `tlsCertificateKeyFile` is specified and `tlsCertificateFile` is not.


##### Is there new documentation needed for these changes?

No.

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fixed accidental deprecation warning

Because of internal options handling, a deprecation was emitted for `tlsCertificateFile` when using `tlsCertificateKeyFile`. That has been corrected.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
