### PR TITLE
docs(NODE-5540): Fix MDB University links in GH pages

### DIFF
--- a/etc/docs/template/layouts/index.html
+++ b/etc/docs/template/layouts/index.html
@@ -25,10 +25,13 @@
         {{ partial "features.html" . }}
 
         {{ partial "quickStart.html" . }}
+        
+        <hr/>
+        
+        {{ partial "mongodbUniversity.html" . }}
       </div>
       <div class="col-md-4">
-        {{ partial "releases.html" . }}
-        {{ partial "mongodbUniversity.html" . }}
+        {{ partial "releases.html" . }}        
      </div>
     </div>
   </div>

--- a/etc/docs/template/layouts/partials/mongodbUniversity.html
+++ b/etc/docs/template/layouts/partials/mongodbUniversity.html
@@ -1,10 +1,15 @@
 <section id="universityPromo">
-<h3><span>MongoDB University</span></h3>
-
-<h4>M101JS: MongoDB for Node.JS Developers</h4>
-<p>Learn everything you need to know to get started building a MongoDB-based app. From basic installation, JSON, schema design, querying, insertion of data, indexing and working with the Node.JS driver.
-</p>
-<p>
-<a href="https://university.mongodb.com/courses/M101JS/about" target="_blank" class="btn btn-success btn-mongo">Learn More</a>
-</p>
+  <h3><span>MongoDB University</span></h3>
+  <br/>
+  <h4>Using MongoDB with Node.js</h4>
+  <p>This course guides you through everything you need to get started with MongoDB in your NodeJS applications. In this course, you’ll get an overview of the official MongoDB NodeJS/Javascript driver and learn how to install it by using npm. You’ll learn how to connect your application, perform basic CRUD operations, troubleshoot, and then build aggregations.</p>
+  <p>
+    <a href="https://learn.mongodb.com/learning-paths/using-mongodb-with-nodejs" target="_blank" class="btn btn-success btn-mongo">Learn More</a>
+  </p>
+  <br/>
+  <h4>MongoDB Node.js Developer Path</h4>
+  <p>This learning path contains a series of courses to teach you MongoDB skills. In this path, you’ll learn the basics of building modern applications with Node.JS, using MongoDB as your database.</p>
+  <p>
+    <a href="https://learn.mongodb.com/learning-paths/mongodb-nodejs-developer-path" target="_blank" class="btn btn-success btn-mongo">Learn More</a>
+  </p>
 </section>


### PR DESCRIPTION
### Description

M101JS no longer exists. Updated templates to link to new courses for Node.js developers

#### What is changing?

- fixed links
- moved MDB University section to below the _Quickstart_ (from below the _Releases_ list)

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
