### PR TITLE
test(NODE-5619): use npm 9 on eol node versions

### DIFF
--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -507,7 +507,7 @@ functions:
         working_dir: "src"
         script: |
           ${PREPARE_SHELL}
-          NODE_LTS_VERSION=${NODE_LTS_VERSION} NPM_OPTIONS=${NPM_OPTIONS}\
+          NODE_LTS_VERSION=${NODE_LTS_VERSION} NPM_OPTIONS=${NPM_OPTIONS} NPM_VERSION=${NPM_VERSION}\
             bash ${PROJECT_DIRECTORY}/.evergreen/install-dependencies.sh
 
   "install aws-credential-providers":
@@ -1139,6 +1139,7 @@ tasks:
       - func: install dependencies
         vars:
           NODE_LTS_VERSION: v18.16.0
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: v6.0-perf
@@ -1152,6 +1153,8 @@ tasks:
   - name: "test-gcpkms-task"
     commands:
       - func: "install dependencies"
+        vars:
+          NPM_VERSION: 9
       # Upload node driver to a GCP instance
       - command: subprocess.exec
         type: setup
@@ -1187,6 +1190,8 @@ tasks:
     # It is expected to fail to obtain GCE credentials.
     commands:
       - func: "install dependencies"
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: latest
@@ -1205,6 +1210,8 @@ tasks:
   - name: "test-azurekms-task"
     commands:
       - func: "install dependencies"
+        vars:
+          NPM_VERSION: 9
       - command: subprocess.exec
         type: setup
         params:
@@ -1226,6 +1233,8 @@ tasks:
   - name: "test-azurekms-fail-task"
     commands:
       - func: "install dependencies"
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: latest
@@ -1243,6 +1252,8 @@ tasks:
   - name: "oidc-auth-test-azure-latest"
     commands:
       - func: "install dependencies"
+        vars:
+          NPM_VERSION: 9
       - command: subprocess.exec
         params:
           working_dir: src
@@ -1258,6 +1269,8 @@ tasks:
   - name: "test-aws-lambda-deployed"
     commands:
       - func: "install dependencies"
+        vars:
+          NPM_VERSION: 9
       - command: ec2.assume_role
         params:
           role_arn: ${LAMBDA_AWS_ROLE_ARN}

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -454,7 +454,7 @@ functions:
         working_dir: src
         script: |
           ${PREPARE_SHELL}
-          NODE_LTS_VERSION=${NODE_LTS_VERSION} NPM_OPTIONS=${NPM_OPTIONS}\
+          NODE_LTS_VERSION=${NODE_LTS_VERSION} NPM_OPTIONS=${NPM_OPTIONS} NPM_VERSION=${NPM_VERSION}\
             bash ${PROJECT_DIRECTORY}/.evergreen/install-dependencies.sh
   install aws-credential-providers:
     - command: shell.exec
@@ -1075,6 +1075,7 @@ tasks:
       - func: install dependencies
         vars:
           NODE_LTS_VERSION: v18.16.0
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: v6.0-perf
@@ -1087,6 +1088,8 @@ tasks:
   - name: test-gcpkms-task
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - command: subprocess.exec
         type: setup
         params:
@@ -1116,6 +1119,8 @@ tasks:
   - name: test-gcpkms-fail-task
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: latest
@@ -1132,6 +1137,8 @@ tasks:
   - name: test-azurekms-task
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - command: subprocess.exec
         type: setup
         params:
@@ -1152,6 +1159,8 @@ tasks:
   - name: test-azurekms-fail-task
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: latest
@@ -1168,6 +1177,8 @@ tasks:
   - name: oidc-auth-test-azure-latest
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - command: subprocess.exec
         params:
           working_dir: src
@@ -1182,6 +1193,8 @@ tasks:
   - name: test-aws-lambda-deployed
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - command: ec2.assume_role
         params:
           role_arn: ${LAMBDA_AWS_ROLE_ARN}
