### PR TITLE
docs(NODE-5535): fix link to Transactions quickstart 

### DIFF
--- a/docs/4.10/classes/ClientSession.html
+++ b/docs/4.10/classes/ClientSession.html
@@ -61,7 +61,7 @@ Any callbacks that do not return a Promise will result in undefined behavior.</p
 <li>Will throw if one of the operations throws or <code>throw</code> statement is used inside the <code>withTransaction</code> callback</li>
 </ul>
 <p>Checkout a descriptive example here:</p>
-</dd><dt>see</dt><dd><p><a href="https://www.mongodb.com/developer/quickstart/node-transactions/">https://www.mongodb.com/developer/quickstart/node-transactions/</a></p>
+</dd><dt>see</dt><dd><p><a href="https://www.mongodb.com/blog/post/quick-start-nodejs--mongodb--how-to-implement-transactions">https://www.mongodb.com/blog/post/quick-start-nodejs--mongodb--how-to-implement-transactions</a></p>
 </dd></dl></div><h4 class="tsd-type-parameters-title">Type parameters</h4><ul class="tsd-type-parameters"><li><h4>T = <span class="tsd-signature-type">void</span></h4></li></ul><h4 class="tsd-parameters-title">Parameters</h4><ul class="tsd-parameters"><li><h5>fn: <a href="../modules.html#WithTransactionCallback" class="tsd-signature-type" data-tsd-kind="Type alias">WithTransactionCallback</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type" data-tsd-kind="Type parameter">T</span><span class="tsd-signature-symbol">&gt;</span></h5><div class="tsd-comment tsd-typography"><div class="lead">
 <p>callback to run within a transaction</p>
 </div></div></li><li><h5><span class="tsd-flag ts-flagOptional">Optional</span> options: <a href="../interfaces/TransactionOptions.html" class="tsd-signature-type" data-tsd-kind="Interface">TransactionOptions</a></h5><div class="tsd-comment tsd-typography"><div class="lead">

--- a/docs/4.11/classes/ClientSession.html
+++ b/docs/4.11/classes/ClientSession.html
@@ -61,7 +61,7 @@ Any callbacks that do not return a Promise will result in undefined behavior.</p
 <li>Will throw if one of the operations throws or <code>throw</code> statement is used inside the <code>withTransaction</code> callback</li>
 </ul>
 <p>Checkout a descriptive example here:</p>
-</dd><dt>see</dt><dd><p><a href="https://www.mongodb.com/developer/quickstart/node-transactions/">https://www.mongodb.com/developer/quickstart/node-transactions/</a></p>
+</dd><dt>see</dt><dd><p><a href="https://www.mongodb.com/blog/post/quick-start-nodejs--mongodb--how-to-implement-transactions">https://www.mongodb.com/blog/post/quick-start-nodejs--mongodb--how-to-implement-transactions</a></p>
 </dd></dl></div><h4 class="tsd-type-parameters-title">Type parameters</h4><ul class="tsd-type-parameters"><li><h4>T = <span class="tsd-signature-type">void</span></h4></li></ul><h4 class="tsd-parameters-title">Parameters</h4><ul class="tsd-parameters"><li><h5>fn: <a href="../modules.html#WithTransactionCallback" class="tsd-signature-type" data-tsd-kind="Type alias">WithTransactionCallback</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type" data-tsd-kind="Type parameter">T</span><span class="tsd-signature-symbol">&gt;</span></h5><div class="tsd-comment tsd-typography"><div class="lead">
 <p>callback to run within a transaction</p>
 </div></div></li><li><h5><span class="tsd-flag ts-flagOptional">Optional</span> options: <a href="../interfaces/TransactionOptions.html" class="tsd-signature-type" data-tsd-kind="Interface">TransactionOptions</a></h5><div class="tsd-comment tsd-typography"><div class="lead">

--- a/docs/4.12/classes/ClientSession.html
+++ b/docs/4.12/classes/ClientSession.html
@@ -61,7 +61,7 @@ Any callbacks that do not return a Promise will result in undefined behavior.</p
 <li>Will throw if one of the operations throws or <code>throw</code> statement is used inside the <code>withTransaction</code> callback</li>
 </ul>
 <p>Checkout a descriptive example here:</p>
