### PR TITLE
feat(NODE-5399): use mongodb-js/saslprep instead of saslprep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "@types/kerberos": "^1.1.2",
         "@types/mocha": "^10.0.1",
         "@types/node": "^20.1.0",
-        "@types/saslprep": "^1.0.1",
         "@types/semver": "^7.5.0",
         "@types/sinon": "^10.0.14",
         "@types/sinon-chai": "^3.2.9",
@@ -65,7 +64,7 @@
         "node": ">=14.20.1"
       },
       "optionalDependencies": {
-        "saslprep": "^1.0.3"
+        "@mongodb-js/saslprep": "^1.1.0"
       },
       "peerDependencies": {
         "@aws-sdk/credential-providers": "^3.201.0",
@@ -2015,6 +2014,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/@mongodb-js/saslprep": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.0.tgz",
+      "integrity": "sha512-Xfijy7HvfzzqiOAhAepF4SGN5e9leLkMvg/OPOF97XemjfVCYN/oWa75wnkc6mltMSTwY+XlbhWgUOJmkFspSw==",
+      "optional": true,
+      "dependencies": {
+        "sparse-bitfield": "^3.0.3"
+      }
+    },
     "node_modules/@mongodb-js/zstd": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@mongodb-js/zstd/-/zstd-1.1.0.tgz",
@@ -2802,12 +2810,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
-      "dev": true
-    },
-    "node_modules/@types/saslprep": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@types/saslprep/-/saslprep-1.0.1.tgz",
-      "integrity": "sha512-JHSoEmJi4Gav2Y53dIGdvW2w2tr8iymXWhI/qNiKx9/eSgREsJkn7gJK22ldVXuisQXreSyXqogtzRtT0ls8Lg==",
       "dev": true
     },
     "node_modules/@types/semver": {
@@ -7423,6 +7425,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
       "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "sparse-bitfield": "^3.0.3"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "socks": "^2.7.1"
   },
   "optionalDependencies": {
-    "saslprep": "^1.0.3"
+    "@mongodb-js/saslprep": "^1.1.0"
   },
   "peerDependencies": {
     "@aws-sdk/credential-providers": "^3.201.0",
@@ -69,7 +69,6 @@
     "@types/kerberos": "^1.1.2",
     "@types/mocha": "^10.0.1",
     "@types/node": "^20.1.0",
-    "@types/saslprep": "^1.0.1",
     "@types/semver": "^7.5.0",
     "@types/sinon": "^10.0.14",
     "@types/sinon-chai": "^3.2.9",

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -126,13 +126,14 @@ export function getSnappy(): SnappyLib | { kModuleError: MongoMissingDependencyE
   }
 }
 
-export let saslprep: typeof import('saslprep') | { kModuleError: MongoMissingDependencyError } =
-  makeErrorModule(
-    new MongoMissingDependencyError(
-      'Optional module `saslprep` not found.' +
-        ' Please install it to enable Stringprep Profile for User Names and Passwords'
-    )
-  );
+export let saslprep:
+  | typeof import('@mongodb-js/saslprep')
+  | { kModuleError: MongoMissingDependencyError } = makeErrorModule(
+  new MongoMissingDependencyError(
+    'Optional module `saslprep` not found.' +
+      ' Please install it to enable Stringprep Profile for User Names and Passwords'
+  )
+);
 
 try {
   // Ensure you always wrap an optional require in the try block NODE-3199


### PR DESCRIPTION
### Description

#### What is changing?

`@mongodb-js/saslprep` has replaced `saslprep` as the optional dependency our driver users on for SCRAM-SHA-256 authentication.

All existing passing tests are passing.  The failures for FLE are unrelated (they also are failing on `5.x`).

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

### `mongodb-js/saslprep` is now installed by default

Until this release, the driver included the `saslprep` package as an optional dependency for SCRAM-SHA-256 authentication.  `saslprep` breaks when bundled with webpack because it attempted to read a file relative to the package location and consequently the driver would throw errors when using SCRAM-SHA-256 if it were bundled.

The driver now depends on `mongodb-js/saslprep`, a fork of `saslprep` that can be bundled with webpack because it includes the necessary saslprep data in memory upon loading. This will be installed by default but will only be used if SCRAM-SHA-256 authentication is used.  

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
