### PR TITLE
feat(NODE-5584)!: adopt bson v6 and mongodb-client-encryption v6

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2763,7 +2763,7 @@ tasks:
       - func: bootstrap kms servers
       - func: install package
         vars:
-          PACKAGE: mongodb-client-encryption@6.0.0-alpha.3
+          PACKAGE: mongodb-client-encryption
       - func: run tests
         vars:
           CLIENT_ENCRYPTION: true

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2749,24 +2749,6 @@ tasks:
       - func: run custom csfle tests
         vars:
           CSFLE_GIT_REF: master
-  - name: test-latest-driver-mongodb-client-encryption-6.0.0
-    tags:
-      - run-custom-dependency-tests
-    commands:
-      - func: install dependencies
-        vars:
-          NODE_LTS_VERSION: 16
-      - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '7.0'
-          TOPOLOGY: replica_set
-      - func: bootstrap kms servers
-      - func: install package
-        vars:
-          PACKAGE: mongodb-client-encryption
-      - func: run tests
-        vars:
-          CLIENT_ENCRYPTION: true
   - name: test-latest-server-noauth
     tags:
       - latest
@@ -4039,7 +4021,6 @@ buildvariants:
       - run-custom-csfle-tests-rapid-master
       - run-custom-csfle-tests-latest-pinned-commit
       - run-custom-csfle-tests-latest-master
