### PR TITLE
fix(NODE-5592): fix withTransaction return type

### DIFF
--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -453,7 +453,7 @@ export class ClientSession extends TypedEventEmitter<ClientSessionEvents> {
   async withTransaction<T = any>(
     fn: WithTransactionCallback<T>,
     options?: TransactionOptions
-  ): Promise<Document | undefined> {
+  ): Promise<T | undefined> {
     const startTime = now();
     return attemptTransaction(this, startTime, fn, options);
   }

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -453,7 +453,7 @@ export class ClientSession extends TypedEventEmitter<ClientSessionEvents> {
   async withTransaction<T = any>(
     fn: WithTransactionCallback<T>,
     options?: TransactionOptions
-  ): Promise<T | undefined> {
+  ): Promise<T> {
     const startTime = now();
     return attemptTransaction(this, startTime, fn, options);
   }

--- a/test/types/community/transaction.test-d.ts
+++ b/test/types/community/transaction.test-d.ts
@@ -1,4 +1,6 @@
-import { type ClientSession, MongoClient, ReadConcern } from '../../mongodb';
+import { expectType } from 'tsd';
+
+import { type ClientSession, type InsertOneResult, MongoClient, ReadConcern } from '../../mongodb';
 
 // TODO(NODE-3345): Improve these tests to use expect assertions more
 
@@ -111,11 +113,7 @@ try {
 client.withSession(session => runTransactionWithRetry(updateEmployeeInfo, client, session));
 
 const col = client.db('test').collection<{ _id: string }>('col');
-const ok = await session.withTransaction(async () => {
+const insertResult = await session.withTransaction(async () => {
   return await col.insertOne({ _id: 'one' }, { session });
 });
-if (ok) {
-  console.log('success');
-} else {
-  console.log('nothing done');
-}
+expectType<InsertOneResult<{ _id: string }>>(insertResult);


### PR DESCRIPTION
### Description

#### What is changing?
- Fixed `withTransaction` return type
- Updated test to check `withTransaction` return type

##### Is there new documentation needed for these changes?
- No
#### What is the motivation for this change?
- Fixing NODE-2014 implementation (#3783)

### Release Highlight
N/A
<!-- RELEASE_HIGHLIGHT_START -->
<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [X] Ran `npm run check:lint` script
- [X] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [X] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [X] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
