### PR TITLE
test(NODE-5606): use npm 9 on eol node versions

### DIFF
--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -509,7 +509,7 @@ functions:
         working_dir: "src"
         script: |
           ${PREPARE_SHELL}
-          NODE_LTS_VERSION=${NODE_LTS_VERSION} NPM_OPTIONS=${NPM_OPTIONS}\
+          NODE_LTS_VERSION=${NODE_LTS_VERSION} NPM_OPTIONS=${NPM_OPTIONS} NPM_VERSION=${NPM_VERSION}\
             bash ${PROJECT_DIRECTORY}/.evergreen/install-dependencies.sh
 
   "install aws-credential-providers":
@@ -1143,6 +1143,7 @@ tasks:
       - func: install dependencies
         vars:
           NODE_LTS_VERSION: v18.16.0
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: v6.0-perf
@@ -1156,6 +1157,8 @@ tasks:
   - name: "test-gcpkms-task"
     commands:
       - func: "install dependencies"
+        vars:
+          NPM_VERSION: 9
       # Upload node driver to a GCP instance
       - command: subprocess.exec
         type: setup
@@ -1191,6 +1194,8 @@ tasks:
     # It is expected to fail to obtain GCE credentials.
     commands:
       - func: "install dependencies"
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: latest
@@ -1209,6 +1214,8 @@ tasks:
   - name: "test-azurekms-task"
     commands:
       - func: "install dependencies"
+        vars:
+          NPM_VERSION: 9
       - command: subprocess.exec
         type: setup
         params:
@@ -1230,6 +1237,8 @@ tasks:
   - name: "test-azurekms-fail-task"
     commands:
       - func: "install dependencies"
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: latest
@@ -1247,6 +1256,8 @@ tasks:
   - name: "oidc-auth-test-azure-latest"
     commands:
       - func: "install dependencies"
+        vars:
+          NPM_VERSION: 9
       - command: subprocess.exec
         params:
           working_dir: src
@@ -1262,6 +1273,8 @@ tasks:
   - name: "test-aws-lambda-deployed"
     commands:
       - func: "install dependencies"
+        vars:
+          NPM_VERSION: 9
       - command: ec2.assume_role
         params:
           role_arn: ${LAMBDA_AWS_ROLE_ARN}

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -456,7 +456,7 @@ functions:
         working_dir: src
         script: |
           ${PREPARE_SHELL}
-          NODE_LTS_VERSION=${NODE_LTS_VERSION} NPM_OPTIONS=${NPM_OPTIONS}\
+          NODE_LTS_VERSION=${NODE_LTS_VERSION} NPM_OPTIONS=${NPM_OPTIONS} NPM_VERSION=${NPM_VERSION}\
             bash ${PROJECT_DIRECTORY}/.evergreen/install-dependencies.sh
   install aws-credential-providers:
     - command: shell.exec
@@ -1079,6 +1079,7 @@ tasks:
       - func: install dependencies
         vars:
           NODE_LTS_VERSION: v18.16.0
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: v6.0-perf
@@ -1091,6 +1092,8 @@ tasks:
   - name: test-gcpkms-task
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - command: subprocess.exec
         type: setup
         params:
@@ -1120,6 +1123,8 @@ tasks:
   - name: test-gcpkms-fail-task
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: latest
@@ -1136,6 +1141,8 @@ tasks:
   - name: test-azurekms-task
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - command: subprocess.exec
         type: setup
         params:
@@ -1156,6 +1163,8 @@ tasks:
   - name: test-azurekms-fail-task
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: latest
@@ -1172,6 +1181,8 @@ tasks:
   - name: oidc-auth-test-azure-latest
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - command: subprocess.exec
         params:
           working_dir: src
@@ -1186,6 +1197,8 @@ tasks:
   - name: test-aws-lambda-deployed
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - command: ec2.assume_role
         params:
           role_arn: ${LAMBDA_AWS_ROLE_ARN}
