### PR TITLE
test(NODE-5739): update data lake test scripts

### DIFF
--- a/.evergreen/ci_matrix_constants.js
+++ b/.evergreen/ci_matrix_constants.js
@@ -17,7 +17,8 @@ const DEFAULT_OS = 'rhel80-large';
 const WINDOWS_OS = 'windows-vsCurrent-large';
 const MACOS_OS = 'macos-1100';
 const UBUNTU_OS = 'ubuntu1804-large';
-const UBUNTU_20_OS = 'ubuntu2004-small'
+const UBUNTU_20_OS = 'ubuntu2004-small';
+const UBUNTU_22_OS = 'ubuntu2204-large';
 const DEBIAN_OS = 'debian11-small';
 
 module.exports = {
@@ -34,5 +35,6 @@ module.exports = {
   MACOS_OS,
   UBUNTU_OS,
   UBUNTU_20_OS,
+  UBUNTU_22_OS,
   DEBIAN_OS
 };

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -85,13 +85,15 @@ functions:
       params:
         script: |
           ${PREPARE_SHELL}
-          DRIVERS_TOOLS="${DRIVERS_TOOLS}" bash ${DRIVERS_TOOLS}/.evergreen/atlas_data_lake/build-mongohouse-local.sh
+          DRIVERS_TOOLS="${DRIVERS_TOOLS}" bash ${DRIVERS_TOOLS}/.evergreen/atlas_data_lake/pull-mongohouse-image.sh
     - command: shell.exec
       params:
         background: true
         script: |
           ${PREPARE_SHELL}
-          DRIVERS_TOOLS="${DRIVERS_TOOLS}" bash ${DRIVERS_TOOLS}/.evergreen/atlas_data_lake/run-mongohouse-local.sh
+          DRIVERS_TOOLS="${DRIVERS_TOOLS}" bash ${DRIVERS_TOOLS}/.evergreen/atlas_data_lake/run-mongohouse-image.sh
+          sleep 1
+          docker ps
 
   "bootstrap kms servers":
     - command: subprocess.exec
@@ -1087,6 +1089,13 @@ functions:
           - ${PROJECT_DIRECTORY}/.evergreen/run-benchmarks.sh
 
 tasks:
+  - name: 'test-atlas-data-lake'
+    tags: ["datalake", "mongohouse"]
+    commands:
+      - func: 'install dependencies'
+      - func: 'bootstrap mongohoused'
+      - func: 'run data lake tests'
+
   - name: "test-serverless"
     tags: ["serverless"]
     commands:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -59,13 +59,15 @@ functions:
       params:
         script: |
           ${PREPARE_SHELL}
-          DRIVERS_TOOLS="${DRIVERS_TOOLS}" bash ${DRIVERS_TOOLS}/.evergreen/atlas_data_lake/build-mongohouse-local.sh
+          DRIVERS_TOOLS="${DRIVERS_TOOLS}" bash ${DRIVERS_TOOLS}/.evergreen/atlas_data_lake/pull-mongohouse-image.sh
     - command: shell.exec
       params:
         background: true
         script: |
           ${PREPARE_SHELL}
-          DRIVERS_TOOLS="${DRIVERS_TOOLS}" bash ${DRIVERS_TOOLS}/.evergreen/atlas_data_lake/run-mongohouse-local.sh
+          DRIVERS_TOOLS="${DRIVERS_TOOLS}" bash ${DRIVERS_TOOLS}/.evergreen/atlas_data_lake/run-mongohouse-image.sh
+          sleep 1
+          docker ps
   bootstrap kms servers:
     - command: subprocess.exec
       params:
@@ -1030,6 +1032,14 @@ functions:
         args:
           - ${PROJECT_DIRECTORY}/.evergreen/run-benchmarks.sh
 tasks:
+  - name: test-atlas-data-lake
+    tags:
+      - datalake
+      - mongohouse
+    commands:
+      - func: install dependencies
+      - func: bootstrap mongohoused
+      - func: run data lake tests
   - name: test-serverless
     tags:
       - serverless
@@ -1682,11 +1692,6 @@ tasks:
     commands:
       - func: install dependencies
       - func: run atlas tests
-  - name: test-atlas-data-lake
-    commands:
-      - func: install dependencies
-      - func: bootstrap mongohoused
-      - func: run data lake tests
   - name: test-5.0-load-balanced
     tags:
       - latest
@@ -3944,7 +3949,6 @@ buildvariants:
       - test-3.6-sharded_cluster
       - test-latest-server-v1-api
       - test-atlas-connectivity
-      - test-atlas-data-lake
       - test-5.0-load-balanced
       - test-6.0-load-balanced
       - test-latest-load-balanced
@@ -3997,7 +4001,6 @@ buildvariants:
       - test-3.6-sharded_cluster
       - test-latest-server-v1-api
       - test-atlas-connectivity
-      - test-atlas-data-lake
       - test-5.0-load-balanced
       - test-6.0-load-balanced
       - test-latest-load-balanced
@@ -4048,7 +4051,6 @@ buildvariants:
       - test-3.6-sharded_cluster
       - test-latest-server-v1-api
       - test-atlas-connectivity
-      - test-atlas-data-lake
       - test-5.0-load-balanced
       - test-6.0-load-balanced
       - test-latest-load-balanced
@@ -4099,7 +4101,6 @@ buildvariants:
       - test-3.6-sharded_cluster
       - test-latest-server-v1-api
       - test-atlas-connectivity
-      - test-atlas-data-lake
       - test-5.0-load-balanced
       - test-6.0-load-balanced
       - test-latest-load-balanced
@@ -4149,7 +4150,6 @@ buildvariants:
       - test-3.6-sharded_cluster
       - test-latest-server-v1-api
       - test-atlas-connectivity
-      - test-atlas-data-lake
       - test-5.0-load-balanced
       - test-6.0-load-balanced
       - test-latest-load-balanced
@@ -4198,7 +4198,6 @@ buildvariants:
       - test-3.6-replica_set
       - test-3.6-sharded_cluster
       - test-latest-server-v1-api
-      - test-atlas-data-lake
       - test-socks5
       - test-socks5-tls
       - test-tls-support-latest
@@ -4241,7 +4240,6 @@ buildvariants:
       - test-3.6-replica_set
       - test-3.6-sharded_cluster
       - test-latest-server-v1-api
-      - test-atlas-data-lake
       - test-socks5
       - test-socks5-tls
       - test-tls-support-latest
@@ -4284,7 +4282,6 @@ buildvariants:
       - test-3.6-replica_set
       - test-3.6-sharded_cluster
       - test-latest-server-v1-api
-      - test-atlas-data-lake
       - test-socks5
       - test-socks5-tls
       - test-tls-support-latest
@@ -4427,6 +4424,13 @@ buildvariants:
         aws-4.4-auth-test-run-aws-auth-test-AssumeRoleWithWebIdentity-with-AWS_ROLE_SESSION_NAME-unset-no-peer-dependencies
       - >-
         aws-4.4-auth-test-run-aws-auth-test-AssumeRoleWithWebIdentity-with-AWS_ROLE_SESSION_NAME-set-no-peer-dependencies
+  - name: ubuntu2204-test-atlas-data-lake
+    display_name: Atlas Data Lake Tests
+    run_on: ubuntu2204-large
+    expansions:
+      NODE_LTS_VERSION: 20
+    tasks:
+      - test-atlas-data-lake
   - name: rhel8-custom-dependency-tests
     display_name: Custom Dependency Version Test
     run_on: rhel80-large

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -16,7 +16,8 @@ const {
   MACOS_OS,
   UBUNTU_OS,
   UBUNTU_20_OS,
-  DEBIAN_OS
+  DEBIAN_OS,
+  UBUNTU_22_OS
 } = require('./ci_matrix_constants');
 
 const OPERATING_SYSTEMS = [
@@ -124,14 +125,6 @@ TASKS.push(
       name: 'test-atlas-connectivity',
       tags: ['atlas-connect'],
       commands: [{ func: 'install dependencies' }, { func: 'run atlas tests' }]
-    },
-    {
-      name: 'test-atlas-data-lake',
-      commands: [
-        { func: 'install dependencies' },
-        { func: 'bootstrap mongohoused' },
-        { func: 'run data lake tests' }
-      ]
     },
     {
       name: 'test-5.0-load-balanced',
@@ -607,6 +600,16 @@ BUILD_VARIANTS.push({
     NPM_VERSION: 9
   },
   tasks: AWS_AUTH_TASKS
+});
+
+BUILD_VARIANTS.push({
+  name: 'ubuntu2204-test-atlas-data-lake',
+  display_name: 'Atlas Data Lake Tests',
+  run_on: UBUNTU_22_OS,
+  expansions: {
+    NODE_LTS_VERSION: LATEST_LTS
+  },
+  tasks: ['test-atlas-data-lake']
 });
 
 const oneOffFuncAsTasks = [];


### PR DESCRIPTION
### Description

Updates the driver to use the new tools data lake test scripts so we don't occasionally fail when the DL team makes breaking changes to their configs. They now own the drivers config on the image and will update them when they make breaking changes.

#### What is changing?
- Updates our evergreen config to use the new `pull-mongohouse-image.sh` and `run-mongohouse-image.sh` scripts.
- Moves Data Lake tests to an Ubuntu 22 variant as these will not work on RHEL8

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-5739

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
