### PR TITLE
test(NODE-5733): remove `at()` usage

### DIFF
--- a/test/integration/crud/crud_api.test.ts
+++ b/test/integration/crud/crud_api.test.ts
@@ -105,9 +105,9 @@ describe('CRUD API', function () {
         const spy = sinon.spy(Collection.prototype, 'find');
         const result = await collection.findOne({});
         expect(result).to.deep.equal({ _id: 1 });
-        expect(events.at(0)).to.be.instanceOf(CommandSucceededEvent);
-        expect(spy.returnValues.at(0)).to.have.property('closed', true);
-        expect(spy.returnValues.at(0)).to.have.nested.property('session.hasEnded', true);
+        expect(events[0]).to.be.instanceOf(CommandSucceededEvent);
+        expect(spy.returnValues[0]).to.have.property('closed', true);
+        expect(spy.returnValues[0]).to.have.nested.property('session.hasEnded', true);
       });
     });
 
@@ -149,9 +149,9 @@ describe('CRUD API', function () {
         const spy = sinon.spy(Collection.prototype, 'find');
         const error = await collection.findOne({}).catch(error => error);
         expect(error).to.be.instanceOf(MongoServerError);
-        expect(events.at(0)).to.be.instanceOf(CommandFailedEvent);
-        expect(spy.returnValues.at(0)).to.have.property('closed', true);
-        expect(spy.returnValues.at(0)).to.have.nested.property('session.hasEnded', true);
+        expect(events[0]).to.be.instanceOf(CommandFailedEvent);
+        expect(spy.returnValues[0]).to.have.property('closed', true);
+        expect(spy.returnValues[0]).to.have.nested.property('session.hasEnded', true);
       });
     });
   });


### PR DESCRIPTION
### Description

#### What is changing?

Remove at usage

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

Fix node 14

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