@@ -1218,6 +1231,8 @@ tasks:
       - server
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: latest
@@ -1231,6 +1246,8 @@ tasks:
       - replica_set
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: latest
@@ -1244,6 +1261,8 @@ tasks:
       - sharded_cluster
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: latest
@@ -1257,6 +1276,8 @@ tasks:
       - server
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: rapid
@@ -1270,6 +1291,8 @@ tasks:
       - replica_set
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: rapid
@@ -1283,6 +1306,8 @@ tasks:
       - sharded_cluster
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: rapid
@@ -1296,6 +1321,8 @@ tasks:
       - server
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '7.0'
@@ -1309,6 +1336,8 @@ tasks:
       - replica_set
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '7.0'
@@ -1322,6 +1351,8 @@ tasks:
       - sharded_cluster
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '7.0'
@@ -1335,6 +1366,8 @@ tasks:
       - server
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '6.0'
@@ -1348,6 +1381,8 @@ tasks:
       - replica_set
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '6.0'
@@ -1361,6 +1396,8 @@ tasks:
       - sharded_cluster
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '6.0'
@@ -1374,6 +1411,8 @@ tasks:
       - server
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '5.0'
@@ -1387,6 +1426,8 @@ tasks:
       - replica_set
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '5.0'
@@ -1400,6 +1441,8 @@ tasks:
       - sharded_cluster
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '5.0'
@@ -1413,6 +1456,8 @@ tasks:
       - server
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '4.4'
@@ -1426,6 +1471,8 @@ tasks:
       - replica_set
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '4.4'
@@ -1439,6 +1486,8 @@ tasks:
       - sharded_cluster
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '4.4'
@@ -1452,6 +1501,8 @@ tasks:
       - server
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '4.2'
@@ -1465,6 +1516,8 @@ tasks:
       - replica_set
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '4.2'
@@ -1478,6 +1531,8 @@ tasks:
       - sharded_cluster
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '4.2'
@@ -1491,6 +1546,8 @@ tasks:
       - server
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '4.0'
@@ -1504,6 +1561,8 @@ tasks:
       - replica_set
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '4.0'
@@ -1517,6 +1576,8 @@ tasks:
       - sharded_cluster
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '4.0'
@@ -1530,6 +1591,8 @@ tasks:
       - server
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '3.6'
@@ -1543,6 +1606,8 @@ tasks:
       - replica_set
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '3.6'
@@ -1556,6 +1621,8 @@ tasks:
       - sharded_cluster
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '3.6'
@@ -2601,6 +2668,7 @@ tasks:
       - func: install dependencies
         vars:
           NODE_LTS_VERSION: 16
+          NPM_VERSION: 9
       - func: run unit tests
   - name: run-lint-checks
     tags:
@@ -2609,6 +2677,7 @@ tasks:
       - func: install dependencies
         vars:
           NODE_LTS_VERSION: 16
+          NPM_VERSION: 9
       - func: run lint checks
   - name: check-types-typescript-next
     tags:
@@ -2617,6 +2686,7 @@ tasks:
       - func: install dependencies
         vars:
           NODE_LTS_VERSION: 16
+          NPM_VERSION: 9
       - func: check types
         vars:
           TS_VERSION: next
@@ -2627,6 +2697,7 @@ tasks:
       - func: install dependencies
         vars:
           NODE_LTS_VERSION: 16
+          NPM_VERSION: 9
       - func: compile driver
         vars:
           TS_VERSION: current
@@ -2637,6 +2708,7 @@ tasks:
       - func: install dependencies
         vars:
           NODE_LTS_VERSION: 16
+          NPM_VERSION: 9
       - func: check types
         vars:
           TS_VERSION: current
@@ -2647,6 +2719,7 @@ tasks:
       - func: install dependencies
         vars:
           NODE_LTS_VERSION: 16
+          NPM_VERSION: 9
       - func: check types
         vars:
           TS_VERSION: 4.1.6
