### PR TITLE
docs(no-story): prevent merge conflicts when generating docs for old branches

### DIFF
--- a/etc/docs/build.ts
+++ b/etc/docs/build.ts
@@ -106,6 +106,9 @@ async function main() {
 
   log('Generating new static site...');
 
+  await exec(`git checkout main ${RELEASES_TOML_FILE}`);
+  await exec(`git checkout main ${RELEASES_JSON_FILE}`);
+
   const tomlVersions = parse(
     await readFile(RELEASES_TOML_FILE, { encoding: 'utf8' })
   ) as unknown as TomlVersionSchema;


### PR DESCRIPTION
### Description

#### What is changing?

When we generate docs for an old branch (5.x for example), we get merge conflicts because the release files in our static docs site are out-of-sync with main.  

Our docs build script already reads these files in, updates the contents and writes them back out.  We can prevent merge conflicts by first updating the files on the target branch (5.x for example) with the contents from main.  Then, when we generate the docs we update the contents of the files already accounting for changes on main.

Hypothetical example: docs generation for a new minor, 5.19 (random version number > our existing latest 5.x)

Current workflow:

- switch to the 5.x branch
- generate docs for 5.19 (new minor)
- merge the changes to 5.x
- open a PR against main, cherry-picking these changes in
- resolve the merge conflicts in releases.toml/json that arise because main has additional releases (6.0) that 5.x doesn't have

Proposed workflow:

- switch to 5.x branch (needed because the release contains changes only present for 5.x)
- generate docs.  This pulls in the releases.toml/json from main before updating them.
- commit the changes
- cherry-pick to main with no merge conflicts

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
