### PR TITLE
feat(NODE-5398): use mongodb-js/saslprep instead of saslprep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,7 @@
       },
       "optionalDependencies": {
         "@aws-sdk/credential-providers": "^3.186.0",
-        "saslprep": "^1.0.3"
+        "@mongodb-js/saslprep": "^1.1.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1930,6 +1930,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@mongodb-js/saslprep": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.0.tgz",
+      "integrity": "sha512-Xfijy7HvfzzqiOAhAepF4SGN5e9leLkMvg/OPOF97XemjfVCYN/oWa75wnkc6mltMSTwY+XlbhWgUOJmkFspSw==",
+      "optional": true,
+      "dependencies": {
+        "sparse-bitfield": "^3.0.3"
       }
     },
     "node_modules/@mongodb-js/zstd": {
@@ -8228,18 +8237,6 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
-    },
-    "node_modules/saslprep": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
-      "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
-      "optional": true,
-      "dependencies": {
-        "sparse-bitfield": "^3.0.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/semver": {
       "version": "7.5.0",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
   "homepage": "https://github.com/mongodb/node-mongodb-native",
   "optionalDependencies": {
     "@aws-sdk/credential-providers": "^3.186.0",
-    "saslprep": "^1.0.3"
+    "@mongodb-js/saslprep": "^1.1.0"
   },
   "scripts": {
     "build:evergreen": "node .evergreen/generate_evergreen_tasks.js",

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -133,13 +133,14 @@ try {
   } catch {} // eslint-disable-line
 } catch {} // eslint-disable-line
 
-export let saslprep: typeof import('saslprep') | { kModuleError: MongoMissingDependencyError } =
-  makeErrorModule(
-    new MongoMissingDependencyError(
-      'Optional module `saslprep` not found.' +
-        ' Please install it to enable Stringprep Profile for User Names and Passwords'
-    )
-  );
+export let saslprep:
+  | typeof import('@mongodb-js/saslprep')
+  | { kModuleError: MongoMissingDependencyError } = makeErrorModule(
+  new MongoMissingDependencyError(
+    'Optional module `@mongodb-js/saslprep` not found.' +
+      ' Please install it to enable Stringprep Profile for User Names and Passwords'
+  )
+);
 
 try {
   // Ensure you always wrap an optional require in the try block NODE-3199


### PR DESCRIPTION
### Description

#### What is changing?

`@mongodb-js/saslprep` has replaced `saslprep` as the optional dependency our driver users on for SCRAM-SHA-256 authentication.

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### `mongodb-js/saslprep` is now installed by default

Until v6, the driver included the `saslprep` package as an optional dependency for SCRAM-SHA-256 authentication.  `saslprep` breaks when bundled with webpack because it attempted to read a file relative to the package location and consequently the driver would throw errors when using SCRAM-SHA-256 if it were bundled.

The driver now depends on `mongodb-js/saslprep`, a fork of `saslprep` that can be bundled with webpack because it includes the necessary saslprep data in memory upon loading. This will be installed by default but will only be used if SCRAM-SHA-256 authentication is used.  

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
