### PR TITLE
ci(NODE-5125): fix flaky case 14 prose test

### DIFF
--- a/test/integration/client-side-encryption/client_side_encryption.prose.14.decryption_events.test.ts
+++ b/test/integration/client-side-encryption/client_side_encryption.prose.14.decryption_events.test.ts
@@ -78,9 +78,9 @@ describe('14. Decryption Events', metadata, function () {
     // Copy ``ciphertext`` into a variable named ``malformedCiphertext``. Change the
     // last byte to a different value. This will produce an invalid HMAC tag.
     const buffer = Buffer.from(cipherText.buffer);
-    const lastByte = buffer.readInt8(buffer.length - 1);
+    const lastByte = buffer.readUInt8(buffer.length - 1);
     const replacementByte = lastByte === 0 ? 1 : 0;
-    buffer.writeUint8(replacementByte, buffer.length - 1);
+    buffer.writeUInt8(replacementByte, buffer.length - 1);
     malformedCiphertext = new Binary(buffer, 6);
 
     // Create a MongoClient named ``encryptedClient`` with these ``AutoEncryptionOpts``:


### PR DESCRIPTION
### Description

#### What is changing?

We missed a [spec commit](https://github.com/mongodb/specifications/commit/e3a59909621afa5d8b7795c19a0ba204f6b20b13) that fixed FLE prose test 14.  

This PR updates the test setup to set the last byte of the malformed ciphertext to a different value instead of always setting it to 0 because sometimes the HMAC tag happens to end in 0.

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
