### PR TITLE
fix(NODE-5536): remove credentials from ConnectionPoolCreatedEvent options

### DIFF
--- a/src/cmap/connection_pool_events.ts
+++ b/src/cmap/connection_pool_events.ts
@@ -28,12 +28,17 @@ export class ConnectionPoolMonitoringEvent {
  */
 export class ConnectionPoolCreatedEvent extends ConnectionPoolMonitoringEvent {
   /** The options used to create this connection pool */
-  options?: ConnectionPoolOptions;
+  options: Omit<ConnectionPoolOptions, 'credentials'> & { credentials?: Record<never, never> };
 
   /** @internal */
   constructor(pool: ConnectionPool) {
     super(pool);
-    this.options = pool.options;
+    if (pool.options.credentials != null) {
+      // Intentionally remove credentials: NODE-5460
+      this.options = { ...pool.options, credentials: {} };
+    } else {
+      this.options = pool.options;
+    }
   }
 }
 

--- a/src/operations/operation.ts
+++ b/src/operations/operation.ts
@@ -19,10 +19,6 @@ export const Aspect = {
 /** @public */
 export type Hint = string | Document;
 
-export interface OperationConstructor extends Function {
-  aspects?: Set<symbol>;
-}
-
 /** @public */
 export interface OperationOptions extends BSONSerializeOptions {
   /** Specify ClientSession for this command */
@@ -122,7 +118,7 @@ export abstract class AbstractOperation<TResult = any> {
 }
 
 export function defineAspects(
-  operation: OperationConstructor,
+  operation: { new (...args: any[]): any },
   aspects: symbol | symbol[] | Set<symbol>
 ): Set<symbol> {
   if (!Array.isArray(aspects) && !(aspects instanceof Set)) {

--- a/src/operations/operation.ts
+++ b/src/operations/operation.ts
@@ -92,7 +92,7 @@ export abstract class AbstractOperation<TResult = any> {
   ): void;
 
   hasAspect(aspect: symbol): boolean {
-    const ctor = this.constructor as OperationConstructor;
+    const ctor = this.constructor as { aspects?: Set<symbol> };
     if (ctor.aspects == null) {
       return false;
     }

--- a/test/integration/connection-monitoring-and-pooling/connection_monitoring_and_pooling.test.ts
+++ b/test/integration/connection-monitoring-and-pooling/connection_monitoring_and_pooling.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { once } from 'events';
 
-import { MongoClient, MongoCredentials } from '../../../src';
+import { MongoClient } from '../../../src';
 import { loadSpecTests } from '../../spec';
 import { CmapTest, runCmapTestSuite } from '../../tools/cmap_spec_runner';
 

--- a/test/integration/connection-monitoring-and-pooling/connection_monitoring_and_pooling.test.ts
+++ b/test/integration/connection-monitoring-and-pooling/connection_monitoring_and_pooling.test.ts
@@ -1,3 +1,7 @@
+import { expect } from 'chai';
+import { once } from 'events';
+
+import { MongoClient } from '../../../src';
 import { loadSpecTests } from '../../spec';
 import { CmapTest, runCmapTestSuite } from '../../tools/cmap_spec_runner';
 
@@ -15,5 +19,38 @@ describe('Connection Monitoring and Pooling (Node Driver)', function () {
         skipReason: 'cannot run against load balancer due to reliance on pool.clear() command'
       }
     ]
+  });
+
+  describe('ConnectionPoolCreatedEvent', () => {
+    let client: MongoClient;
+    beforeEach(async function () {
+      client = this.configuration.newClient();
+    });
+
+    afterEach(async function () {
+      await client.close();
+    });
+
+    describe('constructor()', () => {
+      it('when auth is enabled redacts credentials from options', {
+        metadata: { requires: { auth: 'enabled' } },
+        async test() {
+          const poolCreated = once(client, 'connectionPoolCreated');
+          await client.connect();
+          const [event] = await poolCreated;
+          expect(event).to.have.deep.nested.property('options.credentials', {});
+        }
+      });
+
+      it('when auth is disabled does not add a credentials property to options', {
+        metadata: { requires: { auth: 'disabled' } },
+        async test() {
+          const poolCreated = once(client, 'connectionPoolCreated');
+          await client.connect();
+          const [event] = await poolCreated;
+          expect(event).to.not.have.nested.property('options.credentials');
+        }
+      });
+    });
   });
 });

--- a/test/integration/connection-monitoring-and-pooling/connection_monitoring_and_pooling.test.ts
+++ b/test/integration/connection-monitoring-and-pooling/connection_monitoring_and_pooling.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { once } from 'events';
 
-import { MongoClient } from '../../../src';
+import { MongoClient, MongoCredentials } from '../../../src';
 import { loadSpecTests } from '../../spec';
 import { CmapTest, runCmapTestSuite } from '../../tools/cmap_spec_runner';
 
@@ -39,6 +39,18 @@ describe('Connection Monitoring and Pooling (Node Driver)', function () {
           await client.connect();
           const [event] = await poolCreated;
           expect(event).to.have.deep.nested.property('options.credentials', {});
+
+          const poolOptions = Array.from(client.topology?.s.servers.values() ?? []).map(
+            s => s.s.pool.options
+          );
+          expect(poolOptions).to.have.length.of.at.least(1);
+
+          for (const { credentials = {} } of poolOptions) {
+            expect(
+              Object.keys(credentials),
+              'pool.options.credentials must exist and have keys'
+            ).to.not.equal(0);
+          }
         }
       });
 


### PR DESCRIPTION
### Description

#### What is changing?

- Omit credentials from ConnectionPoolCreatedEvent if they exist

##### Is there new documentation needed for these changes?

No

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Remove credential availability on `ConnectionPoolCreatedEvent`

In order to avoid mistakenly printing credentials the `ConnectionPoolCreatedEvent` will replace the credentials option with an empty object. The credentials are still accessble via MongoClient options: `client.options.credentials`.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
