### PR TITLE
refactor(NODE-5675): refactor server selection and connection checkout to use abort signals for timeout management 

### DIFF
--- a/src/cmap/connection_pool.ts
+++ b/src/cmap/connection_pool.ts
@@ -27,7 +27,7 @@ import {
 } from '../error';
 import { CancellationToken, TypedEventEmitter } from '../mongo_types';
 import type { Server } from '../sdam/server';
-import { type Callback, eachAsync, List, makeCounter } from '../utils';
+import { type Callback, eachAsync, List, makeCounter, TimeoutController } from '../utils';
 import { AUTH_PROVIDERS, connect } from './connect';
 import { Connection, type ConnectionEvents, type ConnectionOptions } from './connection';
 import {
@@ -101,7 +101,7 @@ export interface ConnectionPoolOptions extends Omit<ConnectionOptions, 'id' | 'g
 /** @internal */
 export interface WaitQueueMember {
   callback: Callback<Connection>;
-  timer?: NodeJS.Timeout;
+  timeoutController: TimeoutController;
   [kCancelled]?: boolean;
 }
 
@@ -356,27 +356,29 @@ export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
       new ConnectionCheckOutStartedEvent(this)
     );
 
-    const waitQueueMember: WaitQueueMember = { callback };
     const waitQueueTimeoutMS = this.options.waitQueueTimeoutMS;
-    if (waitQueueTimeoutMS) {
-      waitQueueMember.timer = setTimeout(() => {
-        waitQueueMember[kCancelled] = true;
-        waitQueueMember.timer = undefined;
 
-        this.emitAndLog(
-          ConnectionPool.CONNECTION_CHECK_OUT_FAILED,
-          new ConnectionCheckOutFailedEvent(this, 'timeout')
-        );
-        waitQueueMember.callback(
-          new WaitQueueTimeoutError(
-            this.loadBalanced
-              ? this.waitQueueErrorMetrics()
-              : 'Timed out while checking out a connection from connection pool',
-            this.address
-          )
-        );
-      }, waitQueueTimeoutMS);
-    }
+    const waitQueueMember: WaitQueueMember = {
+      callback,
+      timeoutController: new TimeoutController(waitQueueTimeoutMS)
+    };
+    waitQueueMember.timeoutController.signal.onabort = () => {
+      waitQueueMember[kCancelled] = true;
+      waitQueueMember.timeoutController.clear();
+
+      this.emitAndLog(
+        ConnectionPool.CONNECTION_CHECK_OUT_FAILED,
+        new ConnectionCheckOutFailedEvent(this, 'timeout')
+      );
+      waitQueueMember.callback(
+        new WaitQueueTimeoutError(
+          this.loadBalanced
+            ? this.waitQueueErrorMetrics()
+            : 'Timed out while checking out a connection from connection pool',
+          this.address
+        )
+      );
+    };
 
     this[kWaitQueue].push(waitQueueMember);
     process.nextTick(() => this.processWaitQueue());
@@ -831,9 +833,7 @@ export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
           ConnectionPool.CONNECTION_CHECK_OUT_FAILED,
           new ConnectionCheckOutFailedEvent(this, reason, error)
         );
-        if (waitQueueMember.timer) {
-          clearTimeout(waitQueueMember.timer);
-        }
+        waitQueueMember.timeoutController.clear();
         this[kWaitQueue].shift();
         waitQueueMember.callback(error);
         continue;
@@ -854,9 +854,7 @@ export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
           ConnectionPool.CONNECTION_CHECKED_OUT,
           new ConnectionCheckedOutEvent(this, connection)
         );
-        if (waitQueueMember.timer) {
-          clearTimeout(waitQueueMember.timer);
-        }
+        waitQueueMember.timeoutController.clear();
 
         this[kWaitQueue].shift();
         waitQueueMember.callback(undefined, connection);
@@ -893,9 +891,7 @@ export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
             );
           }
 
-          if (waitQueueMember.timer) {
-            clearTimeout(waitQueueMember.timer);
-          }
+          waitQueueMember.timeoutController.clear();
           waitQueueMember.callback(err, connection);
         }
         process.nextTick(() => this.processWaitQueue());

