### PR TITLE
feat(NODE-5564): bump bson version to ^5.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.8.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "bson": "^5.4.0",
+        "bson": "^5.5.0",
         "mongodb-connection-string-url": "^2.6.0",
         "socks": "^2.7.1"
       },
@@ -3480,9 +3480,9 @@
       }
     },
     "node_modules/bson": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-5.4.0.tgz",
-      "integrity": "sha512-WRZ5SQI5GfUuKnPTNmAYPiKIof3ORXAF4IRU5UcgmivNIon01rWQlw5RUH954dpu8yGL8T59YShVddIPaU/gFA==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-5.5.0.tgz",
+      "integrity": "sha512-B+QB4YmDx9RStKv8LLSl/aVIEV3nYJc3cJNNTK2Cd1TL+7P+cNpw9mAPeCgc5K+j01Dv6sxUzcITXDx7ZU3F0w==",
       "engines": {
         "node": ">=14.20.1"
       }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "email": "dbx-node@mongodb.com"
   },
   "dependencies": {
-    "bson": "^5.4.0",
+    "bson": "^5.5.0",
     "mongodb-connection-string-url": "^2.6.0",
     "socks": "^2.7.1"
   },


### PR DESCRIPTION
### Description

#### What is changing?
Bump bson dependency version to 5.5 to make use of [new `Decimal128` behaviour](https://github.com/mongodb/js-bson/releases/tag/v5.5.0).


##### Is there new documentation needed for these changes?
Just release notes

#### What is the motivation for this change?

NODE-5564

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Bumped `bson` version to make use of new `Decimal128` behaviour

In this release, we have adopted the changes made to `Decimal128` in [bson version 5.5](https://github.com/mongodb/js-bson/releases/tag/v5.5.0). The `Decimal128` constructor and `fromString()` methods now throw when detecting a loss of precision (more than 34 significant digits). We also expose a new `fromStringWithRounding()` method which restores the previous rounding behaviour.

See the [bson v5.5.0 release notes](https://github.com/mongodb/js-bson/releases/tag/v5.5.0) for more information.
<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
