### PR TITLE
feat(NODE-5566): add ability to provide CRL file via tlsCRLFile

### DIFF
--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -636,8 +636,6 @@ functions:
           export PROJECT_DIRECTORY="$(pwd)"
           export NODE_LTS_VERSION=${NODE_LTS_VERSION}
           export DRIVERS_TOOLS="${DRIVERS_TOOLS}"
-          export SSL_CA_FILE="${SSL_CA_FILE}"
-          export SSL_KEY_FILE="${SSL_KEY_FILE}"
           export MONGODB_URI="${MONGODB_URI}"
 
           bash ${PROJECT_DIRECTORY}/.evergreen/run-tls-tests.sh

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -589,8 +589,6 @@ functions:
           export PROJECT_DIRECTORY="$(pwd)"
           export NODE_LTS_VERSION=${NODE_LTS_VERSION}
           export DRIVERS_TOOLS="${DRIVERS_TOOLS}"
-          export SSL_CA_FILE="${SSL_CA_FILE}"
-          export SSL_KEY_FILE="${SSL_KEY_FILE}"
           export MONGODB_URI="${MONGODB_URI}"
 
           bash ${PROJECT_DIRECTORY}/.evergreen/run-tls-tests.sh

--- a/.evergreen/run-tls-tests.sh
+++ b/.evergreen/run-tls-tests.sh
@@ -4,7 +4,8 @@ set -o errexit  # Exit the script with error if any of the commands fail
 
 source "${PROJECT_DIRECTORY}/.evergreen/init-node-and-npm-env.sh"
 
-export SSL_KEY_FILE="$DRIVERS_TOOLS/.evergreen/x509gen/client.pem"
-export SSL_CA_FILE="$DRIVERS_TOOLS/.evergreen/x509gen/ca.pem"
+export TLS_KEY_FILE="$DRIVERS_TOOLS/.evergreen/x509gen/client.pem"
+export TLS_CA_FILE="$DRIVERS_TOOLS/.evergreen/x509gen/ca.pem"
+export TLS_CRL_FILE="$DRIVERS_TOOLS/.evergreen/x509gen/crl.pem"
 
 npm run check:tls

