### PR TITLE
test(NODE-5704): fix explain tests

### DIFF
--- a/test/integration/crud/aggregation.test.ts
+++ b/test/integration/crud/aggregation.test.ts
@@ -326,9 +326,7 @@ describe('Aggregation', function () {
         // Iterate over all the items in the cursor
         cursor.explain(function (err, result) {
           expect(err).to.not.exist;
-          expect(result.stages).to.have.lengthOf.at.least(1);
-          expect(result.stages[0]).to.have.property('$cursor');
-
+          expect(JSON.stringify(result)).to.include('$cursor');
           client.close(done);
         });
       });

--- a/test/integration/crud/explain.test.ts
+++ b/test/integration/crud/explain.test.ts
@@ -101,15 +101,7 @@ describe('CRUD API explain option', function () {
         it(`sets command verbosity to ${explainValue} and includes ${explainValueToExpectation(explainValue)} in the return response`, async function () {
           const response = await op.op(explainValue).catch(error => error);
           const commandStartedEvent = await commandStartedPromise;
-          let explainDocument;
-          if (name === 'aggregate' && explainValue !== 'invalid') {
-            // value changes depending on server version
-            explainDocument =
-              response[0].stages?.[0]?.$cursor ?? response[0]?.stages ?? response[0];
-          } else {
-            explainDocument = response;
-          }
-          const explainJson = JSON.stringify(explainDocument);
+          const explainJson = JSON.stringify(response);
           switch (explainValue) {
             case true:
             case 'allPlansExecution':

--- a/test/integration/crud/explain.test.ts
+++ b/test/integration/crud/explain.test.ts
@@ -109,26 +109,21 @@ describe('CRUD API explain option', function () {
           } else {
             explainDocument = response;
           }
+          const explainJson = JSON.stringify(explainDocument);
           switch (explainValue) {
             case true:
             case 'allPlansExecution':
               expect(commandStartedEvent[0].command.verbosity).to.be.equal('allPlansExecution');
-              expect(explainDocument).to.have.property('queryPlanner');
-              expect(explainDocument).nested.property('executionStats.allPlansExecution').to.exist;
+              expect(explainJson).to.include('queryPlanner');
               break;
             case false:
             case 'queryPlanner':
               expect(commandStartedEvent[0].command.verbosity).to.be.equal('queryPlanner');
-              expect(explainDocument).to.have.property('queryPlanner');
-              expect(explainDocument).to.not.have.property('executionStats');
+              expect(explainJson).to.include('queryPlanner');
               break;
             case 'executionStats':
               expect(commandStartedEvent[0].command.verbosity).to.be.equal('executionStats');
-              expect(explainDocument).to.have.property('queryPlanner');
-              expect(explainDocument).to.have.property('executionStats');
-              expect(explainDocument).to.not.have.nested.property(
-                'executionStats.allPlansExecution'
-              );
+              expect(explainJson).to.include('queryPlanner');
               break;
             default:
               // for invalid values of explain


### PR DESCRIPTION
### Description

Fixes explain tests to be able to handle SBE and non SBE explain results.

#### What is changing?

Looks for specific strings the JSON stringified version of the explain results. Not that SBE results do not contain an "allPlansExecution" or "executionStats" fields so those assertions were removed.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-5617

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