-</dd><dt>see</dt><dd><p><a href="https://www.mongodb.com/developer/quickstart/node-transactions/">https://www.mongodb.com/developer/quickstart/node-transactions/</a></p>
+</dd><dt>see</dt><dd><p><a href="https://www.mongodb.com/blog/post/quick-start-nodejs--mongodb--how-to-implement-transactions">https://www.mongodb.com/blog/post/quick-start-nodejs--mongodb--how-to-implement-transactions</a></p>
 </dd></dl></div><h4 class="tsd-type-parameters-title">Type parameters</h4><ul class="tsd-type-parameters"><li><h4>T = <span class="tsd-signature-type">void</span></h4></li></ul><h4 class="tsd-parameters-title">Parameters</h4><ul class="tsd-parameters"><li><h5>fn: <a href="../modules.html#WithTransactionCallback" class="tsd-signature-type" data-tsd-kind="Type alias">WithTransactionCallback</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type" data-tsd-kind="Type parameter">T</span><span class="tsd-signature-symbol">&gt;</span></h5><div class="tsd-comment tsd-typography"><div class="lead">
 <p>callback to run within a transaction</p>
 </div></div></li><li><h5><span class="tsd-flag ts-flagOptional">Optional</span> options: <a href="../interfaces/TransactionOptions.html" class="tsd-signature-type" data-tsd-kind="Interface">TransactionOptions</a></h5><div class="tsd-comment tsd-typography"><div class="lead">

--- a/docs/4.13/classes/ClientSession.html
+++ b/docs/4.13/classes/ClientSession.html
@@ -61,7 +61,7 @@ Any callbacks that do not return a Promise will result in undefined behavior.</p
 <li>Will throw if one of the operations throws or <code>throw</code> statement is used inside the <code>withTransaction</code> callback</li>
 </ul>
 <p>Checkout a descriptive example here:</p>
-</dd><dt>see</dt><dd><p><a href="https://www.mongodb.com/developer/quickstart/node-transactions/">https://www.mongodb.com/developer/quickstart/node-transactions/</a></p>
+</dd><dt>see</dt><dd><p><a href="https://www.mongodb.com/blog/post/quick-start-nodejs--mongodb--how-to-implement-transactions">https://www.mongodb.com/blog/post/quick-start-nodejs--mongodb--how-to-implement-transactions</a></p>
 </dd></dl></div><h4 class="tsd-type-parameters-title">Type parameters</h4><ul class="tsd-type-parameters"><li><h4>T = <span class="tsd-signature-type">void</span></h4></li></ul><h4 class="tsd-parameters-title">Parameters</h4><ul class="tsd-parameters"><li><h5>fn: <a href="../modules.html#WithTransactionCallback" class="tsd-signature-type" data-tsd-kind="Type alias">WithTransactionCallback</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type" data-tsd-kind="Type parameter">T</span><span class="tsd-signature-symbol">&gt;</span></h5><div class="tsd-comment tsd-typography"><div class="lead">
 <p>callback to run within a transaction</p>
 </div></div></li><li><h5><span class="tsd-flag ts-flagOptional">Optional</span> options: <a href="../interfaces/TransactionOptions.html" class="tsd-signature-type" data-tsd-kind="Interface">TransactionOptions</a></h5><div class="tsd-comment tsd-typography"><div class="lead">

--- a/docs/4.14/classes/ClientSession.html
+++ b/docs/4.14/classes/ClientSession.html
@@ -61,7 +61,7 @@ Any callbacks that do not return a Promise will result in undefined behavior.</p
 <li>Will throw if one of the operations throws or <code>throw</code> statement is used inside the <code>withTransaction</code> callback</li>
 </ul>
 <p>Checkout a descriptive example here:</p>
