### PR TITLE
ci(NODE-5652): move vars to expansions

### DIFF
--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -502,14 +502,14 @@ functions:
           done
 
   "install dependencies":
-    - command: shell.exec
+    - command: subprocess.exec
       type: setup
       params:
         working_dir: "src"
-        script: |
-          ${PREPARE_SHELL}
-          NODE_LTS_VERSION=${NODE_LTS_VERSION} NPM_OPTIONS=${NPM_OPTIONS} NPM_VERSION=${NPM_VERSION}\
-            bash ${PROJECT_DIRECTORY}/.evergreen/install-dependencies.sh
+        binary: bash
+        add_expansions_to_env: true
+        args:
+          - .evergreen/install-dependencies.sh
 
   "install aws-credential-providers":
     - command: shell.exec
@@ -1139,15 +1139,17 @@ tasks:
       - performance
     exec_timeout_secs: 3600
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - { key: NODE_LTS_VERSION, value: v18.16.0 }
+            - { key: NPM_VERSION, value: "9" }
+            - { key: VERSION, value: v6.0-perf }
+            - { key: TOPOLOGY, value: server }
+            - { key: AUTH, value: noauth }
       - func: install dependencies
-        vars:
-          NODE_LTS_VERSION: v18.16.0
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: v6.0-perf
-          TOPOLOGY: server
-          AUTH: noauth
       - func: run spec driver benchmarks
       - command: perf.send
         params:
@@ -1155,9 +1157,12 @@ tasks:
 
   - name: "test-gcpkms-task"
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - { key: NPM_VERSION, value: "9" }
       - func: "install dependencies"
-        vars:
-          NPM_VERSION: 9
       # Upload node driver to a GCP instance
       - command: subprocess.exec
         type: setup
@@ -1191,14 +1196,16 @@ tasks:
     # test-gcpkms-fail-task runs in a non-GCE environment.
     # It is expected to fail to obtain GCE credentials.
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - { key: NPM_VERSION, value: "9" }
+            - { key: VERSION, value: latest }
+            - { key: TOPOLOGY, value: server }
+            - { key: AUTH, value: noauth }
       - func: "install dependencies"
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          TOPOLOGY: server
-          AUTH: noauth
       - command: subprocess.exec
         type: test
         params:
@@ -1210,9 +1217,12 @@ tasks:
 
   - name: "test-azurekms-task"
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - { key: NPM_VERSION, value: "9" }
       - func: "install dependencies"
-        vars:
-          NPM_VERSION: 9
       - command: subprocess.exec
         type: setup
         params:
@@ -1233,14 +1243,16 @@ tasks:
 
   - name: "test-azurekms-fail-task"
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - { key: NPM_VERSION, value: "9" }
+            - { key: VERSION, value: latest }
+            - { key: TOPOLOGY, value: server }
+            - { key: AUTH, value: noauth }
       - func: "install dependencies"
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          TOPOLOGY: server
-          AUTH: noauth
       - command: subprocess.exec
         type: test
         params:
@@ -1252,9 +1264,12 @@ tasks:
 
   - name: "oidc-auth-test-azure-latest"
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - { key: NPM_VERSION, value: "9" }
       - func: "install dependencies"
-        vars:
-          NPM_VERSION: 9
       - command: subprocess.exec
         params:
           working_dir: src
@@ -1269,9 +1284,12 @@ tasks:
 
   - name: "test-aws-lambda-deployed"
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - { key: NPM_VERSION, value: "9" }
       - func: "install dependencies"
-        vars:
-          NPM_VERSION: 9
       - command: ec2.assume_role
         params:
           role_arn: ${LAMBDA_AWS_ROLE_ARN}
@@ -1289,9 +1307,12 @@ tasks:
 
   - name: test-search-index-helpers
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - { key: NODE_LTS_VERSION, value: "20" }
       - func: install dependencies
-        vars:
-          NODE_LTS_VERSION: 20
       - command: subprocess.exec
         params:
           working_dir: src

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -38,7 +38,7 @@ functions:
           is_patch: ${is_patch}
           project: ${project}
         args:
-        - .evergreen/prepare-shell.sh
+          - .evergreen/prepare-shell.sh
 
     # Load the expansion file to make an evergreen variable with the current unique version
     - command: expansions.update
@@ -448,7 +448,6 @@ functions:
         args:
           - "${PROJECT_DIRECTORY}/.evergreen/run-mongosh-scope-test.sh"
 
-
   "reset aws instance profile":
     - command: shell.exec
       params:
@@ -616,16 +615,16 @@ functions:
           bash ${PROJECT_DIRECTORY}/.evergreen/run-ldap-tests.sh
 
   "run data lake tests":
-      - command: shell.exec
-        type: test
-        params:
-          working_dir: src
-          script: |
-            export PROJECT_DIRECTORY="$(pwd)"
-            export MONGODB_URI='mongodb://mhuser:pencil@localhost'
-            export NODE_LTS_VERSION='${NODE_LTS_VERSION}'
+    - command: shell.exec
+      type: test
+      params:
+        working_dir: src
+        script: |
+          export PROJECT_DIRECTORY="$(pwd)"
+          export MONGODB_URI='mongodb://mhuser:pencil@localhost'
+          export NODE_LTS_VERSION='${NODE_LTS_VERSION}'
 
-            bash ${PROJECT_DIRECTORY}/.evergreen/run-data-lake-tests.sh
+          bash ${PROJECT_DIRECTORY}/.evergreen/run-data-lake-tests.sh
 
   "run tls tests":
     - command: shell.exec
@@ -1060,7 +1059,7 @@ functions:
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file:  src/coverage/coverage-final.json
+        local_file: src/coverage/coverage-final.json
         optional: true
         # Upload the coverage report for all tasks in a single build to the same directory.
         # TODO NODE-4707 - change upload directory to ${UPLOAD_BUCKET}
@@ -1107,7 +1106,7 @@ functions:
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file:  src/coverage-report/index.html
+        local_file: src/coverage-report/index.html
         remote_file: mongo-node-driver/${revision}/${version_id}/coverage/index.html
         bucket: mciuploads
         permissions: public-read
@@ -1188,7 +1187,6 @@ tasks:
           args:
             - ${DRIVERS_TOOLS}/.evergreen/csfle/gcpkms/run-command.sh
 
-
   - name: "test-gcpkms-fail-task"
     # test-gcpkms-fail-task runs in a non-GCE environment.
     # It is expected to fail to obtain GCE credentials.
@@ -1209,7 +1207,6 @@ tasks:
             EXPECTED_GCPKMS_OUTCOME: "failure"
           args:
             - src/.evergreen/run-gcp-kms-tests.sh
-
 
   - name: "test-azurekms-task"
     commands:
@@ -1268,7 +1265,7 @@ tasks:
             AZUREOIDC_CLIENTID: ${testazureoidc_clientid}
             PROVIDER_NAME: azure
           args:
-          - .evergreen/run-oidc-tests-azure.sh
+            - .evergreen/run-oidc-tests-azure.sh
 
   - name: "test-aws-lambda-deployed"
     commands:
@@ -1408,31 +1405,31 @@ task_groups:
 
   - name: testazureoidc_task_group
     setup_group:
