### PR TITLE
chore(NODE-5581): pull in bson alpha.1 and mongodb-legacy main

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@mongodb-js/saslprep": "^1.1.0",
-        "bson": "^5.4.0",
+        "bson": "^6.0.0-alpha.1",
         "mongodb-connection-string-url": "^2.6.0"
       },
       "devDependencies": {
@@ -49,7 +49,7 @@
         "mocha": "^10.2.0",
         "mocha-sinon": "^2.1.2",
         "mongodb-client-encryption": "6.0.0-alpha.3",
-        "mongodb-legacy": "^5.0.0",
+        "mongodb-legacy": "github:mongodb-js/nodejs-mongodb-legacy#main",
         "nyc": "^15.1.0",
         "prettier": "^2.8.8",
         "semver": "^7.5.0",
@@ -3556,11 +3556,11 @@
       }
     },
     "node_modules/bson": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-5.4.0.tgz",
-      "integrity": "sha512-WRZ5SQI5GfUuKnPTNmAYPiKIof3ORXAF4IRU5UcgmivNIon01rWQlw5RUH954dpu8yGL8T59YShVddIPaU/gFA==",
+      "version": "6.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.0.0-alpha.1.tgz",
+      "integrity": "sha512-uyXUphm103PYF5hEAV8r06S7plgvfaKRPMC4RV3rZVh204oN3tZtcrY1Mg7/YCr68BgVNYUdxeqMO/2gJoYysQ==",
       "engines": {
-        "node": ">=14.20.1"
+        "node": ">=16.20.1"
       }
     },
     "node_modules/buffer": {
@@ -6668,12 +6668,21 @@
     },
     "node_modules/mongodb-legacy": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/mongodb-legacy/-/mongodb-legacy-5.0.0.tgz",
-      "integrity": "sha512-q2G+MRwde6114bCAF/EZLmMXSsebIKMHmzsfOJq6M/Tj4gr3wLT50+rJsJNkiR0e0kjFx3dllWjqwRR1n11Zsw==",
+      "resolved": "git+ssh://git@github.com/mongodb-js/nodejs-mongodb-legacy.git#fd99bccdb63c0920735df7e17711d2ea8ab1ce71",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "mongodb": "^5.0.0"
       },