-</dd><dt>see</dt><dd><p><a href="https://www.mongodb.com/developer/quickstart/node-transactions/">https://www.mongodb.com/developer/quickstart/node-transactions/</a></p>
+</dd><dt>see</dt><dd><p><a href="https://www.mongodb.com/blog/post/quick-start-nodejs--mongodb--how-to-implement-transactions">https://www.mongodb.com/blog/post/quick-start-nodejs--mongodb--how-to-implement-transactions</a></p>
 </dd></dl></div><h4 class="tsd-type-parameters-title">Type parameters</h4><ul class="tsd-type-parameters"><li><h4>T = <span class="tsd-signature-type">void</span></h4></li></ul><h4 class="tsd-parameters-title">Parameters</h4><ul class="tsd-parameters"><li><h5>fn: <a href="../modules.html#WithTransactionCallback" class="tsd-signature-type" data-tsd-kind="Type alias">WithTransactionCallback</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type" data-tsd-kind="Type parameter">T</span><span class="tsd-signature-symbol">&gt;</span></h5><div class="tsd-comment tsd-typography"><div class="lead">
 <p>callback to run within a transaction</p>
 </div></div></li><li><h5><span class="tsd-flag ts-flagOptional">Optional</span> options: <a href="../interfaces/TransactionOptions.html" class="tsd-signature-type" data-tsd-kind="Interface">TransactionOptions</a></h5><div class="tsd-comment tsd-typography"><div class="lead">

--- a/docs/4.15/classes/ClientSession.html
+++ b/docs/4.15/classes/ClientSession.html
@@ -61,7 +61,7 @@ Any callbacks that do not return a Promise will result in undefined behavior.</p
 <li>Will throw if one of the operations throws or <code>throw</code> statement is used inside the <code>withTransaction</code> callback</li>
 </ul>
 <p>Checkout a descriptive example here:</p>
-</dd><dt>see</dt><dd><p><a href="https://www.mongodb.com/developer/quickstart/node-transactions/">https://www.mongodb.com/developer/quickstart/node-transactions/</a></p>
+</dd><dt>see</dt><dd><p><a href="https://www.mongodb.com/blog/post/quick-start-nodejs--mongodb--how-to-implement-transactions">https://www.mongodb.com/blog/post/quick-start-nodejs--mongodb--how-to-implement-transactions</a></p>
 </dd></dl></div><h4 class="tsd-type-parameters-title">Type parameters</h4><ul class="tsd-type-parameters"><li><h4>T = <span class="tsd-signature-type">void</span></h4></li></ul><h4 class="tsd-parameters-title">Parameters</h4><ul class="tsd-parameters"><li><h5>fn: <a href="../modules.html#WithTransactionCallback" class="tsd-signature-type" data-tsd-kind="Type alias">WithTransactionCallback</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type" data-tsd-kind="Type parameter">T</span><span class="tsd-signature-symbol">&gt;</span></h5><div class="tsd-comment tsd-typography"><div class="lead">
 <p>callback to run within a transaction</p>
 </div></div></li><li><h5><span class="tsd-flag ts-flagOptional">Optional</span> options: <a href="../interfaces/TransactionOptions.html" class="tsd-signature-type" data-tsd-kind="Interface">TransactionOptions</a></h5><div class="tsd-comment tsd-typography"><div class="lead">

--- a/docs/4.16/classes/ClientSession.html
+++ b/docs/4.16/classes/ClientSession.html
@@ -61,7 +61,7 @@ Any callbacks that do not return a Promise will result in undefined behavior.</p
 <li>Will throw if one of the operations throws or <code>throw</code> statement is used inside the <code>withTransaction</code> callback</li>
 </ul>
 <p>Checkout a descriptive example here:</p>
-</dd><dt>see</dt><dd><p><a href="https://www.mongodb.com/developer/quickstart/node-transactions/">https://www.mongodb.com/developer/quickstart/node-transactions/</a></p>
+</dd><dt>see</dt><dd><p><a href="https://www.mongodb.com/blog/post/quick-start-nodejs--mongodb--how-to-implement-transactions">https://www.mongodb.com/blog/post/quick-start-nodejs--mongodb--how-to-implement-transactions</a></p>
 </dd></dl></div><h4 class="tsd-type-parameters-title">Type parameters</h4><ul class="tsd-type-parameters"><li><h4>T = <span class="tsd-signature-type">void</span></h4></li></ul><h4 class="tsd-parameters-title">Parameters</h4><ul class="tsd-parameters"><li><h5>fn: <a href="../modules.html#WithTransactionCallback" class="tsd-signature-type" data-tsd-kind="Type alias">WithTransactionCallback</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type" data-tsd-kind="Type parameter">T</span><span class="tsd-signature-symbol">&gt;</span></h5><div class="tsd-comment tsd-typography"><div class="lead">
 <p>callback to run within a transaction</p>
 </div></div></li><li><h5><span class="tsd-flag ts-flagOptional">Optional</span> options: <a href="../interfaces/TransactionOptions.html" class="tsd-signature-type" data-tsd-kind="Interface">TransactionOptions</a></h5><div class="tsd-comment tsd-typography"><div class="lead">