@@ -1202,6 +1215,8 @@ tasks:
       - server
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: latest
@@ -1215,6 +1230,8 @@ tasks:
       - replica_set
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: latest
@@ -1228,6 +1245,8 @@ tasks:
       - sharded_cluster
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: latest
@@ -1241,6 +1260,8 @@ tasks:
       - server
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: rapid
@@ -1254,6 +1275,8 @@ tasks:
       - replica_set
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: rapid
@@ -1267,6 +1290,8 @@ tasks:
       - sharded_cluster
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: rapid
@@ -1280,6 +1305,8 @@ tasks:
       - server
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '7.0'
@@ -1293,6 +1320,8 @@ tasks:
       - replica_set
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '7.0'
@@ -1306,6 +1335,8 @@ tasks:
       - sharded_cluster
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '7.0'
@@ -1319,6 +1350,8 @@ tasks:
       - server
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '6.0'
@@ -1332,6 +1365,8 @@ tasks:
       - replica_set
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '6.0'
@@ -1345,6 +1380,8 @@ tasks:
       - sharded_cluster
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '6.0'
@@ -1358,6 +1395,8 @@ tasks:
       - server
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '5.0'
@@ -1371,6 +1410,8 @@ tasks:
       - replica_set
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '5.0'
@@ -1384,6 +1425,8 @@ tasks:
       - sharded_cluster
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '5.0'
@@ -1397,6 +1440,8 @@ tasks:
       - server
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '4.4'
@@ -1410,6 +1455,8 @@ tasks:
       - replica_set
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '4.4'
@@ -1423,6 +1470,8 @@ tasks:
       - sharded_cluster
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '4.4'
@@ -1436,6 +1485,8 @@ tasks:
       - server
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '4.2'
@@ -1449,6 +1500,8 @@ tasks:
       - replica_set
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '4.2'
@@ -1462,6 +1515,8 @@ tasks:
       - sharded_cluster
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '4.2'
@@ -1475,6 +1530,8 @@ tasks:
       - server
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '4.0'
@@ -1488,6 +1545,8 @@ tasks:
       - replica_set
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '4.0'
@@ -1501,6 +1560,8 @@ tasks:
       - sharded_cluster
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '4.0'
@@ -1514,6 +1575,8 @@ tasks:
       - server
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '3.6'
@@ -1527,6 +1590,8 @@ tasks:
       - replica_set
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '3.6'
@@ -1540,6 +1605,8 @@ tasks:
       - sharded_cluster
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '3.6'
@@ -2578,6 +2645,7 @@ tasks:
       - func: install dependencies
         vars:
           NODE_LTS_VERSION: 14
+          NPM_VERSION: 9
       - func: run unit tests
   - name: run-lint-checks
     tags:
@@ -2586,6 +2654,7 @@ tasks:
       - func: install dependencies
         vars:
           NODE_LTS_VERSION: 14
+          NPM_VERSION: 9
       - func: run lint checks
   - name: check-types-typescript-next
     tags:
@@ -2594,6 +2663,7 @@ tasks:
       - func: install dependencies
         vars:
           NODE_LTS_VERSION: 14
+          NPM_VERSION: 9
       - func: check types
         vars:
           TS_VERSION: next
@@ -2604,6 +2674,7 @@ tasks:
       - func: install dependencies
         vars:
           NODE_LTS_VERSION: 14
+          NPM_VERSION: 9
       - func: compile driver
         vars:
           TS_VERSION: current
@@ -2614,6 +2685,7 @@ tasks:
       - func: install dependencies
         vars:
           NODE_LTS_VERSION: 14
+          NPM_VERSION: 9
       - func: check types
         vars:
           TS_VERSION: current
@@ -2624,6 +2696,7 @@ tasks:
       - func: install dependencies
         vars:
           NODE_LTS_VERSION: 14
+          NPM_VERSION: 9
       - func: check types
         vars:
           TS_VERSION: 4.1.6
