### PR TITLE
chore: fix env var name in release_notes

### DIFF
--- a/.github/workflows/release_notes.yml
+++ b/.github/workflows/release_notes.yml
@@ -25,7 +25,7 @@ jobs:
       # Not only is 'triggering_actor' common between the trigger events it will also change if someone re-runs an old job
       - name: check if triggering_actor is allowed to generate notes
         env:
-          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
           COMMENTER: ${{ github.triggering_actor && github.triggering_actor || 'empty_triggering_actor' }}
           API_ENDPOINT: /repos/${{ github.repository }}/collaborators?permission=admin
         shell: bash


### PR DESCRIPTION
### Description

#### What is changing?

GH_TOKEN must be GITHUB_TOKEN

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

To give gh access to the api call

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