--- a/src/cmap/connection_pool.ts
+++ b/src/cmap/connection_pool.ts
@@ -362,7 +362,7 @@ export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
       callback,
       timeoutController: new TimeoutController(waitQueueTimeoutMS)
     };
-    waitQueueMember.timeoutController.signal.onabort = () => {
+    waitQueueMember.timeoutController.signal.addEventListener('abort', () => {
       waitQueueMember[kCancelled] = true;
       waitQueueMember.timeoutController.clear();
 
@@ -378,7 +378,7 @@ export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
           this.address
         )
       );
-    };
+    });
 
     this[kWaitQueue].push(waitQueueMember);
     process.nextTick(() => this.processWaitQueue());

--- a/src/index.ts
+++ b/src/index.ts
@@ -524,6 +524,7 @@ export type {
   HostAddress,
   List,
   MongoDBCollectionNamespace,
-  MongoDBNamespace
+  MongoDBNamespace,
+  TimeoutController
 } from './utils';
 export type { W, WriteConcernOptions, WriteConcernSettings } from './write_concern';

--- a/src/sdam/topology.ts
+++ b/src/sdam/topology.ts
@@ -560,7 +560,7 @@ export class Topology extends TypedEventEmitter<TopologyEvents> {
       timeoutController: new TimeoutController(options.serverSelectionTimeoutMS)
     };
 