--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -1095,6 +1095,9 @@ export const OPTIONS = {
   tlsCAFile: {
     type: 'string'
   },
+  tlsCRLFile: {
+    type: 'string'
+  },
   tlsCertificateKeyFile: {
     type: 'string'
   },

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -810,13 +810,13 @@ export interface MongoOptions
    * to a no-op and `rejectUnauthorized` to the inverse value of `tlsAllowInvalidCertificates`. If
    * `tlsAllowInvalidCertificates` is not set, then `rejectUnauthorized` will be set to `true`.
    *
-   * ### Note on `tlsCAFile` and `tlsCertificateKeyFile`
+   * ### Note on `tlsCAFile`, `tlsCertificateKeyFile` and `tlsCRLFile`
    *
-   * The files specified by the paths passed in to the `tlsCAFile` and `tlsCertificateKeyFile` fields
-   * are read lazily on the first call to `MongoClient.connect`. Once these files have been read and
-   * the `ca`, `cert` and `key` fields are populated, they will not be read again on subsequent calls to
+   * The files specified by the paths passed in to the `tlsCAFile`, `tlsCertificateKeyFile` and `tlsCRLFile`
+   * fields are read lazily on the first call to `MongoClient.connect`. Once these files have been read and
+   * the `ca`, `cert`, `crl` and `key` fields are populated, they will not be read again on subsequent calls to
    * `MongoClient.connect`. As a result, until the first call to `MongoClient.connect`, the `ca`,
-   * `cert` and `key` fields will be undefined.
+   * `cert`, `crl` and `key` fields will be undefined.
    */
   tls: boolean;
   tlsCAFile?: string;

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -117,6 +117,8 @@ export interface MongoClientOptions extends BSONSerializeOptions, SupportedNodeC
   tlsCertificateKeyFilePassword?: string;
   /** Specifies the location of a local .pem file that contains the root certificate chain from the Certificate Authority. This file is used to validate the certificate presented by the mongod/mongos instance. */
   tlsCAFile?: string;
+  /** Specifies the location of a local CRL .pem file that contains the client revokation list. */
+  tlsCRLFile?: string;
   /** Bypasses validation of the certificates presented by the mongod/mongos instance */
   tlsAllowInvalidCertificates?: boolean;
   /** Disables hostname validation of the certificate presented by the mongod/mongos instance. */
@@ -436,6 +438,9 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> {
     if (options.tls) {
       if (typeof options.tlsCAFile === 'string') {
         options.ca ??= await fs.readFile(options.tlsCAFile);
+      }
+      if (typeof options.tlsCRLFile === 'string') {
+        options.crl ??= await fs.readFile(options.tlsCRLFile);
       }
       if (typeof options.tlsCertificateKeyFile === 'string') {
         if (!options.key || !options.cert) {
@@ -790,7 +795,7 @@ export interface MongoOptions
    * | nodejs native option  | driver spec equivalent option name            | driver option type |
    * |:----------------------|:----------------------------------------------|:-------------------|
    * | `ca`                  | `tlsCAFile`                                   | `string`           |
-   * | `crl`                 | N/A                                           | `string`           |
+   * | `crl`                 | `tlsCRLFile`                                  | `string`           |
    * | `cert`                | `tlsCertificateKeyFile`                       | `string`           |
    * | `key`                 | `tlsCertificateKeyFile`                       | `string`           |
    * | `passphrase`          | `tlsCertificateKeyFilePassword`               | `string`           |
@@ -814,8 +819,8 @@ export interface MongoOptions
    * `cert` and `key` fields will be undefined.
    */
   tls: boolean;
-
   tlsCAFile?: string;
+  tlsCRLFile?: string;
   tlsCertificateKeyFile?: string;
 
   /** @internal */

--- a/test/manual/tls_support.test.ts
+++ b/test/manual/tls_support.test.ts
@@ -106,7 +106,7 @@ describe('TLS Support', function () {
 
         context('when client has been opened and closed more than once', function () {
           it('should only read files once', async () => {
-            await client.connect();
+            await client.connect().catch(e => e);
             await client.close();
 
             const crlFileAccessTime = (await fs.stat(TLS_CRL_FILE)).atime;

--- a/test/manual/tls_support.test.ts
+++ b/test/manual/tls_support.test.ts
@@ -89,8 +89,8 @@ describe('TLS Support', function () {
           client = new MongoClient(CONNECTION_STRING, {
             tls: true,
             tlsCRLFile: TLS_CRL_FILE,
-            serverSelectionTimeoutMS: 5000,
-            connectTimeoutMS: 5000
+            serverSelectionTimeoutMS: 2000,
+            connectTimeoutMS: 2000
           });
         });
 

--- a/test/manual/tls_support.test.ts
+++ b/test/manual/tls_support.test.ts
@@ -43,8 +43,9 @@ describe('TLS Support', function () {
 
   context('when tls filepaths are provided', () => {
     let client: MongoClient;
+
     afterEach(async () => {
-      if (client) await client.close();
+      await client?.close();
     });
 
     context('when tls filepaths have length > 0', () => {
@@ -102,6 +103,18 @@ describe('TLS Support', function () {
           expect(err).to.be.instanceof(Error);
           expect(client.options).property('crl').to.exist;
         });
+
+        context('when client has been opened and closed more than once', function () {
+          it('should only read files once', async () => {
+            await client.connect();
+            await client.close();
+
+            const crlFileAccessTime = (await fs.stat(TLS_CRL_FILE)).atime;
+
+            await client.connect();
+
+            expect((await fs.stat(TLS_CRL_FILE)).atime).to.deep.equal(crlFileAccessTime);
+          });
       });
     });
 

--- a/test/manual/tls_support.test.ts
+++ b/test/manual/tls_support.test.ts
@@ -111,8 +111,9 @@ describe('TLS Support', function () {
 
             const crlFileAccessTime = (await fs.stat(TLS_CRL_FILE)).atime;
 
-            await client.connect();
+            const err = await client.connect().catch(e => e);
 
+            expect(err).to.be.instanceof(Error);
             expect((await fs.stat(TLS_CRL_FILE)).atime).to.deep.equal(crlFileAccessTime);
           });
         });

--- a/test/manual/tls_support.test.ts
+++ b/test/manual/tls_support.test.ts
@@ -115,6 +115,7 @@ describe('TLS Support', function () {
 
             expect((await fs.stat(TLS_CRL_FILE)).atime).to.deep.equal(crlFileAccessTime);
           });
+        });
       });
     });
 

--- a/test/unit/connection_string.test.ts
+++ b/test/unit/connection_string.test.ts
@@ -438,6 +438,13 @@ describe('Connection String', function () {
     });
   });
 
+  context('when providing tlsCRLFile', function () {
+    it('sets the tlsCRLFile option', function () {
+      const options = parseOptions('mongodb://localhost/?tls=true&tlsCRLFile=path/to/crl.pem');
+      expect(options.tlsCRLFile).to.equal('path/to/crl.pem');
+    });
+  });
+
   context('when both tls and ssl options are provided', function () {
     context('when the options are provided in the URI', function () {
       context('when the options are equal', function () {

--- a/test/unit/mongo_client.test.js
+++ b/test/unit/mongo_client.test.js
@@ -35,6 +35,7 @@ describe('MongoOptions', function () {
     const options = parseOptions('mongodb://localhost:27017/?ssl=true', {
       tlsCertificateKeyFile: filename,
       tlsCAFile: filename,
+      tlsCRLFile: filename,
       tlsCertificateKeyFilePassword: 'tlsCertificateKeyFilePassword'
     });
     fs.unlinkSync(filename);
@@ -61,6 +62,7 @@ describe('MongoOptions', function () {
     expect(options).to.not.have.property('cert');
     expect(options).to.have.property('tlsCertificateKeyFile', filename);
     expect(options).to.have.property('tlsCAFile', filename);
+    expect(options).to.have.property('tlsCRLFile', filename);
     expect(options).has.property('passphrase', 'tlsCertificateKeyFilePassword');
     expect(options).has.property('tls', true);
   });


### PR DESCRIPTION
### Description

Adds the ability to provide a CRL file as an option in the connection string or client options.

#### What is changing?
- Adds a new option, `tlsCRLFile`, that takes a string as a path to the crl.pem.
- Refactors a bit of TLS testing variable names.

##### Is there new documentation needed for these changes?

Yes, TLS options should be updated.

#### What is the motivation for this change?

NODE-5549/NODE-5566

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

#### Users may now provide a CRL file name as a client option.

For users wanting to provide a TLS client revokation list as a filename and not a `Buffer`, a new option `tlsCRLFile` has been added and can be provided in either the connection string or as a `MongoClient` option.

```ts
new MongoClient('mongodb://localhost:27017/db?tls=true&tlsCRLFile=path/to/crl.pem'); // option in connection string.
new MongoClient('mongodb://localhost:27017/db', { tls: true, tlsCRLFile: 'path/to/crl.pem' }) // option in client options.
```

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
