### PR TITLE
test(NODE-5761): skip azure oidc tests

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -4514,12 +4514,6 @@ buildvariants:
     tasks:
       - test_azurekms_task_group
       - test-azurekms-fail-task
-  - name: ubuntu20-test-azure-oidc
-    display_name: Azure OIDC
-    run_on: ubuntu2004-small
-    batchtime: 20160
-    tasks:
-      - testazureoidc_task_group
   - name: rhel8-test-atlas
     display_name: Atlas Cluster Tests
     run_on: rhel80-large

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -700,13 +700,16 @@ BUILD_VARIANTS.push({
   tasks: ['test_azurekms_task_group', 'test-azurekms-fail-task']
 });
 
-BUILD_VARIANTS.push({
-  name: 'ubuntu20-test-azure-oidc',
-  display_name: 'Azure OIDC',
-  run_on: UBUNTU_20_OS,
-  batchtime: 20160,
-  tasks: ['testazureoidc_task_group']
-});
+// TODO(DRIVERS-2416/NODE-4929) - Azure credentials are expired, a new drivers ticket
+//   should be created but at the moment for our test failures we will reference the
+//   open DRIVERS ticket and completed NODE ticket.
+// BUILD_VARIANTS.push({
+//   name: 'ubuntu20-test-azure-oidc',
+//   display_name: 'Azure OIDC',
+//   run_on: UBUNTU_20_OS,
+//   batchtime: 20160,
+//   tasks: ['testazureoidc_task_group']
+// });
 
 BUILD_VARIANTS.push({
   name: 'rhel8-test-atlas',


### PR DESCRIPTION
### Description

Doesn't actually skip the Azure OIDC tests but removes them from the matrix as the failures are in the setup from the drivers tools scripts.

#### What is changing?

Removes the variant from the matrix with a todo.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-5761

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