@@ -2666,6 +2739,7 @@ tasks:
       - func: install dependencies
         vars:
           NODE_LTS_VERSION: 16
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '5.0'
@@ -2681,6 +2755,7 @@ tasks:
       - func: install dependencies
         vars:
           NODE_LTS_VERSION: 16
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '5.0'
@@ -2696,6 +2771,7 @@ tasks:
       - func: install dependencies
         vars:
           NODE_LTS_VERSION: 16
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: rapid
@@ -2711,6 +2787,7 @@ tasks:
       - func: install dependencies
         vars:
           NODE_LTS_VERSION: 16
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: rapid
@@ -2726,6 +2803,7 @@ tasks:
       - func: install dependencies
         vars:
           NODE_LTS_VERSION: 16
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: latest
@@ -2741,6 +2819,7 @@ tasks:
       - func: install dependencies
         vars:
           NODE_LTS_VERSION: 16
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: latest
@@ -2756,6 +2835,7 @@ tasks:
       - func: install dependencies
         vars:
           NODE_LTS_VERSION: 16
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '7.0'
@@ -2774,6 +2854,8 @@ tasks:
       - noauth
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: latest
@@ -2788,6 +2870,8 @@ tasks:
       - noauth
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: latest
@@ -2802,6 +2886,8 @@ tasks:
       - noauth
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: latest
@@ -2816,6 +2902,8 @@ tasks:
       - noauth
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: rapid
@@ -2830,6 +2918,8 @@ tasks:
       - noauth
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: rapid
@@ -2844,6 +2934,8 @@ tasks:
       - noauth
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: rapid
@@ -2858,6 +2950,8 @@ tasks:
       - noauth
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '7.0'
@@ -2872,6 +2966,8 @@ tasks:
       - noauth
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '7.0'
@@ -2886,6 +2982,8 @@ tasks:
       - noauth
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '7.0'
@@ -2900,6 +2998,8 @@ tasks:
       - noauth
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '6.0'
@@ -2914,6 +3014,8 @@ tasks:
       - noauth
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '6.0'
@@ -2928,6 +3030,8 @@ tasks:
       - noauth
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '6.0'
@@ -2942,6 +3046,8 @@ tasks:
       - noauth
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '5.0'
@@ -2956,6 +3062,8 @@ tasks:
       - noauth
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '5.0'
@@ -2970,6 +3078,8 @@ tasks:
       - noauth
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '5.0'
@@ -2984,6 +3094,8 @@ tasks:
       - noauth
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '4.4'
@@ -2998,6 +3110,8 @@ tasks:
       - noauth
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '4.4'
@@ -3012,6 +3126,8 @@ tasks:
       - noauth
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '4.4'
@@ -3026,6 +3142,8 @@ tasks:
       - noauth
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '4.2'
@@ -3040,6 +3158,8 @@ tasks:
       - noauth
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '4.2'
@@ -3054,6 +3174,8 @@ tasks:
       - noauth
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '4.2'
@@ -3068,6 +3190,8 @@ tasks:
       - noauth
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '4.0'
@@ -3082,6 +3206,8 @@ tasks:
       - noauth
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '4.0'
@@ -3096,6 +3222,8 @@ tasks:
       - noauth
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '4.0'
@@ -3110,6 +3238,8 @@ tasks:
       - noauth
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '3.6'
@@ -3124,6 +3254,8 @@ tasks:
       - noauth
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '3.6'
@@ -3138,6 +3270,8 @@ tasks:
       - noauth
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '3.6'
@@ -3151,6 +3285,8 @@ tasks:
       - lambda
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: rapid
@@ -3162,6 +3298,8 @@ tasks:
       - lambda
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: rapid
@@ -3284,6 +3422,7 @@ tasks:
       - func: install dependencies
         vars:
           NODE_LTS_VERSION: 16
+          NPM_VERSION: 9
       - func: run mongosh tests for package
         vars:
           mongosh_package: browser-runtime-electron
@@ -3295,6 +3434,7 @@ tasks:
       - func: install dependencies
         vars:
           NODE_LTS_VERSION: 16
+          NPM_VERSION: 9
       - func: run mongosh tests for package
         vars:
           mongosh_package: cli-repl
@@ -3306,6 +3446,7 @@ tasks:
       - func: install dependencies
         vars:
           NODE_LTS_VERSION: 16
+          NPM_VERSION: 9
       - func: run mongosh tests for package
         vars:
           mongosh_package: connectivity-tests
@@ -3317,6 +3458,7 @@ tasks:
       - func: install dependencies
         vars:
           NODE_LTS_VERSION: 16
+          NPM_VERSION: 9
       - func: run mongosh tests for package
         vars:
           mongosh_package: mongosh