--- a/docs/4.7/classes/ClientSession.html
+++ b/docs/4.7/classes/ClientSession.html
@@ -57,7 +57,7 @@ Any callbacks that do not return a Promise will result in undefined behavior.</p
 <li>Will throw if one of the operations throws or <code>throw</code> statement is used inside the <code>withTransaction</code> callback</li>
 </ul>
 <p>Checkout a descriptive example here:</p>
-</dd><dt>see</dt><dd><p><a href="https://www.mongodb.com/developer/quickstart/node-transactions/">https://www.mongodb.com/developer/quickstart/node-transactions/</a></p>
+</dd><dt>see</dt><dd><p><a href="https://www.mongodb.com/blog/post/quick-start-nodejs--mongodb--how-to-implement-transactions">https://www.mongodb.com/blog/post/quick-start-nodejs--mongodb--how-to-implement-transactions</a></p>
 </dd></dl></div><h4 class="tsd-type-parameters-title">Type parameters</h4><ul class="tsd-type-parameters"><li><h4>T = <span class="tsd-signature-type">void</span></h4></li></ul><h4 class="tsd-parameters-title">Parameters</h4><ul class="tsd-parameters"><li><h5>fn: <a href="../modules.html#WithTransactionCallback" class="tsd-signature-type" data-tsd-kind="Type alias">WithTransactionCallback</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type" data-tsd-kind="Type parameter">T</span><span class="tsd-signature-symbol">&gt;</span></h5><div class="tsd-comment tsd-typography"><div class="lead">
 <p>callback to run within a transaction</p>
 </div></div></li><li><h5><span class="tsd-flag ts-flagOptional">Optional</span> options: <a href="../interfaces/TransactionOptions.html" class="tsd-signature-type" data-tsd-kind="Interface">TransactionOptions</a></h5><div class="tsd-comment tsd-typography"><div class="lead">

--- a/docs/4.8/classes/ClientSession.html
+++ b/docs/4.8/classes/ClientSession.html
@@ -57,7 +57,7 @@ Any callbacks that do not return a Promise will result in undefined behavior.</p
 <li>Will throw if one of the operations throws or <code>throw</code> statement is used inside the <code>withTransaction</code> callback</li>
 </ul>
 <p>Checkout a descriptive example here:</p>
-</dd><dt>see</dt><dd><p><a href="https://www.mongodb.com/developer/quickstart/node-transactions/">https://www.mongodb.com/developer/quickstart/node-transactions/</a></p>
+</dd><dt>see</dt><dd><p><a href="https://www.mongodb.com/blog/post/quick-start-nodejs--mongodb--how-to-implement-transactions">https://www.mongodb.com/blog/post/quick-start-nodejs--mongodb--how-to-implement-transactions</a></p>
 </dd></dl></div><h4 class="tsd-type-parameters-title">Type parameters</h4><ul class="tsd-type-parameters"><li><h4>T = <span class="tsd-signature-type">void</span></h4></li></ul><h4 class="tsd-parameters-title">Parameters</h4><ul class="tsd-parameters"><li><h5>fn: <a href="../modules.html#WithTransactionCallback" class="tsd-signature-type" data-tsd-kind="Type alias">WithTransactionCallback</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type" data-tsd-kind="Type parameter">T</span><span class="tsd-signature-symbol">&gt;</span></h5><div class="tsd-comment tsd-typography"><div class="lead">
 <p>callback to run within a transaction</p>
 </div></div></li><li><h5><span class="tsd-flag ts-flagOptional">Optional</span> options: <a href="../interfaces/TransactionOptions.html" class="tsd-signature-type" data-tsd-kind="Interface">TransactionOptions</a></h5><div class="tsd-comment tsd-typography"><div class="lead">

--- a/docs/4.9/classes/ClientSession.html
+++ b/docs/4.9/classes/ClientSession.html
@@ -57,7 +57,7 @@ Any callbacks that do not return a Promise will result in undefined behavior.</p
 <li>Will throw if one of the operations throws or <code>throw</code> statement is used inside the <code>withTransaction</code> callback</li>
 </ul>
 <p>Checkout a descriptive example here:</p>