-    waitQueueMember.timeoutController.signal.onabort = () => {
+    waitQueueMember.timeoutController.signal.addEventListener('abort', () => {
       waitQueueMember[kCancelled] = true;
       waitQueueMember.timeoutController.clear();
       const timeoutError = new MongoServerSelectionError(
@@ -569,7 +569,7 @@ export class Topology extends TypedEventEmitter<TopologyEvents> {
       );
 
       waitQueueMember.callback(timeoutError);
-    };
+    });
 
     this[kWaitQueue].push(waitQueueMember);
     processWaitQueue(this);

--- a/src/sdam/topology.ts
+++ b/src/sdam/topology.ts
@@ -1,4 +1,3 @@
-import { clearTimeout, setTimeout } from 'timers';
 import { promisify } from 'util';
 
 import type { BSONSerializeOptions, Document } from '../bson';
@@ -43,7 +42,8 @@ import {
   List,
   makeStateMachine,
   ns,
-  shuffle
+  shuffle,
+  TimeoutController
 } from '../utils';
 import {
   _advanceClusterTime,
@@ -94,8 +94,8 @@ export interface ServerSelectionRequest {
   serverSelector: ServerSelector;
   transaction?: Transaction;
   callback: ServerSelectionCallback;
-  timer?: NodeJS.Timeout;
   [kCancelled]?: boolean;
+  timeoutController: TimeoutController;
 }
 
 /** @internal */
@@ -556,22 +556,20 @@ export class Topology extends TypedEventEmitter<TopologyEvents> {
     const waitQueueMember: ServerSelectionRequest = {
       serverSelector,
       transaction,
-      callback
+      callback,
+      timeoutController: new TimeoutController(options.serverSelectionTimeoutMS)
     };
 
-    const serverSelectionTimeoutMS = options.serverSelectionTimeoutMS;
-    if (serverSelectionTimeoutMS) {
-      waitQueueMember.timer = setTimeout(() => {
-        waitQueueMember[kCancelled] = true;
-        waitQueueMember.timer = undefined;
-        const timeoutError = new MongoServerSelectionError(
-          `Server selection timed out after ${serverSelectionTimeoutMS} ms`,
-          this.description
-        );
+    waitQueueMember.timeoutController.signal.onabort = () => {
+      waitQueueMember[kCancelled] = true;
+      waitQueueMember.timeoutController.clear();
+      const timeoutError = new MongoServerSelectionError(
+        `Server selection timed out after ${options.serverSelectionTimeoutMS} ms`,
+        this.description
+      );
 
-        waitQueueMember.callback(timeoutError);
-      }, serverSelectionTimeoutMS);
-    }
+      waitQueueMember.callback(timeoutError);
+    };
 
     this[kWaitQueue].push(waitQueueMember);
     processWaitQueue(this);
@@ -842,9 +840,7 @@ function drainWaitQueue(queue: List<ServerSelectionRequest>, err?: MongoDriverEr
       continue;
     }
 
-    if (waitQueueMember.timer) {
-      clearTimeout(waitQueueMember.timer);
-    }
+    waitQueueMember.timeoutController.clear();
 
     if (!waitQueueMember[kCancelled]) {
       waitQueueMember.callback(err);
@@ -878,9 +874,7 @@ function processWaitQueue(topology: Topology) {
         ? serverSelector(topology.description, serverDescriptions)
         : serverDescriptions;
     } catch (e) {
-      if (waitQueueMember.timer) {
-        clearTimeout(waitQueueMember.timer);
-      }
+      waitQueueMember.timeoutController.clear();
 
       waitQueueMember.callback(e);
       continue;
@@ -917,9 +911,7 @@ function processWaitQueue(topology: Topology) {
       transaction.pinServer(selectedServer);
     }
 
-    if (waitQueueMember.timer) {
-      clearTimeout(waitQueueMember.timer);
-    }
+    waitQueueMember.timeoutController.clear();
 
     waitQueueMember.callback(undefined, selectedServer);
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1269,14 +1269,16 @@ export async function request(
  */
 export class TimeoutController extends AbortController {
   constructor(
-    timeout?: number,
-    private timeoutId = timeout && timeout > 0 ? setTimeout(() => this.abort(), timeout) : null
+    timeout = 0,
+    private timeoutId = timeout > 0 ? setTimeout(() => this.abort(), timeout) : null
   ) {
     super();
   }
 
   clear() {
-    this.timeoutId && clearTimeout(this.timeoutId);
+    if (this.timeoutId != null) {
+      clearTimeout(this.timeoutId);
+    }
     this.timeoutId = null;
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1259,7 +1259,7 @@ export async function request(
 /**
  * A custom AbortController that aborts after a specified timeout.
  *
- * If `timeout` is undefined or 0, the abort controller never aborts.
+ * If `timeout` is undefined or \<=0, the abort controller never aborts.
  *
  * This class provides two benefits over the built-in AbortSignal.timeout() method.
  * - This class provides a mechanism for cancelling the timeout
@@ -1269,10 +1269,8 @@ export async function request(
  */
 export class TimeoutController extends AbortController {
   constructor(
-    timeoutMS?: number,
-    private timeoutId = timeoutMS && timeoutMS > 0
-      ? setTimeout(() => this.abort(), timeoutMS)
-      : null
+    timeout?: number,
+    private timeoutId = timeout && timeout > 0 ? setTimeout(() => this.abort(), timeout) : null
   ) {
     super();
   }

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -1143,7 +1143,7 @@ describe('driver utils', function () {
 
         beforeEach(function () {
           timeoutController = new TimeoutController(3000);
-          timeoutController.signal.onabort = spy;
+          timeoutController.signal.addEventListener('abort', spy);
         });
 
         afterEach(function () {
@@ -1156,11 +1156,11 @@ describe('driver utils', function () {
         });
 
         it('times out after `timeout` milliseconds', () => {
-          expect(spy.called, 'spy was called after creation').to.be.false;
+          expect(spy, 'spy was called after creation').not.to.have.been.called;
           clock.tick(2999);
-          expect(spy.called, 'spy was called before 3000ms has expired').to.be.false;
+          expect(spy, 'spy was called before 3000ms has expired').not.to.have.been.called;
           clock.tick(1);
-          expect(spy.called, 'spy was not called after 3000ms').to.be.true;
+          expect(spy, 'spy was not called after 3000ms').to.have.been.called;
         });
       });
     });

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -1,6 +1,5 @@
 import { expect } from 'chai';
 import * as sinon from 'sinon';
-import { setTimeout } from 'timers/promises';
 
 import {
   BufferPool,


### PR DESCRIPTION
### Description

#### What is changing?

- A custom abort controller, `TimeoutController`, has been added that aborts its signal after a specified timeout
- Server selection and connection checkout have been refactored to use the `TimeoutController` instead of managing timeouts

##### Is there new documentation needed for these changes?

No.

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