-    - func: fetch source
-    - command: shell.exec
-      params:
-        shell: bash
-        script: |-
-          set -o errexit
-          ${PREPARE_SHELL}
-          export AZUREOIDC_CLIENTID="${testazureoidc_clientid}"
-          export AZUREOIDC_TENANTID="${testazureoic_tenantid}"
-          export AZUREOIDC_SECRET="${testazureoidc_secret}"
-          export AZUREOIDC_KEYVAULT=${testazureoidc_keyvault}
-          export AZUREOIDC_DRIVERS_TOOLS="$DRIVERS_TOOLS"
-          export AZUREOIDC_VMNAME_PREFIX="NODE_DRIVER"
-          $DRIVERS_TOOLS/.evergreen/auth_oidc/azure/create-and-setup-vm.sh
+      - func: fetch source
+      - command: shell.exec
+        params:
+          shell: bash
+          script: |-
+            set -o errexit
+            ${PREPARE_SHELL}
+            export AZUREOIDC_CLIENTID="${testazureoidc_clientid}"
+            export AZUREOIDC_TENANTID="${testazureoic_tenantid}"
+            export AZUREOIDC_SECRET="${testazureoidc_secret}"
+            export AZUREOIDC_KEYVAULT=${testazureoidc_keyvault}
+            export AZUREOIDC_DRIVERS_TOOLS="$DRIVERS_TOOLS"
+            export AZUREOIDC_VMNAME_PREFIX="NODE_DRIVER"
+            $DRIVERS_TOOLS/.evergreen/auth_oidc/azure/create-and-setup-vm.sh
     teardown_group:
-    - command: shell.exec
-      params:
-        shell: bash
-        script: |-
-          ${PREPARE_SHELL}
-          $DRIVERS_TOOLS/.evergreen/auth_oidc/azure/delete-vm.sh
+      - command: shell.exec
+        params:
+          shell: bash
+          script: |-
+            ${PREPARE_SHELL}
+            $DRIVERS_TOOLS/.evergreen/auth_oidc/azure/delete-vm.sh
     setup_group_can_fail_task: true
     setup_group_timeout_secs: 1800
     tasks:
-    - oidc-auth-test-azure-latest
+      - oidc-auth-test-azure-latest
 
   - name: test_atlas_task_group
     setup_group:
@@ -1503,7 +1500,7 @@ post:
   - func: "cleanup"
 
 ignore:
-  - '*.md'
+  - "*.md"
 buildvariants:
   - name: performance-tests
     display_name: Performance Test

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -450,14 +450,14 @@ functions:
             chmod +x $i
           done
   install dependencies:
-    - command: shell.exec
+    - command: subprocess.exec
       type: setup
       params:
         working_dir: src
-        script: |
-          ${PREPARE_SHELL}
-          NODE_LTS_VERSION=${NODE_LTS_VERSION} NPM_OPTIONS=${NPM_OPTIONS} NPM_VERSION=${NPM_VERSION}\
-            bash ${PROJECT_DIRECTORY}/.evergreen/install-dependencies.sh
+        binary: bash
+        add_expansions_to_env: true
+        args:
+          - .evergreen/install-dependencies.sh
   install aws-credential-providers:
     - command: shell.exec
       type: setup
@@ -1076,24 +1076,35 @@ tasks:
       - performance
     exec_timeout_secs: 3600
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - key: NODE_LTS_VERSION
+              value: v18.16.0
+            - key: NPM_VERSION
+              value: '9'
+            - key: VERSION
+              value: v6.0-perf
+            - key: TOPOLOGY
+              value: server
+            - key: AUTH
+              value: noauth
       - func: install dependencies
-        vars:
-          NODE_LTS_VERSION: v18.16.0
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: v6.0-perf
-          TOPOLOGY: server
-          AUTH: noauth
       - func: run spec driver benchmarks
       - command: perf.send
         params:
           file: src/results.json
   - name: test-gcpkms-task
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - key: NPM_VERSION
+              value: '9'
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - command: subprocess.exec
         type: setup
         params:
@@ -1122,14 +1133,20 @@ tasks:
             - ${DRIVERS_TOOLS}/.evergreen/csfle/gcpkms/run-command.sh
   - name: test-gcpkms-fail-task
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - key: NPM_VERSION
+              value: '9'
+            - key: VERSION
+              value: latest
+            - key: TOPOLOGY
+              value: server
+            - key: AUTH
+              value: noauth
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          TOPOLOGY: server
-          AUTH: noauth
       - command: subprocess.exec
         type: test
         params:
@@ -1140,9 +1157,13 @@ tasks:
             - src/.evergreen/run-gcp-kms-tests.sh
   - name: test-azurekms-task
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - key: NPM_VERSION
+              value: '9'
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - command: subprocess.exec
         type: setup
         params:
@@ -1162,14 +1183,20 @@ tasks:
             - ${DRIVERS_TOOLS}/.evergreen/csfle/azurekms/run-command.sh
   - name: test-azurekms-fail-task
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - key: NPM_VERSION
+              value: '9'
+            - key: VERSION
+              value: latest
+            - key: TOPOLOGY
+              value: server
+            - key: AUTH
+              value: noauth
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          TOPOLOGY: server
-          AUTH: noauth
       - command: subprocess.exec
         type: test
         params:
@@ -1180,9 +1207,13 @@ tasks:
             - src/.evergreen/run-azure-kms-tests.sh
   - name: oidc-auth-test-azure-latest
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - key: NPM_VERSION
+              value: '9'
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - command: subprocess.exec
         params:
           working_dir: src
@@ -1196,9 +1227,13 @@ tasks:
             - .evergreen/run-oidc-tests-azure.sh
   - name: test-aws-lambda-deployed
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - key: NPM_VERSION
+              value: '9'
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - command: ec2.assume_role
         params:
           role_arn: ${LAMBDA_AWS_ROLE_ARN}
@@ -1215,9 +1250,13 @@ tasks:
             AWS_REGION: us-east-1
   - name: test-search-index-helpers
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - key: NODE_LTS_VERSION
+              value: '20'
       - func: install dependencies
-        vars:
-          NODE_LTS_VERSION: 20
       - command: subprocess.exec
         params:
           working_dir: src

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1718,6 +1718,7 @@ tasks:
             - {key: VERSION, value: latest}
             - {key: TOPOLOGY, value: server}
             - {key: REQUIRE_API_VERSION, value: '1'}
+            - {key: MONGODB_API_VERSION, value: '1'}
             - {key: AUTH, value: auth}
       - func: install dependencies
       - func: bootstrap mongo-orchestration

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1080,16 +1080,11 @@ tasks:
         type: setup
         params:
           updates:
-            - key: NODE_LTS_VERSION
-              value: v18.16.0
-            - key: NPM_VERSION
-              value: '9'
-            - key: VERSION
-              value: v6.0-perf
-            - key: TOPOLOGY
-              value: server
-            - key: AUTH
-              value: noauth
+            - {key: NODE_LTS_VERSION, value: v18.16.0}
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: v6.0-perf}
+            - {key: TOPOLOGY, value: server}
+            - {key: AUTH, value: noauth}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run spec driver benchmarks
@@ -1102,8 +1097,7 @@ tasks:
         type: setup
         params:
           updates:
-            - key: NPM_VERSION
-              value: '9'
+            - {key: NPM_VERSION, value: '9'}
       - func: install dependencies
       - command: subprocess.exec
         type: setup
@@ -1137,14 +1131,10 @@ tasks:
         type: setup
         params:
           updates:
-            - key: NPM_VERSION
-              value: '9'
-            - key: VERSION
-              value: latest
-            - key: TOPOLOGY
-              value: server
-            - key: AUTH
-              value: noauth
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: latest}
+            - {key: TOPOLOGY, value: server}
+            - {key: AUTH, value: noauth}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - command: subprocess.exec
@@ -1161,8 +1151,7 @@ tasks:
         type: setup
         params:
           updates:
-            - key: NPM_VERSION
-              value: '9'
+            - {key: NPM_VERSION, value: '9'}
       - func: install dependencies
       - command: subprocess.exec
         type: setup
@@ -1187,14 +1176,10 @@ tasks:
         type: setup
         params:
           updates:
-            - key: NPM_VERSION
-              value: '9'
-            - key: VERSION
-              value: latest
-            - key: TOPOLOGY
-              value: server
-            - key: AUTH
-              value: noauth
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: latest}
+            - {key: TOPOLOGY, value: server}
+            - {key: AUTH, value: noauth}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - command: subprocess.exec
@@ -1211,8 +1196,7 @@ tasks:
         type: setup
         params:
           updates:
-            - key: NPM_VERSION
-              value: '9'
+            - {key: NPM_VERSION, value: '9'}
       - func: install dependencies
       - command: subprocess.exec
         params:
@@ -1231,8 +1215,7 @@ tasks:
         type: setup
         params:
           updates:
-            - key: NPM_VERSION
-              value: '9'
+            - {key: NPM_VERSION, value: '9'}
       - func: install dependencies
       - command: ec2.assume_role
         params:
@@ -1254,8 +1237,7 @@ tasks:
         type: setup
         params:
           updates:
-            - key: NODE_LTS_VERSION
-              value: '20'
+            - {key: NODE_LTS_VERSION, value: '20'}
       - func: install dependencies
       - command: subprocess.exec
         params:
@@ -1269,14 +1251,16 @@ tasks:
       - latest
       - server
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: latest}
+            - {key: TOPOLOGY, value: server}
+            - {key: AUTH, value: auth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          TOPOLOGY: server
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-latest-replica_set
@@ -1284,14 +1268,16 @@ tasks:
       - latest
       - replica_set
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: latest}
+            - {key: TOPOLOGY, value: replica_set}
+            - {key: AUTH, value: auth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          TOPOLOGY: replica_set
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-latest-sharded_cluster
@@ -1299,14 +1285,16 @@ tasks:
       - latest
       - sharded_cluster
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: latest}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: AUTH, value: auth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          TOPOLOGY: sharded_cluster
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-rapid-server
@@ -1314,14 +1302,16 @@ tasks:
       - rapid
       - server
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: rapid}
+            - {key: TOPOLOGY, value: server}
+            - {key: AUTH, value: auth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: rapid
-          TOPOLOGY: server
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-rapid-replica_set
@@ -1329,14 +1319,16 @@ tasks:
       - rapid
       - replica_set
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: rapid}
+            - {key: TOPOLOGY, value: replica_set}
+            - {key: AUTH, value: auth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: rapid
-          TOPOLOGY: replica_set
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-rapid-sharded_cluster
@@ -1344,14 +1336,16 @@ tasks:
       - rapid
       - sharded_cluster
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: rapid}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: AUTH, value: auth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: rapid
-          TOPOLOGY: sharded_cluster
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-7.0-server
@@ -1359,14 +1353,16 @@ tasks:
       - '7.0'
       - server
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '7.0'}
+            - {key: TOPOLOGY, value: server}
+            - {key: AUTH, value: auth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '7.0'
-          TOPOLOGY: server
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-7.0-replica_set
@@ -1374,14 +1370,16 @@ tasks:
       - '7.0'
       - replica_set
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '7.0'}
+            - {key: TOPOLOGY, value: replica_set}
+            - {key: AUTH, value: auth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '7.0'
-          TOPOLOGY: replica_set
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-7.0-sharded_cluster
@@ -1389,14 +1387,16 @@ tasks:
       - '7.0'
       - sharded_cluster
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '7.0'}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: AUTH, value: auth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '7.0'
-          TOPOLOGY: sharded_cluster
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-6.0-server
@@ -1404,14 +1404,16 @@ tasks:
       - '6.0'
       - server
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '6.0'}
+            - {key: TOPOLOGY, value: server}
+            - {key: AUTH, value: auth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '6.0'
-          TOPOLOGY: server
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-6.0-replica_set
@@ -1419,14 +1421,16 @@ tasks:
       - '6.0'
       - replica_set
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '6.0'}
+            - {key: TOPOLOGY, value: replica_set}
+            - {key: AUTH, value: auth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '6.0'
-          TOPOLOGY: replica_set
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-6.0-sharded_cluster
@@ -1434,14 +1438,16 @@ tasks:
       - '6.0'
       - sharded_cluster
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '6.0'}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: AUTH, value: auth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '6.0'
-          TOPOLOGY: sharded_cluster
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-5.0-server
@@ -1449,14 +1455,16 @@ tasks:
       - '5.0'
       - server
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '5.0'}
+            - {key: TOPOLOGY, value: server}
+            - {key: AUTH, value: auth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '5.0'
-          TOPOLOGY: server
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-5.0-replica_set
@@ -1464,14 +1472,16 @@ tasks:
       - '5.0'
       - replica_set
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '5.0'}
+            - {key: TOPOLOGY, value: replica_set}
+            - {key: AUTH, value: auth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '5.0'
-          TOPOLOGY: replica_set
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-5.0-sharded_cluster
@@ -1479,14 +1489,16 @@ tasks:
       - '5.0'
       - sharded_cluster
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '5.0'}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: AUTH, value: auth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '5.0'
-          TOPOLOGY: sharded_cluster
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-4.4-server
@@ -1494,14 +1506,16 @@ tasks:
       - '4.4'
       - server
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '4.4'}
+            - {key: TOPOLOGY, value: server}
+            - {key: AUTH, value: auth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.4'
-          TOPOLOGY: server
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-4.4-replica_set
@@ -1509,14 +1523,16 @@ tasks:
       - '4.4'
       - replica_set
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '4.4'}
+            - {key: TOPOLOGY, value: replica_set}
+            - {key: AUTH, value: auth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.4'
-          TOPOLOGY: replica_set
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-4.4-sharded_cluster
@@ -1524,14 +1540,16 @@ tasks:
       - '4.4'
       - sharded_cluster
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '4.4'}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: AUTH, value: auth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.4'
-          TOPOLOGY: sharded_cluster
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-4.2-server
@@ -1539,14 +1557,16 @@ tasks:
       - '4.2'
       - server
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '4.2'}
+            - {key: TOPOLOGY, value: server}
+            - {key: AUTH, value: auth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.2'
-          TOPOLOGY: server
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-4.2-replica_set
@@ -1554,14 +1574,16 @@ tasks:
       - '4.2'
       - replica_set
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '4.2'}
+            - {key: TOPOLOGY, value: replica_set}
+            - {key: AUTH, value: auth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.2'
-          TOPOLOGY: replica_set
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-4.2-sharded_cluster
@@ -1569,14 +1591,16 @@ tasks:
       - '4.2'
       - sharded_cluster
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '4.2'}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: AUTH, value: auth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.2'
-          TOPOLOGY: sharded_cluster
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-4.0-server
@@ -1584,14 +1608,16 @@ tasks:
       - '4.0'
       - server
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '4.0'}
+            - {key: TOPOLOGY, value: server}
+            - {key: AUTH, value: auth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.0'
-          TOPOLOGY: server
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-4.0-replica_set
@@ -1599,14 +1625,16 @@ tasks:
       - '4.0'
       - replica_set
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '4.0'}
+            - {key: TOPOLOGY, value: replica_set}
+            - {key: AUTH, value: auth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.0'
-          TOPOLOGY: replica_set
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-4.0-sharded_cluster
@@ -1614,14 +1642,16 @@ tasks:
       - '4.0'
       - sharded_cluster
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '4.0'}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: AUTH, value: auth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.0'
-          TOPOLOGY: sharded_cluster
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-3.6-server
@@ -1629,14 +1659,16 @@ tasks:
       - '3.6'
       - server
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '3.6'}
+            - {key: TOPOLOGY, value: server}
+            - {key: AUTH, value: auth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '3.6'
-          TOPOLOGY: server
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-3.6-replica_set
@@ -1644,14 +1676,16 @@ tasks:
       - '3.6'
       - replica_set
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '3.6'}
+            - {key: TOPOLOGY, value: replica_set}
+            - {key: AUTH, value: auth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '3.6'
-          TOPOLOGY: replica_set
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-3.6-sharded_cluster
@@ -1659,14 +1693,16 @@ tasks:
       - '3.6'
       - sharded_cluster
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '3.6'}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: AUTH, value: auth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '3.6'
-          TOPOLOGY: sharded_cluster
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-latest-server-v1-api
@@ -1675,17 +1711,18 @@ tasks:
       - server
       - v1-api
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: latest}
+            - {key: TOPOLOGY, value: server}
+            - {key: REQUIRE_API_VERSION, value: '1'}
+            - {key: AUTH, value: auth}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          TOPOLOGY: server
-          REQUIRE_API_VERSION: '1'
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
-        vars:
-          MONGODB_API_VERSION: '1'
   - name: test-atlas-connectivity
     tags:
       - atlas-connect
