### PR TITLE
ci(NODE-5424): test driver latest, client-encryption 6.0.0 in CI

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2749,6 +2749,24 @@ tasks:
       - func: run custom csfle tests
         vars:
           CSFLE_GIT_REF: master
+  - name: test-latest-driver-mongodb-client-encryption-6.0.0
+    tags:
+      - run-custom-dependency-tests
+    commands:
+      - func: install dependencies
+        vars:
+          NODE_LTS_VERSION: 16
+      - func: bootstrap mongo-orchestration
+        vars:
+          VERSION: '7.0'
+          TOPOLOGY: replica_set
+      - func: bootstrap kms servers
+      - func: install package
+        vars:
+          PACKAGE: mongodb-client-encryption@6.0.0
+      - func: run tests
+        vars:
+          CLIENT_ENCRYPTION: true
   - name: test-latest-server-noauth
     tags:
       - latest
@@ -4021,6 +4039,7 @@ buildvariants:
       - run-custom-csfle-tests-rapid-master
       - run-custom-csfle-tests-latest-pinned-commit
       - run-custom-csfle-tests-latest-master
+      - test-latest-driver-mongodb-client-encryption-6.0.0
   - name: rhel8-test-serverless
     display_name: Serverless Test
     run_on: rhel80-large

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -677,6 +677,38 @@ for (const version of ['5.0', 'rapid', 'latest']) {
   }
 }
 
+oneOffFuncAsTasks.push({
+  name: `test-latest-driver-mongodb-client-encryption-6.0.0`,
+  tags: ['run-custom-dependency-tests'],
+  commands: [
+    {
+      func: 'install dependencies',
+      vars: {
+        NODE_LTS_VERSION: LOWEST_LTS
+      }
+    },
+    {
+      func: 'bootstrap mongo-orchestration',
+      vars: {
+        VERSION: '7.0',
+        TOPOLOGY: 'replica_set'
+      }
+    },
+    { func: 'bootstrap kms servers' },
+    {
+      func: 'install package',
+      vars: {
+        PACKAGE: 'mongodb-client-encryption@6.0.0'
+      }
+    },
+    {
+      func: 'run tests',
+      vars: {
+        CLIENT_ENCRYPTION: true
+      }
+    }
+  ]
+});
 
 const coverageTask = {
   name: 'download and merge coverage'.split(' ').join('-'),


### PR DESCRIPTION
### Description

#### What is changing?

- Accidental removal of coverage in https://github.com/mongodb/node-mongodb-native/pull/3845 reverted here.

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

- The latest driver must remain compatible with v6.0.0 of mongodb-client-encryption the task reintroduced here specifically pins to that version and runs our test suite.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