-</dd><dt>see</dt><dd><p><a href="https://www.mongodb.com/developer/quickstart/node-transactions/">https://www.mongodb.com/developer/quickstart/node-transactions/</a></p>
+</dd><dt>see</dt><dd><p><a href="https://www.mongodb.com/blog/post/quick-start-nodejs--mongodb--how-to-implement-transactions">https://www.mongodb.com/blog/post/quick-start-nodejs--mongodb--how-to-implement-transactions</a></p>
 </dd></dl></div><h4 class="tsd-type-parameters-title">Type parameters</h4><ul class="tsd-type-parameters"><li><h4>T = <span class="tsd-signature-type">void</span></h4></li></ul><h4 class="tsd-parameters-title">Parameters</h4><ul class="tsd-parameters"><li><h5>fn: <a href="../modules.html#WithTransactionCallback" class="tsd-signature-type" data-tsd-kind="Type alias">WithTransactionCallback</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type" data-tsd-kind="Type parameter">T</span><span class="tsd-signature-symbol">&gt;</span></h5><div class="tsd-comment tsd-typography"><div class="lead">
 <p>callback to run within a transaction</p>
 </div></div></li><li><h5><span class="tsd-flag ts-flagOptional">Optional</span> options: <a href="../interfaces/TransactionOptions.html" class="tsd-signature-type" data-tsd-kind="Interface">TransactionOptions</a></h5><div class="tsd-comment tsd-typography"><div class="lead">

--- a/docs/5.0/classes/ClientSession.html
+++ b/docs/5.0/classes/ClientSession.html
@@ -59,7 +59,7 @@ Any callbacks that do not return a Promise will result in undefined behavior.</p
 <li>Will throw if one of the operations throws or <code>throw</code> statement is used inside the <code>withTransaction</code> callback</li>
 </ul>
 <p>Checkout a descriptive example here:</p>
-</dd><dt>see</dt><dd><p><a href="https://www.mongodb.com/developer/quickstart/node-transactions/">https://www.mongodb.com/developer/quickstart/node-transactions/</a></p>
+</dd><dt>see</dt><dd><p><a href="https://www.mongodb.com/blog/post/quick-start-nodejs--mongodb--how-to-implement-transactions">https://www.mongodb.com/blog/post/quick-start-nodejs--mongodb--how-to-implement-transactions</a></p>
 </dd></dl></div><h4 class="tsd-type-parameters-title">Type parameters</h4><ul class="tsd-type-parameters"><li><h4>T = <span class="tsd-signature-type">void</span></h4></li></ul><h4 class="tsd-parameters-title">Parameters</h4><ul class="tsd-parameters"><li><h5>fn: <a href="../modules.html#WithTransactionCallback" class="tsd-signature-type" data-tsd-kind="Type alias">WithTransactionCallback</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type" data-tsd-kind="Type parameter">T</span><span class="tsd-signature-symbol">&gt;</span></h5><div class="tsd-comment tsd-typography"><div class="lead">
 <p>callback to run within a transaction</p>
 </div></div></li><li><h5><span class="tsd-flag ts-flagOptional">Optional</span> options: <a href="../interfaces/TransactionOptions.html" class="tsd-signature-type" data-tsd-kind="Interface">TransactionOptions</a></h5><div class="tsd-comment tsd-typography"><div class="lead">

--- a/docs/5.1/classes/ClientSession.html
+++ b/docs/5.1/classes/ClientSession.html
@@ -59,7 +59,7 @@ Any callbacks that do not return a Promise will result in undefined behavior.</p
 <li>Will throw if one of the operations throws or <code>throw</code> statement is used inside the <code>withTransaction</code> callback</li>
 </ul>
 <p>Checkout a descriptive example here:</p>
