### PR TITLE
chore(NODE-5585): use mongodb-legacy 6 for tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "mocha": "^10.2.0",
         "mocha-sinon": "^2.1.2",
         "mongodb-client-encryption": "^6.0.0",
-        "mongodb-legacy": "github:mongodb-js/nodejs-mongodb-legacy#main",
+        "mongodb-legacy": "^6.0.0",
         "nyc": "^15.1.0",
         "prettier": "^2.8.8",
         "semver": "^7.5.0",
@@ -6633,6 +6633,52 @@
         "node": ">=10"
       }
     },
+    "node_modules/mongodb": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.0.0.tgz",
+      "integrity": "sha512-wUIYesF4DTyDccm0noE5TwGi9ISdXUAi9T2cQ4xPc+EUBZG44bfMVt2ecOG5Ypca7eCz3oRpJm6YI6c7jAnuNw==",
+      "dev": true,
+      "dependencies": {
+        "@mongodb-js/saslprep": "^1.1.0",
+        "bson": "^6.0.0",
+        "mongodb-connection-string-url": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.188.0",
+        "@mongodb-js/zstd": "^1.1.0",
+        "gcp-metadata": "^5.2.0",
+        "kerberos": "^2.0.1",
+        "mongodb-client-encryption": ">=6.0.0 <7",
+        "snappy": "^7.2.2",
+        "socks": "^2.7.1"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "gcp-metadata": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        },
+        "socks": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/mongodb-client-encryption": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-6.0.0.tgz",
@@ -6667,96 +6713,15 @@
       }
     },
     "node_modules/mongodb-legacy": {
-      "version": "5.0.0",
-      "resolved": "git+ssh://git@github.com/mongodb-js/nodejs-mongodb-legacy.git#fd99bccdb63c0920735df7e17711d2ea8ab1ce71",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/mongodb-legacy/-/mongodb-legacy-6.0.0.tgz",
+      "integrity": "sha512-XSnUhIK854VEkQTR7WTRCY0yttV/LJVxw4qWmJPYMbsMUE03mE8PXo9IdeHkXg4C3Fj/E1KXiBOuXt9LB8iRgw==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "mongodb": "^5.0.0"
+        "mongodb": "^6.0.0"
       },
       "engines": {
         "node": ">=16.20.1"
-      }
-    },
-    "node_modules/mongodb-legacy/node_modules/bson": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-5.4.0.tgz",
-      "integrity": "sha512-WRZ5SQI5GfUuKnPTNmAYPiKIof3ORXAF4IRU5UcgmivNIon01rWQlw5RUH954dpu8yGL8T59YShVddIPaU/gFA==",
-      "dev": true,
-      "engines": {
-        "node": ">=14.20.1"
-      }
-    },
-    "node_modules/mongodb-legacy/node_modules/mongodb": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.7.0.tgz",
-      "integrity": "sha512-zm82Bq33QbqtxDf58fLWBwTjARK3NSvKYjyz997KSy6hpat0prjeX/kxjbPVyZY60XYPDNETaHkHJI2UCzSLuw==",
-      "dev": true,
-      "dependencies": {
-        "bson": "^5.4.0",
-        "mongodb-connection-string-url": "^2.6.0",
-        "socks": "^2.7.1"
-      },
-      "engines": {
-        "node": ">=14.20.1"
-      },
-      "optionalDependencies": {
-        "saslprep": "^1.0.3"
-      },
-      "peerDependencies": {
-        "@aws-sdk/credential-providers": "^3.201.0",
-        "@mongodb-js/zstd": "^1.1.0",
-        "kerberos": "^2.0.1",
-        "mongodb-client-encryption": ">=2.3.0 <3",
-        "snappy": "^7.2.2"
-      },
-      "peerDependenciesMeta": {
-        "@aws-sdk/credential-providers": {
-          "optional": true
-        },
-        "@mongodb-js/zstd": {
-          "optional": true
-        },
-        "kerberos": {
-          "optional": true
-        },
-        "mongodb-client-encryption": {
-          "optional": true
-        },
-        "snappy": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/mongodb-legacy/node_modules/mongodb-client-encryption": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-2.9.0.tgz",
-      "integrity": "sha512-OGMfTnS+JJ49ksWdExQ5048ynaQJLhPjbOi3i44PbU2sdufKH0Z4YZqn1pvd/eQ4WgLfbmSws3u9kAiFNFxpOg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "node-addon-api": "^4.3.0",
-        "prebuild-install": "^7.1.1",
-        "socks": "^2.7.1"
-      },
-      "engines": {
-        "node": ">=12.9.0"
-      },
-      "peerDependencies": {
-        "@aws-sdk/credential-providers": "^3.186.0",
-        "gcp-metadata": "^5.2.0",
-        "mongodb": ">=3.4.0"
-      },
-      "peerDependenciesMeta": {
-        "@aws-sdk/credential-providers": {
-          "optional": true
-        },
-        "gcp-metadata": {
-          "optional": true
-        }
       }
     },
     "node_modules/ms": {
@@ -7886,19 +7851,6 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
-    },
-    "node_modules/saslprep": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
-      "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "sparse-bitfield": "^3.0.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/semver": {
       "version": "7.5.0",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "mocha": "^10.2.0",
     "mocha-sinon": "^2.1.2",
     "mongodb-client-encryption": "^6.0.0",
-    "mongodb-legacy": "github:mongodb-js/nodejs-mongodb-legacy#main",
+    "mongodb-legacy": "^6.0.0",
     "nyc": "^15.1.0",
     "prettier": "^2.8.8",
     "semver": "^7.5.0",


### PR DESCRIPTION
### Description

#### What is changing?

- instead of a git branch we can use the released v6 legacy driver

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

- Some day we will remove our callback tests.... not today

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
