### PR TITLE
fix(NODE-5587): recursive calls to next cause memory leak

### DIFF
--- a/src/cursor/find_cursor.ts
+++ b/src/cursor/find_cursor.ts
@@ -1,4 +1,4 @@
-import type { Document } from '../bson';
+import { type Document, Long } from '../bson';
 import { MongoInvalidArgumentError, MongoTailableCursorError } from '../error';
 import type { ExplainVerbosityLike } from '../explain';
 import type { MongoClient } from '../mongo_client';
@@ -101,7 +101,9 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
         limit && limit > 0 && numReturned + batchSize > limit ? limit - numReturned : batchSize;
 
       if (batchSize <= 0) {
-        this.close().finally(() => callback());
+        this.close().finally(() =>
+          callback(undefined, { cursor: { id: Long.ZERO, nextBatch: [] } })
+        );
         return;
       }
     }


### PR DESCRIPTION
### Description

#### What is changing?

- Modified the isDead condition (moved it to a getter)
  - If the cursorId is zero, if it has been closed or has been killed, it's "dead"
  - if kId is nullish, it has not been initialized yet, a not-even-started-yet cursor is not dead
  - `(this[kId]?.isZero() ?? false) || this[kClosed] || this[kKilled];`

##### Is there new documentation needed for these changes?

No

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fix memory leak with ChangeStreams

In a previous release, 5.7.0, we refactored cursor internals from callbacks to async/await. In particular, the `next` function that powers cursors was written with callbacks and would recursively call itself depending on the cursor type. For `ChangeStreams`, this function would call itself if there were no new changes to return to the user. After converting that code to async/await each recursive call created a new promise that saved the current async context. This would slowly build up memory usage if no new changes came in to unwind the recursive calls. 

The function is now implemented as a loop, memory leak be gone!

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
