### PR TITLE
refactor(NODE-5778): change kConnection to connection, split polling and streaming functions, define exhaustCommand

### DIFF
--- a/src/cmap/commands.ts
+++ b/src/cmap/commands.ts
@@ -317,6 +317,9 @@ export class OpQueryResponse {
   bsonRegExp?: boolean;
   index?: number;
 
+  /** moreToCome is an OP_MSG only concept */
+  moreToCome = false;
+
   constructor(
     message: Buffer,
     msgHeader: MessageHeader,
@@ -598,6 +601,7 @@ export class OpMsgResponse {
   fromCompressed?: boolean;
   responseFlags: number;
   checksumPresent: boolean;
+  /** Indicates the server will be sending more responses on this connection */
   moreToCome: boolean;
   exhaustAllowed: boolean;
   useBigInt64: boolean;

--- a/src/cmap/connection.ts
+++ b/src/cmap/connection.ts
@@ -563,13 +563,13 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
     }
   }
 
-  moreToComeCommand(
+  exhaustCommand(
     ns: MongoDBNamespace,
     command: Document,
     options: CommandOptions | undefined,
-    callback: Callback
+    replyListener: Callback
   ) {
-    return this.command(ns, command, options, callback);
+    return this.command(ns, command, options, replyListener);
   }
 }
 
@@ -1164,6 +1164,15 @@ export class ModernConnection extends TypedEventEmitter<ConnectionEvents> {
     }
 
     return document;
+  }
+
+  exhaustCommand(
+    _ns: MongoDBNamespace,
+    _command: Document,
+    _options: CommandOptions,
+    _replyListener: Callback
+  ) {
+    throw new Error('NODE-5742: not implemented.');
   }
 }
 

--- a/src/cmap/connection.ts
+++ b/src/cmap/connection.ts
@@ -562,6 +562,15 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
       callback(err);
     }
   }
+
+  moreToComeCommand(
+    ns: MongoDBNamespace,
+    command: Document,
+    options: CommandOptions | undefined,
+    callback: Callback
+  ) {
+    return this.command(ns, command, options, callback);
+  }
 }
 
 /** @internal */

--- a/src/cmap/connection.ts
+++ b/src/cmap/connection.ts
@@ -1253,7 +1253,7 @@ export async function* readMany(
     const response = await decompressResponse(message);
     yield response;
 
-    if (!('moreToCome' in response) || !response.moreToCome) {
+    if (!response.moreToCome) {
       return;
     }
   }

--- a/src/sdam/monitor.ts
+++ b/src/sdam/monitor.ts
@@ -328,7 +328,7 @@ function checkServer(monitor: Monitor, callback: Callback<Document | null>) {
 
     if (isAwaitable) {
       awaited = true;
-      return connection.moreToComeCommand(ns('admin.$cmd'), cmd, options, (error, hello) => {
+      return connection.exhaustCommand(ns('admin.$cmd'), cmd, options, (error, hello) => {
         if (error) return onHeartbeatFailed(error);
         return onHeartbeatSucceeded(hello);
       });


### PR DESCRIPTION
### Description

#### What is changing?

Some minor refactors to the monitoring class 

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

To pull them out of the "feature" work of adding streaming support to the new monitoring class.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