@@ -1703,13 +1740,16 @@ tasks:
       - sharded_cluster
       - load_balancer
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '5.0'}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: AUTH, value: auth}
+            - {key: LOAD_BALANCER, value: 'true'}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '5.0'
-          TOPOLOGY: sharded_cluster
-          AUTH: auth
-          LOAD_BALANCER: 'true'
       - func: start-load-balancer
       - func: run-lb-tests
       - func: stop-load-balancer
@@ -1719,13 +1759,16 @@ tasks:
       - sharded_cluster
       - load_balancer
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '6.0'}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: AUTH, value: auth}
+            - {key: LOAD_BALANCER, value: 'true'}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '6.0'
-          TOPOLOGY: sharded_cluster
-          AUTH: auth
-          LOAD_BALANCER: 'true'
       - func: start-load-balancer
       - func: run-lb-tests
       - func: stop-load-balancer
@@ -1735,13 +1778,16 @@ tasks:
       - sharded_cluster
       - load_balancer
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: latest}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: AUTH, value: auth}
+            - {key: LOAD_BALANCER, value: 'true'}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          TOPOLOGY: sharded_cluster
-          AUTH: auth
-          LOAD_BALANCER: 'true'
       - func: start-load-balancer
       - func: run-lb-tests
       - func: stop-load-balancer
@@ -1765,938 +1811,1160 @@ tasks:
       - replica_set
       - oidc
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: latest}
+            - {key: TOPOLOGY, value: replica_set}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-oidc.json}
       - func: install dependencies
       - func: bootstrap oidc
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          TOPOLOGY: replica_set
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-oidc.json
       - func: setup oidc roles
       - func: run oidc tests aws
   - name: test-socks5
     tags: []
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: latest}
+            - {key: TOPOLOGY, value: replica_set}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          TOPOLOGY: replica_set
       - func: bootstrap kms servers
       - func: run socks5 tests
   - name: test-socks5-csfle
     tags:
       - socks5-csfle
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: latest}
+            - {key: TOPOLOGY, value: replica_set}
+            - {key: TEST_SOCKS5_CSFLE, value: 'true'}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          TOPOLOGY: replica_set
       - func: bootstrap kms servers
       - func: run socks5 tests
-        vars:
-          TEST_SOCKS5_CSFLE: 'true'
   - name: test-socks5-tls
     tags: []
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: SSL, value: ssl}
+            - {key: VERSION, value: latest}
+            - {key: TOPOLOGY, value: replica_set}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          SSL: ssl
-          VERSION: latest
-          TOPOLOGY: replica_set
       - func: run socks5 tests