@@ -2654,6 +2727,7 @@ tasks:
       - func: install dependencies
         vars:
           NODE_LTS_VERSION: 14
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '5.0'
@@ -2669,6 +2743,7 @@ tasks:
       - func: install dependencies
         vars:
           NODE_LTS_VERSION: 14
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '5.0'
@@ -2684,6 +2759,7 @@ tasks:
       - func: install dependencies
         vars:
           NODE_LTS_VERSION: 14
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: rapid
@@ -2699,6 +2775,7 @@ tasks:
       - func: install dependencies
         vars:
           NODE_LTS_VERSION: 14
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: rapid
@@ -2714,6 +2791,7 @@ tasks:
       - func: install dependencies
         vars:
           NODE_LTS_VERSION: 14
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: latest
@@ -2729,6 +2807,7 @@ tasks:
       - func: install dependencies
         vars:
           NODE_LTS_VERSION: 14
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: latest
@@ -2744,6 +2823,8 @@ tasks:
       - noauth
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: latest
@@ -2758,6 +2839,8 @@ tasks:
       - noauth
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: latest
@@ -2772,6 +2855,8 @@ tasks:
       - noauth
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: latest
@@ -2786,6 +2871,8 @@ tasks:
       - noauth
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: rapid
@@ -2800,6 +2887,8 @@ tasks:
       - noauth
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: rapid
@@ -2814,6 +2903,8 @@ tasks:
       - noauth
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: rapid
@@ -2828,6 +2919,8 @@ tasks:
       - noauth
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '7.0'
@@ -2842,6 +2935,8 @@ tasks:
       - noauth
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '7.0'
@@ -2856,6 +2951,8 @@ tasks:
       - noauth
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '7.0'
@@ -2870,6 +2967,8 @@ tasks:
       - noauth
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '6.0'
@@ -2884,6 +2983,8 @@ tasks:
       - noauth
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '6.0'
@@ -2898,6 +2999,8 @@ tasks:
       - noauth
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '6.0'
@@ -2912,6 +3015,8 @@ tasks:
       - noauth
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '5.0'
@@ -2926,6 +3031,8 @@ tasks:
       - noauth
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '5.0'
@@ -2940,6 +3047,8 @@ tasks:
       - noauth
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '5.0'
@@ -2954,6 +3063,8 @@ tasks:
       - noauth
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '4.4'
@@ -2968,6 +3079,8 @@ tasks:
       - noauth
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '4.4'
@@ -2982,6 +3095,8 @@ tasks:
       - noauth
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '4.4'
@@ -2996,6 +3111,8 @@ tasks:
       - noauth
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '4.2'
@@ -3010,6 +3127,8 @@ tasks:
       - noauth
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '4.2'
@@ -3024,6 +3143,8 @@ tasks:
       - noauth
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '4.2'
@@ -3038,6 +3159,8 @@ tasks:
       - noauth
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '4.0'
@@ -3052,6 +3175,8 @@ tasks:
       - noauth
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '4.0'
@@ -3066,6 +3191,8 @@ tasks:
       - noauth
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '4.0'
@@ -3080,6 +3207,8 @@ tasks:
       - noauth
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '3.6'
@@ -3094,6 +3223,8 @@ tasks:
       - noauth
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '3.6'
@@ -3108,6 +3239,8 @@ tasks:
       - noauth
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: '3.6'
@@ -3121,6 +3254,8 @@ tasks:
       - lambda
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: rapid
@@ -3132,6 +3267,8 @@ tasks:
       - lambda
     commands:
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
         vars:
           VERSION: rapid
@@ -3254,6 +3391,7 @@ tasks:
       - func: install dependencies
         vars:
           NODE_LTS_VERSION: 16
+          NPM_VERSION: 9
       - func: run mongosh tests for package
         vars:
           mongosh_package: browser-runtime-electron
@@ -3265,6 +3403,7 @@ tasks:
       - func: install dependencies
         vars:
           NODE_LTS_VERSION: 16
+          NPM_VERSION: 9
       - func: run mongosh tests for package
         vars:
           mongosh_package: cli-repl
@@ -3276,6 +3415,7 @@ tasks:
       - func: install dependencies
         vars:
           NODE_LTS_VERSION: 16
+          NPM_VERSION: 9
       - func: run mongosh tests for package
         vars:
           mongosh_package: connectivity-tests
@@ -3287,6 +3427,7 @@ tasks:
       - func: install dependencies
         vars:
           NODE_LTS_VERSION: 16
+          NPM_VERSION: 9
       - func: run mongosh tests for package
         vars:
           mongosh_package: mongosh
@@ -3298,6 +3439,7 @@ tasks:
       - func: install dependencies
         vars:
           NODE_LTS_VERSION: 16
