### PR TITLE
chore: update release automation scripts 4.x

### DIFF
--- a/.github/scripts/highlights.mjs
+++ b/.github/scripts/highlights.mjs
@@ -70,7 +70,10 @@ async function pullRequestHighlights(prs) {
   if (!highlights.length) return '';
 
   highlights.unshift('## Release Notes\n\n');
-  return highlights.join('\n\n');
+
+  const highlight = highlights.join('\n\n');
+  console.log(`Total highlight is ${highlight.length} characters long`);
+  return highlight;
 }
 
 console.log('List of PRs to collect highlights from:', prs);

--- a/.github/scripts/pr_list.mjs
+++ b/.github/scripts/pr_list.mjs
@@ -13,10 +13,14 @@ const historyFilePath = path.join(__dirname, '..', '..', 'HISTORY.md');
  */
 function parsePRList(history) {
   const prRegexp = /node-mongodb-native\/issues\/(?<prNum>\d+)\)/iu;
-  return history
-    .split('\n')
-    .map(line => prRegexp.exec(line)?.groups?.prNum ?? '')
-    .filter(prNum => prNum !== '');
+  return Array.from(
+    new Set(
+      history
+        .split('\n')
+        .map(line => prRegexp.exec(line)?.groups?.prNum ?? '')
+        .filter(prNum => prNum !== '')
+    )
+  );
 }
 
 const historyContents = await fs.readFile(historyFilePath, { encoding: 'utf8' });

--- a/.github/workflows/release-4.x.yml
+++ b/.github/workflows/release-4.x.yml
@@ -1,0 +1,38 @@
+on:
+  push:
+    branches: [4.x]
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write
+
+name: release-4x
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - id: release
+        uses: google-github-actions/release-please-action@v3
+        with:
+          release-type: node
+          package-name: mongodb
+          # Example: chore(main): release 5.7.0 [skip-ci]
+          # ${scope} - parenthesis included, base branch name
+          pull-request-title-pattern: 'chore${scope}: release ${version} [skip-ci]'
+          pull-request-header: 'Please run the release_notes action before releasing to generate release highlights'
+          changelog-path: HISTORY.md
+          default-branch: 4.x
+
+      # If release-please created a release, publish to npm
+      - if: ${{ steps.release.outputs.release_created }}
+        uses: actions/checkout@v3
+      - if: ${{ steps.release.outputs.release_created }}
+        name: actions/setup
+        uses: ./.github/actions/setup
+      - if: ${{ steps.release.outputs.release_created }}
+        run: npm publish --provenance --tag=4x
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release_notes.yml
+++ b/.github/workflows/release_notes.yml
@@ -1,0 +1,48 @@
+name: release_notes
+
+on:
+  workflow_dispatch:
+    inputs:
+      releasePr:
+        description: 'Enter release PR number'
+        required: true
+        type: number
+
+jobs:
+  release_notes:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: actions/setup
+        uses: ./.github/actions/setup
+
+      # See: https://github.com/googleapis/release-please/issues/1274
+
+      # Get the PRs that are in this release
+      # Outputs a list of comma seperated PR numbers, parsed from HISTORY.md
+      - id: pr_list
+        run: node .github/scripts/pr_list.mjs
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      # From the list of PRs, gather the highlight sections of the PR body
+      # output JSON with "highlights" key (to preserve newlines)
+      - id: highlights
+        run: node .github/scripts/highlights.mjs
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PR_LIST: ${{ steps.pr_list.outputs.pr_list }}
+
+      # The combined output is available
+      - id: release_notes
+        run: node .github/scripts/release_notes.mjs
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          HIGHLIGHTS: ${{ steps.highlights.outputs.highlights }}
+
+      # Update the release PR body
+      - run: gh pr edit ${{ inputs.releasePr }} --body-file ${{ steps.release_notes.outputs.release_notes_path }}
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
### Description

#### What is changing?

- sync scripts

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

4.x needs a copy of the release_notes workflow in order to manually dispatch from the release PR's branch.

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