-      - test-latest-driver-mongodb-client-encryption-6.0.0
   - name: rhel8-test-serverless
     display_name: Serverless Test
     run_on: rhel80-large

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -698,7 +698,7 @@ oneOffFuncAsTasks.push({
     {
       func: 'install package',
       vars: {
-        PACKAGE: 'mongodb-client-encryption@6.0.0-alpha.3'
+        PACKAGE: 'mongodb-client-encryption'
       }
     },
     {

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -677,38 +677,6 @@ for (const version of ['5.0', 'rapid', 'latest']) {
   }
 }
 
-oneOffFuncAsTasks.push({
-  name: `test-latest-driver-mongodb-client-encryption-6.0.0`,
-  tags: ['run-custom-dependency-tests'],
-  commands: [
-    {
-      func: 'install dependencies',
-      vars: {
-        NODE_LTS_VERSION: LOWEST_LTS
-      }
-    },
-    {
-      func: 'bootstrap mongo-orchestration',
-      vars: {
-        VERSION: '7.0',
-        TOPOLOGY: 'replica_set'
-      }
-    },
-    { func: 'bootstrap kms servers' },
-    {
-      func: 'install package',
-      vars: {
-        PACKAGE: 'mongodb-client-encryption'
-      }
-    },
-    {
-      func: 'run tests',
-      vars: {
-        CLIENT_ENCRYPTION: true
-      }
-    }
-  ]
-});
 
 const coverageTask = {
   name: 'download and merge coverage'.split(' ').join('-'),

--- a/.evergreen/run-socks5-tests.sh
+++ b/.evergreen/run-socks5-tests.sh
@@ -20,7 +20,7 @@ function setup_fle() {
   # CSFLE_AWS_TEMP_ACCESS_KEY_ID, CSFLE_AWS_TEMP_SECRET_ACCESS_KEY, CSFLE_AWS_TEMP_SESSION_TOKEN
   . "$DRIVERS_TOOLS"/.evergreen/csfle/set-temp-creds.sh
 
-  npm i mongodb-client-encryption@alpha
+  npm i mongodb-client-encryption
   export KMIP_TLS_CA_FILE="${DRIVERS_TOOLS}/.evergreen/x509gen/ca.pem"
   export KMIP_TLS_CERT_FILE="${DRIVERS_TOOLS}/.evergreen/x509gen/client.pem"
   export TEST_CSFLE=true

--- a/.evergreen/run-socks5-tests.sh
+++ b/.evergreen/run-socks5-tests.sh
@@ -20,7 +20,6 @@ function setup_fle() {
   # CSFLE_AWS_TEMP_ACCESS_KEY_ID, CSFLE_AWS_TEMP_SECRET_ACCESS_KEY, CSFLE_AWS_TEMP_SESSION_TOKEN
   . "$DRIVERS_TOOLS"/.evergreen/csfle/set-temp-creds.sh
 
-  npm i mongodb-client-encryption
   export KMIP_TLS_CA_FILE="${DRIVERS_TOOLS}/.evergreen/x509gen/ca.pem"
   export KMIP_TLS_CERT_FILE="${DRIVERS_TOOLS}/.evergreen/x509gen/client.pem"
   export TEST_CSFLE=true

--- a/.evergreen/run-unit-tests.sh
+++ b/.evergreen/run-unit-tests.sh
@@ -4,6 +4,6 @@ set -o errexit # Exit the script with error if any of the commands fail
 source "${PROJECT_DIRECTORY}/.evergreen/init-node-and-npm-env.sh"
 set -o xtrace
 
-npm i mongodb-client-encryption@alpha
+npm i mongodb-client-encryption
 
 npx nyc npm run check:unit

--- a/.evergreen/run-unit-tests.sh
+++ b/.evergreen/run-unit-tests.sh
@@ -4,6 +4,4 @@ set -o errexit # Exit the script with error if any of the commands fail
 source "${PROJECT_DIRECTORY}/.evergreen/init-node-and-npm-env.sh"
 set -o xtrace
 
-npm i mongodb-client-encryption
-
 npx nyc npm run check:unit

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@mongodb-js/saslprep": "^1.1.0",
-        "bson": "^6.0.0-alpha.1",
+        "bson": "^6.0.0",
         "mongodb-connection-string-url": "^2.6.0"
       },
       "devDependencies": {
@@ -48,7 +48,7 @@
         "js-yaml": "^4.1.0",
         "mocha": "^10.2.0",
         "mocha-sinon": "^2.1.2",
-        "mongodb-client-encryption": "6.0.0-alpha.3",
+        "mongodb-client-encryption": "^6.0.0",
         "mongodb-legacy": "github:mongodb-js/nodejs-mongodb-legacy#main",
         "nyc": "^15.1.0",
         "prettier": "^2.8.8",
@@ -73,7 +73,7 @@
         "@mongodb-js/zstd": "^1.1.0",
         "gcp-metadata": "^5.2.0",
         "kerberos": "^2.0.1",
-        "mongodb-client-encryption": ">=6.0.0-alpha.3 <7",
+        "mongodb-client-encryption": ">=6.0.0 <7",
         "snappy": "^7.2.2",
         "socks": "^2.7.1"
       },
@@ -3556,9 +3556,9 @@
       }
     },
     "node_modules/bson": {
-      "version": "6.0.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-6.0.0-alpha.1.tgz",
-      "integrity": "sha512-uyXUphm103PYF5hEAV8r06S7plgvfaKRPMC4RV3rZVh204oN3tZtcrY1Mg7/YCr68BgVNYUdxeqMO/2gJoYysQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.0.0.tgz",
+      "integrity": "sha512-FoWvdELfF2wQaUo8S/a1Rh2BDwJEUancDDnzdTpYymJTZjmvRpLWoqRPelKn+XSeh5D4YddWDG66cLtEhGGvcg==",
       "engines": {
         "node": ">=16.20.1"
       }
@@ -6634,9 +6634,9 @@
       }
     },
     "node_modules/mongodb-client-encryption": {
-      "version": "6.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-6.0.0-alpha.3.tgz",
-      "integrity": "sha512-4mMs1SHfeE7c69xzqzXEC8psx8mh1o+6DOuXgft83RkBAIaI/YwfnHAHKxYH1KtwEmq60CK3tE3fai+JZjh8BA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-6.0.0.tgz",
+      "integrity": "sha512-GtqkqlSq19acX006/U1odA3l+gwhvABeoTUlvvgtvSs6qcN3qSHPnur3Z5N4oKOv6fZ7EtT8rIsWP2riI0+Eyg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@mongodb-js/saslprep": "^1.1.0",
-    "bson": "^6.0.0-alpha.1",
+    "bson": "^6.0.0",
     "mongodb-connection-string-url": "^2.6.0"
   },
   "peerDependencies": {
@@ -34,7 +34,7 @@
     "@mongodb-js/zstd": "^1.1.0",
     "gcp-metadata": "^5.2.0",
     "kerberos": "^2.0.1",
-    "mongodb-client-encryption": ">=6.0.0-alpha.3 <7",
+    "mongodb-client-encryption": ">=6.0.0 <7",
     "snappy": "^7.2.2",
     "socks": "^2.7.1"
   },
@@ -96,7 +96,7 @@
     "js-yaml": "^4.1.0",
     "mocha": "^10.2.0",
     "mocha-sinon": "^2.1.2",
-    "mongodb-client-encryption": "6.0.0-alpha.3",
+    "mongodb-client-encryption": "^6.0.0",
     "mongodb-legacy": "github:mongodb-js/nodejs-mongodb-legacy#main",
     "nyc": "^15.1.0",
     "prettier": "^2.8.8",

--- a/test/action/dependency.test.ts
+++ b/test/action/dependency.test.ts
@@ -91,10 +91,6 @@ describe('package.json', function () {
 
       context(`when ${depName} is installed`, () => {
         beforeEach(async function () {
-          if (depName === 'mongodb-client-encryption') {
-            execSync(`npm install --no-save "${depName}"@alpha`);
-            return;
-          }
           execSync(`npm install --no-save "${depName}"@"${depMajor}"`);
         });
 


### PR DESCRIPTION
### Description

#### What is changing?

- bumping mongodb-client-encryption and bson to v6
- Remove manual mongodb-client-encryption installs in CI config and scripts
- Remove `test-latest-driver-mongodb-client-encryption-6.0.0` CI task
- Remove manual mongodb-client-encryption installs in test files

##### Is there new documentation needed for these changes?

No.

### Release Highlight

### BSON dependency upgraded to v6

https://github.com/mongodb/js-bson/releases/tag/v6.0.0

### mongodb-client-encryption dependency upgraded to v6

https://github.com/mongodb/libmongocrypt/releases/tag/node-v6.0.0

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