-</dd><dt>see</dt><dd><p><a href="https://www.mongodb.com/developer/quickstart/node-transactions/">https://www.mongodb.com/developer/quickstart/node-transactions/</a></p>
+</dd><dt>see</dt><dd><p><a href="https://www.mongodb.com/blog/post/quick-start-nodejs--mongodb--how-to-implement-transactions">https://www.mongodb.com/blog/post/quick-start-nodejs--mongodb--how-to-implement-transactions</a></p>
 </dd></dl></div><h4 class="tsd-type-parameters-title">Type parameters</h4><ul class="tsd-type-parameters"><li><h4>T = <span class="tsd-signature-type">void</span></h4></li></ul><h4 class="tsd-parameters-title">Parameters</h4><ul class="tsd-parameters"><li><h5>fn: <a href="../modules.html#WithTransactionCallback" class="tsd-signature-type" data-tsd-kind="Type alias">WithTransactionCallback</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type" data-tsd-kind="Type parameter">T</span><span class="tsd-signature-symbol">&gt;</span></h5><div class="tsd-comment tsd-typography"><div class="lead">
 <p>callback to run within a transaction</p>
 </div></div></li><li><h5><span class="tsd-flag ts-flagOptional">Optional</span> options: <a href="../interfaces/TransactionOptions.html" class="tsd-signature-type" data-tsd-kind="Interface">TransactionOptions</a></h5><div class="tsd-comment tsd-typography"><div class="lead">

--- a/docs/5.2/classes/ClientSession.html
+++ b/docs/5.2/classes/ClientSession.html
@@ -59,7 +59,7 @@ Any callbacks that do not return a Promise will result in undefined behavior.</p
 <li>Will throw if one of the operations throws or <code>throw</code> statement is used inside the <code>withTransaction</code> callback</li>
 </ul>
 <p>Checkout a descriptive example here:</p>
-</dd><dt>see</dt><dd><p><a href="https://www.mongodb.com/developer/quickstart/node-transactions/">https://www.mongodb.com/developer/quickstart/node-transactions/</a></p>
+</dd><dt>see</dt><dd><p><a href="https://www.mongodb.com/blog/post/quick-start-nodejs--mongodb--how-to-implement-transactions">https://www.mongodb.com/blog/post/quick-start-nodejs--mongodb--how-to-implement-transactions</a></p>
 </dd></dl></div><h4 class="tsd-type-parameters-title">Type parameters</h4><ul class="tsd-type-parameters"><li><h4>T = <span class="tsd-signature-type">void</span></h4></li></ul><h4 class="tsd-parameters-title">Parameters</h4><ul class="tsd-parameters"><li><h5>fn: <a href="../modules.html#WithTransactionCallback" class="tsd-signature-type" data-tsd-kind="Type alias">WithTransactionCallback</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type" data-tsd-kind="Type parameter">T</span><span class="tsd-signature-symbol">&gt;</span></h5><div class="tsd-comment tsd-typography"><div class="lead">
 <p>callback to run within a transaction</p>
 </div></div></li><li><h5><span class="tsd-flag ts-flagOptional">Optional</span> options: <a href="../interfaces/TransactionOptions.html" class="tsd-signature-type" data-tsd-kind="Interface">TransactionOptions</a></h5><div class="tsd-comment tsd-typography"><div class="lead">

--- a/docs/5.3/classes/ClientSession.html
+++ b/docs/5.3/classes/ClientSession.html
@@ -59,7 +59,7 @@ Any callbacks that do not return a Promise will result in undefined behavior.</p
 <li>Will throw if one of the operations throws or <code>throw</code> statement is used inside the <code>withTransaction</code> callback</li>
 </ul>
 <p>Checkout a descriptive example here:</p>
-</dd><dt>see</dt><dd><p><a href="https://www.mongodb.com/developer/quickstart/node-transactions/">https://www.mongodb.com/developer/quickstart/node-transactions/</a></p>
+</dd><dt>see</dt><dd><p><a href="https://www.mongodb.com/blog/post/quick-start-nodejs--mongodb--how-to-implement-transactions">https://www.mongodb.com/blog/post/quick-start-nodejs--mongodb--how-to-implement-transactions</a></p>
 </dd></dl></div><h4 class="tsd-type-parameters-title">Type parameters</h4><ul class="tsd-type-parameters"><li><h4>T = <span class="tsd-signature-type">void</span></h4></li></ul><h4 class="tsd-parameters-title">Parameters</h4><ul class="tsd-parameters"><li><h5>fn: <a href="../modules.html#WithTransactionCallback" class="tsd-signature-type" data-tsd-kind="Type alias">WithTransactionCallback</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type" data-tsd-kind="Type parameter">T</span><span class="tsd-signature-symbol">&gt;</span></h5><div class="tsd-comment tsd-typography"><div class="lead">
 <p>callback to run within a transaction</p>
 </div></div></li><li><h5><span class="tsd-flag ts-flagOptional">Optional</span> options: <a href="../interfaces/TransactionOptions.html" class="tsd-signature-type" data-tsd-kind="Interface">TransactionOptions</a></h5><div class="tsd-comment tsd-typography"><div class="lead">

