### PR TITLE
docs(NODE-5562): update upcoming crl option changes

### DIFF
--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -1108,7 +1108,7 @@ export const OPTIONS = {
   },
   sslCRL: {
     deprecated:
-      'sslCRL is deprecated and will be removed in the next major version. Please use tlsCertificateKeyFile instead.',
+      'sslCRL is deprecated and will be removed in the next major version and be replaced by tlsCRLFile in that release.',
     target: 'crl',
     transform({ values: [value] }) {
       return fs.readFileSync(String(value), { encoding: 'ascii' });

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -814,7 +814,7 @@ export interface MongoOptions
    * | nodejs native option  | driver spec compliant option name             | legacy option name | driver option type |
    * |:----------------------|:----------------------------------------------|:-------------------|:-------------------|
    * | `ca`                  | `tlsCAFile`                                   | `sslCA`            | `string`           |
-   * | `crl`                 | N/A                                           | `sslCRL`           | `string`           |
+   * | `crl`                 | `tlsCRLFile` (next major version)             | `sslCRL`           | `string`           |
    * | `cert`                | `tlsCertificateFile`, `tlsCertificateKeyFile` | `sslCert`          | `string`           |
    * | `key`                 | `tlsCertificateKeyFile`                       | `sslKey`           | `string`           |
    * | `passphrase`          | `tlsCertificateKeyFilePassword`               | `sslPass`          | `string`           |


### PR DESCRIPTION
### Description

Adds a note on the new 6.0 `tlsCRLFile` option to SSL docs.

#### What is changing?

Doc changes and deprecation message.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-5562

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
