### PR TITLE
chore(NODE-5767): add comment trigger for release notes

### DIFF
--- a/.github/workflows/release_notes.yml
+++ b/.github/workflows/release_notes.yml
@@ -7,13 +7,43 @@ on:
         description: 'Enter release PR number'
         required: true
         type: number
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   release_notes:
     runs-on: ubuntu-latest
+    # Run only if dispatched or comment on a pull request
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' && github.event.issue.pull_request && github.event.comment.body == 'run release_notes') }}
     steps:
-      - uses: actions/checkout@v3
+      # Determine if the triggering_actor is allowed to run this action
+      # We only permit admins
+      # Not only is 'triggering_actor' common between the trigger events it will also change if someone re-runs an old job
+      - name: check if triggering_actor is allowed to generate notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COMMENTER: ${{ github.triggering_actor && github.triggering_actor || 'non-empty-string' }}
+          API_ENDPOINT: /repos/${{ github.repository }}/collaborators?permission=admin
+        shell: bash
+        run: |
+          set -o pipefail
+          if gh api "$API_ENDPOINT" --paginate --jq ".[].login" | grep -q "$COMMENTER"; then
+            echo "$COMMENTER permitted to trigger notes!" && exit 0
+          else
+            echo "$COMMENTER not permitted to trigger notes" && exit 1
+          fi
 
+      # checkout the HEAD ref from prNumber
+      - uses: actions/checkout@v3
+        with:
+          ref: refs/pull/${{ github.event_name == 'issue_comment' && github.event.issue.number || inputs.releasePr }}/head
+
+
+      # Setup Node.js and npm install
       - name: actions/setup
         uses: ./.github/actions/setup
 
@@ -42,7 +72,7 @@ jobs:
           HIGHLIGHTS: ${{ steps.highlights.outputs.highlights }}
 
       # Update the release PR body
-      - run: gh pr edit ${{ inputs.releasePr }} --body-file ${{ steps.release_notes.outputs.release_notes_path }}
+      - run: gh pr edit ${{ github.event_name == 'issue_comment' && github.event.issue.number || inputs.releasePr }} --body-file ${{ steps.release_notes.outputs.release_notes_path }}
         shell: bash
         env:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
### Description

#### What is changing?

A comment "run release_notes" from an admin will now trigger the release notes automation. The workflow dispatch also works.

##### Is there new documentation needed for these changes?

Will update the release instructions document.

#### What is the motivation for this change?

Commenting on the release PR is a more convenient UX than the workflow dispatch. This also removes the need to select the branch from that pane as we checkout the ref based on PR number.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