-        vars:
-          SSL: ssl
   - name: test-zstd-compression
     tags:
       - latest
       - zstd
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: latest}
+            - {key: TOPOLOGY, value: replica_set}
+            - {key: AUTH, value: auth}
+            - {key: COMPRESSOR, value: zstd}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          TOPOLOGY: replica_set
-          AUTH: auth
-          COMPRESSOR: zstd
       - func: run-compression-tests
   - name: test-snappy-compression
     tags:
       - latest
       - snappy
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: latest}
+            - {key: TOPOLOGY, value: replica_set}
+            - {key: AUTH, value: auth}
+            - {key: COMPRESSOR, value: snappy}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          TOPOLOGY: replica_set
-          AUTH: auth
-          COMPRESSOR: snappy
       - func: run-compression-tests
   - name: test-tls-support-latest
     tags:
       - tls-support
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: latest}
+            - {key: SSL, value: ssl}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          SSL: ssl
-          TOPOLOGY: server
       - func: run tls tests
   - name: test-tls-support-6.0
     tags:
       - tls-support
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '6.0'}
+            - {key: SSL, value: ssl}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '6.0'
-          SSL: ssl
-          TOPOLOGY: server
       - func: run tls tests
   - name: test-tls-support-5.0
     tags:
       - tls-support
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '5.0'}
+            - {key: SSL, value: ssl}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '5.0'
-          SSL: ssl
-          TOPOLOGY: server
       - func: run tls tests
   - name: test-tls-support-4.4
     tags:
       - tls-support
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '4.4'}
+            - {key: SSL, value: ssl}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.4'
-          SSL: ssl
-          TOPOLOGY: server
       - func: run tls tests
   - name: test-tls-support-4.2
     tags:
       - tls-support
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '4.2'}
+            - {key: SSL, value: ssl}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.2'
-          SSL: ssl
-          TOPOLOGY: server
       - func: run tls tests
   - name: aws-latest-auth-test-run-aws-auth-test-with-regular-aws-credentials
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: latest}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with regular aws credentials
   - name: aws-latest-auth-test-run-aws-auth-test-with-assume-role-credentials
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: latest}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with assume role credentials
   - name: aws-latest-auth-test-run-aws-auth-test-with-aws-EC2-credentials
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: latest}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with aws EC2 credentials
   - name: aws-latest-auth-test-run-aws-auth-test-with-aws-credentials-as-environment-variables
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: latest}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with aws credentials as environment variables
   - name: aws-latest-auth-test-run-aws-auth-test-with-aws-credentials-and-session-token-as-environment-variables
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: latest}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with aws credentials and session token as environment variables
   - name: aws-latest-auth-test-run-aws-ECS-auth-test
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: latest}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws ECS auth test
   - name: aws-latest-auth-test-run-aws-auth-test-AssumeRoleWithWebIdentity-with-AWS_ROLE_SESSION_NAME-unset
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: latest}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test AssumeRoleWithWebIdentity with AWS_ROLE_SESSION_NAME unset
   - name: aws-latest-auth-test-run-aws-auth-test-AssumeRoleWithWebIdentity-with-AWS_ROLE_SESSION_NAME-set
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: latest}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test AssumeRoleWithWebIdentity with AWS_ROLE_SESSION_NAME set
   - name: aws-latest-auth-test-run-aws-auth-test-with-regular-aws-credentials-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: latest}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with regular aws credentials
   - name: aws-latest-auth-test-run-aws-auth-test-with-assume-role-credentials-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: latest}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with assume role credentials
   - name: aws-latest-auth-test-run-aws-auth-test-with-aws-EC2-credentials-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: latest}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with aws EC2 credentials
   - name: aws-latest-auth-test-run-aws-auth-test-with-aws-credentials-as-environment-variables-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: latest}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with aws credentials as environment variables
   - name: >-
       aws-latest-auth-test-run-aws-auth-test-with-aws-credentials-and-session-token-as-environment-variables-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: latest}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with aws credentials and session token as environment variables
   - name: aws-latest-auth-test-run-aws-ECS-auth-test-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: latest}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws ECS auth test
   - name: >-
       aws-latest-auth-test-run-aws-auth-test-AssumeRoleWithWebIdentity-with-AWS_ROLE_SESSION_NAME-unset-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: latest}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test AssumeRoleWithWebIdentity with AWS_ROLE_SESSION_NAME unset
   - name: >-
       aws-latest-auth-test-run-aws-auth-test-AssumeRoleWithWebIdentity-with-AWS_ROLE_SESSION_NAME-set-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: latest}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test AssumeRoleWithWebIdentity with AWS_ROLE_SESSION_NAME set
   - name: aws-6.0-auth-test-run-aws-auth-test-with-regular-aws-credentials
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '6.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '6.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with regular aws credentials
   - name: aws-6.0-auth-test-run-aws-auth-test-with-assume-role-credentials
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '6.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '6.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with assume role credentials
   - name: aws-6.0-auth-test-run-aws-auth-test-with-aws-EC2-credentials
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '6.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '6.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with aws EC2 credentials
   - name: aws-6.0-auth-test-run-aws-auth-test-with-aws-credentials-as-environment-variables
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '6.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '6.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with aws credentials as environment variables
   - name: aws-6.0-auth-test-run-aws-auth-test-with-aws-credentials-and-session-token-as-environment-variables
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '6.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '6.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with aws credentials and session token as environment variables
   - name: aws-6.0-auth-test-run-aws-ECS-auth-test
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '6.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '6.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws ECS auth test
   - name: aws-6.0-auth-test-run-aws-auth-test-AssumeRoleWithWebIdentity-with-AWS_ROLE_SESSION_NAME-unset
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '6.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '6.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test AssumeRoleWithWebIdentity with AWS_ROLE_SESSION_NAME unset
   - name: aws-6.0-auth-test-run-aws-auth-test-AssumeRoleWithWebIdentity-with-AWS_ROLE_SESSION_NAME-set
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '6.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '6.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test AssumeRoleWithWebIdentity with AWS_ROLE_SESSION_NAME set
   - name: aws-6.0-auth-test-run-aws-auth-test-with-regular-aws-credentials-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '6.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '6.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with regular aws credentials
   - name: aws-6.0-auth-test-run-aws-auth-test-with-assume-role-credentials-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '6.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '6.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with assume role credentials
   - name: aws-6.0-auth-test-run-aws-auth-test-with-aws-EC2-credentials-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '6.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '6.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with aws EC2 credentials
   - name: aws-6.0-auth-test-run-aws-auth-test-with-aws-credentials-as-environment-variables-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '6.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '6.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with aws credentials as environment variables
   - name: >-
       aws-6.0-auth-test-run-aws-auth-test-with-aws-credentials-and-session-token-as-environment-variables-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '6.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '6.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with aws credentials and session token as environment variables
   - name: aws-6.0-auth-test-run-aws-ECS-auth-test-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '6.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '6.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws ECS auth test
   - name: >-
       aws-6.0-auth-test-run-aws-auth-test-AssumeRoleWithWebIdentity-with-AWS_ROLE_SESSION_NAME-unset-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '6.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '6.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test AssumeRoleWithWebIdentity with AWS_ROLE_SESSION_NAME unset
   - name: aws-6.0-auth-test-run-aws-auth-test-AssumeRoleWithWebIdentity-with-AWS_ROLE_SESSION_NAME-set-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '6.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '6.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test AssumeRoleWithWebIdentity with AWS_ROLE_SESSION_NAME set
   - name: aws-5.0-auth-test-run-aws-auth-test-with-regular-aws-credentials
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '5.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '5.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with regular aws credentials
   - name: aws-5.0-auth-test-run-aws-auth-test-with-assume-role-credentials
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '5.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '5.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with assume role credentials
   - name: aws-5.0-auth-test-run-aws-auth-test-with-aws-EC2-credentials
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '5.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '5.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with aws EC2 credentials
   - name: aws-5.0-auth-test-run-aws-auth-test-with-aws-credentials-as-environment-variables
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '5.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '5.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with aws credentials as environment variables
   - name: aws-5.0-auth-test-run-aws-auth-test-with-aws-credentials-and-session-token-as-environment-variables
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '5.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '5.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with aws credentials and session token as environment variables
   - name: aws-5.0-auth-test-run-aws-ECS-auth-test
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '5.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '5.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws ECS auth test
   - name: aws-5.0-auth-test-run-aws-auth-test-AssumeRoleWithWebIdentity-with-AWS_ROLE_SESSION_NAME-unset
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '5.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '5.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test AssumeRoleWithWebIdentity with AWS_ROLE_SESSION_NAME unset
   - name: aws-5.0-auth-test-run-aws-auth-test-AssumeRoleWithWebIdentity-with-AWS_ROLE_SESSION_NAME-set
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '5.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '5.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test AssumeRoleWithWebIdentity with AWS_ROLE_SESSION_NAME set
   - name: aws-5.0-auth-test-run-aws-auth-test-with-regular-aws-credentials-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '5.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '5.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with regular aws credentials
   - name: aws-5.0-auth-test-run-aws-auth-test-with-assume-role-credentials-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '5.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '5.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with assume role credentials
   - name: aws-5.0-auth-test-run-aws-auth-test-with-aws-EC2-credentials-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '5.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '5.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with aws EC2 credentials
   - name: aws-5.0-auth-test-run-aws-auth-test-with-aws-credentials-as-environment-variables-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '5.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '5.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with aws credentials as environment variables
   - name: >-
       aws-5.0-auth-test-run-aws-auth-test-with-aws-credentials-and-session-token-as-environment-variables-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '5.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '5.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with aws credentials and session token as environment variables
   - name: aws-5.0-auth-test-run-aws-ECS-auth-test-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '5.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '5.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws ECS auth test
   - name: >-
       aws-5.0-auth-test-run-aws-auth-test-AssumeRoleWithWebIdentity-with-AWS_ROLE_SESSION_NAME-unset-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '5.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '5.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test AssumeRoleWithWebIdentity with AWS_ROLE_SESSION_NAME unset
   - name: aws-5.0-auth-test-run-aws-auth-test-AssumeRoleWithWebIdentity-with-AWS_ROLE_SESSION_NAME-set-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '5.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '5.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test AssumeRoleWithWebIdentity with AWS_ROLE_SESSION_NAME set
   - name: aws-4.4-auth-test-run-aws-auth-test-with-regular-aws-credentials
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '4.4'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.4'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with regular aws credentials
   - name: aws-4.4-auth-test-run-aws-auth-test-with-assume-role-credentials
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '4.4'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.4'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with assume role credentials
   - name: aws-4.4-auth-test-run-aws-auth-test-with-aws-EC2-credentials
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '4.4'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.4'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with aws EC2 credentials
   - name: aws-4.4-auth-test-run-aws-auth-test-with-aws-credentials-as-environment-variables
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '4.4'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.4'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with aws credentials as environment variables
   - name: aws-4.4-auth-test-run-aws-auth-test-with-aws-credentials-and-session-token-as-environment-variables
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '4.4'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.4'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with aws credentials and session token as environment variables
   - name: aws-4.4-auth-test-run-aws-ECS-auth-test
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '4.4'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.4'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws ECS auth test
   - name: aws-4.4-auth-test-run-aws-auth-test-AssumeRoleWithWebIdentity-with-AWS_ROLE_SESSION_NAME-unset
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '4.4'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.4'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test AssumeRoleWithWebIdentity with AWS_ROLE_SESSION_NAME unset
   - name: aws-4.4-auth-test-run-aws-auth-test-AssumeRoleWithWebIdentity-with-AWS_ROLE_SESSION_NAME-set
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '4.4'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.4'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test AssumeRoleWithWebIdentity with AWS_ROLE_SESSION_NAME set
   - name: aws-4.4-auth-test-run-aws-auth-test-with-regular-aws-credentials-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '4.4'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.4'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with regular aws credentials
   - name: aws-4.4-auth-test-run-aws-auth-test-with-assume-role-credentials-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '4.4'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.4'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with assume role credentials
   - name: aws-4.4-auth-test-run-aws-auth-test-with-aws-EC2-credentials-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '4.4'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.4'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with aws EC2 credentials
   - name: aws-4.4-auth-test-run-aws-auth-test-with-aws-credentials-as-environment-variables-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '4.4'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.4'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with aws credentials as environment variables
   - name: >-
       aws-4.4-auth-test-run-aws-auth-test-with-aws-credentials-and-session-token-as-environment-variables-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '4.4'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.4'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with aws credentials and session token as environment variables
   - name: aws-4.4-auth-test-run-aws-ECS-auth-test-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '4.4'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.4'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws ECS auth test
   - name: >-
       aws-4.4-auth-test-run-aws-auth-test-AssumeRoleWithWebIdentity-with-AWS_ROLE_SESSION_NAME-unset-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '4.4'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.4'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test AssumeRoleWithWebIdentity with AWS_ROLE_SESSION_NAME unset
   - name: aws-4.4-auth-test-run-aws-auth-test-AssumeRoleWithWebIdentity-with-AWS_ROLE_SESSION_NAME-set-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '4.4'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.4'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test AssumeRoleWithWebIdentity with AWS_ROLE_SESSION_NAME set
