### PR TITLE
fix(NODE-5550): set AWS region from environment variable for STSClient

### DIFF
--- a/src/deps.ts
+++ b/src/deps.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 import type { Document } from './bson';
-import type { AWSCredentials } from './cmap/auth/mongodb_aws';
 import type { ProxyOptions } from './cmap/connection';
 import { MongoMissingDependencyError } from './error';
 import type { MongoClient } from './mongo_client';

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -76,7 +76,23 @@ export function getZstdLibrary(): typeof ZStandard | { kModuleError: MongoMissin
   }
 }
 
+/**
+ * @internal
+ * Copy of the AwsCredentialIdentityProvider interface from [`smithy/types`](https://socket.dev/npm/package/\@smithy/types/files/1.1.1/dist-types/identity/awsCredentialIdentity.d.ts),
+ * the return type of the aws-sdk's `fromNodeProviderChain().provider()`.
+ */
+export interface AWSCredentials {
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken: string;
+  expiration?: Date;
+}
+
 type CredentialProvider = {
+  fromNodeProviderChain(
+    this: void,
+    options: { clientConfig: { region: string } }
+  ): () => Promise<AWSCredentials>;
   fromNodeProviderChain(this: void): () => Promise<AWSCredentials>;
 };
 


### PR DESCRIPTION
### Description

#### What is changing?

- Same as #3831

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Use region settings for STS AWS credentials request

When using [IAM AssumeRoleWithWebIdentity](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html) AWS authentication the driver uses the [@aws-sdk/credential-providers](https://github.com/aws/aws-sdk-js-v3) package to contact the Security Token Service API for temporary credentials. AWS recommends using Regional AWS STS endpoints instead of the global endpoint to reduce latency, build-in redundancy, and increase session token validity. Unfortunately, environment variables `AWS_STS_REGIONAL_ENDPOINTS` and `AWS_REGION` do not directly control the region the SDK's STS client contacts for credentials. 

The driver now has added support for detecting these variables and setting the appropriate options when calling the SDK's API: [fromNodeProviderChain()](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-aws-sdk-credential-providers/#fromNodeProviderChain). 

> [!IMPORTANT] 
> The driver will only set region options if **BOTH** environment variables are present. `AWS_STS_REGIONAL_ENDPOINTS` **MUST** be set to either `'legacy'` or `'regional'`, and `AWS_REGION` must be set.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
