### PR TITLE
Fix typo in options

### DIFF
--- a/src/operations/find_and_modify.ts
+++ b/src/operations/find_and_modify.ts
@@ -141,7 +141,7 @@ class FindAndModifyOperation extends CommandOperation<Document> {
       upsert: false
     };
 
-    options.includeResultMetadata ??= false;
+    options.includeResultMetadata ?? false;
 
     const sort = formatSort(options.sort);
     if (sort) {


### PR DESCRIPTION
### Description
 A small typo fixed in find_and_modify.ts file with Nullish coalescing operator. It was throwing an error when trying to run the nodejs server.
