### PR TITLE
ci(NODE-5664): unit test on all supported Node versions

### DIFF
--- a/.evergreen/ci_matrix_constants.js
+++ b/.evergreen/ci_matrix_constants.js
@@ -1,9 +1,9 @@
 const MONGODB_VERSIONS = ['latest', 'rapid', '7.0', '6.0', '5.0', '4.4', '4.2', '4.0', '3.6'];
 const versions = [
-  { codeName: 'fermium', versionNumber: 14 },
-  { codeName: 'gallium', versionNumber: 16 },
-  { codeName: 'hydrogen', versionNumber: 18 },
-  { codeName: 'iron', versionNumber: 20 }
+  { codeName: 'fermium', versionNumber: 14, npmVersion: 9 },
+  { codeName: 'gallium', versionNumber: 16, npmVersion: 9 },
+  { codeName: 'hydrogen', versionNumber: 18, npmVersion: 'latest' },
+  { codeName: 'iron', versionNumber: 20, npmVersion: 'latest' }
 ];
 const NODE_VERSIONS = versions.map(({ versionNumber }) => versionNumber).sort((a, b) => a - b);
 const LOWEST_LTS = NODE_VERSIONS[0];

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2914,9 +2914,9 @@ tasks:
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test AssumeRoleWithWebIdentity with AWS_ROLE_SESSION_NAME set
-  - name: run-unit-tests
+  - name: run-unit-tests-node-14
     tags:
-      - run-unit-tests
+      - unit-tests
     commands:
       - command: expansions.update
         type: setup
@@ -2926,9 +2926,45 @@ tasks:
             - {key: NPM_VERSION, value: '9'}
       - func: install dependencies
       - func: run unit tests
+  - name: run-unit-tests-node-16
+    tags:
+      - unit-tests
+    commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NODE_LTS_VERSION, value: '16'}
+            - {key: NPM_VERSION, value: '9'}
+      - func: install dependencies
+      - func: run unit tests
+  - name: run-unit-tests-node-18
+    tags:
+      - unit-tests
+    commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NODE_LTS_VERSION, value: '18'}
+            - {key: NPM_VERSION, value: latest}
+      - func: install dependencies
+      - func: run unit tests
+  - name: run-unit-tests-node-20
+    tags:
+      - unit-tests
+    commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NODE_LTS_VERSION, value: '20'}
+            - {key: NPM_VERSION, value: latest}
+      - func: install dependencies
+      - func: run unit tests
   - name: run-lint-checks
     tags:
-      - run-lint-checks
+      - lint-checks
     commands:
       - command: expansions.update
         type: setup
@@ -2941,6 +2977,7 @@ tasks:
   - name: check-types-typescript-next
     tags:
       - check-types-typescript-next
+      - typescript-compilation
     commands:
       - command: expansions.update
         type: setup
@@ -2954,6 +2991,7 @@ tasks:
   - name: compile-driver-typescript-current
     tags:
       - compile-driver-typescript-current
+      - typescript-compilation
     commands:
       - command: expansions.update
         type: setup
@@ -2967,6 +3005,7 @@ tasks:
   - name: check-types-typescript-current
     tags:
       - check-types-typescript-current
+      - typescript-compilation
     commands:
       - command: expansions.update
         type: setup
@@ -2980,6 +3019,7 @@ tasks:
   - name: check-types-typescript-4.1.6
     tags:
       - check-types-typescript-4.1.6
+      - typescript-compilation
     commands:
       - command: expansions.update
         type: setup
@@ -4347,12 +4387,9 @@ buildvariants:
     display_name: lint
     run_on: rhel80-large
     tasks:
-      - run-unit-tests
-      - run-lint-checks
-      - check-types-typescript-next
-      - compile-driver-typescript-current
-      - check-types-typescript-current
-      - check-types-typescript-4.1.6
+      - .unit-tests
+      - .lint-checks
+      - .typescript-compilation
   - name: generate-combined-coverage
     display_name: Generate Combined Coverage
     run_on: rhel80-large

--- a/test/unit/assorted/polling_srv_records_for_mongos_discovery.prose.test.ts
+++ b/test/unit/assorted/polling_srv_records_for_mongos_discovery.prose.test.ts
@@ -3,13 +3,13 @@ import * as dns from 'dns';
 import * as sinon from 'sinon';
 
 import {
+  type SrvPollerOptions,
+  type TopologyOptions,
   HostAddress,
   isHello,
   MongoClient,
   SrvPoller,
-  type SrvPollerOptions,
   SrvPollingEvent,
-  type TopologyOptions,
   TopologyType
 } from '../../mongodb';
 import * as mock from '../../tools/mongodb-mock/index';