@@ -2704,64 +2972,78 @@ tasks:
     tags:
       - run-unit-tests
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NODE_LTS_VERSION, value: '16'}
+            - {key: NPM_VERSION, value: '9'}
       - func: install dependencies
-        vars:
-          NODE_LTS_VERSION: 16
-          NPM_VERSION: 9
       - func: run unit tests
   - name: run-lint-checks
     tags:
       - run-lint-checks
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NODE_LTS_VERSION, value: '16'}
+            - {key: NPM_VERSION, value: '9'}
       - func: install dependencies
-        vars:
-          NODE_LTS_VERSION: 16
-          NPM_VERSION: 9
       - func: run lint checks
   - name: check-types-typescript-next
     tags:
       - check-types-typescript-next
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NODE_LTS_VERSION, value: '16'}
+            - {key: NPM_VERSION, value: '9'}
+            - {key: TS_VERSION, value: next}
       - func: install dependencies
-        vars:
-          NODE_LTS_VERSION: 16
-          NPM_VERSION: 9
       - func: check types
-        vars:
-          TS_VERSION: next
   - name: compile-driver-typescript-current
     tags:
       - compile-driver-typescript-current
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NODE_LTS_VERSION, value: '16'}
+            - {key: NPM_VERSION, value: '9'}
+            - {key: TS_VERSION, value: current}
       - func: install dependencies
-        vars:
-          NODE_LTS_VERSION: 16
-          NPM_VERSION: 9
       - func: compile driver
-        vars:
-          TS_VERSION: current
   - name: check-types-typescript-current
     tags:
       - check-types-typescript-current
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NODE_LTS_VERSION, value: '16'}
+            - {key: NPM_VERSION, value: '9'}
+            - {key: TS_VERSION, value: current}
       - func: install dependencies
-        vars:
-          NODE_LTS_VERSION: 16
-          NPM_VERSION: 9
       - func: check types
-        vars:
-          TS_VERSION: current
   - name: check-types-typescript-4.1.6
     tags:
       - check-types-typescript-4.1.6
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NODE_LTS_VERSION, value: '16'}
+            - {key: NPM_VERSION, value: '9'}
+            - {key: TS_VERSION, value: 4.1.6}
       - func: install dependencies
-        vars:
-          NODE_LTS_VERSION: 16
-          NPM_VERSION: 9
       - func: check types
-        vars:
-          TS_VERSION: 4.1.6
   - name: download-and-merge-coverage
     tags: []
     commands:
@@ -2775,131 +3057,139 @@ tasks:
     tags:
       - run-custom-dependency-tests
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NODE_LTS_VERSION, value: '16'}
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '5.0'}
+            - {key: TOPOLOGY, value: replica_set}
+            - {key: CSFLE_GIT_REF, value: 974a4614f8c1c3786e5e39fa63568d83f4f69ebd}
       - func: install dependencies
-        vars:
-          NODE_LTS_VERSION: 16
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '5.0'
-          TOPOLOGY: replica_set
       - func: bootstrap kms servers
       - func: run custom csfle tests
-        vars:
-          CSFLE_GIT_REF: 974a4614f8c1c3786e5e39fa63568d83f4f69ebd
   - name: run-custom-csfle-tests-5.0-master
     tags:
       - run-custom-dependency-tests
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NODE_LTS_VERSION, value: '16'}
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '5.0'}
+            - {key: TOPOLOGY, value: replica_set}
+            - {key: CSFLE_GIT_REF, value: master}
       - func: install dependencies
-        vars:
-          NODE_LTS_VERSION: 16
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '5.0'
-          TOPOLOGY: replica_set
       - func: bootstrap kms servers
       - func: run custom csfle tests
-        vars:
-          CSFLE_GIT_REF: master
   - name: run-custom-csfle-tests-rapid-pinned-commit
     tags:
       - run-custom-dependency-tests
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NODE_LTS_VERSION, value: '16'}
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: rapid}
+            - {key: TOPOLOGY, value: replica_set}
+            - {key: CSFLE_GIT_REF, value: 974a4614f8c1c3786e5e39fa63568d83f4f69ebd}
       - func: install dependencies
-        vars:
-          NODE_LTS_VERSION: 16
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: rapid
-          TOPOLOGY: replica_set
       - func: bootstrap kms servers
       - func: run custom csfle tests
-        vars:
-          CSFLE_GIT_REF: 974a4614f8c1c3786e5e39fa63568d83f4f69ebd
   - name: run-custom-csfle-tests-rapid-master
     tags:
       - run-custom-dependency-tests
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NODE_LTS_VERSION, value: '16'}
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: rapid}
+            - {key: TOPOLOGY, value: replica_set}
+            - {key: CSFLE_GIT_REF, value: master}
       - func: install dependencies
-        vars:
-          NODE_LTS_VERSION: 16
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: rapid
-          TOPOLOGY: replica_set
       - func: bootstrap kms servers
       - func: run custom csfle tests
-        vars:
-          CSFLE_GIT_REF: master
   - name: run-custom-csfle-tests-latest-pinned-commit
     tags:
       - run-custom-dependency-tests
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NODE_LTS_VERSION, value: '16'}
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: latest}
+            - {key: TOPOLOGY, value: replica_set}
+            - {key: CSFLE_GIT_REF, value: 974a4614f8c1c3786e5e39fa63568d83f4f69ebd}
       - func: install dependencies
