### PR TITLE
feat(NODE-5634): bump bson version to ^6.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@mongodb-js/saslprep": "^1.1.0",
-        "bson": "^6.0.0",
+        "bson": "^6.1.0",
         "mongodb-connection-string-url": "^2.6.0"
       },
       "devDependencies": {
@@ -3530,9 +3530,9 @@
       }
     },
     "node_modules/bson": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-6.0.0.tgz",
-      "integrity": "sha512-FoWvdELfF2wQaUo8S/a1Rh2BDwJEUancDDnzdTpYymJTZjmvRpLWoqRPelKn+XSeh5D4YddWDG66cLtEhGGvcg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.1.0.tgz",
+      "integrity": "sha512-yiQ3KxvpVoRpx1oD1uPz4Jit9tAVTJgjdmjDKtUErkOoL9VNoF8Dd58qtAOL5E40exx2jvAT9sqdRSK/r+SHlA==",
       "engines": {
         "node": ">=16.20.1"
       }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@mongodb-js/saslprep": "^1.1.0",
-    "bson": "^6.0.0",
+    "bson": "^6.1.0",
     "mongodb-connection-string-url": "^2.6.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
### Description

#### What is changing?

Bump bson dependency version to 6.1.0 to expose new `Decimal128.fromStringWithRounding()` method.

##### Is there new documentation needed for these changes?

Release notes

#### What is the motivation for this change?

NODE-5634

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Bump bson version to expose new `Decimal128.fromStringWithRounding()` method

In this release, we have adopted the changes made to Decimal128 in [bson version 6.1.0](https://github.com/mongodb/js-bson/releases/tag/v6.1.0). We have added a new `fromStringWithRounding()` method which exposes the previously available inexact rounding behaviour.

See the [bson v6.1.0 release notes](https://github.com/mongodb/js-bson/releases/tag/v6.1.0) for more information.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