@@ -3328,6 +3470,7 @@ tasks:
       - func: install dependencies
         vars:
           NODE_LTS_VERSION: 16
+          NPM_VERSION: 9
       - func: run mongosh tests for package
         vars:
           mongosh_package: node-runtime-worker-thread
@@ -3339,6 +3482,7 @@ tasks:
       - func: install dependencies
         vars:
           NODE_LTS_VERSION: 16
+          NPM_VERSION: 9
       - func: run mongosh tests for package
         vars:
           mongosh_package: service-provider-server
@@ -3349,6 +3493,7 @@ tasks:
       - func: install dependencies
         vars:
           NODE_LTS_VERSION: 16
+          NPM_VERSION: 9
       - func: compile mongosh
   - name: verify-mongosh-scopes
     tags:
@@ -3357,6 +3502,7 @@ tasks:
       - func: install dependencies
         vars:
           NODE_LTS_VERSION: 16
+          NPM_VERSION: 9
       - func: run mongosh package scope test
 task_groups:
   - name: serverless_task_group
@@ -3557,6 +3703,7 @@ buildvariants:
     run_on: rhel80-large
     expansions:
       NODE_LTS_VERSION: 16
+      NPM_VERSION: 9
       CLIENT_ENCRYPTION: true
     tasks:
       - test-latest-server
@@ -3608,6 +3755,7 @@ buildvariants:
     run_on: rhel80-large
     expansions:
       NODE_LTS_VERSION: 18
+      NPM_VERSION: latest
       CLIENT_ENCRYPTION: true
     tasks:
       - test-latest-server
@@ -3659,6 +3807,7 @@ buildvariants:
     run_on: rhel80-large
     expansions:
       NODE_LTS_VERSION: 20
+      NPM_VERSION: latest
       CLIENT_ENCRYPTION: true
     tasks:
       - test-latest-server
@@ -3761,6 +3910,7 @@ buildvariants:
     run_on: windows-vsCurrent-large
     expansions:
       NODE_LTS_VERSION: 16
+      NPM_VERSION: 9
     tasks:
       - test-latest-server
       - test-latest-replica_set
@@ -3803,6 +3953,7 @@ buildvariants:
     run_on: windows-vsCurrent-large
     expansions:
       NODE_LTS_VERSION: 18
+      NPM_VERSION: latest
     tasks:
       - test-latest-server
       - test-latest-replica_set
@@ -3845,6 +3996,7 @@ buildvariants:
     run_on: windows-vsCurrent-large
     expansions:
       NODE_LTS_VERSION: 20
+      NPM_VERSION: latest
     tasks:
       - test-latest-server
       - test-latest-replica_set
@@ -3889,6 +4041,7 @@ buildvariants:
       CLIENT_ENCRYPTION: true
       RUN_WITH_MONGOCRYPTD: true
       NODE_LTS_VERSION: 16
+      NPM_VERSION: 9
     tasks:
       - test-latest-csfle-mongocryptd
       - test-rapid-csfle-mongocryptd
@@ -3904,6 +4057,7 @@ buildvariants:
       CLIENT_ENCRYPTION: true
       RUN_WITH_MONGOCRYPTD: true
       NODE_LTS_VERSION: 16
+      NPM_VERSION: 9
     tasks:
       - test-latest-csfle-mongocryptd
       - test-rapid-csfle-mongocryptd
@@ -3952,6 +4106,7 @@ buildvariants:
     run_on: ubuntu1804-large
     expansions:
       NODE_LTS_VERSION: 16
+      NPM_VERSION: 9
     tasks:
       - aws-latest-auth-test-run-aws-auth-test-with-regular-aws-credentials
       - aws-latest-auth-test-run-aws-auth-test-with-assume-role-credentials
@@ -4045,6 +4200,7 @@ buildvariants:
     run_on: rhel80-large
     expansions:
       NODE_LTS_VERSION: 16