-        vars:
-          NODE_LTS_VERSION: 16
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          TOPOLOGY: replica_set
       - func: bootstrap kms servers
       - func: run custom csfle tests
-        vars:
-          CSFLE_GIT_REF: 974a4614f8c1c3786e5e39fa63568d83f4f69ebd
   - name: run-custom-csfle-tests-latest-master
     tags:
       - run-custom-dependency-tests
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NODE_LTS_VERSION, value: '16'}
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: latest}
+            - {key: TOPOLOGY, value: replica_set}
+            - {key: CSFLE_GIT_REF, value: master}
       - func: install dependencies
-        vars:
-          NODE_LTS_VERSION: 16
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          TOPOLOGY: replica_set
       - func: bootstrap kms servers
       - func: run custom csfle tests
-        vars:
-          CSFLE_GIT_REF: master
   - name: test-latest-driver-mongodb-client-encryption-6.0.0
     tags:
       - run-custom-dependency-tests
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NODE_LTS_VERSION, value: '16'}
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '7.0'}
+            - {key: TOPOLOGY, value: replica_set}
+            - {key: PACKAGE, value: mongodb-client-encryption@6.0.0}
+            - {key: CLIENT_ENCRYPTION, value: 'true'}
       - func: install dependencies
-        vars:
-          NODE_LTS_VERSION: 16
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '7.0'
-          TOPOLOGY: replica_set
       - func: bootstrap kms servers
       - func: install package
-        vars:
-          PACKAGE: mongodb-client-encryption@6.0.0
       - func: run tests
-        vars:
-          CLIENT_ENCRYPTION: true
   - name: test-latest-server-noauth
     tags:
       - latest
       - server
       - noauth
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: latest}
+            - {key: TOPOLOGY, value: server}
+            - {key: AUTH, value: noauth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          TOPOLOGY: server
-          AUTH: noauth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-latest-replica_set-noauth
@@ -2908,14 +3198,16 @@ tasks:
       - replica_set
       - noauth
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: latest}
+            - {key: TOPOLOGY, value: replica_set}
+            - {key: AUTH, value: noauth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          TOPOLOGY: replica_set
-          AUTH: noauth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-latest-sharded_cluster-noauth
@@ -2924,14 +3216,16 @@ tasks:
       - sharded_cluster
       - noauth
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: latest}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: AUTH, value: noauth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          TOPOLOGY: sharded_cluster
-          AUTH: noauth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-rapid-server-noauth
@@ -2940,14 +3234,16 @@ tasks:
       - server
       - noauth
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: rapid}
+            - {key: TOPOLOGY, value: server}
+            - {key: AUTH, value: noauth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: rapid
-          TOPOLOGY: server
-          AUTH: noauth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-rapid-replica_set-noauth
@@ -2956,14 +3252,16 @@ tasks:
       - replica_set
       - noauth
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: rapid}
+            - {key: TOPOLOGY, value: replica_set}
+            - {key: AUTH, value: noauth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: rapid
-          TOPOLOGY: replica_set
-          AUTH: noauth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-rapid-sharded_cluster-noauth
@@ -2972,14 +3270,16 @@ tasks:
       - sharded_cluster
       - noauth
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: rapid}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: AUTH, value: noauth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: rapid
-          TOPOLOGY: sharded_cluster
-          AUTH: noauth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-7.0-server-noauth
@@ -2988,14 +3288,16 @@ tasks:
       - server
       - noauth
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '7.0'}
+            - {key: TOPOLOGY, value: server}
+            - {key: AUTH, value: noauth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '7.0'
-          TOPOLOGY: server
-          AUTH: noauth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-7.0-replica_set-noauth
@@ -3004,14 +3306,16 @@ tasks:
       - replica_set
       - noauth
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '7.0'}
+            - {key: TOPOLOGY, value: replica_set}
+            - {key: AUTH, value: noauth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '7.0'
-          TOPOLOGY: replica_set
-          AUTH: noauth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-7.0-sharded_cluster-noauth
@@ -3020,14 +3324,16 @@ tasks:
       - sharded_cluster
       - noauth
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '7.0'}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: AUTH, value: noauth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '7.0'
-          TOPOLOGY: sharded_cluster
-          AUTH: noauth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-6.0-server-noauth
@@ -3036,14 +3342,16 @@ tasks:
       - server
       - noauth
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '6.0'}
+            - {key: TOPOLOGY, value: server}
+            - {key: AUTH, value: noauth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '6.0'
-          TOPOLOGY: server
-          AUTH: noauth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-6.0-replica_set-noauth
@@ -3052,14 +3360,16 @@ tasks:
       - replica_set
       - noauth
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '6.0'}
+            - {key: TOPOLOGY, value: replica_set}
+            - {key: AUTH, value: noauth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '6.0'
-          TOPOLOGY: replica_set
-          AUTH: noauth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-6.0-sharded_cluster-noauth
@@ -3068,14 +3378,16 @@ tasks:
       - sharded_cluster
       - noauth
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '6.0'}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: AUTH, value: noauth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '6.0'
-          TOPOLOGY: sharded_cluster
-          AUTH: noauth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-5.0-server-noauth
@@ -3084,14 +3396,16 @@ tasks:
       - server
       - noauth
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '5.0'}
+            - {key: TOPOLOGY, value: server}
+            - {key: AUTH, value: noauth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '5.0'
-          TOPOLOGY: server
-          AUTH: noauth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-5.0-replica_set-noauth
@@ -3100,14 +3414,16 @@ tasks:
       - replica_set
       - noauth
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '5.0'}
+            - {key: TOPOLOGY, value: replica_set}
+            - {key: AUTH, value: noauth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '5.0'
-          TOPOLOGY: replica_set
-          AUTH: noauth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-5.0-sharded_cluster-noauth
@@ -3116,14 +3432,16 @@ tasks:
       - sharded_cluster
       - noauth
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '5.0'}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: AUTH, value: noauth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '5.0'
-          TOPOLOGY: sharded_cluster
-          AUTH: noauth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-4.4-server-noauth
@@ -3132,14 +3450,16 @@ tasks:
       - server
       - noauth
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '4.4'}
+            - {key: TOPOLOGY, value: server}
+            - {key: AUTH, value: noauth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.4'
-          TOPOLOGY: server
-          AUTH: noauth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-4.4-replica_set-noauth
@@ -3148,14 +3468,16 @@ tasks:
       - replica_set
       - noauth
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '4.4'}
+            - {key: TOPOLOGY, value: replica_set}
+            - {key: AUTH, value: noauth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.4'
-          TOPOLOGY: replica_set
-          AUTH: noauth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-4.4-sharded_cluster-noauth
@@ -3164,14 +3486,16 @@ tasks:
       - sharded_cluster
       - noauth
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '4.4'}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: AUTH, value: noauth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.4'
-          TOPOLOGY: sharded_cluster
-          AUTH: noauth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-4.2-server-noauth
@@ -3180,14 +3504,16 @@ tasks:
       - server
       - noauth
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '4.2'}
+            - {key: TOPOLOGY, value: server}
+            - {key: AUTH, value: noauth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.2'
-          TOPOLOGY: server
-          AUTH: noauth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-4.2-replica_set-noauth
@@ -3196,14 +3522,16 @@ tasks:
       - replica_set
       - noauth
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '4.2'}
+            - {key: TOPOLOGY, value: replica_set}
+            - {key: AUTH, value: noauth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.2'
-          TOPOLOGY: replica_set
-          AUTH: noauth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-4.2-sharded_cluster-noauth
@@ -3212,14 +3540,16 @@ tasks:
       - sharded_cluster
       - noauth
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '4.2'}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: AUTH, value: noauth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.2'
-          TOPOLOGY: sharded_cluster
-          AUTH: noauth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-4.0-server-noauth
@@ -3228,14 +3558,16 @@ tasks:
       - server
       - noauth
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '4.0'}
+            - {key: TOPOLOGY, value: server}
+            - {key: AUTH, value: noauth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.0'
-          TOPOLOGY: server
-          AUTH: noauth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-4.0-replica_set-noauth
@@ -3244,14 +3576,16 @@ tasks:
       - replica_set
       - noauth
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '4.0'}
+            - {key: TOPOLOGY, value: replica_set}
+            - {key: AUTH, value: noauth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.0'
-          TOPOLOGY: replica_set
-          AUTH: noauth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-4.0-sharded_cluster-noauth
@@ -3260,14 +3594,16 @@ tasks:
       - sharded_cluster
       - noauth
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '4.0'}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: AUTH, value: noauth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.0'
-          TOPOLOGY: sharded_cluster
-          AUTH: noauth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-3.6-server-noauth
@@ -3276,14 +3612,16 @@ tasks:
       - server
       - noauth
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '3.6'}
+            - {key: TOPOLOGY, value: server}
+            - {key: AUTH, value: noauth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '3.6'
-          TOPOLOGY: server
-          AUTH: noauth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-3.6-replica_set-noauth
@@ -3292,14 +3630,16 @@ tasks:
       - replica_set
       - noauth
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '3.6'}
+            - {key: TOPOLOGY, value: replica_set}
+            - {key: AUTH, value: noauth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '3.6'
-          TOPOLOGY: replica_set
-          AUTH: noauth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-3.6-sharded_cluster-noauth
@@ -3308,14 +3648,16 @@ tasks:
       - sharded_cluster
       - noauth
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '3.6'}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: AUTH, value: noauth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '3.6'
-          TOPOLOGY: sharded_cluster
-          AUTH: noauth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-lambda-example
@@ -3323,28 +3665,32 @@ tasks:
       - latest
       - lambda
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: rapid}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: rapid
-          TOPOLOGY: server
       - func: run lambda handler example tests
   - name: test-lambda-aws-auth-example
     tags:
       - latest
       - lambda
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: rapid}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: rapid
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run lambda handler example tests with aws auth
@@ -3353,106 +3699,120 @@ tasks:
       - latest
       - sharded_cluster
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: latest}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: AUTH, value: auth}
+            - {key: TEST_NPM_SCRIPT, value: check:csfle}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          TOPOLOGY: sharded_cluster
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
-        vars:
-          TEST_NPM_SCRIPT: check:csfle
   - name: test-rapid-csfle-mongocryptd
     tags:
       - rapid
       - sharded_cluster
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: rapid}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: AUTH, value: auth}
+            - {key: TEST_NPM_SCRIPT, value: check:csfle}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: rapid
-          TOPOLOGY: sharded_cluster
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
-        vars:
-          TEST_NPM_SCRIPT: check:csfle
   - name: test-7.0-csfle-mongocryptd
     tags:
       - '7.0'
       - sharded_cluster
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '7.0'}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: AUTH, value: auth}
+            - {key: TEST_NPM_SCRIPT, value: check:csfle}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '7.0'
-          TOPOLOGY: sharded_cluster
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
-        vars:
-          TEST_NPM_SCRIPT: check:csfle
   - name: test-6.0-csfle-mongocryptd
     tags:
       - '6.0'
       - sharded_cluster
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '6.0'}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: AUTH, value: auth}
+            - {key: TEST_NPM_SCRIPT, value: check:csfle}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '6.0'
-          TOPOLOGY: sharded_cluster
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
-        vars:
-          TEST_NPM_SCRIPT: check:csfle
   - name: test-5.0-csfle-mongocryptd
     tags:
       - '5.0'
       - sharded_cluster
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '5.0'}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: AUTH, value: auth}
+            - {key: TEST_NPM_SCRIPT, value: check:csfle}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '5.0'
-          TOPOLOGY: sharded_cluster
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
-        vars:
-          TEST_NPM_SCRIPT: check:csfle
   - name: test-4.4-csfle-mongocryptd
     tags:
       - '4.4'
       - sharded_cluster
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '4.4'}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: AUTH, value: auth}
+            - {key: TEST_NPM_SCRIPT, value: check:csfle}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.4'
-          TOPOLOGY: sharded_cluster
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
-        vars:
-          TEST_NPM_SCRIPT: check:csfle
   - name: test-4.2-csfle-mongocryptd
     tags:
       - '4.2'
       - sharded_cluster
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '4.2'}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: AUTH, value: auth}
+            - {key: TEST_NPM_SCRIPT, value: check:csfle}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.2'
-          TOPOLOGY: sharded_cluster
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
-        vars:
-          TEST_NPM_SCRIPT: check:csfle
   - name: run-mongosh-browser-runtime-electron
     tags:
       - run-mongosh-integration-tests

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -3168,12 +3168,13 @@ tasks:
             - {key: NPM_VERSION, value: '9'}
             - {key: VERSION, value: '7.0'}
             - {key: TOPOLOGY, value: replica_set}