--- a/test/unit/assorted/polling_srv_records_for_mongos_discovery.prose.test.ts
+++ b/test/unit/assorted/polling_srv_records_for_mongos_discovery.prose.test.ts
@@ -1,15 +1,16 @@
 import { expect } from 'chai';
 import * as dns from 'dns';
+import { coerce } from 'semver';
 import * as sinon from 'sinon';
 
 import {
-  type SrvPollerOptions,
-  type TopologyOptions,
   HostAddress,
   isHello,
   MongoClient,
   SrvPoller,
+  type SrvPollerOptions,
   SrvPollingEvent,
+  type TopologyOptions,
   TopologyType
 } from '../../mongodb';
 import * as mock from '../../tools/mongodb-mock/index';
@@ -44,6 +45,18 @@ interface ShardedClusterMocks {
 // TODO(NODE-3773): Make use of the shared driver's DNS records
 // TODO(NODE-3773): Implement tests 6-9
 describe('Polling Srv Records for Mongos Discovery', () => {
+  beforeEach(function () {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const test = this.currentTest!;
+
+    const { major } = coerce(process.version);
+    test.skipReason =
+      major === 18 || major === 20
+        ? 'TODO(NODE-5666): fix failing unit tests on Node18'
+        : undefined;
+
+    if (test.skipReason) this.skip();
+  });
   describe('SRV polling prose cases 1-5', () => {
     const SRV_HOST = 'darmok.tanagra.com';
     const context: Record<string, any> = {};

--- a/test/unit/connection_string.spec.test.ts
+++ b/test/unit/connection_string.spec.test.ts
@@ -1,3 +1,5 @@
+import { coerce } from 'semver';
+
 import { loadSpecTests } from '../spec';
 import { executeUriValidationTest } from '../tools/uri_spec_runner';
 
@@ -13,6 +15,23 @@ describe('Connection String spec tests', function () {
   // TODO(NODE-3920): validate repeated options
   const testsThatDoNotThrowOnWarn = ['Repeated option keys'];
   const suites = loadSpecTests('connection-string');
+
+  beforeEach(function () {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const test = this.currentTest!;
+
+    const { major } = coerce(process.version);
+    const skippedTests = [
+      'Invalid port (zero) with IP literal',
+      'Invalid port (zero) with hostname'
+    ];
+    test.skipReason =
+      major === 20 && skippedTests.includes(test.title)
+        ? 'TODO(NODE-5666): fix failing unit tests on Node18'
+        : undefined;
+
+    if (test.skipReason) this.skip();
+  });
 
   for (const suite of suites) {
     describe(suite.name, function () {

--- a/test/unit/sdam/monitor.test.ts
+++ b/test/unit/sdam/monitor.test.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import { coerce } from 'semver';
 import * as sinon from 'sinon';
 import { setTimeout } from 'timers';
 
@@ -28,6 +29,26 @@ class MockServer {
 
 describe('monitoring', function () {
   let mockServer;
+
+  beforeEach(function () {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const test = this.currentTest!;
+
+    const { major } = coerce(process.version);
+    const failingTests = [
+      'should connect and issue an initial server check',
+      'should ignore attempts to connect when not already closed',
+      'should not initiate another check if one is in progress',
+      'should not close the monitor on a failed heartbeat',
+      'should upgrade to hello from legacy hello when initial handshake contains helloOk'
+    ];
+    test.skipReason =
+      (major === 18 || major === 20) && failingTests.includes(test.title)
+        ? 'TODO(NODE-5666): fix failing unit tests on Node18'
+        : undefined;
+
+    if (test.skipReason) this.skip();
+  });
 
   after(() => mock.cleanup());
   beforeEach(function () {

--- a/test/unit/sdam/topology.test.js
+++ b/test/unit/sdam/topology.test.js
@@ -15,6 +15,7 @@ const { TopologyType } = require('../../mongodb');
 const { SrvPoller, SrvPollingEvent } = require('../../mongodb');
 const { getSymbolFrom, topologyWithPlaceholderClient } = require('../../tools/utils');
 const { LEGACY_NOT_WRITABLE_PRIMARY_ERROR_MESSAGE } = require('../../mongodb');
+const { coerce } = require('semver');
 
 describe('Topology (unit)', function () {
   let client, topology;
@@ -292,6 +293,15 @@ describe('Topology (unit)', function () {
     });
 
     it('should encounter a server selection timeout on garbled server responses', function (done) {
+      const test = this.test;
+
+      const { major } = coerce(process.version);
+      test.skipReason =
+        major === 18 || major === 20
+          ? 'TODO(NODE-5666): fix failing unit tests on Node18'
+          : undefined;
+
+      if (test.skipReason) this.skip();
       const server = net.createServer();
       const p = Promise.resolve();
       let unexpectedError, expectedError;


### PR DESCRIPTION
### Description

#### What is changing?

We now unit test on all supported Node versions.  Backports https://github.com/mongodb/node-mongodb-native/pull/3879.

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
