### PR TITLE
fix(NODE-5537): remove credentials from ConnectionPoolCreatedEvent options

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -1,4 +1,4 @@
-import { OneOrMore } from './src/mongo_types';
+import { type OneOrMore } from './src/mongo_types';
 import type { TestConfiguration } from './test/tools/runner/config';
 
 declare global {

--- a/src/cmap/connection_pool_events.ts
+++ b/src/cmap/connection_pool_events.ts
@@ -54,14 +54,19 @@ export abstract class ConnectionPoolMonitoringEvent {
  */
 export class ConnectionPoolCreatedEvent extends ConnectionPoolMonitoringEvent {
   /** The options used to create this connection pool */
-  options?: ConnectionPoolOptions;
+  options: Omit<ConnectionPoolOptions, 'credentials'> & { credentials?: Record<never, never> };
   /** @internal */
   name = CONNECTION_POOL_CREATED;
 
   /** @internal */
   constructor(pool: ConnectionPool) {
     super(pool);
-    this.options = pool.options;
+    if (pool.options.credentials != null) {
+      // Intentionally remove credentials: NODE-5460
+      this.options = { ...pool.options, credentials: {} };
+    } else {
+      this.options = pool.options;
+    }
   }
 }
 

--- a/test/integration/connection-monitoring-and-pooling/connection_monitoring_and_pooling.test.ts
+++ b/test/integration/connection-monitoring-and-pooling/connection_monitoring_and_pooling.test.ts
@@ -1,3 +1,7 @@
+import { expect } from 'chai';
+import { once } from 'events';
+
+import { type MongoClient } from '../../mongodb';
 import { loadSpecTests } from '../../spec';
 import { type CmapTest, runCmapTestSuite } from '../../tools/cmap_spec_runner';
 import { runUnifiedSuite } from '../../tools/unified-spec-runner/runner';
@@ -23,4 +27,37 @@ describe('Connection Monitoring and Pooling (Node Driver)', function () {
     '../integration/connection-monitoring-and-pooling/unified-cmap-node-specs'
   );
   runUnifiedSuite(unifiedTests);
+
+  describe('ConnectionPoolCreatedEvent', () => {
+    let client: MongoClient;
+    beforeEach(async function () {
+      client = this.configuration.newClient();
+    });
+
+    afterEach(async function () {
+      await client.close();
+    });
+
+    describe('constructor()', () => {
+      it('when auth is enabled redacts credentials from options', {
+        metadata: { requires: { auth: 'enabled' } },
+        async test() {
+          const poolCreated = once(client, 'connectionPoolCreated');
+          await client.connect();
+          const [event] = await poolCreated;
+          expect(event).to.have.deep.nested.property('options.credentials', {});
+        }
+      });
+
+      it('when auth is disabled does not add a credentials property to options', {
+        metadata: { requires: { auth: 'disabled' } },
+        async test() {
+          const poolCreated = once(client, 'connectionPoolCreated');
+          await client.connect();
+          const [event] = await poolCreated;
+          expect(event).to.not.have.nested.property('options.credentials');
+        }
+      });
+    });
+  });
 });


### PR DESCRIPTION
### Description

#### What is changing?

- Omit credentials from ConnectionPoolCreatedEvent if they exist

##### Is there new documentation needed for these changes?

No

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Remove credential availability on `ConnectionPoolCreatedEvent`

In order to avoid mistakenly printing credentials the `ConnectionPoolCreatedEvent` will replace the credentials option with an empty object. The credentials are still accessble via MongoClient options: `client.options.credentials`.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
