### PR TITLE
feat(NODE-5590): deprecate GridFS fields

### DIFF
--- a/src/gridfs/download.ts
+++ b/src/gridfs/download.ts
@@ -46,13 +46,9 @@ export interface GridFSFile {
   filename: string;
   metadata?: Document;
   uploadDate: Date;
-  /**
-   * @deprecated Will be removed in the next major version.
-   */
+  /** @deprecated Will be removed in the next major version. */
   contentType?: string;
-  /**
-   * @deprecated Will be removed in the next major version.
-   */
+  /** @deprecated Will be removed in the next major version. */
   aliases?: string[];
 }
 

--- a/src/gridfs/download.ts
+++ b/src/gridfs/download.ts
@@ -44,10 +44,16 @@ export interface GridFSFile {
   length: number;
   chunkSize: number;
   filename: string;
-  contentType?: string;
-  aliases?: string[];
   metadata?: Document;
   uploadDate: Date;
+  /**
+   * @deprecated Will be removed in the next major version.
+   */
+  contentType?: string;
+  /**
+   * @deprecated Will be removed in the next major version.
+   */
+  aliases?: string[];
 }
 
 /** @internal */

--- a/src/gridfs/upload.ts
+++ b/src/gridfs/upload.ts
@@ -26,9 +26,15 @@ export interface GridFSBucketWriteStreamOptions extends WriteConcernOptions {
   id?: ObjectId;
   /** Object to store in the file document's `metadata` field */
   metadata?: Document;
-  /** String to store in the file document's `contentType` field */
+  /**
+   * String to store in the file document's `contentType` field.
+   * @deprecated Will be removed in the next major version. Add a contentType field to the metadata document instead.
+   */
   contentType?: string;
-  /** Array of strings to store in the file document's `aliases` field */
+  /**
+   * Array of strings to store in the file document's `aliases` field.
+   * @deprecated Will be removed in the next major version. Add an aliases field to the metadata document instead.
+   */
   aliases?: string[];
 }
 


### PR DESCRIPTION
### Description
Deprecate unused GridFS fields.

#### What is changing?
Deprecates `contentType` and `aliases` options.

##### Is there new documentation needed for these changes?
None

#### What is the motivation for this change?
[NODE-5590](https://jira.mongodb.org/browse/NODE-5590)

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->
The GridFS `contentType` and `aliases` options are deprecated. According to [the GridFS spec](https://github.com/mongodb/specifications/blob/master/source/gridfs/gridfs-spec.rst), applications wishing to store `contentType` and `aliases` should add a corresponding field to the `metadata` document instead.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