-            - {key: PACKAGE, value: mongodb-client-encryption@6.0.0}
             - {key: CLIENT_ENCRYPTION, value: 'true'}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: bootstrap kms servers
       - func: install package
+        vars:
+          PACKAGE: mongodb-client-encryption@6.0.0
       - func: run tests
   - name: test-latest-server-noauth
     tags:

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -100,6 +100,7 @@ BASE_TASKS.push({
       VERSION: 'latest',
       TOPOLOGY: 'server',
       REQUIRE_API_VERSION: '1',
+      MONGODB_API_VERSION: '1',
       AUTH: 'auth'
     }),
     { func: 'install dependencies' },

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -636,13 +636,17 @@ oneOffFuncAsTasks.push({
       NPM_VERSION: 9,
       VERSION: '7.0',
       TOPOLOGY: 'replica_set',
-      PACKAGE: 'mongodb-client-encryption@6.0.0',
       CLIENT_ENCRYPTION: true
     }),
     { func: 'install dependencies' },
     { func: 'bootstrap mongo-orchestration' },
     { func: 'bootstrap kms servers' },
-    { func: 'install package' },
+    {
+      func: 'install package',
+      vars: {
+        PACKAGE: 'mongodb-client-encryption@6.0.0'
+      }
+    },
     { func: 'run tests' }
   ]
 });

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -51,7 +51,10 @@ const WINDOWS_SKIP_TAGS = new Set([
 const TASKS = [];
 const SINGLETON_TASKS = [];
 
-/** Accepts {key: value} -> returns {key, value}[] */
+/**
+ * @param {Record<string, any>} expansions - keys become expansion names and values are stringified and become expansion value.
+ * @returns {{command: 'expansions.update'; type: 'setup'; params: { updates: Array<{key: string, value: string}> } }}
+ */
 function updateExpansions(expansions) {
   const updates = Object.entries(expansions).map(([key, value]) => ({ key, value: `${value}` }));
   return {


### PR DESCRIPTION
### Description

#### What is changing?

- Move all usages of `vars` to expansions
- set `add_expansions_to_env: true`
- formatting

**Note to reviewer** it is easier to follow changes per commit to skip over misc formatting fixes

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

Avoiding use of var removes the risk of breakages when evergreen removes the behavior where vars persist across functions

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