--- a/docs/5.4/classes/ClientSession.html
+++ b/docs/5.4/classes/ClientSession.html
@@ -59,7 +59,7 @@ Any callbacks that do not return a Promise will result in undefined behavior.</p
 <li>Will throw if one of the operations throws or <code>throw</code> statement is used inside the <code>withTransaction</code> callback</li>
 </ul>
 <p>Checkout a descriptive example here:</p>
-</dd><dt>see</dt><dd><p><a href="https://www.mongodb.com/developer/quickstart/node-transactions/">https://www.mongodb.com/developer/quickstart/node-transactions/</a></p>
+</dd><dt>see</dt><dd><p><a href="https://www.mongodb.com/blog/post/quick-start-nodejs--mongodb--how-to-implement-transactions">https://www.mongodb.com/blog/post/quick-start-nodejs--mongodb--how-to-implement-transactions</a></p>
 </dd></dl></div><h4 class="tsd-type-parameters-title">Type parameters</h4><ul class="tsd-type-parameters"><li><h4>T = <span class="tsd-signature-type">void</span></h4></li></ul><h4 class="tsd-parameters-title">Parameters</h4><ul class="tsd-parameters"><li><h5>fn: <a href="../modules.html#WithTransactionCallback" class="tsd-signature-type" data-tsd-kind="Type alias">WithTransactionCallback</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type" data-tsd-kind="Type parameter">T</span><span class="tsd-signature-symbol">&gt;</span></h5><div class="tsd-comment tsd-typography"><div class="lead">
 <p>callback to run within a transaction</p>
 </div></div></li><li><h5><span class="tsd-flag ts-flagOptional">Optional</span> options: <a href="../interfaces/TransactionOptions.html" class="tsd-signature-type" data-tsd-kind="Interface">TransactionOptions</a></h5><div class="tsd-comment tsd-typography"><div class="lead">

--- a/docs/5.5/classes/ClientSession.html
+++ b/docs/5.5/classes/ClientSession.html
@@ -59,7 +59,7 @@ Any callbacks that do not return a Promise will result in undefined behavior.</p
 <li>Will throw if one of the operations throws or <code>throw</code> statement is used inside the <code>withTransaction</code> callback</li>
 </ul>
 <p>Checkout a descriptive example here:</p>
-</dd><dt>see</dt><dd><p><a href="https://www.mongodb.com/developer/quickstart/node-transactions/">https://www.mongodb.com/developer/quickstart/node-transactions/</a></p>
+</dd><dt>see</dt><dd><p><a href="https://www.mongodb.com/blog/post/quick-start-nodejs--mongodb--how-to-implement-transactions">https://www.mongodb.com/blog/post/quick-start-nodejs--mongodb--how-to-implement-transactions</a></p>
 </dd></dl></div><h4 class="tsd-type-parameters-title">Type parameters</h4><ul class="tsd-type-parameters"><li><h4>T = <span class="tsd-signature-type">void</span></h4></li></ul><h4 class="tsd-parameters-title">Parameters</h4><ul class="tsd-parameters"><li><h5>fn: <a href="../modules.html#WithTransactionCallback" class="tsd-signature-type" data-tsd-kind="Type alias">WithTransactionCallback</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type" data-tsd-kind="Type parameter">T</span><span class="tsd-signature-symbol">&gt;</span></h5><div class="tsd-comment tsd-typography"><div class="lead">
 <p>callback to run within a transaction</p>
 </div></div></li><li><h5><span class="tsd-flag ts-flagOptional">Optional</span> options: <a href="../interfaces/TransactionOptions.html" class="tsd-signature-type" data-tsd-kind="Interface">TransactionOptions</a></h5><div class="tsd-comment tsd-typography"><div class="lead">

--- a/docs/5.6/classes/ClientSession.html
+++ b/docs/5.6/classes/ClientSession.html
@@ -59,7 +59,7 @@ Any callbacks that do not return a Promise will result in undefined behavior.</p
 <li>Will throw if one of the operations throws or <code>throw</code> statement is used inside the <code>withTransaction</code> callback</li>
 </ul>
 <p>Checkout a descriptive example here:</p>