+      "engines": {
+        "node": ">=16.20.1"
+      }
+    },
+    "node_modules/mongodb-legacy/node_modules/bson": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-5.4.0.tgz",
+      "integrity": "sha512-WRZ5SQI5GfUuKnPTNmAYPiKIof3ORXAF4IRU5UcgmivNIon01rWQlw5RUH954dpu8yGL8T59YShVddIPaU/gFA==",
+      "dev": true,
       "engines": {
         "node": ">=14.20.1"
       }

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
     "email": "dbx-node@mongodb.com"
   },
   "dependencies": {
-    "bson": "^5.4.0",
-    "mongodb-connection-string-url": "^2.6.0",
-    "@mongodb-js/saslprep": "^1.1.0"
+    "@mongodb-js/saslprep": "^1.1.0",
+    "bson": "^6.0.0-alpha.1",
+    "mongodb-connection-string-url": "^2.6.0"
   },
   "peerDependencies": {
     "@aws-sdk/credential-providers": "^3.188.0",
@@ -97,7 +97,7 @@
     "mocha": "^10.2.0",
     "mocha-sinon": "^2.1.2",
     "mongodb-client-encryption": "6.0.0-alpha.3",
-    "mongodb-legacy": "^5.0.0",
+    "mongodb-legacy": "github:mongodb-js/nodejs-mongodb-legacy#main",
     "nyc": "^15.1.0",
     "prettier": "^2.8.8",
     "semver": "^7.5.0",

--- a/test/action/dependency.test.ts
+++ b/test/action/dependency.test.ts
@@ -6,9 +6,12 @@ import { expect } from 'chai';
 
 import { dependencies, peerDependencies, peerDependenciesMeta } from '../../package.json';
 import { setDifference } from '../mongodb';
-import { itInNodeProcess } from '../tools/utils';
+import { alphabetically, itInNodeProcess, sorted } from '../tools/utils';
 
-const EXPECTED_DEPENDENCIES = ['bson', 'mongodb-connection-string-url', '@mongodb-js/saslprep'];
+const EXPECTED_DEPENDENCIES = sorted(
+  ['@mongodb-js/saslprep', 'bson', 'mongodb-connection-string-url'],
+  alphabetically
+);
 const EXPECTED_PEER_DEPENDENCIES = [
   '@aws-sdk/credential-providers',
   '@mongodb-js/zstd',
@@ -22,7 +25,9 @@ const EXPECTED_PEER_DEPENDENCIES = [
 describe('package.json', function () {
   describe('dependencies', function () {
     it('only contains the expected dependencies', function () {
-      expect(Object.keys(dependencies)).to.deep.equal(EXPECTED_DEPENDENCIES);
+      expect(sorted(Object.keys(dependencies), alphabetically)).to.deep.equal(
+        EXPECTED_DEPENDENCIES
+      );
     });
   });
 

--- a/test/integration/crud/insert.test.js
+++ b/test/integration/crud/insert.test.js
@@ -247,7 +247,10 @@ describe('crud - insert', function () {
               test.equal(date.toString(), doc.date.toString());
               test.equal(date.getTime(), doc.date.getTime());
               test.equal(motherOfAllDocuments.oid.toHexString(), doc.oid.toHexString());
-              test.equal(motherOfAllDocuments.binary.value(), doc.binary.value());
+              test.equal(
+                motherOfAllDocuments.binary.value().toString('hex'),
+                doc.binary.value().toString('hex')
+              );
 
               test.equal(motherOfAllDocuments.int, doc.int);
               test.equal(motherOfAllDocuments.long, doc.long);
@@ -398,7 +401,10 @@ describe('crud - insert', function () {
                 test.equal(date.toString(), doc.date.toString());
                 test.equal(date.getTime(), doc.date.getTime());
                 test.equal(motherOfAllDocuments.oid.toHexString(), doc.oid.toHexString());
-                test.equal(motherOfAllDocuments.binary.value(), doc.binary.value());
+                test.equal(
+                  motherOfAllDocuments.binary.value().toString('hex'),
+                  doc.binary.value().toString('hex')
+                );
 
                 test.equal(motherOfAllDocuments.int, doc.int);
                 test.equal(motherOfAllDocuments.long, doc.long);

--- a/test/integration/crud/pk_factory.test.js
+++ b/test/integration/crud/pk_factory.test.js
@@ -19,7 +19,7 @@ describe('PkFactory', function () {
       // Custom factory (need to provide a 12 byte array);
       var CustomPKFactory = {
         createPk() {
-          return new ObjectId('aaaaaaaaaaaa');
+          return new ObjectId('a'.repeat(24));
         }
       };
 
@@ -39,7 +39,7 @@ describe('PkFactory', function () {
 
         collection.insert({ a: 1 }, { writeConcern: { w: 1 } }, function (err) {
           expect(err).to.not.exist;
-          collection.find({ _id: new ObjectId('aaaaaaaaaaaa') }).toArray(function (err, items) {
+          collection.find({ _id: new ObjectId('a'.repeat(24)) }).toArray(function (err, items) {
             expect(items.length).to.equal(1);
 
             client.close(done);

--- a/test/tools/common.js
+++ b/test/tools/common.js
@@ -122,7 +122,7 @@ class ReplSetFixture {
 function genClusterTime(time) {
   return {
     clusterTime: new BSON.Timestamp(BSON.Long.fromNumber(time, true)),
-    signature: { hash: new BSON.Binary('test'), keyId: new BSON.Long(1) }
+    signature: { hash: new BSON.Binary(Buffer.from('test', 'utf8')), keyId: new BSON.Long(1) }
   };
 }
 

--- a/test/tools/utils.ts
+++ b/test/tools/utils.ts
@@ -476,7 +476,7 @@ export class UnifiedTestSuiteBuilder {
   }
 }
 
-export const byStrings = (a: any, b: any) => {
+export const alphabetically = (a: any, b: any) => {
   const res = `${a}`.localeCompare(`${b}`);
   return res < 0 ? -1 : res > 0 ? 1 : 0;
 };

--- a/test/tools/utils.ts
+++ b/test/tools/utils.ts
@@ -477,7 +477,11 @@ export class UnifiedTestSuiteBuilder {
 }
 
 export const alphabetically = (a: any, b: any) => {
-  const res = `${a}`.localeCompare(`${b}`);
+  const res = `${a}`.localeCompare(`${b}`, 'en-US', {
+    usage: 'sort',
+    numeric: true,
+    ignorePunctuation: false
+  });
   return res < 0 ? -1 : res > 0 ? 1 : 0;
 };
 

--- a/test/types/community/collection/filterQuery.test-d.ts
+++ b/test/types/community/collection/filterQuery.test-d.ts
@@ -94,7 +94,7 @@ const spot = {
   treats: ['kibble', 'bone'],
   playTimePercent: new Decimal128('0.999999'),
 
-  binary: new Binary('', 2),
+  binary: new Binary(Buffer.from('', 'utf8'), 2),
   code: new Code(() => true),
   minKey: new MinKey(),
   maxKey: new MaxKey(),
@@ -161,7 +161,7 @@ expectNotType<Filter<PetModel>>({ bestFriend: [spot] });
 expectNotType<Filter<PetModel>>({ bestFriend: [{ name: 'Andersons' }] });
 
 // it should permit all our BSON types as query values
-expectAssignable<Filter<PetModel>>({ binary: new Binary('', 2) });
+expectAssignable<Filter<PetModel>>({ binary: new Binary(Buffer.from('abc', 'utf8'), 2) });
 expectAssignable<Filter<PetModel>>({ code: new Code(() => true) });
 expectAssignable<Filter<PetModel>>({ minKey: new MinKey() });
 expectAssignable<Filter<PetModel>>({ maxKey: new MaxKey() });

--- a/test/unit/client-side-encryption/auto_encrypter.test.ts
+++ b/test/unit/client-side-encryption/auto_encrypter.test.ts
@@ -191,8 +191,12 @@ describe('AutoEncrypter', function () {
       expect(decrypted.filter[Symbol.for('@@mdb.decryptedKeys')]).to.eql(['ssn']);
 
       // The same, but with an object containing different data types as the input
-      decrypted = await mc.decrypt({ a: [null, 1, { c: new bson.Binary('foo', 1) }] });
-      expect(decrypted).to.eql({ a: [null, 1, { c: new bson.Binary('foo', 1) }] });
+      decrypted = await mc.decrypt({
+        a: [null, 1, { c: new bson.Binary(Buffer.from('foo', 'utf8'), 1) }]
+      });
+      expect(decrypted).to.eql({
+        a: [null, 1, { c: new bson.Binary(Buffer.from('foo', 'utf8'), 1) }]
+      });
       expect(decrypted).to.not.have.property(Symbol.for('@@mdb.decryptedKeys'));
 
       // The same, but with nested data inside the decrypted input

--- a/test/unit/index.test.ts
+++ b/test/unit/index.test.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 // Exception to the import from mongodb rule we're unit testing our public API
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import * as mongodb from '../../src/index';
-import { byStrings, sorted } from '../tools/utils';
+import { alphabetically, sorted } from '../tools/utils';
 
 /**
  * TS-NODE Adds these keys but they are undefined, they are not present when you import from lib
@@ -134,8 +134,8 @@ const EXPECTED_EXPORTS = [
 
 describe('mongodb entrypoint', () => {
   it('should export all and only the expected keys in expected_exports', () => {
-    expect(sorted(Object.keys(mongodb), byStrings)).to.deep.equal(
-      sorted(EXPECTED_EXPORTS, byStrings)
+    expect(sorted(Object.keys(mongodb), alphabetically)).to.deep.equal(
+      sorted(EXPECTED_EXPORTS, alphabetically)
     );
   });
 

--- a/test/unit/sessions.test.js
+++ b/test/unit/sessions.test.js
@@ -119,7 +119,7 @@ describe('Sessions - unit', function () {
       it('sets clusterTime to the one provided when the signature.keyId is a bigint', () => {
         const validClusterTime = {
           clusterTime: new BSON.Timestamp(BSON.Long.fromNumber(1, true)),
-          signature: { hash: new BSON.Binary('test'), keyId: 100n }
+          signature: { hash: new BSON.Binary(Buffer.from('test', 'utf8')), keyId: 100n }
         };
 
         session.advanceClusterTime(validClusterTime);


### PR DESCRIPTION
### Description

#### What is changing?

- Update bson to alpha.1
- Pull in mongodb-legacy main branch

##### Is there new documentation needed for these changes?

No.

#### What is the motivation for this change?

Test the nearly ready stuff!

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
