### PR TITLE
fix(NODE-5751): RTTPinger always sends legacy hello

### DIFF
--- a/src/sdam/monitor.ts
+++ b/src/sdam/monitor.ts
@@ -26,8 +26,6 @@ const kConnection = Symbol('connection');
 /** @internal */
 const kCancellationToken = Symbol('cancellationToken');
 /** @internal */
-const kRTTPinger = Symbol('rttPinger');
-/** @internal */
 const kRoundTripTime = Symbol('roundTripTime');
 
 const STATE_IDLE = 'idle';
@@ -81,7 +79,7 @@ export class Monitor extends TypedEventEmitter<MonitorEvents> {
   [kCancellationToken]: CancellationToken;
   /** @internal */
   [kMonitorId]?: MonitorInterval;
-  [kRTTPinger]?: RTTPinger;
+  rttPinger?: RTTPinger;
 
   get connection(): Connection | undefined {
     return this[kConnection];
@@ -197,8 +195,8 @@ function resetMonitorState(monitor: Monitor) {
   monitor[kMonitorId]?.stop();
   monitor[kMonitorId] = undefined;
 
-  monitor[kRTTPinger]?.close();
-  monitor[kRTTPinger] = undefined;
+  monitor.rttPinger?.close();
+  monitor.rttPinger = undefined;
 
   monitor[kCancellationToken].emit('cancel');
 
@@ -251,8 +249,8 @@ function checkServer(monitor: Monitor, callback: Callback<Document | null>) {
         }
       : { socketTimeoutMS: connectTimeoutMS };
 
-    if (isAwaitable && monitor[kRTTPinger] == null) {
-      monitor[kRTTPinger] = new RTTPinger(
+    if (isAwaitable && monitor.rttPinger == null) {
+      monitor.rttPinger = new RTTPinger(
         monitor[kCancellationToken],
         Object.assign(
           { heartbeatFrequencyMS: monitor.options.heartbeatFrequencyMS },
@@ -271,9 +269,10 @@ function checkServer(monitor: Monitor, callback: Callback<Document | null>) {
         hello.isWritablePrimary = hello[LEGACY_HELLO_COMMAND];
       }
 
-      const rttPinger = monitor[kRTTPinger];
       const duration =
-        isAwaitable && rttPinger ? rttPinger.roundTripTime : calculateDurationInMs(start);
+        isAwaitable && monitor.rttPinger
+          ? monitor.rttPinger.roundTripTime
+          : calculateDurationInMs(start);
 
       monitor.emit(
         Server.SERVER_HEARTBEAT_SUCCEEDED,
@@ -289,8 +288,8 @@ function checkServer(monitor: Monitor, callback: Callback<Document | null>) {
         );
         start = now();
       } else {
-        monitor[kRTTPinger]?.close();
-        monitor[kRTTPinger] = undefined;
+        monitor.rttPinger?.close();
+        monitor.rttPinger = undefined;
 
         callback(undefined, hello);
       }
@@ -383,7 +382,7 @@ export interface RTTPingerOptions extends ConnectionOptions {
 /** @internal */
 export class RTTPinger {
   /** @internal */
-  [kConnection]?: Connection;
+  connection?: Connection;
   /** @internal */
   [kCancellationToken]: CancellationToken;
   /** @internal */
@@ -393,7 +392,7 @@ export class RTTPinger {
   closed: boolean;
 
   constructor(cancellationToken: CancellationToken, options: RTTPingerOptions) {
-    this[kConnection] = undefined;
+    this.connection = undefined;
     this[kCancellationToken] = cancellationToken;
     this[kRoundTripTime] = 0;
     this.closed = false;
@@ -410,8 +409,8 @@ export class RTTPinger {
     this.closed = true;
     clearTimeout(this[kMonitorId]);
 
-    this[kConnection]?.destroy({ force: true });
-    this[kConnection] = undefined;
+    this.connection?.destroy({ force: true });
+    this.connection = undefined;
   }
 }
 
@@ -430,8 +429,8 @@ function measureRoundTripTime(rttPinger: RTTPinger, options: RTTPingerOptions) {
       return;
     }
 
-    if (rttPinger[kConnection] == null) {
-      rttPinger[kConnection] = conn;
+    if (rttPinger.connection == null) {
+      rttPinger.connection = conn;
     }
 
     rttPinger[kRoundTripTime] = calculateDurationInMs(start);
@@ -441,11 +440,11 @@ function measureRoundTripTime(rttPinger: RTTPinger, options: RTTPingerOptions) {
     );
   }
 
-  const connection = rttPinger[kConnection];
+  const connection = rttPinger.connection;
   if (connection == null) {
     connect(options, (err, conn) => {
       if (err) {
-        rttPinger[kConnection] = undefined;
+        rttPinger.connection = undefined;
         rttPinger[kRoundTripTime] = 0;
         return;
       }
@@ -456,9 +455,12 @@ function measureRoundTripTime(rttPinger: RTTPinger, options: RTTPingerOptions) {
     return;
   }
 
-  connection.command(ns('admin.$cmd'), { [LEGACY_HELLO_COMMAND]: 1 }, undefined, err => {
+  const commandName =
+    connection.serverApi?.version || connection.helloOk ? 'hello' : LEGACY_HELLO_COMMAND;
+  connection.command(ns('admin.$cmd'), { [commandName]: 1 }, undefined, err => {
     if (err) {
-      rttPinger[kConnection] = undefined;
+      rttPinger.connection?.destroy({ force: true });
+      rttPinger.connection = undefined;
       rttPinger[kRoundTripTime] = 0;
       return;
     }

--- a/test/integration/connection-monitoring-and-pooling/rtt_pinger.test.ts
+++ b/test/integration/connection-monitoring-and-pooling/rtt_pinger.test.ts
@@ -3,25 +3,28 @@ import * as semver from 'semver';
 import * as sinon from 'sinon';
 
 import { type Connection, type MongoClient, type RTTPinger } from '../../../src';
+import { LEGACY_HELLO_COMMAND } from '../../../src/constants';
 import { sleep } from '../../tools/utils';
 
 /**
- * RTTPinger creation depends on getting a response to the monitor's initial hello
- * and that hello containing a topologyVersion.
- * Subsequently the rttPinger creates its connection asynchronously
+ * RTTPingers are only created after getting a hello from the server that defines topologyVersion
+ * Each monitor is reaching out to a different node and rttPinger's are created async as a result.
  *
- * I just went with a sleepy loop, until we have what we need, One could also use SDAM events in a clever way perhaps?
+ * This function checks for rttPingers and sleeps if none are found.
  */
 async function getRTTPingers(client: MongoClient) {
+  type RTTPingerConnection = Omit<RTTPinger, 'connection'> & { connection: Connection };
+  const pingers = (rtt => rtt?.connection != null) as (r?: RTTPinger) => r is RTTPingerConnection;
+
+  if (!client.topology) expect.fail('Must provide a connected client');
+
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const rttPingers = Array.from(client.topology?.s.servers.values() ?? [], s => {
-      if (s.monitor?.rttPinger?.connection != null) return s.monitor?.rttPinger;
-      else null;
-    }).filter(rtt => rtt != null);
+    const servers = client.topology.s.servers.values();
+    const rttPingers = Array.from(servers, s => s.monitor?.rttPinger).filter(pingers);
 
     if (rttPingers.length !== 0) {
-      return rttPingers as (Omit<RTTPinger, 'connection'> & { connection: Connection })[];
+      return rttPingers;
     }
 
     await sleep(5);
@@ -32,25 +35,26 @@ describe('class RTTPinger', () => {
   afterEach(() => sinon.restore());
 
   beforeEach(async function () {
+    if (!this.currentTest) return;
     if (this.configuration.isLoadBalanced) {
-      if (this.currentTest)
-        this.currentTest.skipReason = 'No monitoring in LB mode, test not relevant';
+      this.currentTest.skipReason = 'No monitoring in LB mode, test not relevant';
       return this.skip();
     }
     if (semver.gte('4.4.0', this.configuration.version)) {
-      if (this.currentTest)
-        this.currentTest.skipReason =
-          'Test requires streaming monitoring, needs to be on MongoDB 4.4+';
+      this.currentTest.skipReason =
+        'Test requires streaming monitoring, needs to be on MongoDB 4.4+';
       return this.skip();
     }
   });
 
   context('when serverApi is enabled', () => {
     let serverApiClient: MongoClient;
+
     beforeEach(async function () {
+      if (!this.currentTest) return;
+
       if (semver.gte('5.0.0', this.configuration.version)) {
-        if (this.currentTest)
-          this.currentTest.skipReason = 'Test requires serverApi, needs to be on MongoDB 5.0+';
+        this.currentTest.skipReason = 'Test requires serverApi, needs to be on MongoDB 5.0+';
         return this.skip();
       }
 
@@ -79,7 +83,69 @@ describe('class RTTPinger', () => {
     });
   });
 
-  context('when rtt hello receives an error', () => {
+  context('when serverApi is disabled', () => {
+    let client: MongoClient;
+
+    beforeEach(async function () {
+      if (!this.currentTest) return;
+      if (this.configuration.serverApi) {
+        this.currentTest.skipReason = 'Test requires serverApi to NOT be enabled';
+        return this.skip();
+      }
+
+      client = this.configuration.newClient({}, { heartbeatFrequencyMS: 10 });
+    });
+
+    afterEach(async () => {
+      await client?.close();
+    });
+
+    context('connected to a pre-hello server', () => {
+      it('measures rtt with a LEGACY_HELLO_COMMAND command', async function () {
+        await client.connect();
+        const rttPingers = await getRTTPingers(client);
+
+        // Fake pre-hello server.
+        // Hello was back-ported to feature versions of the server so we would need to pin
+        // versions prior to 4.4.2, 4.2.10, 4.0.21, and 3.6.21 to integration test
+        for (const rtt of rttPingers) rtt.connection.helloOk = false;
+
+        const spies = rttPingers.map(rtt => sinon.spy(rtt.connection, 'command'));
+
+        await sleep(11); // allow for another ping after spies have been made
+
+        expect(spies).to.have.lengthOf.at.least(1);
+        for (const spy of spies) {
+          expect(spy).to.have.been.calledWith(
+            sinon.match.any,
+            { [LEGACY_HELLO_COMMAND]: 1 },
+            sinon.match.any
+          );
+        }
+      });
+    });
+
+    context('connected to a helloOk server', () => {
+      it('measures rtt with a hello command', async function () {
+        await client.connect();
+        const rttPingers = await getRTTPingers(client);
+
+        const spies = rttPingers.map(rtt => sinon.spy(rtt.connection, 'command'));
+
+        // We should always be connected to helloOk servers
+        for (const rtt of rttPingers) expect(rtt.connection).to.have.property('helloOk', true);
+
+        await sleep(11); // allow for another ping after spies have been made
+
+        expect(spies).to.have.lengthOf.at.least(1);
+        for (const spy of spies) {
+          expect(spy).to.have.been.calledWith(sinon.match.any, { hello: 1 }, sinon.match.any);
+        }
+      });
+    });
+  });
+
+  context(`when the RTTPinger's hello command receives any error`, () => {
     let client: MongoClient;
     beforeEach(async function () {
       client = this.configuration.newClient({}, { heartbeatFrequencyMS: 10 });
@@ -89,12 +155,12 @@ describe('class RTTPinger', () => {
       await client?.close();
     });
 
-    it('destroys the connection', async function () {
+    it('destroys the connection with force=true', async function () {
       await client.connect();
       const rttPingers = await getRTTPingers(client);
 
       for (const rtt of rttPingers) {
-        sinon.stub(rtt.connection, 'command').yieldsRight(new Error('any'));
+        sinon.stub(rtt.connection, 'command').yieldsRight(new Error('any error'));
       }
       const spies = rttPingers.map(rtt => sinon.spy(rtt.connection, 'destroy'));
 
@@ -102,7 +168,7 @@ describe('class RTTPinger', () => {
 
       expect(spies).to.have.lengthOf.at.least(1);
       for (const spy of spies) {
-        expect(spy).to.have.been.called;
+        expect(spy).to.have.been.calledWithExactly({ force: true });
       }
     });
   });

--- a/test/integration/connection-monitoring-and-pooling/rtt_pinger.test.ts
+++ b/test/integration/connection-monitoring-and-pooling/rtt_pinger.test.ts
@@ -1,0 +1,109 @@
+import { expect } from 'chai';
+import * as semver from 'semver';
+import * as sinon from 'sinon';
+
+import { type Connection, type MongoClient, type RTTPinger } from '../../../src';
+import { sleep } from '../../tools/utils';
+
+/**
+ * RTTPinger creation depends on getting a response to the monitor's initial hello
+ * and that hello containing a topologyVersion.
+ * Subsequently the rttPinger creates its connection asynchronously
+ *
+ * I just went with a sleepy loop, until we have what we need, One could also use SDAM events in a clever way perhaps?
+ */
+async function getRTTPingers(client: MongoClient) {
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const rttPingers = Array.from(client.topology?.s.servers.values() ?? [], s => {
+      if (s.monitor?.rttPinger?.connection != null) return s.monitor?.rttPinger;
+      else null;
+    }).filter(rtt => rtt != null);
+
+    if (rttPingers.length !== 0) {
+      return rttPingers as (Omit<RTTPinger, 'connection'> & { connection: Connection })[];
+    }
+
+    await sleep(5);
+  }
+}
+
+describe('class RTTPinger', () => {
+  afterEach(() => sinon.restore());
+
+  beforeEach(async function () {
+    if (this.configuration.isLoadBalanced) {
+      if (this.currentTest)
+        this.currentTest.skipReason = 'No monitoring in LB mode, test not relevant';
+      return this.skip();
+    }
+    if (semver.gte('4.4.0', this.configuration.version)) {
+      if (this.currentTest)
+        this.currentTest.skipReason =
+          'Test requires streaming monitoring, needs to be on MongoDB 4.4+';
+      return this.skip();
+    }
+  });
+
+  context('when serverApi is enabled', () => {
+    let serverApiClient: MongoClient;
+    beforeEach(async function () {
+      if (semver.gte('5.0.0', this.configuration.version)) {
+        if (this.currentTest)
+          this.currentTest.skipReason = 'Test requires serverApi, needs to be on MongoDB 5.0+';
+        return this.skip();
+      }
+
+      serverApiClient = this.configuration.newClient(
+        {},
+        { serverApi: { version: '1', strict: true }, heartbeatFrequencyMS: 10 }
+      );
+    });
+
+    afterEach(async () => {
+      await serverApiClient?.close();
+    });
+
+    it('measures rtt with a hello command', async function () {
+      await serverApiClient.connect();
+      const rttPingers = await getRTTPingers(serverApiClient);
+
+      const spies = rttPingers.map(rtt => sinon.spy(rtt.connection, 'command'));
+
+      await sleep(11); // allow for another ping after spies have been made
+
+      expect(spies).to.have.lengthOf.at.least(1);
+      for (const spy of spies) {
+        expect(spy).to.have.been.calledWith(sinon.match.any, { hello: 1 }, sinon.match.any);
+      }
+    });
+  });
+
+  context('when rtt hello receives an error', () => {
+    let client: MongoClient;
+    beforeEach(async function () {
+      client = this.configuration.newClient({}, { heartbeatFrequencyMS: 10 });
+    });
+
+    afterEach(async () => {
+      await client?.close();
+    });
+
+    it('destroys the connection', async function () {
+      await client.connect();
+      const rttPingers = await getRTTPingers(client);
+
+      for (const rtt of rttPingers) {
+        sinon.stub(rtt.connection, 'command').yieldsRight(new Error('any'));
+      }
+      const spies = rttPingers.map(rtt => sinon.spy(rtt.connection, 'destroy'));
+
+      await sleep(11); // allow for another ping after spies have been made
+
+      expect(spies).to.have.lengthOf.at.least(1);
+      for (const spy of spies) {
+        expect(spy).to.have.been.called;
+      }
+    });
+  });
+});

--- a/test/unit/sdam/topology.test.js
+++ b/test/unit/sdam/topology.test.js
@@ -414,9 +414,8 @@ describe('Topology (unit)', function () {
       afterEach(() => {
         // The srv event starts a monitor that we need to clean up
         for (const [, server] of topology.s.servers) {
-          const kMonitor = getSymbolFrom(server, 'monitor');
-          const kMonitorId = getSymbolFrom(server[kMonitor], 'monitorId');
-          server[kMonitor][kMonitorId].stop();
+          const kMonitorId = getSymbolFrom(server.monitor, 'monitorId');
+          server.monitor[kMonitorId].stop();
         }
       });
 


### PR DESCRIPTION
### Description

#### What is changing?

- Adds serverApi and helloOk logic to RTTPinger
- Calls destory on connection when an error is recv-ed
- Replaced symbol properties with string properties

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

Fixes a connection leak when serverApi is enabled.

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fix connection leak when serverApi is enabled

When enabling serverApi the driver's RTT mesurment logic (used to determine the closest node) still sent the legacy hello command "isMaster" causing the server to return an error. Unfortunately, the error handling logic did not correctly destroy the socket which would cause a leak.

Both sending the correct hello command and the error handling connection clean up logic are fixed in this change.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
