### PR TITLE
feat(NODE-5613): add `awaited` field to SDAM heartbeat events

### DIFF
--- a/src/sdam/events.ts
+++ b/src/sdam/events.ts
@@ -154,12 +154,15 @@ export class ServerHeartbeatSucceededEvent {
   duration: number;
   /** The command reply */
   reply: Document;
+  /** Is true when using the streaming protocol. */
+  awaited: boolean;
 
   /** @internal */
-  constructor(connectionId: string, duration: number, reply: Document | null) {
+  constructor(connectionId: string, duration: number, reply: Document | null, awaited: boolean) {
     this.connectionId = connectionId;
     this.duration = duration;
     this.reply = reply ?? {};
+    this.awaited = awaited;
   }
 }
 
@@ -175,11 +178,14 @@ export class ServerHeartbeatFailedEvent {
   duration: number;
   /** The command failure */
   failure: Error;
+  /** Is true when using the streaming protocol. */
+  awaited: boolean;
 
   /** @internal */
-  constructor(connectionId: string, duration: number, failure: Error) {
+  constructor(connectionId: string, duration: number, failure: Error, awaited: boolean) {
     this.connectionId = connectionId;
     this.duration = duration;
     this.failure = failure;
+    this.awaited = awaited;
   }
 }

--- a/src/sdam/events.ts
+++ b/src/sdam/events.ts
@@ -132,10 +132,13 @@ export class TopologyClosedEvent {
 export class ServerHeartbeatStartedEvent {
   /** The connection id for the command */
   connectionId: string;
+  /** Is true when using the streaming protocol. */
+  awaited: boolean;
 
   /** @internal */
-  constructor(connectionId: string) {
+  constructor(connectionId: string, awaited: boolean) {
     this.connectionId = connectionId;
+    this.awaited = awaited;
   }
 }
 


### PR DESCRIPTION
### Description

Adds an `awaited` field to server heartbeat events.

#### What is changing?

- Adds the `awaited` field and sets it to true when using the streaming protocol.
- Tests will come as part of NODE-5197

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

Need the field to pass tests coming in NODE-5197

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Server heartbeat events now contain an `awaited` field that is `true` when using the streaming protocol.

```typescript
const client = new MongoClient(process.env.MONGODB_URI);
client.on('serverHeartbeatStarted', (event) => {
  console.log(event.awaited);
});
client.on('serverHeartbeatSucceeded', (event) => {
  console.log(event.awaited);
});
client.on('serverHeartbeatFailed', (event) => {
  console.log(event.awaited);
});
```

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
