### PR TITLE
fix(NODE-5691): make findOne() close implicit session to avoid memory leak

### DIFF
--- a/src/collection.ts
+++ b/src/collection.ts
@@ -493,7 +493,10 @@ export class Collection<TSchema extends Document = Document> {
     filter: Filter<TSchema> = {},
     options: FindOptions = {}
   ): Promise<WithId<TSchema> | null> {
-    return this.find(filter, options).limit(-1).batchSize(1).next();
+    const cursor = this.find(filter, options).limit(-1).batchSize(1);
+    const res = await cursor.next();
+    await cursor.close();
+    return res;
   }
 
   /**

--- a/test/integration/crud/crud_api.test.ts
+++ b/test/integration/crud/crud_api.test.ts
@@ -75,7 +75,7 @@ describe('CRUD API', function () {
     await client.close();
   });
 
-  describe('findOne()', () => {
+  describe.only('findOne()', () => {
     let client: MongoClient;
     let events;
     let collection: Collection<{ _id: number }>;
@@ -107,6 +107,7 @@ describe('CRUD API', function () {
         expect(result).to.deep.equal({ _id: 1 });
         expect(events.at(0)).to.be.instanceOf(CommandSucceededEvent);
         expect(spy.returnValues.at(0)).to.have.property('closed', true);
+        expect(spy.returnValues.at(0)).to.have.nested.property('session.hasEnded', true);
       });
     });
 
@@ -139,6 +140,7 @@ describe('CRUD API', function () {
         expect(error).to.be.instanceOf(MongoServerError);
         expect(events.at(0)).to.be.instanceOf(CommandFailedEvent);
         expect(spy.returnValues.at(0)).to.have.property('closed', true);
+        expect(spy.returnValues.at(0)).to.have.nested.property('session.hasEnded', true);
       });
     });
   });

--- a/test/integration/crud/crud_api.test.ts
+++ b/test/integration/crud/crud_api.test.ts
@@ -3,7 +3,6 @@ import { on } from 'events';
 import * as sinon from 'sinon';
 
 import {
-  AbstractCursor,
   Collection,
   CommandFailedEvent,
   CommandSucceededEvent,

--- a/test/integration/crud/crud_api.test.ts
+++ b/test/integration/crud/crud_api.test.ts
@@ -1,7 +1,14 @@
 import { expect } from 'chai';
 import { on } from 'events';
+import * as sinon from 'sinon';
 
-import { type MongoClient, MongoError, ObjectId, ReturnDocument } from '../../mongodb';
+import {
+  AbstractCursor,
+  type MongoClient,
+  MongoError,
+  ObjectId,
+  ReturnDocument
+} from '../../mongodb';
 import { assert as test } from '../shared';
 
 // instanceof cannot be use reliably to detect the new models in js due to scoping and new
@@ -31,6 +38,8 @@ describe('CRUD API', function () {
   });
 
   afterEach(async function () {
+    sinon.restore();
+
     await client?.close();
     client = null;
 
@@ -59,6 +68,12 @@ describe('CRUD API', function () {
 
     await collection.drop();
     await client.close();
+  });
+
+  it('findOne calls cursor.close()', async function () {
+    const spy = sinon.spy(AbstractCursor.prototype, 'close');
+    await client.db().collection('t').findOne({});
+    expect(spy).to.be.calledOnce;
   });
 
   context('when creating a cursor with find', () => {

--- a/test/integration/crud/crud_api.test.ts
+++ b/test/integration/crud/crud_api.test.ts
@@ -75,7 +75,7 @@ describe('CRUD API', function () {
     await client.close();
   });
 
-  describe.only('findOne()', () => {
+  describe('findOne()', () => {
     let client: MongoClient;
     let events;
     let collection: Collection<{ _id: number }>;

--- a/test/integration/crud/crud_api.test.ts
+++ b/test/integration/crud/crud_api.test.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import { on } from 'events';
+import * as semver from 'semver';
 import * as sinon from 'sinon';
 
 import {
@@ -111,7 +112,14 @@ describe('CRUD API', function () {
     });
 
     describe('when the find operation fails', () => {
-      beforeEach(async () => {
+      beforeEach(async function () {
+        if (semver.lt(this.configuration.version, '4.2.0')) {
+          if (this.currentTest) {
+            this.currentTest.skipReason = `Cannot run fail points on server version: ${this.configuration.version}`;
+          }
+          return this.currentTest?.skip();
+        }
+
         const failPoint: FailPoint = {
           configureFailPoint: 'failCommand',
           mode: 'alwaysOn',

--- a/test/integration/crud/crud_api.test.ts
+++ b/test/integration/crud/crud_api.test.ts
@@ -117,7 +117,7 @@ describe('CRUD API', function () {
           if (this.currentTest) {
             this.currentTest.skipReason = `Cannot run fail points on server version: ${this.configuration.version}`;
           }
-          return this.currentTest?.skip();
+          return this.skip();
         }
 
         const failPoint: FailPoint = {
@@ -132,7 +132,11 @@ describe('CRUD API', function () {
         await client.db().admin().command(failPoint);
       });
 
-      afterEach(async () => {
+      afterEach(async function () {
+        if (semver.lt(this.configuration.version, '4.2.0')) {
+          return;
+        }
+
         const failPoint: FailPoint = {
           configureFailPoint: 'failCommand',
           mode: 'off',


### PR DESCRIPTION
### Description

I found this potential issue while troubleshooting https://github.com/Automattic/mongoose/issues/13829. Running the following Mongoose script:

```
import v8 from 'node:v8';
import mongoose from 'mongoose';

await mongoose.connect('mongodb://127.0.0.1:27017/mongoose_test');
  
const testSchema = new mongoose.Schema(
    {
        data: String,
        createdAt: { type: Date, default: Date.now },
    },
    {
        timeseries: {
            timeField: 'createdAt'
        },
        expireAfterSeconds: 60 * 60 * 24 * 7
    }
);

const TestModel = mongoose.model('Test', testSchema);

await TestModel.deleteMany({});
const docs = [];
for (let i = 0; i < 1000; ++i) {
    docs.push({ data: '0'.repeat(1024 * 2 * 10) });
}
await TestModel.create(docs);
console.log('Created docs');

let start = Date.now();
let count = 0;

await TestModel.deleteMany({});
const docs = [];
for (let i = 0; i < 1000; ++i) {
    docs.push({ data: '0'.repeat(1024 * 2 * 10) });
}
await TestModel.create(docs);
console.log('Created docs');

let start = Date.now();
let count = 0;

while (++count) {
    const res = await TestModel.findOne({}).lean().exec();
    if (count % 1000 === 0) {
        console.log(`{ x: ${Date.now() - start}, y: ${v8.getHeapStatistics().used_heap_size} },`);
    }
    await new Promise(resolve => setTimeout(resolve, 1));
};
```

Using --max-heap-size to constrain memory, without this PR, leads to OOM:

```
$ node --max-old-space-size=42 gh-13829.mjs 
Created docs
{ x: 3546, y: 40780432 },
{ x: 7021, y: 26150200 },
{ x: 12514, y: 26803160 },
{ x: 15310, y: 27629264 },
{ x: 155712, y: 28427984 },
{ x: 158292, y: 30820408 },
{ x: 168100, y: 33326456 },
{ x: 256559, y: 35073952 },

<--- Last few GCs --->
al[1079899:0x5b19830]   257664 ms: Mark-sweep 33.9 (69.3) -> 33.6 (69.3) MB, 1.5 / 0.0 ms  (+ 5.5 ms in 76 steps since start of marking, biggest step 0.2 ms, walltime since start of marking 9 ms) (average mu = 0.376, current mu = 0.388) finalize incremental[1079899:0x5b19830]   257676 ms: Mark-sweep 34.1 (69.3) -> 33.7 (69.1) MB, 1.8 / 0.0 ms  (+ 5.9 ms in 81 steps since start of marking, biggest step 0.2 ms, walltime since start of marking 10 ms) (average mu = 0.378, current mu = 0.379) finalize incrementa
```

With this PR:

```
$ node --max-old-space-size=42 gh-13829.mjs 
Created docs
{ x: 3839, y: 39456136 },
{ x: 7508, y: 19674968 },
{ x: 10814, y: 20988120 },
{ x: 13826, y: 19179712 },
{ x: 16398, y: 19229168 },
{ x: 18885, y: 19254040 },
{ x: 21368, y: 19296360 },
{ x: 23841, y: 19218352 },
{ x: 26327, y: 19381648 },
{ x: 28803, y: 19321888 },
{ x: 31316, y: 19338768 },
{ x: 33770, y: 19400056 },
{ x: 36273, y: 19374016 },
{ x: 38757, y: 19314128 },
{ x: 41267, y: 19250920 },
{ x: 43754, y: 19443352 },
```

It looks like the issue is that, while [`toArray()` and `asyncIterator`](https://github.com/vkarpov15/node-mongodb-native/blob/2ab2189561736e354437df88d2ea26cf35b483d1/src/cursor/abstract_cursor.ts#L330-L332) call `close()`, `findOne()` does not. And that means [`findOne()`'s implicitly created session never ends](https://github.com/vkarpov15/node-mongodb-native/blob/2ab2189561736e354437df88d2ea26cf35b483d1/src/cursor/abstract_cursor.ts#L820-L824), leading to what looks like a memory leak.

#### What is changing?

Explicitly `close()` cursor in `findOne()` in order to ensure that the driver calls `endSession()` on the implicitly created session.

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

See description

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