+          NPM_VERSION: 9
       - func: run mongosh tests for package
         vars:
           mongosh_package: node-runtime-worker-thread
@@ -3309,6 +3451,7 @@ tasks:
       - func: install dependencies
         vars:
           NODE_LTS_VERSION: 16
+          NPM_VERSION: 9
       - func: run mongosh tests for package
         vars:
           mongosh_package: service-provider-server
@@ -3319,6 +3462,7 @@ tasks:
       - func: install dependencies
         vars:
           NODE_LTS_VERSION: 16
+          NPM_VERSION: 9
       - func: compile mongosh
   - name: verify-mongosh-scopes
     tags:
@@ -3327,6 +3471,7 @@ tasks:
       - func: install dependencies
         vars:
           NODE_LTS_VERSION: 16
+          NPM_VERSION: 9
       - func: run mongosh package scope test
 task_groups:
   - name: serverless_task_group
@@ -3498,6 +3643,7 @@ buildvariants:
     run_on: rhel80-large
     expansions:
       NODE_LTS_VERSION: 14
+      NPM_VERSION: latest
       CLIENT_ENCRYPTION: true
     tasks:
       - test-latest-server
@@ -3550,6 +3696,7 @@ buildvariants:
     run_on: rhel80-large
     expansions:
       NODE_LTS_VERSION: 16
+      NPM_VERSION: 9
       CLIENT_ENCRYPTION: true
     tasks:
       - test-latest-server
@@ -3600,6 +3747,7 @@ buildvariants:
     run_on: rhel80-large
     expansions:
       NODE_LTS_VERSION: 18
+      NPM_VERSION: latest
       CLIENT_ENCRYPTION: true
     tasks:
       - test-latest-server
@@ -3650,6 +3798,7 @@ buildvariants:
     run_on: rhel80-large
     expansions:
       NODE_LTS_VERSION: 20
+      NPM_VERSION: latest
       CLIENT_ENCRYPTION: true
     tasks:
       - test-latest-server
@@ -3750,6 +3899,7 @@ buildvariants:
     run_on: windows-vsCurrent-large
     expansions:
       NODE_LTS_VERSION: 16
+      NPM_VERSION: 9
     tasks:
       - test-latest-server
       - test-latest-replica_set
@@ -3792,6 +3942,7 @@ buildvariants:
     run_on: windows-vsCurrent-large
     expansions:
       NODE_LTS_VERSION: 18
+      NPM_VERSION: latest
     tasks:
       - test-latest-server
       - test-latest-replica_set
@@ -3834,6 +3985,7 @@ buildvariants:
     run_on: windows-vsCurrent-large
     expansions:
       NODE_LTS_VERSION: 20
+      NPM_VERSION: latest
     tasks:
       - test-latest-server
       - test-latest-replica_set
@@ -3878,6 +4030,7 @@ buildvariants:
       CLIENT_ENCRYPTION: true
       RUN_WITH_MONGOCRYPTD: true
       NODE_LTS_VERSION: 14
+      NPM_VERSION: 9
     tasks:
       - test-latest-csfle-mongocryptd
       - test-rapid-csfle-mongocryptd
@@ -3893,6 +4046,7 @@ buildvariants:
       CLIENT_ENCRYPTION: true
       RUN_WITH_MONGOCRYPTD: true
       NODE_LTS_VERSION: 14
+      NPM_VERSION: 9
     tasks:
       - test-latest-csfle-mongocryptd
       - test-rapid-csfle-mongocryptd
@@ -3941,6 +4095,7 @@ buildvariants:
     run_on: ubuntu1804-large
     expansions:
       NODE_LTS_VERSION: 14
+      NPM_VERSION: 9
     tasks:
       - aws-latest-auth-test-run-aws-auth-test-with-regular-aws-credentials
       - aws-latest-auth-test-run-aws-auth-test-with-assume-role-credentials
@@ -4033,6 +4188,7 @@ buildvariants:
     run_on: rhel80-large
     expansions:
       NODE_LTS_VERSION: 14
+      NPM_VERSION: 9
     tasks:
       - serverless_task_group
   - name: rhel8-test-gcp-kms

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -3643,7 +3643,7 @@ buildvariants:
     run_on: rhel80-large
     expansions:
       NODE_LTS_VERSION: 14
