### PR TITLE
ci(NODE-5667): remove custom dep tests against master and fix prose test 14

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2508,7 +2508,7 @@ tasks:
       - func: bootstrap kms servers
       - func: run custom csfle tests
         vars:
-          CSFLE_GIT_REF: c56c70340093070b1ef5c8a28190187eea21a6e9
+          CSFLE_GIT_REF: 5e922eb1302f1efbf4e8ddeb5f2ef113fd58ced0
   - name: run-custom-csfle-tests-rapid-pinned-commit
     tags:
       - run-custom-dependency-tests
@@ -2524,7 +2524,7 @@ tasks:
       - func: bootstrap kms servers
       - func: run custom csfle tests
         vars:
-          CSFLE_GIT_REF: c56c70340093070b1ef5c8a28190187eea21a6e9
+          CSFLE_GIT_REF: 5e922eb1302f1efbf4e8ddeb5f2ef113fd58ced0
   - name: run-custom-csfle-tests-latest-pinned-commit
     tags:
       - run-custom-dependency-tests
@@ -2540,7 +2540,7 @@ tasks:
       - func: bootstrap kms servers
       - func: run custom csfle tests
         vars:
-          CSFLE_GIT_REF: c56c70340093070b1ef5c8a28190187eea21a6e9
+          CSFLE_GIT_REF: 5e922eb1302f1efbf4e8ddeb5f2ef113fd58ced0
   - name: test-latest-server-noauth
     tags:
       - latest

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2509,22 +2509,6 @@ tasks:
       - func: run custom csfle tests
         vars:
           CSFLE_GIT_REF: c56c70340093070b1ef5c8a28190187eea21a6e9
-  - name: run-custom-csfle-tests-5.0-master
-    tags:
-      - run-custom-dependency-tests
-    commands:
-      - func: install dependencies
-        vars:
-          NODE_LTS_VERSION: 12
-          NPM_VERSION: 8
-      - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '5.0'
-          TOPOLOGY: replica_set
-      - func: bootstrap kms servers
-      - func: run custom csfle tests
-        vars:
-          CSFLE_GIT_REF: master
   - name: run-custom-csfle-tests-rapid-pinned-commit
     tags:
       - run-custom-dependency-tests
@@ -2541,22 +2525,6 @@ tasks:
       - func: run custom csfle tests
         vars:
           CSFLE_GIT_REF: c56c70340093070b1ef5c8a28190187eea21a6e9
-  - name: run-custom-csfle-tests-rapid-master
-    tags:
-      - run-custom-dependency-tests
-    commands:
-      - func: install dependencies
-        vars:
-          NODE_LTS_VERSION: 12
-          NPM_VERSION: 8
-      - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: rapid
-          TOPOLOGY: replica_set
-      - func: bootstrap kms servers
-      - func: run custom csfle tests
-        vars:
-          CSFLE_GIT_REF: master
   - name: run-custom-csfle-tests-latest-pinned-commit
     tags:
       - run-custom-dependency-tests
@@ -2573,22 +2541,6 @@ tasks:
       - func: run custom csfle tests
         vars:
           CSFLE_GIT_REF: c56c70340093070b1ef5c8a28190187eea21a6e9
-  - name: run-custom-csfle-tests-latest-master
-    tags:
-      - run-custom-dependency-tests
-    commands:
-      - func: install dependencies
-        vars:
-          NODE_LTS_VERSION: 12
-          NPM_VERSION: 8
-      - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          TOPOLOGY: replica_set
-      - func: bootstrap kms servers
-      - func: run custom csfle tests
-        vars:
-          CSFLE_GIT_REF: master
   - name: test-latest-server-noauth
     tags:
       - latest
@@ -3740,11 +3692,8 @@ buildvariants:
       - run-bson-ext-integration
       - run-bson-ext-unit
       - run-custom-csfle-tests-5.0-pinned-commit
-      - run-custom-csfle-tests-5.0-master
       - run-custom-csfle-tests-rapid-pinned-commit
-      - run-custom-csfle-tests-rapid-master
       - run-custom-csfle-tests-latest-pinned-commit
