### PR TITLE
fix(NODE-4863): do not use RetryableWriteError for non-server errors

### DIFF
--- a/src/cmap/errors.ts
+++ b/src/cmap/errors.ts
@@ -56,7 +56,7 @@ export class PoolClearedError extends MongoNetworkError {
     super(errorMessage, pool.serverError ? { cause: pool.serverError } : undefined);
     this.address = pool.address;
 
-    this.addErrorLabel(MongoErrorLabel.RetryableWriteError);
+    this.addErrorLabel(MongoErrorLabel.PoolRequstedRetry);
   }
 
   override get name(): string {

--- a/src/error.ts
+++ b/src/error.ts
@@ -1163,7 +1163,7 @@ export function needsRetryableWriteLabel(error: Error, maxWireVersion: number): 
 
   if (error instanceof MongoError) {
     if (
-      (maxWireVersion >= 9 || error.hasErrorLabel(MongoErrorLabel.RetryableWriteError)) &&
+      (maxWireVersion >= 9 || isRetryableWriteError(error)) &&
       !error.hasErrorLabel(MongoErrorLabel.HandshakeError)
     ) {
       // If we already have the error label no need to add it again. 4.4+ servers add the label.

--- a/src/error.ts
+++ b/src/error.ts
@@ -92,6 +92,7 @@ export const MongoErrorLabel = Object.freeze({
   ResumableChangeStreamError: 'ResumableChangeStreamError',
   HandshakeError: 'HandshakeError',
   ResetPool: 'ResetPool',
+  PoolRequstedRetry: 'PoolRequstedRetry',
   InterruptInUseConnections: 'InterruptInUseConnections',
   NoWritesPerformed: 'NoWritesPerformed'
 } as const);
@@ -1194,7 +1195,10 @@ export function needsRetryableWriteLabel(error: Error, maxWireVersion: number): 
 }
 
 export function isRetryableWriteError(error: MongoError): boolean {
-  return error.hasErrorLabel(MongoErrorLabel.RetryableWriteError);
+  return (
+    error.hasErrorLabel(MongoErrorLabel.RetryableWriteError) ||
+    error.hasErrorLabel(MongoErrorLabel.PoolRequstedRetry)
+  );
 }
 
 /** Determines whether an error is something the driver should attempt to retry */


### PR DESCRIPTION
### Description

Use the `MongoErrorLabel.PoolRequstedRetry` label instead of misused `MongoErrorLabel.RetryableWriteError` for non-server errors according to [spec](https://github.com/mongodb/specifications/blob/master/source/retryable-writes/retryable-writes.rst).

#### What is changing?

- The `PoolClearedError` constructor adds the new `MongoErrorLabel.PoolRequstedRetry` label instead of misused `MongoErrorLabel.RetryableWriteError`.
- The `isRetryableWriteError` function checks if PoolRequstedRetry or RetryableWriteError is set to determine if `retryOperation` is required.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

[NODE-4863](https://jira.mongodb.org/browse/NODE-4863)

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
