### PR TITLE
fix(NODE-4996): swallow any errors in maybeCallback

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -347,10 +347,17 @@ export function maybeCallback<T>(
     return promise;
   }
 
-  promise.then(
-    result => callback(undefined, result),
-    error => callback(error)
-  );
+  promise
+    .then(
+      result => callback(undefined, result),
+      error => callback(error)
+    )
+    .catch(() => {
+      // in the case that `callback` throws, another promise rejection will be thrown.  we don't really have
+      // many options here - we can't call the callback again with the second error so we just swallow it.
+      // In the long-term, we should refactor the two remaining usages of `maybeCallback` to
+      // be async functions and we and remove this helper.
+    });
   return;
 }
 

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -1,6 +1,4 @@
-import { nextTick } from 'node:process';
 import { setTimeout } from 'node:timers/promises';
-import { promisify } from 'node:util';
 
 import { expect } from 'chai';
 import * as sinon from 'sinon';

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -1,3 +1,7 @@
+import { nextTick } from 'node:process';
+import { setTimeout } from 'node:timers/promises';
+import { promisify } from 'node:util';
+
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 
@@ -937,6 +941,21 @@ describe('driver utils', function () {
         expect(result).to.equal(superPromiseSuccess);
         expect(await result).to.equal(2);
       });
+    });
+
+    it('suppresses errors when `callback` throws an error', async () => {
+      const superPromiseRejection = Promise.reject(new Error('fail'));
+      const unhandledRejections = [];
+      process.on('unhandledRejection', unhandledRejections.push.bind(unhandledRejections));
+      maybeCallback(
+        () => superPromiseRejection,
+        () => {
+          throw new Error('second error thrown from the callback');
+        }
+      );
+      // // arbitrary delay to let any asynchronous processing occur
+      await setTimeout(5);
+      expect(unhandledRejections).to.have.lengthOf(0);
     });
   });
 


### PR DESCRIPTION
### Description

#### What is changing?

If the `callback` in `maybeCallback` throws, then `maybeCallback` throws an uncatchable promise rejection.  This PR adds a catch that swallows any errors thrown in the callback.

Long-term, we should refactor the remaining usages of `maybeCallback` to use async-await and this problem will go away.  This currently is only used by the callback overload of executeOperation, which is used in bulk write and sessions.  I thought it was too much work for a quick fix to refactor that code to async-await in this PR.

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
