### PR TITLE
chore(no-story): skip failing aggregate explain tests

### DIFF
--- a/test/integration/crud/explain.test.ts
+++ b/test/integration/crud/explain.test.ts
@@ -78,7 +78,6 @@ describe('CRUD API explain option', function () {
     const test = this.currentTest;
     if (
       test?.fullTitle().includes('aggregate') &&
-      !test?.fullTitle().includes('false') &&
       gte(this.configuration.version, '7.1.0') &&
       this.currentTest
     ) {

--- a/test/integration/crud/explain.test.ts
+++ b/test/integration/crud/explain.test.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import { once } from 'events';
+import { gte } from 'semver';
 
 import {
   type Collection,
@@ -73,6 +74,18 @@ describe('CRUD API explain option', function () {
     collection = db.collection('test');
     await collection.insertOne({ a: 1 });
     commandStartedPromise = once(client, 'commandStarted');
+
+    const test = this.currentTest;
+    if (
+      test?.fullTitle().includes('aggregate') &&
+      !test?.fullTitle().includes('false') &&
+      gte(this.configuration.version, '7.1.0') &&
+      this.currentTest
+    ) {
+      this.currentTest.skipReason =
+        'TODO(NODE-5617): aggregate explain tests failing on latest servers';
+      this.skip();
+    }
   });
 
   afterEach(async function () {


### PR DESCRIPTION
### Description

#### What is changing?

Failing aggregate + explain tests are skipped on latest servers.

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
