### PR TITLE
fix(NODE-5573): fix saslprep import

### DIFF
--- a/src/deps.ts
+++ b/src/deps.ts
@@ -144,7 +144,7 @@ export let saslprep:
 
 try {
   // Ensure you always wrap an optional require in the try block NODE-3199
-  saslprep = require('saslprep');
+  saslprep = require('@mongodb-js/saslprep');
 } catch {} // eslint-disable-line
 
 interface AWS4 {


### PR DESCRIPTION
### Description

Require @mongodb-js/saslprep not saslprep

#### What is changing?

Fixes the saslprep import.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-5573

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

#### Import of `saslprep` updated to correct library.

Fixes the import of saslprep to be the correct `@mongodb-js/saslprep` library.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
