### PR TITLE
feat(NODE-5465,NODE-5538): lower `@aws-sdk/credential-providers` version to 3.188.0 and `zstd` to `^1.0.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
       },
       "peerDependencies": {
         "@aws-sdk/credential-providers": "^3.188.0",
-        "@mongodb-js/zstd": "^1.1.0",
+        "@mongodb-js/zstd": "^1.0.0",
         "kerberos": "^1.0.0 || ^2.0.0",
         "mongodb-client-encryption": ">=2.3.0 <3",
         "snappy": "^7.2.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
         "@mongodb-js/saslprep": "^1.1.0"
       },
       "peerDependencies": {
-        "@aws-sdk/credential-providers": "^3.201.0",
+        "@aws-sdk/credential-providers": "^3.188.0",
         "@mongodb-js/zstd": "^1.1.0",
         "kerberos": "^1.0.0 || ^2.0.0",
         "mongodb-client-encryption": ">=2.3.0 <3",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "peerDependencies": {
     "@aws-sdk/credential-providers": "^3.188.0",
-    "@mongodb-js/zstd": "^1.1.0",
+    "@mongodb-js/zstd": "^1.0.0",
     "kerberos": "^1.0.0 || ^2.0.0",
     "mongodb-client-encryption": ">=2.3.0 <3",
     "snappy": "^7.2.2"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@mongodb-js/saslprep": "^1.1.0"
   },
   "peerDependencies": {
-    "@aws-sdk/credential-providers": "^3.201.0",
+    "@aws-sdk/credential-providers": "^3.188.0",
     "@mongodb-js/zstd": "^1.1.0",
     "kerberos": "^1.0.0 || ^2.0.0",
     "mongodb-client-encryption": ">=2.3.0 <3",


### PR DESCRIPTION
### Description

#### What is changing?

`@aws-sdk/credential-providers` has been lowered to `^3.188.0` to align with AWS Lambda's version.

`zstd` has been lowered to `1.0.0`. 

##### Is there new documentation needed for these changes?

No.

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

#### `@aws-sdk/credential-providers` peer dependency version has been lowered to `3.188.0`

The Node18 runtime on AWS Lambda comes with version `@aws-sdk/credential-providers@3.188.0` installed.  Our peer dependency version of 3.201.0 caused installation issues for users who wanted to use the driver with aws authentication on Lambda.

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
