### PR TITLE
feat: update bson to 6.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@mongodb-js/saslprep": "^1.1.0",
-        "bson": "^6.1.0",
+        "bson": "^6.2.0",
         "mongodb-connection-string-url": "^2.6.0"
       },
       "devDependencies": {
@@ -3530,9 +3530,9 @@
       }
     },
     "node_modules/bson": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-6.1.0.tgz",
-      "integrity": "sha512-yiQ3KxvpVoRpx1oD1uPz4Jit9tAVTJgjdmjDKtUErkOoL9VNoF8Dd58qtAOL5E40exx2jvAT9sqdRSK/r+SHlA==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.2.0.tgz",
+      "integrity": "sha512-ID1cI+7bazPDyL9wYy9GaQ8gEEohWvcUl/Yf0dIdutJxnmInEEyCsb4awy/OiBfall7zBA179Pahi3vCdFze3Q==",
       "engines": {
         "node": ">=16.20.1"
       }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@mongodb-js/saslprep": "^1.1.0",
-    "bson": "^6.1.0",
+    "bson": "^6.2.0",
     "mongodb-connection-string-url": "^2.6.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
### Description

#### What is changing?

- Pulls in bson ^6.2.0 

##### Is there new documentation needed for these changes?

No.

#### What is the motivation for this change?

See below.

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Updated to BSON 6.2.0

BSON now prints in full color! :rainbow: :rocket: 

<img src="https://github.com/mongodb/node-mongodb-native/assets/10873993/b32cd46e-518b-477a-b976-76930b743d01" width="580" height="28">

See our release notes for [BSON 6.2.0 here](https://github.com/mongodb/js-bson/releases/tag/v6.2.0) for more examples!

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
