### PR TITLE
chore: update release automation scripts 5.x

### DIFF
--- a/.github/scripts/highlights.mjs
+++ b/.github/scripts/highlights.mjs
@@ -70,7 +70,10 @@ async function pullRequestHighlights(prs) {
   if (!highlights.length) return '';
 
   highlights.unshift('## Release Notes\n\n');
-  return highlights.join('\n\n');
+
+  const highlight = highlights.join('\n\n');
+  console.log(`Total highlight is ${highlight.length} characters long`);
+  return highlight;
 }
 
 console.log('List of PRs to collect highlights from:', prs);

--- a/.github/scripts/pr_list.mjs
+++ b/.github/scripts/pr_list.mjs
@@ -13,10 +13,14 @@ const historyFilePath = path.join(__dirname, '..', '..', 'HISTORY.md');
  */
 function parsePRList(history) {
   const prRegexp = /node-mongodb-native\/issues\/(?<prNum>\d+)\)/iu;
-  return history
-    .split('\n')
-    .map(line => prRegexp.exec(line)?.groups?.prNum ?? '')
-    .filter(prNum => prNum !== '');
+  return Array.from(
+    new Set(
+      history
+        .split('\n')
+        .map(line => prRegexp.exec(line)?.groups?.prNum ?? '')
+        .filter(prNum => prNum !== '')
+    )
+  );
 }
 
 const historyContents = await fs.readFile(historyFilePath, { encoding: 'utf8' });

--- a/.github/workflows/release-4.x.yml
+++ b/.github/workflows/release-4.x.yml
@@ -6,6 +6,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 name: release-4x
 

--- a/.github/workflows/release-5.x.yml
+++ b/.github/workflows/release-5.x.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: [main]
+    branches: [5.x]
   workflow_dispatch: {}
 
 permissions:
@@ -8,7 +8,7 @@ permissions:
   pull-requests: write
   id-token: write
 
-name: release
+name: release-5x
 
 jobs:
   release-please:
@@ -24,7 +24,7 @@ jobs:
           pull-request-title-pattern: 'chore${scope}: release ${version} [skip-ci]'
           pull-request-header: 'Please run the release_notes action before releasing to generate release highlights'
           changelog-path: HISTORY.md
-          default-branch: main
+          default-branch: 5.x
 
       # If release-please created a release, publish to npm
       - if: ${{ steps.release.outputs.release_created }}
@@ -33,6 +33,6 @@ jobs:
         name: actions/setup
         uses: ./.github/actions/setup
       - if: ${{ steps.release.outputs.release_created }}
-        run: npm publish --provenance
+        run: npm publish --provenance --tag=5x
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -8,13 +8,14 @@ on:
         required: true
         type: string
 
+permissions:
+  id-token: write
+
 name: release-alpha
 
 jobs:
   release-alpha:
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
     steps:
       - shell: bash
         run: |

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -11,13 +11,14 @@ on:
   # As long as the commit hash has changed on main a release will be published
   workflow_dispatch: {}
 
+permissions:
+  id-token: write
+
 name: release-nightly
 
 jobs:
   release-nightly:
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
     steps:
       - uses: actions/checkout@v3
       - name: actions/setup

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@microsoft/api-extractor": "^7.35.1",
         "@microsoft/tsdoc-config": "^0.16.2",
         "@mongodb-js/zstd": "^1.1.0",
-        "@octokit/core": "^4.2.1",
+        "@octokit/core": "^4.2.4",
         "@types/chai": "^4.3.5",
         "@types/chai-subset": "^1.3.3",
         "@types/express": "^4.17.17",
@@ -2406,9 +2406,9 @@
       }
     },
     "node_modules/@octokit/core": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.2.1.tgz",
-      "integrity": "sha512-tEDxFx8E38zF3gT7sSMDrT1tGumDgsw5yPG6BBh/X+5ClIQfMH/Yqocxz1PnHx6CHyF6pxmovUTOfZAUvQ0Lvw==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.2.4.tgz",
+      "integrity": "sha512-rYKilwgzQ7/imScn3M9/pFfUf4I1AZEH3KhyJmtPdE2zfaXAn2mFfUy4FbKewzc2We5y/LlKLj36fWJLKC2SIQ==",
       "dev": true,
       "dependencies": {
         "@octokit/auth-token": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@microsoft/api-extractor": "^7.35.1",
     "@microsoft/tsdoc-config": "^0.16.2",
     "@mongodb-js/zstd": "^1.1.0",
-    "@octokit/core": "^4.2.1",
+    "@octokit/core": "^4.2.4",
     "@types/chai": "^4.3.5",
     "@types/chai-subset": "^1.3.3",
     "@types/express": "^4.17.17",


### PR DESCRIPTION
### Description

#### What is changing?

- Sync scripts from main

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->


<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