-</dd><dt>see</dt><dd><p><a href="https://www.mongodb.com/developer/quickstart/node-transactions/">https://www.mongodb.com/developer/quickstart/node-transactions/</a></p>
+</dd><dt>see</dt><dd><p><a href="https://www.mongodb.com/blog/post/quick-start-nodejs--mongodb--how-to-implement-transactions">https://www.mongodb.com/blog/post/quick-start-nodejs--mongodb--how-to-implement-transactions</a></p>
 </dd></dl></div><h4 class="tsd-type-parameters-title">Type parameters</h4><ul class="tsd-type-parameters"><li><h4>T = <span class="tsd-signature-type">void</span></h4></li></ul><h4 class="tsd-parameters-title">Parameters</h4><ul class="tsd-parameters"><li><h5>fn: <a href="../modules.html#WithTransactionCallback" class="tsd-signature-type" data-tsd-kind="Type alias">WithTransactionCallback</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type" data-tsd-kind="Type parameter">T</span><span class="tsd-signature-symbol">&gt;</span></h5><div class="tsd-comment tsd-typography"><div class="lead">
 <p>callback to run within a transaction</p>
 </div></div></li><li><h5><span class="tsd-flag ts-flagOptional">Optional</span> options: <a href="../interfaces/TransactionOptions.html" class="tsd-signature-type" data-tsd-kind="Interface">TransactionOptions</a></h5><div class="tsd-comment tsd-typography"><div class="lead">

--- a/docs/5.7/classes/ClientSession.html
+++ b/docs/5.7/classes/ClientSession.html
@@ -960,7 +960,7 @@ Any callbacks that do not return a Promise will result in undefined behavior.</p
 </ul>
 <p>Checkout a descriptive example here:</p>
 
-<h4>See</h4><p><a href="https://www.mongodb.com/developer/quickstart/node-transactions/">https://www.mongodb.com/developer/quickstart/node-transactions/</a></p>
+<h4>See</h4><p><a href="https://www.mongodb.com/blog/post/quick-start-nodejs--mongodb--how-to-implement-transactions">https://www.mongodb.com/blog/post/quick-start-nodejs--mongodb--how-to-implement-transactions</a></p>
 </div><aside class="tsd-sources">
 <ul>
 <li>Defined in <a href="https://github.com/mongodb/node-mongodb-native/blob/v5.7.0/src/sessions.ts#L455">src/sessions.ts:455</a></li></ul></aside></li></ul></section>

--- a/docs/Next/classes/ClientSession.html
+++ b/docs/Next/classes/ClientSession.html
@@ -960,7 +960,7 @@ Any callbacks that do not return a Promise will result in undefined behavior.</p
 </ul>
 <p>Checkout a descriptive example here:</p>
 
-<h4>See</h4><p><a href="https://www.mongodb.com/developer/quickstart/node-transactions/">https://www.mongodb.com/developer/quickstart/node-transactions/</a></p>
+<h4>See</h4><p><a href="https://www.mongodb.com/blog/post/quick-start-nodejs--mongodb--how-to-implement-transactions">https://www.mongodb.com/blog/post/quick-start-nodejs--mongodb--how-to-implement-transactions</a></p>
 </div><aside class="tsd-sources">
 <ul>
 <li>Defined in <a href="https://github.com/mongodb/node-mongodb-native/blob/main/src/sessions.ts#L454">src/sessions.ts:454</a></li></ul></aside></li></ul></section>

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -444,7 +444,7 @@ export class ClientSession extends TypedEventEmitter<ClientSessionEvents> {
    * - May be called multiple times if the driver needs to attempt to retry the operations.
    *
    * Checkout a descriptive example here:
-   * @see https://www.mongodb.com/developer/quickstart/node-transactions/
+   * @see https://www.mongodb.com/blog/post/quick-start-nodejs--mongodb--how-to-implement-transactions
    *
    * @param fn - callback to run within a transaction
    * @param options - optional settings for the transaction


### PR DESCRIPTION
### Description

Previous link (https://www.mongodb.com/developer/quickstart/node-transactions/) returns a 404.

#### What is changing?

Based on the last valid [web archive](https://web.archive.org/web/20220516091725/https://www.mongodb.com/developer/quickstart/node-transactions/) of this page it appears this [MongoDB blog post](https://www.mongodb.com/blog/post/quick-start-nodejs--mongodb--how-to-implement-transactions) contains the same content.

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