-      NPM_VERSION: latest
+      NPM_VERSION: 9
       CLIENT_ENCRYPTION: true
     tasks:
       - test-latest-server

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -448,7 +448,7 @@ for (const {
     const nodeLtsDisplayName = `Node${NODE_LTS_VERSION}`;
     const name = `${osName}-${NODE_LTS_VERSION >= 20 ? nodeLtsDisplayName : nodeLTSCodeName}`;
     const display_name = `${osDisplayName} ${nodeLtsDisplayName}`;
-    const expansions = { NODE_LTS_VERSION, NPM_VERSION: NODE_LTS_VERSION === 16 ? 9 : 'latest' };
+    const expansions = { NODE_LTS_VERSION, NPM_VERSION: NODE_LTS_VERSION <= 16 ? 9 : 'latest' };
     const taskNames = tasks.map(({ name }) => name);
 
     if (clientEncryption) {

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -50,7 +50,12 @@ function makeTask({ mongoVersion, topology, tags = [], auth = 'auth' }) {
     name: `test-${mongoVersion}-${topology}${auth === 'noauth' ? '-noauth' : ''}`,
     tags: [mongoVersion, topology, ...tags],
     commands: [
-      { func: 'install dependencies' },
+      {
+        func: 'install dependencies',
+        vars: {
+          NPM_VERSION: 9
+        }
+      },
       {
         func: 'bootstrap mongo-orchestration',
         vars: {
@@ -291,7 +296,12 @@ AWS_LAMBDA_HANDLER_TASKS.push({
   name: 'test-lambda-example',
   tags: ['latest', 'lambda'],
   commands: [
-    { func: 'install dependencies' },
+    {
+      func: 'install dependencies',
+      vars: {
+        NPM_VERSION: 9
+      }
+    },
     {
       func: 'bootstrap mongo-orchestration',
       vars: {
@@ -308,7 +318,12 @@ AWS_LAMBDA_HANDLER_TASKS.push({
   name: 'test-lambda-aws-auth-example',
   tags: ['latest', 'lambda'],
   commands: [
-    { func: 'install dependencies' },
+    {
+      func: 'install dependencies',
+      vars: {
+        NPM_VERSION: 9
+      }
+    },
     {
       func: 'bootstrap mongo-orchestration',
       vars: {
@@ -433,7 +448,7 @@ for (const {
     const nodeLtsDisplayName = `Node${NODE_LTS_VERSION}`;
     const name = `${osName}-${NODE_LTS_VERSION >= 20 ? nodeLtsDisplayName : nodeLTSCodeName}`;
     const display_name = `${osDisplayName} ${nodeLtsDisplayName}`;
-    const expansions = { NODE_LTS_VERSION };
+    const expansions = { NODE_LTS_VERSION, NPM_VERSION: NODE_LTS_VERSION === 16 ? 9 : 'latest' };
     const taskNames = tasks.map(({ name }) => name);
 
     if (clientEncryption) {
@@ -499,7 +514,8 @@ for (const nodeVersion of [LOWEST_LTS, LATEST_LTS]) {
     expansions: {
       CLIENT_ENCRYPTION: true,
       RUN_WITH_MONGOCRYPTD: true,
-      NODE_LTS_VERSION: LOWEST_LTS
+      NODE_LTS_VERSION: LOWEST_LTS,
+      NPM_VERSION: 9
     },
     tasks:
       MONGOCRYPTD_CSFLE_TASKS.map(task => task.name)
@@ -527,7 +543,8 @@ SINGLETON_TASKS.push(
         {
           func: 'install dependencies',
           vars: {
-            NODE_LTS_VERSION: LOWEST_LTS
+            NODE_LTS_VERSION: LOWEST_LTS,
+            NPM_VERSION: 9
           }
         },
         { func: 'run unit tests' }
@@ -540,7 +557,8 @@ SINGLETON_TASKS.push(
         {
           func: 'install dependencies',
           vars: {
-            NODE_LTS_VERSION: LOWEST_LTS
+            NODE_LTS_VERSION: LOWEST_LTS,
+            NPM_VERSION: 9
           }
         },
         { func: 'run lint checks' }
@@ -561,7 +579,8 @@ function* makeTypescriptTasks() {
           {
             func: 'install dependencies',
             vars: {
-              NODE_LTS_VERSION: LOWEST_LTS
+              NODE_LTS_VERSION: LOWEST_LTS,
+              NPM_VERSION: 9
             }
           },
           {
@@ -581,7 +600,8 @@ function* makeTypescriptTasks() {
         {
           func: 'install dependencies',
           vars: {
-            NODE_LTS_VERSION: LOWEST_LTS
+            NODE_LTS_VERSION: LOWEST_LTS,
+            NPM_VERSION: 9
           }
         },
         {
@@ -600,7 +620,8 @@ function* makeTypescriptTasks() {
       {
         func: 'install dependencies',
         vars: {
-          NODE_LTS_VERSION: LOWEST_LTS
+          NODE_LTS_VERSION: LOWEST_LTS,
+          NPM_VERSION: 9
         }
       },
       { func: 'run typescript next' }
@@ -639,7 +660,8 @@ BUILD_VARIANTS.push({
   display_name: 'MONGODB-AWS Auth test',
   run_on: UBUNTU_OS,
   expansions: {
-    NODE_LTS_VERSION: LOWEST_LTS
+    NODE_LTS_VERSION: LOWEST_LTS,
+    NPM_VERSION: 9
   },
   tasks: AWS_AUTH_TASKS
 });
@@ -657,7 +679,8 @@ for (const version of ['5.0', 'rapid', 'latest']) {
         {
           func: 'install dependencies',
           vars: {
-            NODE_LTS_VERSION: LOWEST_LTS
+            NODE_LTS_VERSION: LOWEST_LTS,
+            NPM_VERSION: 9
           }
         },
         {
@@ -726,7 +749,8 @@ BUILD_VARIANTS.push({
   display_name: 'Serverless Test',
   run_on: DEFAULT_OS,
   expansions: {
-    NODE_LTS_VERSION: LOWEST_LTS
+    NODE_LTS_VERSION: LOWEST_LTS,
+    NPM_VERSION: 9
   },
   tasks: ['serverless_task_group']
 });

--- a/.evergreen/generate_mongosh_tasks.js
+++ b/.evergreen/generate_mongosh_tasks.js
@@ -16,7 +16,8 @@ const mongoshTestTasks = scopes.map(packageName => {
       {
         func: 'install dependencies',
         vars: {
-          NODE_LTS_VERSION: 16
+          NODE_LTS_VERSION: 16,
+          NPM_VERSION: 9
         }
       },
       {
@@ -36,7 +37,8 @@ const compileTask = {
     {
       func: 'install dependencies',
       vars: {
-        NODE_LTS_VERSION: 16
+        NODE_LTS_VERSION: 16,
+        NPM_VERSION: 9
       }
     },
     { func: 'compile mongosh' }
@@ -50,7 +52,8 @@ const scopeVerificationTask = {
     {
       func: 'install dependencies',
       vars: {
-        NODE_LTS_VERSION: 16
+        NODE_LTS_VERSION: 16,
+        NPM_VERSION: 9
       }
     },
     { func: 'run mongosh package scope test' }

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -2,6 +2,9 @@
 set -o errexit  # Exit the script with error if any of the commands fail
 
 NODE_LTS_VERSION=${NODE_LTS_VERSION:-14}
+# npm version can be defined in the environment for cases where we need to install
+# a version lower than latest to support EOL Node versions.
+NPM_VERSION=${NPM_VERSION:-latest}
 
 source "${PROJECT_DIRECTORY}/.evergreen/init-node-and-npm-env.sh"
 
@@ -95,8 +98,7 @@ else
 fi
 
 if [[ $operating_system != "win" ]]; then
-  # Update npm to latest when we can
-  npm install --global npm@latest
+  npm install --global npm@$NPM_VERSION
   hash -r
 fi
 


### PR DESCRIPTION
### Description

Fixes Node 16 failures with npm 10 on 5.x branch.

#### What is changing?

- Installs npm@9 when on Node 16 or lower.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NOE-5619

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
