### PR TITLE
test(NODE-5736): update aws ecs task definition

### DIFF
--- a/.evergreen/ci_matrix_constants.js
+++ b/.evergreen/ci_matrix_constants.js
@@ -19,6 +19,7 @@ const DEFAULT_OS = 'rhel80-large';
 const WINDOWS_OS = 'windows-vsCurrent-large';
 const MACOS_OS = 'macos-1100';
 const UBUNTU_OS = 'ubuntu1804-large';
+const UBUNTU_20_OS = 'ubuntu2004-small'
 const DEBIAN_OS = 'debian11-small';
 
 module.exports = {
@@ -34,5 +35,6 @@ module.exports = {
   WINDOWS_OS,
   MACOS_OS,
   UBUNTU_OS,
+  UBUNTU_20_OS,
   DEBIAN_OS
 };

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -582,9 +582,10 @@ functions:
         shell: bash
         script: |
           ${PREPARE_SHELL}
+          set -ex
           cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
           . ./activate-authawsvenv.sh
-          ${MONGODB_BINARIES}/mongo aws_e2e_regular_aws.js
+          python aws_tester.py regular
     - command: shell.exec
       type: test
       params:
@@ -613,9 +614,10 @@ functions:
         shell: bash
         script: |
           ${PREPARE_SHELL}
+          set -ex
           cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
           . ./activate-authawsvenv.sh
-          ${MONGODB_BINARIES}/mongo aws_e2e_assume_role.js
+          python aws_tester.py assume-role
     - command: shell.exec
       type: test
       params:
@@ -652,9 +654,10 @@ functions:
           # Write an empty prepare_mongodb_aws so no auth environment variables
           # are set.
           echo "" > "${PROJECT_DIRECTORY}/prepare_mongodb_aws.sh"
+          set -ex
           cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
           . ./activate-authawsvenv.sh
-          ${MONGODB_BINARIES}/mongo aws_e2e_ec2.js
+          python aws_tester.py ec2
     - command: shell.exec
       type: test
       params:
@@ -671,8 +674,10 @@ functions:
         working_dir: "src"
         silent: true
         script: |
+          set -ex
           cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
-          ${MONGODB_BINARIES}/mongo --verbose aws_e2e_regular_aws.js
+          . ./activate-authawsvenv.sh
+          python aws_tester.py regular
           cd -
           cat <<EOF > "${PROJECT_DIRECTORY}/prepare_mongodb_aws.sh"
             export AWS_ACCESS_KEY_ID=${iam_auth_ecs_account}
@@ -694,8 +699,10 @@ functions:
         working_dir: "src"
         silent: true
         script: |
+          set -ex
           cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
-          ${MONGODB_BINARIES}/mongo --verbose aws_e2e_assume_role.js
+          . ./activate-authawsvenv.sh
+          python aws_tester.py assume-role
           cd -
           cat <<'EOF' > "${PROJECT_DIRECTORY}/prepare_mongodb_aws.sh"
             export AWS_ACCESS_KEY_ID=$(jq -r '.AccessKeyId' ${DRIVERS_TOOLS}/.evergreen/auth_aws/creds.json)
@@ -718,9 +725,10 @@ functions:
         working_dir: "src"
         silent: true
         script: |
+          set -ex
           cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
-          . ./activate_venv.sh
-          ${MONGODB_BINARIES}/mongo --verbose aws_e2e_web_identity.js
+          . ./activate-authawsvenv.sh
+          python aws_tester.py web-identity
           cd -
           cat <<'EOF' > "${PROJECT_DIRECTORY}/prepare_mongodb_aws.sh"
             export AWS_WEB_IDENTITY_TOKEN_FILE=${iam_web_identity_token_file}
@@ -743,9 +751,10 @@ functions:
         working_dir: "src"
         silent: true
         script: |
+          set -ex
           cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
-          . ./activate_venv.sh
-          ${MONGODB_BINARIES}/mongo --verbose aws_e2e_web_identity.js
+          . ./activate-authawsvenv.sh
+          python aws_tester.py web-identity
           cd -
           cat <<'EOF' > "${PROJECT_DIRECTORY}/prepare_mongodb_aws.sh"
             export AWS_WEB_IDENTITY_TOKEN_FILE=${iam_web_identity_token_file}
@@ -771,23 +780,17 @@ functions:
           AUTH_AWS_DIR=${DRIVERS_TOOLS}/.evergreen/auth_aws
           ECS_SRC_DIR=$AUTH_AWS_DIR/src
 
-          # fix issue with `TestData` in SERVER-46340
-          sed -i '1s+^+TestData = {};\n+' $AUTH_AWS_DIR/lib/ecs_hosted_test.js
-
           # pack up project directory to ssh it to the container
           mkdir -p $ECS_SRC_DIR/.evergreen
           cp $PROJECT_DIRECTORY/.evergreen/run-mongodb-aws-ecs-test.sh $ECS_SRC_DIR/.evergreen
           tar -czf $ECS_SRC_DIR/src.tgz -C $PROJECT_DIRECTORY .
 
-          cd $AUTH_AWS_DIR
-          cat <<EOF > setup.js
-            const mongo_binaries = "$MONGODB_BINARIES";
-            const project_dir = "$ECS_SRC_DIR";
-          EOF
-
-          cat setup.js
+          set -ex
+          cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
           . ./activate-authawsvenv.sh
-          ${MONGODB_BINARIES}/mongo --nodb setup.js aws_e2e_ecs.js
+          export MONGODB_BINARIES="${MONGODB_BINARIES}";
+          export PROJECT_DIRECTORY=$ECS_SRC_DIR;
+          python aws_tester.py ecs
 
   "run-ocsp-test":
     - command: shell.exec

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -544,7 +544,7 @@ functions:
               "iam_auth_ecs_secret_access_key" : "${iam_auth_ecs_secret_access_key}",
               "iam_auth_ecs_account_arn": "arn:aws:iam::557821124784:user/authtest_fargate_user",
               "iam_auth_ecs_cluster": "${iam_auth_ecs_cluster}",
-              "iam_auth_ecs_task_definition": "${iam_auth_ecs_task_definition}",
+              "iam_auth_ecs_task_definition": "${iam_auth_ecs_task_definition_ubuntu2004}",
               "iam_auth_ecs_subnet_a": "${iam_auth_ecs_subnet_a}",
               "iam_auth_ecs_subnet_b": "${iam_auth_ecs_subnet_b}",
               "iam_auth_ecs_security_group": "${iam_auth_ecs_security_group}",
@@ -592,7 +592,7 @@ functions:
         silent: true
         script: |
           cat <<'EOF' > "${PROJECT_DIRECTORY}/prepare_mongodb_aws.sh"
-            alias urlencode='python -c "import sys, urllib as ul; print ul.quote_plus(sys.argv[1])"'
+            alias urlencode='python3 -c "import sys, urllib.parse as ulp; sys.stdout.write(ulp.quote_plus(sys.argv[1]))"'
             USER=$(urlencode ${iam_auth_ecs_account})
             PASS=$(urlencode ${iam_auth_ecs_secret_access_key})
             export MONGODB_URI="mongodb://$USER:$PASS@localhost:27017/aws?authMechanism=MONGODB-AWS"
@@ -623,12 +623,13 @@ functions:
         silent: true
         script: |
           cat <<'EOF' > "${PROJECT_DIRECTORY}/prepare_mongodb_aws.sh"
-            alias urlencode='python -c "import sys, urllib as ul; print ul.quote_plus(sys.argv[1])"'
-            USER=$(jq -r '.AccessKeyId' ${DRIVERS_TOOLS}/.evergreen/auth_aws/creds.json)
+            alias urlencode='python3 -c "import sys, urllib.parse as ulp; sys.stdout.write(ulp.quote_plus(sys.argv[1]))"'
+            alias jsonkey='python3 -c "import json,sys;sys.stdout.write(json.load(sys.stdin)[sys.argv[1]])" < ${DRIVERS_TOOLS}/.evergreen/auth_aws/creds.json'
+            USER=$(jsonkey AccessKeyId)
             USER=$(urlencode $USER)
-            PASS=$(jq -r '.SecretAccessKey' ${DRIVERS_TOOLS}/.evergreen/auth_aws/creds.json)
+            PASS=$(jsonkey SecretAccessKey)
             PASS=$(urlencode $PASS)
-            SESSION_TOKEN=$(jq -r '.SessionToken' ${DRIVERS_TOOLS}/.evergreen/auth_aws/creds.json)
+            SESSION_TOKEN=$(jsonkey SessionToken)
             SESSION_TOKEN=$(urlencode $SESSION_TOKEN)
             export MONGODB_URI="mongodb://$USER:$PASS@localhost:27017/aws?authMechanism=MONGODB-AWS&authMechanismProperties=AWS_SESSION_TOKEN:$SESSION_TOKEN"
           EOF

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -537,9 +537,10 @@ functions:
         shell: bash
         script: |
           ${PREPARE_SHELL}
+          set -ex
           cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
           . ./activate-authawsvenv.sh
-          ${MONGODB_BINARIES}/mongo aws_e2e_regular_aws.js
+          python aws_tester.py regular
     - command: shell.exec
       type: test
       params:
@@ -567,9 +568,10 @@ functions:
         shell: bash
         script: |
           ${PREPARE_SHELL}
+          set -ex
           cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
           . ./activate-authawsvenv.sh
-          ${MONGODB_BINARIES}/mongo aws_e2e_assume_role.js
+          python aws_tester.py assume-role
     - command: shell.exec
       type: test
       params:
@@ -605,9 +607,10 @@ functions:
           # Write an empty prepare_mongodb_aws so no auth environment variables
           # are set.
           echo "" > "${PROJECT_DIRECTORY}/prepare_mongodb_aws.sh"
+          set -ex
           cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
           . ./activate-authawsvenv.sh
-          ${MONGODB_BINARIES}/mongo aws_e2e_ec2.js
+          python aws_tester.py ec2
     - command: shell.exec
       type: test
       params:
@@ -623,8 +626,10 @@ functions:
         working_dir: src
         silent: true
         script: |
+          set -ex
           cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
-          ${MONGODB_BINARIES}/mongo --verbose aws_e2e_regular_aws.js
+          . ./activate-authawsvenv.sh
+          python aws_tester.py regular
           cd -
           cat <<EOF > "${PROJECT_DIRECTORY}/prepare_mongodb_aws.sh"
             export AWS_ACCESS_KEY_ID=${iam_auth_ecs_account}
@@ -645,8 +650,10 @@ functions:
         working_dir: src
         silent: true
         script: |
+          set -ex
           cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
-          ${MONGODB_BINARIES}/mongo --verbose aws_e2e_assume_role.js
+          . ./activate-authawsvenv.sh
+          python aws_tester.py assume-role
           cd -
           cat <<'EOF' > "${PROJECT_DIRECTORY}/prepare_mongodb_aws.sh"
             export AWS_ACCESS_KEY_ID=$(jq -r '.AccessKeyId' ${DRIVERS_TOOLS}/.evergreen/auth_aws/creds.json)
@@ -668,9 +675,10 @@ functions:
         working_dir: src
         silent: true
         script: |
+          set -ex
           cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
-          . ./activate_venv.sh
-          ${MONGODB_BINARIES}/mongo --verbose aws_e2e_web_identity.js
+          . ./activate-authawsvenv.sh
+          python aws_tester.py web-identity
           cd -
           cat <<'EOF' > "${PROJECT_DIRECTORY}/prepare_mongodb_aws.sh"
             export AWS_WEB_IDENTITY_TOKEN_FILE=${iam_web_identity_token_file}
@@ -692,9 +700,10 @@ functions:
         working_dir: src
         silent: true
         script: |
+          set -ex
           cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
-          . ./activate_venv.sh
-          ${MONGODB_BINARIES}/mongo --verbose aws_e2e_web_identity.js
+          . ./activate-authawsvenv.sh
+          python aws_tester.py web-identity
           cd -
           cat <<'EOF' > "${PROJECT_DIRECTORY}/prepare_mongodb_aws.sh"
             export AWS_WEB_IDENTITY_TOKEN_FILE=${iam_web_identity_token_file}
@@ -719,23 +728,17 @@ functions:
           AUTH_AWS_DIR=${DRIVERS_TOOLS}/.evergreen/auth_aws
           ECS_SRC_DIR=$AUTH_AWS_DIR/src
 
-          # fix issue with `TestData` in SERVER-46340
-          sed -i '1s+^+TestData = {};\n+' $AUTH_AWS_DIR/lib/ecs_hosted_test.js
-
           # pack up project directory to ssh it to the container
           mkdir -p $ECS_SRC_DIR/.evergreen
           cp $PROJECT_DIRECTORY/.evergreen/run-mongodb-aws-ecs-test.sh $ECS_SRC_DIR/.evergreen
           tar -czf $ECS_SRC_DIR/src.tgz -C $PROJECT_DIRECTORY .
 
-          cd $AUTH_AWS_DIR
-          cat <<EOF > setup.js
-            const mongo_binaries = "$MONGODB_BINARIES";
-            const project_dir = "$ECS_SRC_DIR";
-          EOF
-
-          cat setup.js
+          set -ex
+          cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
           . ./activate-authawsvenv.sh
-          ${MONGODB_BINARIES}/mongo --nodb setup.js aws_e2e_ecs.js
+          export MONGODB_BINARIES="${MONGODB_BINARIES}";
+          export PROJECT_DIRECTORY=$ECS_SRC_DIR;
+          python aws_tester.py ecs
   run-ocsp-test:
     - command: shell.exec
       type: test

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -501,7 +501,7 @@ functions:
               "iam_auth_ecs_secret_access_key" : "${iam_auth_ecs_secret_access_key}",
               "iam_auth_ecs_account_arn": "arn:aws:iam::557821124784:user/authtest_fargate_user",
               "iam_auth_ecs_cluster": "${iam_auth_ecs_cluster}",
-              "iam_auth_ecs_task_definition": "${iam_auth_ecs_task_definition}",
+              "iam_auth_ecs_task_definition": "${iam_auth_ecs_task_definition_ubuntu2004}",
               "iam_auth_ecs_subnet_a": "${iam_auth_ecs_subnet_a}",
               "iam_auth_ecs_subnet_b": "${iam_auth_ecs_subnet_b}",
               "iam_auth_ecs_security_group": "${iam_auth_ecs_security_group}",
@@ -547,7 +547,7 @@ functions:
         silent: true
         script: |
           cat <<'EOF' > "${PROJECT_DIRECTORY}/prepare_mongodb_aws.sh"
-            alias urlencode='python -c "import sys, urllib as ul; print ul.quote_plus(sys.argv[1])"'
+            alias urlencode='python3 -c "import sys, urllib.parse as ulp; sys.stdout.write(ulp.quote_plus(sys.argv[1]))"'
             USER=$(urlencode ${iam_auth_ecs_account})
             PASS=$(urlencode ${iam_auth_ecs_secret_access_key})
             export MONGODB_URI="mongodb://$USER:$PASS@localhost:27017/aws?authMechanism=MONGODB-AWS"
@@ -577,12 +577,13 @@ functions:
         silent: true
         script: |
           cat <<'EOF' > "${PROJECT_DIRECTORY}/prepare_mongodb_aws.sh"
-            alias urlencode='python -c "import sys, urllib as ul; print ul.quote_plus(sys.argv[1])"'
-            USER=$(jq -r '.AccessKeyId' ${DRIVERS_TOOLS}/.evergreen/auth_aws/creds.json)
+            alias urlencode='python3 -c "import sys, urllib.parse as ulp; sys.stdout.write(ulp.quote_plus(sys.argv[1]))"'
+            alias jsonkey='python3 -c "import json,sys;sys.stdout.write(json.load(sys.stdin)[sys.argv[1]])" < ${DRIVERS_TOOLS}/.evergreen/auth_aws/creds.json'
+            USER=$(jsonkey AccessKeyId)
             USER=$(urlencode $USER)
-            PASS=$(jq -r '.SecretAccessKey' ${DRIVERS_TOOLS}/.evergreen/auth_aws/creds.json)
+            PASS=$(jsonkey SecretAccessKey)
             PASS=$(urlencode $PASS)
-            SESSION_TOKEN=$(jq -r '.SessionToken' ${DRIVERS_TOOLS}/.evergreen/auth_aws/creds.json)
+            SESSION_TOKEN=$(jsonkey SessionToken)
             SESSION_TOKEN=$(urlencode $SESSION_TOKEN)
             export MONGODB_URI="mongodb://$USER:$PASS@localhost:27017/aws?authMechanism=MONGODB-AWS&authMechanismProperties=AWS_SESSION_TOKEN:$SESSION_TOKEN"
           EOF
@@ -3991,12 +3992,11 @@ buildvariants:
       - run-mongosh-service-provider-server
       - compile-mongosh
       - verify-mongosh-scopes
-  - name: ubuntu1804-test-mongodb-aws
+  - name: ubuntu2004-test-mongodb-aws
     display_name: MONGODB-AWS Auth test
-    run_on: ubuntu1804-large
+    run_on: ubuntu2004-small
     expansions:
-      NODE_LTS_VERSION: 12
-      NPM_VERSION: 8
+      NODE_LTS_VERSION: 20
     tasks:
       - aws-latest-auth-test-run-aws-auth-test-with-regular-aws-credentials
       - aws-latest-auth-test-run-aws-auth-test-with-assume-role-credentials

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -15,6 +15,7 @@ const {
   WINDOWS_OS,
   MACOS_OS,
   UBUNTU_OS,
+  UBUNTU_20_OS,
   DEBIAN_OS
 } = require('./ci_matrix_constants');
 
@@ -531,12 +532,11 @@ BUILD_VARIANTS.push({
 
 // special case for MONGODB-AWS authentication
 BUILD_VARIANTS.push({
-  name: 'ubuntu1804-test-mongodb-aws',
+  name: 'ubuntu2004-test-mongodb-aws',
   display_name: 'MONGODB-AWS Auth test',
-  run_on: UBUNTU_OS,
+  run_on: UBUNTU_20_OS,
   expansions: {
-    NODE_LTS_VERSION: LOWEST_LTS,
-    NPM_VERSION: 8
+    NODE_LTS_VERSION: LATEST_LTS
   },
   tasks: AWS_AUTH_TASKS
 });


### PR DESCRIPTION
### Description

Updates the AWS ECS task definition ARN to run on Ubuntu 20.

#### What is changing?

- Creates a new Evergreen environment variable for the new ARN
- Updates AWS tests to run on Ubuntu 20 and use the new ARN.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-5736

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
