### PR TITLE
docs: fix cutoff sentence on CommandStartedEvent

### DIFF
--- a/src/cmap/command_monitoring_events.ts
+++ b/src/cmap/command_monitoring_events.ts
@@ -11,7 +11,7 @@ import { Msg, type WriteProtocolMessageType } from './commands';
 import type { Connection } from './connection';
 
 /**
- * An event indicating the start of a given
+ * An event indicating the start of a given command
  * @public
  * @category Event
  */


### PR DESCRIPTION
### Description
Fix docs on CommandStartedEvent