+      NPM_VERSION: 9
     tasks:
       - serverless_task_group
   - name: rhel8-test-gcp-kms

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -50,7 +50,12 @@ function makeTask({ mongoVersion, topology, tags = [], auth = 'auth' }) {
     name: `test-${mongoVersion}-${topology}${auth === 'noauth' ? '-noauth' : ''}`,
     tags: [mongoVersion, topology, ...tags],
     commands: [
-      { func: 'install dependencies' },
+      {
+        func: 'install dependencies',
+        vars: {
+          NPM_VERSION: 9
+        }
+      },
       {
         func: 'bootstrap mongo-orchestration',
         vars: {
@@ -290,7 +295,12 @@ AWS_LAMBDA_HANDLER_TASKS.push({
   name: 'test-lambda-example',
   tags: ['latest', 'lambda'],
   commands: [
-    { func: 'install dependencies' },
+    {
+      func: 'install dependencies',
+      vars: {
+        NPM_VERSION: 9
+      }
+    },
     {
       func: 'bootstrap mongo-orchestration',
       vars: {
@@ -307,7 +317,12 @@ AWS_LAMBDA_HANDLER_TASKS.push({
   name: 'test-lambda-aws-auth-example',
   tags: ['latest', 'lambda'],
   commands: [
-    { func: 'install dependencies' },
+    {
+      func: 'install dependencies',
+      vars: {
+        NPM_VERSION: 9
+      }
+    },
     {
       func: 'bootstrap mongo-orchestration',
       vars: {
@@ -430,7 +445,7 @@ for (const {
     const nodeLtsDisplayName = `Node${NODE_LTS_VERSION}`;
     const name = `${osName}-${NODE_LTS_VERSION >= 20 ? nodeLtsDisplayName : nodeLTSCodeName}`;
     const display_name = `${osDisplayName} ${nodeLtsDisplayName}`;
-    const expansions = { NODE_LTS_VERSION };
+    const expansions = { NODE_LTS_VERSION, NPM_VERSION: NODE_LTS_VERSION === 16 ? 9 : 'latest' };
     const taskNames = tasks.map(({ name }) => name);
 
     if (clientEncryption) {
@@ -496,7 +511,8 @@ for (const nodeVersion of [LOWEST_LTS, LATEST_LTS]) {
     expansions: {
       CLIENT_ENCRYPTION: true,
       RUN_WITH_MONGOCRYPTD: true,
-      NODE_LTS_VERSION: LOWEST_LTS
+      NODE_LTS_VERSION: LOWEST_LTS,
+      NPM_VERSION: 9
     },
     tasks:
       MONGOCRYPTD_CSFLE_TASKS.map(task => task.name)
@@ -524,7 +540,8 @@ SINGLETON_TASKS.push(
         {
           func: 'install dependencies',
           vars: {
-            NODE_LTS_VERSION: LOWEST_LTS
+            NODE_LTS_VERSION: LOWEST_LTS,
+            NPM_VERSION: 9
           }
         },
         { func: 'run unit tests' }
@@ -537,7 +554,8 @@ SINGLETON_TASKS.push(
         {
           func: 'install dependencies',
           vars: {
-            NODE_LTS_VERSION: LOWEST_LTS
+            NODE_LTS_VERSION: LOWEST_LTS,
+            NPM_VERSION: 9
           }
         },
         { func: 'run lint checks' }
@@ -559,7 +577,8 @@ function* makeTypescriptTasks() {
           {
             func: 'install dependencies',
             vars: {
-              NODE_LTS_VERSION: LOWEST_LTS
+              NODE_LTS_VERSION: LOWEST_LTS,
+              NPM_VERSION: 9
             }
           },
           {
@@ -579,7 +598,8 @@ function* makeTypescriptTasks() {
         {
           func: 'install dependencies',
           vars: {
-            NODE_LTS_VERSION: LOWEST_LTS
+            NODE_LTS_VERSION: LOWEST_LTS,
+            NPM_VERSION: 9
           }
         },
         {
@@ -598,7 +618,8 @@ function* makeTypescriptTasks() {
       {
         func: 'install dependencies',
         vars: {
-          NODE_LTS_VERSION: LOWEST_LTS
+          NODE_LTS_VERSION: LOWEST_LTS,
+          NPM_VERSION: 9
         }
       },
       { func: 'run typescript next' }
@@ -637,7 +658,8 @@ BUILD_VARIANTS.push({
   display_name: 'MONGODB-AWS Auth test',
   run_on: UBUNTU_OS,
   expansions: {
-    NODE_LTS_VERSION: LOWEST_LTS
+    NODE_LTS_VERSION: LOWEST_LTS,
+    NPM_VERSION: 9
   },
   tasks: AWS_AUTH_TASKS
 });
@@ -655,7 +677,8 @@ for (const version of ['5.0', 'rapid', 'latest']) {
         {
           func: 'install dependencies',
           vars: {
-            NODE_LTS_VERSION: LOWEST_LTS
+            NODE_LTS_VERSION: LOWEST_LTS,
+            NPM_VERSION: 9
           }
         },
         {
@@ -684,7 +707,8 @@ oneOffFuncAsTasks.push({
     {
       func: 'install dependencies',
       vars: {
-        NODE_LTS_VERSION: LOWEST_LTS
+        NODE_LTS_VERSION: LOWEST_LTS,
+        NPM_VERSION: 9
       }
     },
     {
@@ -737,7 +761,8 @@ BUILD_VARIANTS.push({
   display_name: 'Serverless Test',
   run_on: DEFAULT_OS,
   expansions: {
-    NODE_LTS_VERSION: LOWEST_LTS
+    NODE_LTS_VERSION: LOWEST_LTS,
+    NPM_VERSION: 9
   },
   tasks: ['serverless_task_group']
 });

--- a/.evergreen/generate_mongosh_tasks.js
+++ b/.evergreen/generate_mongosh_tasks.js
@@ -16,7 +16,8 @@ const mongoshTestTasks = scopes.map(packageName => {
       {
         func: 'install dependencies',
         vars: {
-          NODE_LTS_VERSION: 16
+          NODE_LTS_VERSION: 16,
+          NPM_VERSION: 9
         }
       },
       {
@@ -36,7 +37,8 @@ const compileTask = {
     {
       func: 'install dependencies',
       vars: {
-        NODE_LTS_VERSION: 16
+        NODE_LTS_VERSION: 16,
+        NPM_VERSION: 9
       }
     },
     { func: 'compile mongosh' }
@@ -50,7 +52,8 @@ const scopeVerificationTask = {
     {
       func: 'install dependencies',
       vars: {
-        NODE_LTS_VERSION: 16
+        NODE_LTS_VERSION: 16,
+        NPM_VERSION: 9
       }
     },
     { func: 'run mongosh package scope test' }

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -2,6 +2,7 @@
 set -o errexit  # Exit the script with error if any of the commands fail
 
 NODE_LTS_VERSION=${NODE_LTS_VERSION:-16}
+NODE_LOWEST_LTS=18
 
 source "${PROJECT_DIRECTORY}/.evergreen/init-node-and-npm-env.sh"
 
@@ -96,7 +97,11 @@ fi
 
 if [[ $operating_system != "win" ]]; then
   # Update npm to latest when we can
-  npm install --global npm@latest
+  if [[ $NODE_LTS_VERSION -lt $NODE_LOWEST_LTS ]]; then
+    npm install --global npm@9
+  else
+    npm install --global npm@latest
+  fi
   hash -r
 fi
 

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -2,7 +2,9 @@
 set -o errexit  # Exit the script with error if any of the commands fail
 
 NODE_LTS_VERSION=${NODE_LTS_VERSION:-16}
-NODE_LOWEST_LTS=18
+# npm version can be defined in the environment for cases where we need to install
+# a version lower than latest to support EOL Node versions.
+NPM_VERSION=${NPM_VERSION:-latest}
 
 source "${PROJECT_DIRECTORY}/.evergreen/init-node-and-npm-env.sh"
 
@@ -96,12 +98,7 @@ else
 fi
 
 if [[ $operating_system != "win" ]]; then
-  # Update npm to latest when we can
-  if [[ $NODE_LTS_VERSION -lt $NODE_LOWEST_LTS ]]; then
-    npm install --global npm@9
-  else
-    npm install --global npm@latest
-  fi
+  npm install --global npm@$NPM_VERSION
   hash -r
 fi
 


### PR DESCRIPTION
### Description

Fixes Node 16 failures with npm 10.

#### What is changing?

- Installs npm@9 when on Node 16 or lower.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-5606

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