-      - run-custom-csfle-tests-latest-master
   - name: rhel8-test-serverless
     display_name: Serverless Test
     run_on: rhel80-large

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -647,7 +647,7 @@ for (const version of ['5.0', 'rapid', 'latest']) {
       {
         func: 'run custom csfle tests',
         vars: {
-          CSFLE_GIT_REF: 'c56c70340093070b1ef5c8a28190187eea21a6e9'
+          CSFLE_GIT_REF: '5e922eb1302f1efbf4e8ddeb5f2ef113fd58ced0'
         }
       }
     ]

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -435,9 +435,8 @@ for (const {
 
 BUILD_VARIANTS.push({
   name: MACOS_OS,
-  display_name: `MacOS 11 Node${
-    versions.find(version => version.versionNumber === LATEST_LTS).versionNumber
-  }`,
+  display_name: `MacOS 11 Node${versions.find(version => version.versionNumber === LATEST_LTS).versionNumber
+    }`,
   run_on: MACOS_OS,
   expansions: {
     NODE_LTS_VERSION: LATEST_LTS,
@@ -625,38 +624,34 @@ const oneOffFuncAsTasks = oneOffFuncs.map(oneOffFunc => ({
   ]
 }));
 
-const FLE_PINNED_COMMIT = 'c56c70340093070b1ef5c8a28190187eea21a6e9';
-
 for (const version of ['5.0', 'rapid', 'latest']) {
-  for (const ref of [FLE_PINNED_COMMIT, 'master']) {
-    oneOffFuncAsTasks.push({
-      name: `run-custom-csfle-tests-${version}-${ref === 'master' ? ref : 'pinned-commit'}`,
-      tags: ['run-custom-dependency-tests'],
-      commands: [
-        {
-          func: 'install dependencies',
-          vars: {
-            NODE_LTS_VERSION: LOWEST_LTS,
-            NPM_VERSION: 8
-          }
-        },
-        {
-          func: 'bootstrap mongo-orchestration',
-          vars: {
-            VERSION: version,
-            TOPOLOGY: 'replica_set'
-          }
-        },
-        { func: 'bootstrap kms servers' },
-        {
-          func: 'run custom csfle tests',
-          vars: {
-            CSFLE_GIT_REF: ref
-          }
+  oneOffFuncAsTasks.push({
+    name: `run-custom-csfle-tests-${version}-pinned-commit`,
+    tags: ['run-custom-dependency-tests'],
+    commands: [
+      {
+        func: 'install dependencies',
+        vars: {
+          NODE_LTS_VERSION: LOWEST_LTS,
+          NPM_VERSION: 8
         }
-      ]
-    });
-  }
+      },
+      {
+        func: 'bootstrap mongo-orchestration',
+        vars: {
+          VERSION: version,
+          TOPOLOGY: 'replica_set'
+        }
+      },
+      { func: 'bootstrap kms servers' },
+      {
+        func: 'run custom csfle tests',
+        vars: {
+          CSFLE_GIT_REF: 'c56c70340093070b1ef5c8a28190187eea21a6e9'
+        }
+      }
+    ]
+  });
 }
 
 const coverageTask = {

--- a/.evergreen/run-bson-ext-test.sh
+++ b/.evergreen/run-bson-ext-test.sh
@@ -23,7 +23,7 @@ fi
 # run tests
 echo "Running $AUTH tests over $SSL, connecting to $MONGODB_URI"
 
-npm install mongodb-client-encryption@">=2.3.0"
+npm install "mongodb-client-encryption@2.x"
 npm install bson-ext
 
 export MONGODB_API_VERSION=${MONGODB_API_VERSION}

--- a/.evergreen/run-serverless-tests.sh
+++ b/.evergreen/run-serverless-tests.sh
@@ -10,7 +10,7 @@ if [ -z ${MONGODB_URI+omitted} ]; then echo "MONGODB_URI is unset" && exit 1; fi
 if [ -z ${SERVERLESS_ATLAS_USER+omitted} ]; then echo "SERVERLESS_ATLAS_USER is unset" && exit 1; fi
 if [ -z ${SERVERLESS_ATLAS_PASSWORD+omitted} ]; then echo "SERVERLESS_ATLAS_PASSWORD is unset" && exit 1; fi
 
-npm install mongodb-client-encryption
+npm install "mongodb-client-encryption@2.x"
 
 npx mocha \
   --config test/mocha_mongodb.json \

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -50,9 +50,10 @@ else
   echo "adding temporary AWS credentials to environment"
   # CSFLE_AWS_TEMP_ACCESS_KEY_ID, CSFLE_AWS_TEMP_SECRET_ACCESS_KEY, CSFLE_AWS_TEMP_SESSION_TOKEN
   source "$DRIVERS_TOOLS"/.evergreen/csfle/set-temp-creds.sh
+
+  npm install "mongodb-client-encryption@2.x"
 fi
 
-npm install mongodb-client-encryption
 npm install @mongodb-js/zstd
 npm install snappy
 

--- a/test/integration/client-side-encryption/client_side_encryption.prose.test.js
+++ b/test/integration/client-side-encryption/client_side_encryption.prose.test.js
@@ -1893,10 +1893,12 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
         keyId: keyId,
         algorithm: 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'
       });
-      // Copy ``ciphertext`` into a variable named ``malformedCiphertext``.
-      // Change the last byte to 0. This will produce an invalid HMAC tag.
+      // Copy ``ciphertext`` into a variable named ``malformedCiphertext``. Change the
+      // last byte to a different value. This will produce an invalid HMAC tag.
       const buffer = Buffer.from(cipherText.buffer);
-      buffer.writeInt8(0, buffer.length - 1);
+      const lastByte = buffer.readUInt8(buffer.length - 1);
+      const replacementByte = lastByte === 0 ? 1 : 0;
+      buffer.writeUInt8(replacementByte, buffer.length - 1);
       malformedCiphertext = new Binary(buffer, 6);
       // Create a MongoClient named ``encryptedClient`` with these ``AutoEncryptionOpts``:
       //   AutoEncryptionOpts {


### PR DESCRIPTION
### Description

#### What is changing?

- 4.x only has custom dependency tests against the pinned commit
- FLE prose test 14 has been fixed, with the same fix from https://github.com/mongodb/node-mongodb-native/pull/3833/files


Unrelated to NODE-5667 - this PR also incorporates changes from https://jira.mongodb.org/browse/NODE-5632.  Notably, it

- sets the pinned commit to the mongodb-client-encryption@2.9.1 release commit
- specifies version 2.x of mongodb-client-encryption for driver 4.x CI

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
