### PR TITLE
chore(NODE-5777): track aws credential as a devDep in addition to peerDep (#3939)

### DIFF
--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -474,7 +474,7 @@ functions:
         args:
           - .evergreen/install-dependencies.sh
 
-  "install aws-credential-providers":
+  "remove aws-credential-providers":
     - command: shell.exec
       type: setup
       params:
@@ -483,7 +483,7 @@ functions:
         script: |
           ${PREPARE_SHELL}
           source "${PROJECT_DIRECTORY}/.evergreen/init-node-and-npm-env.sh"
-          npm install @aws-sdk/credential-providers
+          rm -rf ./node_modules/@aws-sdk/credential-providers
 
   "run atlas tests":
     - command: shell.exec
@@ -674,6 +674,8 @@ functions:
     - command: shell.exec
       type: test
       params:
+        env:
+          MONGODB_AWS_SDK: ${MONGODB_AWS_SDK}
         working_dir: "src"
         script: |
           ${PREPARE_SHELL}
@@ -711,6 +713,8 @@ functions:
     - command: shell.exec
       type: test
       params:
+        env:
+          MONGODB_AWS_SDK: ${MONGODB_AWS_SDK}
         working_dir: "src"
         script: |
           ${PREPARE_SHELL}
@@ -734,6 +738,8 @@ functions:
     - command: shell.exec
       type: test
       params:
+        env:
+          MONGODB_AWS_SDK: ${MONGODB_AWS_SDK}
         working_dir: "src"
         script: |
           ${PREPARE_SHELL}
@@ -761,6 +767,8 @@ functions:
     - command: shell.exec
       type: test
       params:
+        env:
+          MONGODB_AWS_SDK: ${MONGODB_AWS_SDK}
         working_dir: "src"
         script: |
           ${PREPARE_SHELL}
@@ -788,6 +796,7 @@ functions:
     - command: shell.exec
       type: test
       params:
+        add_expansions_to_env: true
         working_dir: "src"
         script: |
           ${PREPARE_SHELL}
@@ -815,6 +824,8 @@ functions:
     - command: shell.exec
       type: test
       params:
+        env:
+          MONGODB_AWS_SDK: ${MONGODB_AWS_SDK}
         working_dir: "src"
         script: |
           ${PREPARE_SHELL}
@@ -841,6 +852,8 @@ functions:
     - command: shell.exec
       type: test
       params:
+        env:
+          MONGODB_AWS_SDK: ${MONGODB_AWS_SDK}
         working_dir: "src"
         script: |
           ${PREPARE_SHELL}
@@ -851,6 +864,8 @@ functions:
       type: test
       params:
         working_dir: src
+        env:
+          MONGODB_AWS_SDK: ${MONGODB_AWS_SDK}
         shell: bash
         script: |
           ${PREPARE_SHELL}
@@ -859,10 +874,16 @@ functions:
 
           # pack up project directory to ssh it to the container
           mkdir -p $ECS_SRC_DIR/.evergreen
+
+          set -ex
+
+          echo "export MONGODB_AWS_SDK=$MONGODB_AWS_SDK" >> $PROJECT_DIRECTORY/.evergreen/run-mongodb-aws-ecs-test.sh
+          echo "if [ $MONGODB_AWS_SDK = 'false' ]; then rm -rf ./node_modules/@aws-sdk/credential-providers; fi" >> $PROJECT_DIRECTORY/.evergreen/run-mongodb-aws-ecs-test.sh
+          echo "npm run check:aws" >> $PROJECT_DIRECTORY/.evergreen/run-mongodb-aws-ecs-test.sh
+
           cp $PROJECT_DIRECTORY/.evergreen/run-mongodb-aws-ecs-test.sh $ECS_SRC_DIR/.evergreen
           tar -czf $ECS_SRC_DIR/src.tgz -C $PROJECT_DIRECTORY .
 
-          set -ex
           cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
           . ./activate-authawsvenv.sh
           export MONGODB_BINARIES="${MONGODB_BINARIES}";

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -427,7 +427,7 @@ functions:
         add_expansions_to_env: true
         args:
           - .evergreen/install-dependencies.sh
-  install aws-credential-providers:
+  remove aws-credential-providers:
     - command: shell.exec
       type: setup
       params:
@@ -436,7 +436,7 @@ functions:
         script: |
           ${PREPARE_SHELL}
           source "${PROJECT_DIRECTORY}/.evergreen/init-node-and-npm-env.sh"
-          npm install @aws-sdk/credential-providers
+          rm -rf ./node_modules/@aws-sdk/credential-providers
   run atlas tests:
     - command: shell.exec
       type: test
@@ -631,6 +631,8 @@ functions:
     - command: shell.exec
       type: test
       params:
+        env:
+          MONGODB_AWS_SDK: ${MONGODB_AWS_SDK}
         working_dir: src
         script: |
           ${PREPARE_SHELL}
@@ -667,6 +669,8 @@ functions:
     - command: shell.exec
       type: test
       params:
+        env:
+          MONGODB_AWS_SDK: ${MONGODB_AWS_SDK}
         working_dir: src
         script: |
           ${PREPARE_SHELL}
@@ -689,6 +693,8 @@ functions:
     - command: shell.exec
       type: test
       params:
+        env:
+          MONGODB_AWS_SDK: ${MONGODB_AWS_SDK}
         working_dir: src
         script: |
           ${PREPARE_SHELL}
@@ -715,6 +721,8 @@ functions:
     - command: shell.exec
       type: test
       params:
+        env:
+          MONGODB_AWS_SDK: ${MONGODB_AWS_SDK}
         working_dir: src
         script: |
           ${PREPARE_SHELL}
@@ -741,6 +749,7 @@ functions:
     - command: shell.exec
       type: test
       params:
+        add_expansions_to_env: true
         working_dir: src
         script: |
           ${PREPARE_SHELL}
@@ -767,6 +776,8 @@ functions:
     - command: shell.exec
       type: test
       params:
+        env:
+          MONGODB_AWS_SDK: ${MONGODB_AWS_SDK}
         working_dir: src
         script: |
           ${PREPARE_SHELL}
@@ -792,6 +803,8 @@ functions:
     - command: shell.exec
       type: test
       params:
+        env:
+          MONGODB_AWS_SDK: ${MONGODB_AWS_SDK}
         working_dir: src
         script: |
           ${PREPARE_SHELL}
@@ -801,22 +814,46 @@ functions:
       type: test
       params:
         working_dir: src
+        env:
+          MONGODB_AWS_SDK: ${MONGODB_AWS_SDK}
         shell: bash
-        script: |
+        script: >
           ${PREPARE_SHELL}
+
           AUTH_AWS_DIR=${DRIVERS_TOOLS}/.evergreen/auth_aws
+
           ECS_SRC_DIR=$AUTH_AWS_DIR/src
 
+
           # pack up project directory to ssh it to the container
+
           mkdir -p $ECS_SRC_DIR/.evergreen
-          cp $PROJECT_DIRECTORY/.evergreen/run-mongodb-aws-ecs-test.sh $ECS_SRC_DIR/.evergreen
-          tar -czf $ECS_SRC_DIR/src.tgz -C $PROJECT_DIRECTORY .
+
 
           set -ex
+
+
+          echo "export MONGODB_AWS_SDK=$MONGODB_AWS_SDK" >> $PROJECT_DIRECTORY/.evergreen/run-mongodb-aws-ecs-test.sh
+
+          echo "if [ $MONGODB_AWS_SDK = 'false' ]; then rm -rf ./node_modules/@aws-sdk/credential-providers; fi" >>
+          $PROJECT_DIRECTORY/.evergreen/run-mongodb-aws-ecs-test.sh
+
+          echo "npm run check:aws" >> $PROJECT_DIRECTORY/.evergreen/run-mongodb-aws-ecs-test.sh
+
+
+          cp $PROJECT_DIRECTORY/.evergreen/run-mongodb-aws-ecs-test.sh $ECS_SRC_DIR/.evergreen
+
+          tar -czf $ECS_SRC_DIR/src.tgz -C $PROJECT_DIRECTORY .
+
+
           cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
+
           . ./activate-authawsvenv.sh
+
           export MONGODB_BINARIES="${MONGODB_BINARIES}";
+
           export PROJECT_DIRECTORY=$ECS_SRC_DIR;
+
           python aws_tester.py ecs
   run-ocsp-test:
     - command: shell.exec
@@ -1929,8 +1966,8 @@ tasks:
             - {key: AUTH, value: auth}
             - {key: ORCHESTRATION_FILE, value: auth-aws.json}
             - {key: TOPOLOGY, value: server}
+            - {key: MONGODB_AWS_SDK, value: 'true'}
       - func: install dependencies
-      - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
       - func: add aws auth variables to file
       - func: setup aws env
@@ -1945,8 +1982,8 @@ tasks:
             - {key: AUTH, value: auth}
             - {key: ORCHESTRATION_FILE, value: auth-aws.json}
             - {key: TOPOLOGY, value: server}
+            - {key: MONGODB_AWS_SDK, value: 'true'}
       - func: install dependencies
-      - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
       - func: add aws auth variables to file
       - func: setup aws env
@@ -1961,8 +1998,8 @@ tasks:
             - {key: AUTH, value: auth}
             - {key: ORCHESTRATION_FILE, value: auth-aws.json}
             - {key: TOPOLOGY, value: server}
+            - {key: MONGODB_AWS_SDK, value: 'true'}
       - func: install dependencies
-      - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
       - func: add aws auth variables to file
       - func: setup aws env
@@ -1977,8 +2014,8 @@ tasks:
             - {key: AUTH, value: auth}
             - {key: ORCHESTRATION_FILE, value: auth-aws.json}
             - {key: TOPOLOGY, value: server}
+            - {key: MONGODB_AWS_SDK, value: 'true'}
       - func: install dependencies
-      - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
       - func: add aws auth variables to file
       - func: setup aws env
@@ -1993,8 +2030,8 @@ tasks:
             - {key: AUTH, value: auth}
             - {key: ORCHESTRATION_FILE, value: auth-aws.json}
             - {key: TOPOLOGY, value: server}
+            - {key: MONGODB_AWS_SDK, value: 'true'}
       - func: install dependencies
-      - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
       - func: add aws auth variables to file
       - func: setup aws env
@@ -2009,8 +2046,8 @@ tasks:
             - {key: AUTH, value: auth}
             - {key: ORCHESTRATION_FILE, value: auth-aws.json}
             - {key: TOPOLOGY, value: server}
+            - {key: MONGODB_AWS_SDK, value: 'true'}
       - func: install dependencies
-      - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
       - func: add aws auth variables to file
       - func: setup aws env
@@ -2025,8 +2062,8 @@ tasks:
             - {key: AUTH, value: auth}
             - {key: ORCHESTRATION_FILE, value: auth-aws.json}
             - {key: TOPOLOGY, value: server}
+            - {key: MONGODB_AWS_SDK, value: 'true'}
       - func: install dependencies
-      - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
       - func: add aws auth variables to file
       - func: setup aws env
@@ -2041,8 +2078,8 @@ tasks:
             - {key: AUTH, value: auth}
             - {key: ORCHESTRATION_FILE, value: auth-aws.json}
             - {key: TOPOLOGY, value: server}
+            - {key: MONGODB_AWS_SDK, value: 'true'}
       - func: install dependencies
-      - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
       - func: add aws auth variables to file
       - func: setup aws env
@@ -2057,10 +2094,12 @@ tasks:
             - {key: AUTH, value: auth}
             - {key: ORCHESTRATION_FILE, value: auth-aws.json}
             - {key: TOPOLOGY, value: server}
+            - {key: MONGODB_AWS_SDK, value: 'false'}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: add aws auth variables to file
       - func: setup aws env
+      - func: remove aws-credential-providers
       - func: run aws auth test with regular aws credentials
   - name: aws-latest-auth-test-run-aws-auth-test-with-assume-role-credentials-no-peer-dependencies
     commands:
@@ -2072,26 +2111,13 @@ tasks:
             - {key: AUTH, value: auth}
             - {key: ORCHESTRATION_FILE, value: auth-aws.json}
             - {key: TOPOLOGY, value: server}
+            - {key: MONGODB_AWS_SDK, value: 'false'}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: add aws auth variables to file
       - func: setup aws env
+      - func: remove aws-credential-providers
       - func: run aws auth test with assume role credentials
-  - name: aws-latest-auth-test-run-aws-auth-test-with-aws-EC2-credentials-no-peer-dependencies
-    commands:
-      - command: expansions.update
-        type: setup
-        params:
-          updates:
-            - {key: VERSION, value: latest}
-            - {key: AUTH, value: auth}
-            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
-            - {key: TOPOLOGY, value: server}
-      - func: install dependencies
-      - func: bootstrap mongo-orchestration
-      - func: add aws auth variables to file
-      - func: setup aws env
-      - func: run aws auth test with aws EC2 credentials
   - name: aws-latest-auth-test-run-aws-auth-test-with-aws-credentials-as-environment-variables-no-peer-dependencies
     commands:
       - command: expansions.update
@@ -2102,10 +2128,12 @@ tasks:
             - {key: AUTH, value: auth}
             - {key: ORCHESTRATION_FILE, value: auth-aws.json}
             - {key: TOPOLOGY, value: server}
+            - {key: MONGODB_AWS_SDK, value: 'false'}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: add aws auth variables to file
       - func: setup aws env
+      - func: remove aws-credential-providers
       - func: run aws auth test with aws credentials as environment variables
   - name: >-
       aws-latest-auth-test-run-aws-auth-test-with-aws-credentials-and-session-token-as-environment-variables-no-peer-dependencies
@@ -2118,10 +2146,12 @@ tasks:
             - {key: AUTH, value: auth}
             - {key: ORCHESTRATION_FILE, value: auth-aws.json}
             - {key: TOPOLOGY, value: server}
+            - {key: MONGODB_AWS_SDK, value: 'false'}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: add aws auth variables to file
       - func: setup aws env
+      - func: remove aws-credential-providers
       - func: run aws auth test with aws credentials and session token as environment variables
   - name: aws-latest-auth-test-run-aws-ECS-auth-test-no-peer-dependencies
     commands:
@@ -2133,43 +2163,13 @@ tasks:
             - {key: AUTH, value: auth}
             - {key: ORCHESTRATION_FILE, value: auth-aws.json}
             - {key: TOPOLOGY, value: server}
+            - {key: MONGODB_AWS_SDK, value: 'false'}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: add aws auth variables to file
       - func: setup aws env
+      - func: remove aws-credential-providers
       - func: run aws ECS auth test
-  - name: >-
-      aws-latest-auth-test-run-aws-auth-test-AssumeRoleWithWebIdentity-with-AWS_ROLE_SESSION_NAME-unset-no-peer-dependencies
-    commands:
-      - command: expansions.update
-        type: setup
-        params:
-          updates:
-            - {key: VERSION, value: latest}
-            - {key: AUTH, value: auth}
-            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
-            - {key: TOPOLOGY, value: server}
-      - func: install dependencies
-      - func: bootstrap mongo-orchestration
-      - func: add aws auth variables to file
-      - func: setup aws env
-      - func: run aws auth test AssumeRoleWithWebIdentity with AWS_ROLE_SESSION_NAME unset
-  - name: >-
-      aws-latest-auth-test-run-aws-auth-test-AssumeRoleWithWebIdentity-with-AWS_ROLE_SESSION_NAME-set-no-peer-dependencies
-    commands:
-      - command: expansions.update
-        type: setup
-        params:
-          updates:
-            - {key: VERSION, value: latest}
-            - {key: AUTH, value: auth}
-            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
-            - {key: TOPOLOGY, value: server}
-      - func: install dependencies
-      - func: bootstrap mongo-orchestration
-      - func: add aws auth variables to file
-      - func: setup aws env
-      - func: run aws auth test AssumeRoleWithWebIdentity with AWS_ROLE_SESSION_NAME set
   - name: aws-6.0-auth-test-run-aws-auth-test-with-regular-aws-credentials
     commands:
       - command: expansions.update
@@ -2180,8 +2180,8 @@ tasks:
             - {key: AUTH, value: auth}
             - {key: ORCHESTRATION_FILE, value: auth-aws.json}
             - {key: TOPOLOGY, value: server}
+            - {key: MONGODB_AWS_SDK, value: 'true'}
       - func: install dependencies
-      - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
       - func: add aws auth variables to file
       - func: setup aws env
@@ -2196,8 +2196,8 @@ tasks:
             - {key: AUTH, value: auth}
             - {key: ORCHESTRATION_FILE, value: auth-aws.json}
             - {key: TOPOLOGY, value: server}
+            - {key: MONGODB_AWS_SDK, value: 'true'}
       - func: install dependencies
-      - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
       - func: add aws auth variables to file
       - func: setup aws env
@@ -2212,8 +2212,8 @@ tasks:
             - {key: AUTH, value: auth}
             - {key: ORCHESTRATION_FILE, value: auth-aws.json}
             - {key: TOPOLOGY, value: server}
+            - {key: MONGODB_AWS_SDK, value: 'true'}
       - func: install dependencies
-      - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
       - func: add aws auth variables to file
       - func: setup aws env
@@ -2228,8 +2228,8 @@ tasks:
             - {key: AUTH, value: auth}
             - {key: ORCHESTRATION_FILE, value: auth-aws.json}
             - {key: TOPOLOGY, value: server}
+            - {key: MONGODB_AWS_SDK, value: 'true'}
       - func: install dependencies
-      - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
       - func: add aws auth variables to file
       - func: setup aws env
@@ -2244,8 +2244,8 @@ tasks:
             - {key: AUTH, value: auth}
             - {key: ORCHESTRATION_FILE, value: auth-aws.json}
             - {key: TOPOLOGY, value: server}
+            - {key: MONGODB_AWS_SDK, value: 'true'}
       - func: install dependencies
-      - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
       - func: add aws auth variables to file
       - func: setup aws env
@@ -2260,8 +2260,8 @@ tasks:
             - {key: AUTH, value: auth}
             - {key: ORCHESTRATION_FILE, value: auth-aws.json}
             - {key: TOPOLOGY, value: server}
+            - {key: MONGODB_AWS_SDK, value: 'true'}
       - func: install dependencies
-      - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
       - func: add aws auth variables to file
       - func: setup aws env
@@ -2276,8 +2276,8 @@ tasks:
             - {key: AUTH, value: auth}
             - {key: ORCHESTRATION_FILE, value: auth-aws.json}
             - {key: TOPOLOGY, value: server}
+            - {key: MONGODB_AWS_SDK, value: 'true'}
       - func: install dependencies
-      - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
       - func: add aws auth variables to file
       - func: setup aws env
@@ -2292,8 +2292,8 @@ tasks:
             - {key: AUTH, value: auth}
             - {key: ORCHESTRATION_FILE, value: auth-aws.json}
             - {key: TOPOLOGY, value: server}
+            - {key: MONGODB_AWS_SDK, value: 'true'}
       - func: install dependencies
-      - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
       - func: add aws auth variables to file
       - func: setup aws env
@@ -2308,10 +2308,12 @@ tasks:
             - {key: AUTH, value: auth}
             - {key: ORCHESTRATION_FILE, value: auth-aws.json}
             - {key: TOPOLOGY, value: server}
+            - {key: MONGODB_AWS_SDK, value: 'false'}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: add aws auth variables to file
       - func: setup aws env
+      - func: remove aws-credential-providers
       - func: run aws auth test with regular aws credentials
   - name: aws-6.0-auth-test-run-aws-auth-test-with-assume-role-credentials-no-peer-dependencies
     commands:
@@ -2323,26 +2325,13 @@ tasks:
             - {key: AUTH, value: auth}
             - {key: ORCHESTRATION_FILE, value: auth-aws.json}
             - {key: TOPOLOGY, value: server}
+            - {key: MONGODB_AWS_SDK, value: 'false'}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: add aws auth variables to file
       - func: setup aws env
+      - func: remove aws-credential-providers
       - func: run aws auth test with assume role credentials
-  - name: aws-6.0-auth-test-run-aws-auth-test-with-aws-EC2-credentials-no-peer-dependencies
-    commands:
-      - command: expansions.update
-        type: setup
-        params:
-          updates:
-            - {key: VERSION, value: '6.0'}
-            - {key: AUTH, value: auth}
-            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
-            - {key: TOPOLOGY, value: server}
-      - func: install dependencies
-      - func: bootstrap mongo-orchestration
-      - func: add aws auth variables to file
-      - func: setup aws env
-      - func: run aws auth test with aws EC2 credentials
   - name: aws-6.0-auth-test-run-aws-auth-test-with-aws-credentials-as-environment-variables-no-peer-dependencies
     commands:
       - command: expansions.update
@@ -2353,10 +2342,12 @@ tasks:
             - {key: AUTH, value: auth}
             - {key: ORCHESTRATION_FILE, value: auth-aws.json}
             - {key: TOPOLOGY, value: server}
+            - {key: MONGODB_AWS_SDK, value: 'false'}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: add aws auth variables to file
       - func: setup aws env
+      - func: remove aws-credential-providers
       - func: run aws auth test with aws credentials as environment variables
   - name: >-
       aws-6.0-auth-test-run-aws-auth-test-with-aws-credentials-and-session-token-as-environment-variables-no-peer-dependencies
@@ -2369,10 +2360,12 @@ tasks:
             - {key: AUTH, value: auth}
             - {key: ORCHESTRATION_FILE, value: auth-aws.json}
             - {key: TOPOLOGY, value: server}
+            - {key: MONGODB_AWS_SDK, value: 'false'}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: add aws auth variables to file
       - func: setup aws env
+      - func: remove aws-credential-providers
       - func: run aws auth test with aws credentials and session token as environment variables
   - name: aws-6.0-auth-test-run-aws-ECS-auth-test-no-peer-dependencies
     commands:
@@ -2384,42 +2377,13 @@ tasks:
             - {key: AUTH, value: auth}
             - {key: ORCHESTRATION_FILE, value: auth-aws.json}
             - {key: TOPOLOGY, value: server}
+            - {key: MONGODB_AWS_SDK, value: 'false'}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: add aws auth variables to file
       - func: setup aws env
+      - func: remove aws-credential-providers
       - func: run aws ECS auth test
-  - name: >-
-      aws-6.0-auth-test-run-aws-auth-test-AssumeRoleWithWebIdentity-with-AWS_ROLE_SESSION_NAME-unset-no-peer-dependencies
-    commands:
-      - command: expansions.update
-        type: setup
-        params:
-          updates:
-            - {key: VERSION, value: '6.0'}
-            - {key: AUTH, value: auth}
-            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
-            - {key: TOPOLOGY, value: server}
-      - func: install dependencies
-      - func: bootstrap mongo-orchestration
-      - func: add aws auth variables to file
-      - func: setup aws env
-      - func: run aws auth test AssumeRoleWithWebIdentity with AWS_ROLE_SESSION_NAME unset
-  - name: aws-6.0-auth-test-run-aws-auth-test-AssumeRoleWithWebIdentity-with-AWS_ROLE_SESSION_NAME-set-no-peer-dependencies
-    commands:
-      - command: expansions.update
-        type: setup
-        params:
-          updates:
-            - {key: VERSION, value: '6.0'}
-            - {key: AUTH, value: auth}
-            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
-            - {key: TOPOLOGY, value: server}
-      - func: install dependencies
-      - func: bootstrap mongo-orchestration
-      - func: add aws auth variables to file
-      - func: setup aws env
-      - func: run aws auth test AssumeRoleWithWebIdentity with AWS_ROLE_SESSION_NAME set
   - name: aws-5.0-auth-test-run-aws-auth-test-with-regular-aws-credentials
     commands:
       - command: expansions.update
@@ -2430,8 +2394,8 @@ tasks:
             - {key: AUTH, value: auth}
             - {key: ORCHESTRATION_FILE, value: auth-aws.json}
             - {key: TOPOLOGY, value: server}
+            - {key: MONGODB_AWS_SDK, value: 'true'}
       - func: install dependencies
-      - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
       - func: add aws auth variables to file
       - func: setup aws env
@@ -2446,8 +2410,8 @@ tasks:
             - {key: AUTH, value: auth}
             - {key: ORCHESTRATION_FILE, value: auth-aws.json}
             - {key: TOPOLOGY, value: server}
+            - {key: MONGODB_AWS_SDK, value: 'true'}
       - func: install dependencies
-      - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
       - func: add aws auth variables to file
       - func: setup aws env
@@ -2462,8 +2426,8 @@ tasks:
             - {key: AUTH, value: auth}
             - {key: ORCHESTRATION_FILE, value: auth-aws.json}
             - {key: TOPOLOGY, value: server}
+            - {key: MONGODB_AWS_SDK, value: 'true'}
       - func: install dependencies
-      - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
       - func: add aws auth variables to file
       - func: setup aws env
@@ -2478,8 +2442,8 @@ tasks:
             - {key: AUTH, value: auth}
             - {key: ORCHESTRATION_FILE, value: auth-aws.json}
             - {key: TOPOLOGY, value: server}
+            - {key: MONGODB_AWS_SDK, value: 'true'}
       - func: install dependencies
-      - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
       - func: add aws auth variables to file
       - func: setup aws env
@@ -2494,8 +2458,8 @@ tasks:
             - {key: AUTH, value: auth}
             - {key: ORCHESTRATION_FILE, value: auth-aws.json}
             - {key: TOPOLOGY, value: server}
+            - {key: MONGODB_AWS_SDK, value: 'true'}
       - func: install dependencies
-      - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
       - func: add aws auth variables to file
       - func: setup aws env
@@ -2510,8 +2474,8 @@ tasks:
             - {key: AUTH, value: auth}
             - {key: ORCHESTRATION_FILE, value: auth-aws.json}
             - {key: TOPOLOGY, value: server}
+            - {key: MONGODB_AWS_SDK, value: 'true'}
       - func: install dependencies
-      - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
       - func: add aws auth variables to file
       - func: setup aws env
@@ -2526,8 +2490,8 @@ tasks:
             - {key: AUTH, value: auth}
             - {key: ORCHESTRATION_FILE, value: auth-aws.json}
             - {key: TOPOLOGY, value: server}
+            - {key: MONGODB_AWS_SDK, value: 'true'}
       - func: install dependencies
-      - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
       - func: add aws auth variables to file
       - func: setup aws env
@@ -2542,8 +2506,8 @@ tasks:
             - {key: AUTH, value: auth}
             - {key: ORCHESTRATION_FILE, value: auth-aws.json}
             - {key: TOPOLOGY, value: server}
+            - {key: MONGODB_AWS_SDK, value: 'true'}
       - func: install dependencies
-      - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
       - func: add aws auth variables to file
       - func: setup aws env
@@ -2558,10 +2522,12 @@ tasks:
             - {key: AUTH, value: auth}
             - {key: ORCHESTRATION_FILE, value: auth-aws.json}
             - {key: TOPOLOGY, value: server}
+            - {key: MONGODB_AWS_SDK, value: 'false'}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: add aws auth variables to file
       - func: setup aws env
+      - func: remove aws-credential-providers
       - func: run aws auth test with regular aws credentials
   - name: aws-5.0-auth-test-run-aws-auth-test-with-assume-role-credentials-no-peer-dependencies
     commands:
@@ -2573,26 +2539,13 @@ tasks:
             - {key: AUTH, value: auth}
             - {key: ORCHESTRATION_FILE, value: auth-aws.json}
             - {key: TOPOLOGY, value: server}
+            - {key: MONGODB_AWS_SDK, value: 'false'}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: add aws auth variables to file
       - func: setup aws env
+      - func: remove aws-credential-providers
       - func: run aws auth test with assume role credentials
-  - name: aws-5.0-auth-test-run-aws-auth-test-with-aws-EC2-credentials-no-peer-dependencies
-    commands:
-      - command: expansions.update
-        type: setup
-        params:
-          updates:
-            - {key: VERSION, value: '5.0'}
-            - {key: AUTH, value: auth}
-            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
-            - {key: TOPOLOGY, value: server}
-      - func: install dependencies
-      - func: bootstrap mongo-orchestration
-      - func: add aws auth variables to file
-      - func: setup aws env
-      - func: run aws auth test with aws EC2 credentials
   - name: aws-5.0-auth-test-run-aws-auth-test-with-aws-credentials-as-environment-variables-no-peer-dependencies
     commands:
       - command: expansions.update
@@ -2603,10 +2556,12 @@ tasks:
             - {key: AUTH, value: auth}
             - {key: ORCHESTRATION_FILE, value: auth-aws.json}
             - {key: TOPOLOGY, value: server}
+            - {key: MONGODB_AWS_SDK, value: 'false'}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: add aws auth variables to file
       - func: setup aws env
+      - func: remove aws-credential-providers
       - func: run aws auth test with aws credentials as environment variables
   - name: >-
       aws-5.0-auth-test-run-aws-auth-test-with-aws-credentials-and-session-token-as-environment-variables-no-peer-dependencies
@@ -2619,10 +2574,12 @@ tasks:
             - {key: AUTH, value: auth}
             - {key: ORCHESTRATION_FILE, value: auth-aws.json}
             - {key: TOPOLOGY, value: server}
+            - {key: MONGODB_AWS_SDK, value: 'false'}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: add aws auth variables to file
       - func: setup aws env
+      - func: remove aws-credential-providers
       - func: run aws auth test with aws credentials and session token as environment variables
   - name: aws-5.0-auth-test-run-aws-ECS-auth-test-no-peer-dependencies
     commands:
@@ -2634,42 +2591,13 @@ tasks:
             - {key: AUTH, value: auth}
             - {key: ORCHESTRATION_FILE, value: auth-aws.json}
             - {key: TOPOLOGY, value: server}
+            - {key: MONGODB_AWS_SDK, value: 'false'}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: add aws auth variables to file
       - func: setup aws env
+      - func: remove aws-credential-providers
       - func: run aws ECS auth test
-  - name: >-
-      aws-5.0-auth-test-run-aws-auth-test-AssumeRoleWithWebIdentity-with-AWS_ROLE_SESSION_NAME-unset-no-peer-dependencies
-    commands:
-      - command: expansions.update
-        type: setup
-        params:
-          updates:
-            - {key: VERSION, value: '5.0'}
-            - {key: AUTH, value: auth}
-            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
-            - {key: TOPOLOGY, value: server}
-      - func: install dependencies
-      - func: bootstrap mongo-orchestration
-      - func: add aws auth variables to file
-      - func: setup aws env
-      - func: run aws auth test AssumeRoleWithWebIdentity with AWS_ROLE_SESSION_NAME unset
-  - name: aws-5.0-auth-test-run-aws-auth-test-AssumeRoleWithWebIdentity-with-AWS_ROLE_SESSION_NAME-set-no-peer-dependencies
-    commands:
-      - command: expansions.update
-        type: setup
-        params:
-          updates:
-            - {key: VERSION, value: '5.0'}
-            - {key: AUTH, value: auth}
-            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
-            - {key: TOPOLOGY, value: server}
-      - func: install dependencies
-      - func: bootstrap mongo-orchestration
-      - func: add aws auth variables to file
-      - func: setup aws env
-      - func: run aws auth test AssumeRoleWithWebIdentity with AWS_ROLE_SESSION_NAME set
   - name: aws-4.4-auth-test-run-aws-auth-test-with-regular-aws-credentials
     commands:
       - command: expansions.update
@@ -2680,8 +2608,8 @@ tasks:
             - {key: AUTH, value: auth}
             - {key: ORCHESTRATION_FILE, value: auth-aws.json}
             - {key: TOPOLOGY, value: server}
+            - {key: MONGODB_AWS_SDK, value: 'true'}
       - func: install dependencies
-      - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
       - func: add aws auth variables to file
       - func: setup aws env
@@ -2696,8 +2624,8 @@ tasks:
             - {key: AUTH, value: auth}
             - {key: ORCHESTRATION_FILE, value: auth-aws.json}
             - {key: TOPOLOGY, value: server}
+            - {key: MONGODB_AWS_SDK, value: 'true'}
       - func: install dependencies
-      - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
       - func: add aws auth variables to file
       - func: setup aws env
@@ -2712,8 +2640,8 @@ tasks:
             - {key: AUTH, value: auth}
             - {key: ORCHESTRATION_FILE, value: auth-aws.json}
             - {key: TOPOLOGY, value: server}
+            - {key: MONGODB_AWS_SDK, value: 'true'}
       - func: install dependencies
-      - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
       - func: add aws auth variables to file
       - func: setup aws env
@@ -2728,8 +2656,8 @@ tasks:
             - {key: AUTH, value: auth}
             - {key: ORCHESTRATION_FILE, value: auth-aws.json}
             - {key: TOPOLOGY, value: server}
+            - {key: MONGODB_AWS_SDK, value: 'true'}
       - func: install dependencies
-      - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
       - func: add aws auth variables to file
       - func: setup aws env
@@ -2744,8 +2672,8 @@ tasks:
             - {key: AUTH, value: auth}
             - {key: ORCHESTRATION_FILE, value: auth-aws.json}
             - {key: TOPOLOGY, value: server}
+            - {key: MONGODB_AWS_SDK, value: 'true'}
       - func: install dependencies
-      - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
       - func: add aws auth variables to file
       - func: setup aws env
@@ -2760,8 +2688,8 @@ tasks:
             - {key: AUTH, value: auth}
             - {key: ORCHESTRATION_FILE, value: auth-aws.json}
             - {key: TOPOLOGY, value: server}
+            - {key: MONGODB_AWS_SDK, value: 'true'}
       - func: install dependencies
-      - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
       - func: add aws auth variables to file
       - func: setup aws env
@@ -2776,8 +2704,8 @@ tasks:
             - {key: AUTH, value: auth}
             - {key: ORCHESTRATION_FILE, value: auth-aws.json}
             - {key: TOPOLOGY, value: server}
+            - {key: MONGODB_AWS_SDK, value: 'true'}
       - func: install dependencies
-      - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
       - func: add aws auth variables to file
       - func: setup aws env
@@ -2792,8 +2720,8 @@ tasks:
             - {key: AUTH, value: auth}
             - {key: ORCHESTRATION_FILE, value: auth-aws.json}
             - {key: TOPOLOGY, value: server}
+            - {key: MONGODB_AWS_SDK, value: 'true'}
       - func: install dependencies
-      - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
       - func: add aws auth variables to file
       - func: setup aws env
@@ -2808,10 +2736,12 @@ tasks:
             - {key: AUTH, value: auth}
             - {key: ORCHESTRATION_FILE, value: auth-aws.json}
             - {key: TOPOLOGY, value: server}
+            - {key: MONGODB_AWS_SDK, value: 'false'}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: add aws auth variables to file
       - func: setup aws env
+      - func: remove aws-credential-providers
       - func: run aws auth test with regular aws credentials
   - name: aws-4.4-auth-test-run-aws-auth-test-with-assume-role-credentials-no-peer-dependencies
     commands:
@@ -2823,26 +2753,13 @@ tasks:
             - {key: AUTH, value: auth}
             - {key: ORCHESTRATION_FILE, value: auth-aws.json}
             - {key: TOPOLOGY, value: server}
+            - {key: MONGODB_AWS_SDK, value: 'false'}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: add aws auth variables to file
       - func: setup aws env
+      - func: remove aws-credential-providers
       - func: run aws auth test with assume role credentials
-  - name: aws-4.4-auth-test-run-aws-auth-test-with-aws-EC2-credentials-no-peer-dependencies
-    commands:
-      - command: expansions.update
-        type: setup
-        params:
-          updates:
-            - {key: VERSION, value: '4.4'}
-            - {key: AUTH, value: auth}
-            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
-            - {key: TOPOLOGY, value: server}
-      - func: install dependencies
-      - func: bootstrap mongo-orchestration
-      - func: add aws auth variables to file
-      - func: setup aws env
-      - func: run aws auth test with aws EC2 credentials
   - name: aws-4.4-auth-test-run-aws-auth-test-with-aws-credentials-as-environment-variables-no-peer-dependencies
     commands:
       - command: expansions.update
@@ -2853,10 +2770,12 @@ tasks:
             - {key: AUTH, value: auth}
             - {key: ORCHESTRATION_FILE, value: auth-aws.json}
             - {key: TOPOLOGY, value: server}
+            - {key: MONGODB_AWS_SDK, value: 'false'}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: add aws auth variables to file
       - func: setup aws env
+      - func: remove aws-credential-providers
       - func: run aws auth test with aws credentials as environment variables
   - name: >-
       aws-4.4-auth-test-run-aws-auth-test-with-aws-credentials-and-session-token-as-environment-variables-no-peer-dependencies
@@ -2869,10 +2788,12 @@ tasks:
             - {key: AUTH, value: auth}
             - {key: ORCHESTRATION_FILE, value: auth-aws.json}
             - {key: TOPOLOGY, value: server}
+            - {key: MONGODB_AWS_SDK, value: 'false'}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: add aws auth variables to file
       - func: setup aws env
+      - func: remove aws-credential-providers
       - func: run aws auth test with aws credentials and session token as environment variables
   - name: aws-4.4-auth-test-run-aws-ECS-auth-test-no-peer-dependencies
     commands:
@@ -2884,42 +2805,13 @@ tasks:
             - {key: AUTH, value: auth}
             - {key: ORCHESTRATION_FILE, value: auth-aws.json}
             - {key: TOPOLOGY, value: server}
+            - {key: MONGODB_AWS_SDK, value: 'false'}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: add aws auth variables to file
       - func: setup aws env
+      - func: remove aws-credential-providers
       - func: run aws ECS auth test
-  - name: >-
-      aws-4.4-auth-test-run-aws-auth-test-AssumeRoleWithWebIdentity-with-AWS_ROLE_SESSION_NAME-unset-no-peer-dependencies
-    commands:
-      - command: expansions.update
-        type: setup
-        params:
-          updates:
-            - {key: VERSION, value: '4.4'}
-            - {key: AUTH, value: auth}
-            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
-            - {key: TOPOLOGY, value: server}
-      - func: install dependencies
-      - func: bootstrap mongo-orchestration
-      - func: add aws auth variables to file
-      - func: setup aws env
-      - func: run aws auth test AssumeRoleWithWebIdentity with AWS_ROLE_SESSION_NAME unset
-  - name: aws-4.4-auth-test-run-aws-auth-test-AssumeRoleWithWebIdentity-with-AWS_ROLE_SESSION_NAME-set-no-peer-dependencies
-    commands:
-      - command: expansions.update
-        type: setup
-        params:
-          updates:
-            - {key: VERSION, value: '4.4'}
-            - {key: AUTH, value: auth}
-            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
-            - {key: TOPOLOGY, value: server}
-      - func: install dependencies
-      - func: bootstrap mongo-orchestration
-      - func: add aws auth variables to file
-      - func: setup aws env
-      - func: run aws auth test AssumeRoleWithWebIdentity with AWS_ROLE_SESSION_NAME set
   - name: run-unit-tests-node-14
     tags:
       - unit-tests
@@ -4358,15 +4250,10 @@ buildvariants:
       - aws-latest-auth-test-run-aws-auth-test-AssumeRoleWithWebIdentity-with-AWS_ROLE_SESSION_NAME-set
       - aws-latest-auth-test-run-aws-auth-test-with-regular-aws-credentials-no-peer-dependencies
       - aws-latest-auth-test-run-aws-auth-test-with-assume-role-credentials-no-peer-dependencies
-      - aws-latest-auth-test-run-aws-auth-test-with-aws-EC2-credentials-no-peer-dependencies
       - aws-latest-auth-test-run-aws-auth-test-with-aws-credentials-as-environment-variables-no-peer-dependencies
       - >-
         aws-latest-auth-test-run-aws-auth-test-with-aws-credentials-and-session-token-as-environment-variables-no-peer-dependencies
       - aws-latest-auth-test-run-aws-ECS-auth-test-no-peer-dependencies
-      - >-
-        aws-latest-auth-test-run-aws-auth-test-AssumeRoleWithWebIdentity-with-AWS_ROLE_SESSION_NAME-unset-no-peer-dependencies
-      - >-
-        aws-latest-auth-test-run-aws-auth-test-AssumeRoleWithWebIdentity-with-AWS_ROLE_SESSION_NAME-set-no-peer-dependencies
       - aws-6.0-auth-test-run-aws-auth-test-with-regular-aws-credentials
       - aws-6.0-auth-test-run-aws-auth-test-with-assume-role-credentials
       - aws-6.0-auth-test-run-aws-auth-test-with-aws-EC2-credentials
@@ -4377,15 +4264,10 @@ buildvariants:
       - aws-6.0-auth-test-run-aws-auth-test-AssumeRoleWithWebIdentity-with-AWS_ROLE_SESSION_NAME-set
       - aws-6.0-auth-test-run-aws-auth-test-with-regular-aws-credentials-no-peer-dependencies
       - aws-6.0-auth-test-run-aws-auth-test-with-assume-role-credentials-no-peer-dependencies
-      - aws-6.0-auth-test-run-aws-auth-test-with-aws-EC2-credentials-no-peer-dependencies
       - aws-6.0-auth-test-run-aws-auth-test-with-aws-credentials-as-environment-variables-no-peer-dependencies
       - >-
         aws-6.0-auth-test-run-aws-auth-test-with-aws-credentials-and-session-token-as-environment-variables-no-peer-dependencies
       - aws-6.0-auth-test-run-aws-ECS-auth-test-no-peer-dependencies
-      - >-
-        aws-6.0-auth-test-run-aws-auth-test-AssumeRoleWithWebIdentity-with-AWS_ROLE_SESSION_NAME-unset-no-peer-dependencies
-      - >-
-        aws-6.0-auth-test-run-aws-auth-test-AssumeRoleWithWebIdentity-with-AWS_ROLE_SESSION_NAME-set-no-peer-dependencies
       - aws-5.0-auth-test-run-aws-auth-test-with-regular-aws-credentials
       - aws-5.0-auth-test-run-aws-auth-test-with-assume-role-credentials
       - aws-5.0-auth-test-run-aws-auth-test-with-aws-EC2-credentials
@@ -4396,15 +4278,10 @@ buildvariants:
       - aws-5.0-auth-test-run-aws-auth-test-AssumeRoleWithWebIdentity-with-AWS_ROLE_SESSION_NAME-set
       - aws-5.0-auth-test-run-aws-auth-test-with-regular-aws-credentials-no-peer-dependencies
       - aws-5.0-auth-test-run-aws-auth-test-with-assume-role-credentials-no-peer-dependencies
-      - aws-5.0-auth-test-run-aws-auth-test-with-aws-EC2-credentials-no-peer-dependencies
       - aws-5.0-auth-test-run-aws-auth-test-with-aws-credentials-as-environment-variables-no-peer-dependencies
       - >-
         aws-5.0-auth-test-run-aws-auth-test-with-aws-credentials-and-session-token-as-environment-variables-no-peer-dependencies
       - aws-5.0-auth-test-run-aws-ECS-auth-test-no-peer-dependencies
-      - >-
-        aws-5.0-auth-test-run-aws-auth-test-AssumeRoleWithWebIdentity-with-AWS_ROLE_SESSION_NAME-unset-no-peer-dependencies
-      - >-
-        aws-5.0-auth-test-run-aws-auth-test-AssumeRoleWithWebIdentity-with-AWS_ROLE_SESSION_NAME-set-no-peer-dependencies
       - aws-4.4-auth-test-run-aws-auth-test-with-regular-aws-credentials
       - aws-4.4-auth-test-run-aws-auth-test-with-assume-role-credentials
       - aws-4.4-auth-test-run-aws-auth-test-with-aws-EC2-credentials
@@ -4415,15 +4292,10 @@ buildvariants:
       - aws-4.4-auth-test-run-aws-auth-test-AssumeRoleWithWebIdentity-with-AWS_ROLE_SESSION_NAME-set
       - aws-4.4-auth-test-run-aws-auth-test-with-regular-aws-credentials-no-peer-dependencies
       - aws-4.4-auth-test-run-aws-auth-test-with-assume-role-credentials-no-peer-dependencies
-      - aws-4.4-auth-test-run-aws-auth-test-with-aws-EC2-credentials-no-peer-dependencies
       - aws-4.4-auth-test-run-aws-auth-test-with-aws-credentials-as-environment-variables-no-peer-dependencies
       - >-
         aws-4.4-auth-test-run-aws-auth-test-with-aws-credentials-and-session-token-as-environment-variables-no-peer-dependencies
       - aws-4.4-auth-test-run-aws-ECS-auth-test-no-peer-dependencies
-      - >-
-        aws-4.4-auth-test-run-aws-auth-test-AssumeRoleWithWebIdentity-with-AWS_ROLE_SESSION_NAME-unset-no-peer-dependencies
-      - >-
-        aws-4.4-auth-test-run-aws-auth-test-AssumeRoleWithWebIdentity-with-AWS_ROLE_SESSION_NAME-set-no-peer-dependencies
   - name: ubuntu2204-test-atlas-data-lake
     display_name: Atlas Data Lake Tests
     run_on: ubuntu2204-large

--- a/.evergreen/run-mongodb-aws-ecs-test.sh
+++ b/.evergreen/run-mongodb-aws-ecs-test.sh
@@ -10,11 +10,7 @@ cd $PROJECT_DIRECTORY
 tar -xzf src.tgz .
 
 # load node.js
-set +x
 source "${PROJECT_DIRECTORY}/.evergreen/init-node-and-npm-env.sh"
-set -x
 
 # run the tests
 npm install aws4
-
-npm run check:aws

--- a/.evergreen/run-mongodb-aws-test.sh
+++ b/.evergreen/run-mongodb-aws-test.sh
@@ -21,4 +21,5 @@ shopt -s expand_aliases # needed for `urlencode` alias
 set -x
 
 npm install aws4
+if [ $MONGODB_AWS_SDK = 'false' ]; then rm -rf ./node_modules/@aws-sdk/credential-providers; fi
 npm run check:aws

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "socks": "^2.7.1"
       },
       "devDependencies": {
+        "@aws-sdk/credential-providers": "^3.462.0",
         "@iarna/toml": "^2.2.5",
         "@istanbuljs/nyc-config-typescript": "^1.0.2",
         "@microsoft/api-extractor": "^7.35.1",
@@ -104,12 +105,28 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
+      "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/crc32/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
     "node_modules/@aws-crypto/ie11-detection": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
       "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
-      "optional": true,
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "tslib": "^1.11.1"
       }
@@ -118,15 +135,13 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@aws-crypto/sha256-browser": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
       "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
-      "optional": true,
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@aws-crypto/ie11-detection": "^3.0.0",
         "@aws-crypto/sha256-js": "^3.0.0",
@@ -142,15 +157,13 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@aws-crypto/sha256-js": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
       "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
-      "optional": true,
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@aws-crypto/util": "^3.0.0",
         "@aws-sdk/types": "^3.222.0",
@@ -161,15 +174,13 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@aws-crypto/supports-web-crypto": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
       "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
-      "optional": true,
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "tslib": "^1.11.1"
       }
@@ -178,15 +189,13 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@aws-crypto/util": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
       "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
-      "optional": true,
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "^3.222.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
@@ -197,64 +206,52 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/@aws-sdk/abort-controller": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.310.0.tgz",
-      "integrity": "sha512-v1zrRQxDLA1MdPim159Vx/CPHqsB4uybSxRi1CnfHO5ZjHryx3a5htW2gdGAykVCul40+yJXvfpufMrELVxH+g==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
+      "dev": true
     },
     "node_modules/@aws-sdk/client-cognito-identity": {
-      "version": "3.325.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.325.0.tgz",
-      "integrity": "sha512-YSH1W88rDxYYxTbVOlM+32nSNlCyGHOU6dxlIsItwbqINFmM/GRSS77fmRFugZfDavMlm3f0Zoi6OfUIdorSFQ==",
-      "optional": true,
-      "peer": true,
+      "version": "3.462.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.462.0.tgz",
+      "integrity": "sha512-NGsFxb2ysXWUPKCRoa4KIJTcL8kddY73EV0hbw9li7+pTFzzkiYiNg6RxfHp3U+sBlhN8poItQrkAXZTDIJ1yQ==",
+      "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.325.0",
-        "@aws-sdk/config-resolver": "3.310.0",
-        "@aws-sdk/credential-provider-node": "3.325.0",
-        "@aws-sdk/fetch-http-handler": "3.310.0",
-        "@aws-sdk/hash-node": "3.310.0",
-        "@aws-sdk/invalid-dependency": "3.310.0",
-        "@aws-sdk/middleware-content-length": "3.325.0",
-        "@aws-sdk/middleware-endpoint": "3.325.0",
-        "@aws-sdk/middleware-host-header": "3.325.0",
-        "@aws-sdk/middleware-logger": "3.325.0",
-        "@aws-sdk/middleware-recursion-detection": "3.325.0",
-        "@aws-sdk/middleware-retry": "3.325.0",
-        "@aws-sdk/middleware-serde": "3.325.0",
-        "@aws-sdk/middleware-signing": "3.325.0",
-        "@aws-sdk/middleware-stack": "3.325.0",
-        "@aws-sdk/middleware-user-agent": "3.325.0",
-        "@aws-sdk/node-config-provider": "3.310.0",
-        "@aws-sdk/node-http-handler": "3.321.1",
-        "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/smithy-client": "3.325.0",
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/url-parser": "3.310.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-body-length-browser": "3.310.0",
-        "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.325.0",
-        "@aws-sdk/util-defaults-mode-node": "3.325.0",
-        "@aws-sdk/util-endpoints": "3.319.0",
-        "@aws-sdk/util-retry": "3.310.0",
-        "@aws-sdk/util-user-agent-browser": "3.310.0",
-        "@aws-sdk/util-user-agent-node": "3.310.0",
-        "@aws-sdk/util-utf8": "3.310.0",
+        "@aws-sdk/client-sts": "3.462.0",
+        "@aws-sdk/core": "3.451.0",
+        "@aws-sdk/credential-provider-node": "3.460.0",
+        "@aws-sdk/middleware-host-header": "3.460.0",
+        "@aws-sdk/middleware-logger": "3.460.0",
+        "@aws-sdk/middleware-recursion-detection": "3.460.0",
+        "@aws-sdk/middleware-signing": "3.461.0",
+        "@aws-sdk/middleware-user-agent": "3.460.0",
+        "@aws-sdk/region-config-resolver": "3.451.0",
+        "@aws-sdk/types": "3.460.0",
+        "@aws-sdk/util-endpoints": "3.460.0",
+        "@aws-sdk/util-user-agent-browser": "3.460.0",
+        "@aws-sdk/util-user-agent-node": "3.460.0",
+        "@smithy/config-resolver": "^2.0.18",
+        "@smithy/fetch-http-handler": "^2.2.6",
+        "@smithy/hash-node": "^2.0.15",
+        "@smithy/invalid-dependency": "^2.0.13",
+        "@smithy/middleware-content-length": "^2.0.15",
+        "@smithy/middleware-endpoint": "^2.2.0",
+        "@smithy/middleware-retry": "^2.0.20",
+        "@smithy/middleware-serde": "^2.0.13",
+        "@smithy/middleware-stack": "^2.0.7",
+        "@smithy/node-config-provider": "^2.1.5",
+        "@smithy/node-http-handler": "^2.1.9",
+        "@smithy/protocol-http": "^3.0.9",
+        "@smithy/smithy-client": "^2.1.15",
+        "@smithy/types": "^2.5.0",
+        "@smithy/url-parser": "^2.0.13",
+        "@smithy/util-base64": "^2.0.1",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.19",
+        "@smithy/util-defaults-mode-node": "^2.0.25",
+        "@smithy/util-endpoints": "^1.0.4",
+        "@smithy/util-retry": "^2.0.6",
+        "@smithy/util-utf8": "^2.0.2",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -262,87 +259,46 @@
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.325.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.325.0.tgz",
-      "integrity": "sha512-ajxL7cVtK0OPQz37hnKDbL6hPBNv3+sTgyZ+RTuBxjS3MKh/TVu/yXfrL+hfFFMijk494b7CctgRZrTABEvWdw==",
-      "optional": true,
-      "peer": true,
+      "version": "3.460.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.460.0.tgz",
+      "integrity": "sha512-p5D9C8LKJs5yoBn5cCs2Wqzrp5YP5BYcP774bhGMFEu/LCIUyWzudwN3+/AObSiq8R8SSvBY2zQD4h+k3NjgTQ==",
+      "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.310.0",
-        "@aws-sdk/fetch-http-handler": "3.310.0",
-        "@aws-sdk/hash-node": "3.310.0",
-        "@aws-sdk/invalid-dependency": "3.310.0",
-        "@aws-sdk/middleware-content-length": "3.325.0",
-        "@aws-sdk/middleware-endpoint": "3.325.0",
-        "@aws-sdk/middleware-host-header": "3.325.0",
-        "@aws-sdk/middleware-logger": "3.325.0",
-        "@aws-sdk/middleware-recursion-detection": "3.325.0",
-        "@aws-sdk/middleware-retry": "3.325.0",
-        "@aws-sdk/middleware-serde": "3.325.0",
-        "@aws-sdk/middleware-stack": "3.325.0",
-        "@aws-sdk/middleware-user-agent": "3.325.0",
-        "@aws-sdk/node-config-provider": "3.310.0",
-        "@aws-sdk/node-http-handler": "3.321.1",
-        "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/smithy-client": "3.325.0",
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/url-parser": "3.310.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-body-length-browser": "3.310.0",
-        "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.325.0",
-        "@aws-sdk/util-defaults-mode-node": "3.325.0",
-        "@aws-sdk/util-endpoints": "3.319.0",
-        "@aws-sdk/util-retry": "3.310.0",
-        "@aws-sdk/util-user-agent-browser": "3.310.0",
-        "@aws-sdk/util-user-agent-node": "3.310.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.325.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.325.0.tgz",
-      "integrity": "sha512-D20mpgiZ5/O/CAR18F16h7hJlcmPvOjh6IcjtZexte0NhkSO4oV1MzgmXT/aWOo2zIeovPRzZTNULAH24sosNQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.310.0",
-        "@aws-sdk/fetch-http-handler": "3.310.0",
-        "@aws-sdk/hash-node": "3.310.0",
-        "@aws-sdk/invalid-dependency": "3.310.0",
-        "@aws-sdk/middleware-content-length": "3.325.0",
-        "@aws-sdk/middleware-endpoint": "3.325.0",
-        "@aws-sdk/middleware-host-header": "3.325.0",
-        "@aws-sdk/middleware-logger": "3.325.0",
-        "@aws-sdk/middleware-recursion-detection": "3.325.0",
-        "@aws-sdk/middleware-retry": "3.325.0",
-        "@aws-sdk/middleware-serde": "3.325.0",
-        "@aws-sdk/middleware-stack": "3.325.0",
-        "@aws-sdk/middleware-user-agent": "3.325.0",
-        "@aws-sdk/node-config-provider": "3.310.0",
-        "@aws-sdk/node-http-handler": "3.321.1",
-        "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/smithy-client": "3.325.0",
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/url-parser": "3.310.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-body-length-browser": "3.310.0",
-        "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.325.0",
-        "@aws-sdk/util-defaults-mode-node": "3.325.0",
-        "@aws-sdk/util-endpoints": "3.319.0",
-        "@aws-sdk/util-retry": "3.310.0",
-        "@aws-sdk/util-user-agent-browser": "3.310.0",
-        "@aws-sdk/util-user-agent-node": "3.310.0",
-        "@aws-sdk/util-utf8": "3.310.0",
+        "@aws-sdk/core": "3.451.0",
+        "@aws-sdk/middleware-host-header": "3.460.0",
+        "@aws-sdk/middleware-logger": "3.460.0",
+        "@aws-sdk/middleware-recursion-detection": "3.460.0",
+        "@aws-sdk/middleware-user-agent": "3.460.0",
+        "@aws-sdk/region-config-resolver": "3.451.0",
+        "@aws-sdk/types": "3.460.0",
+        "@aws-sdk/util-endpoints": "3.460.0",
+        "@aws-sdk/util-user-agent-browser": "3.460.0",
+        "@aws-sdk/util-user-agent-node": "3.460.0",
+        "@smithy/config-resolver": "^2.0.18",
+        "@smithy/fetch-http-handler": "^2.2.6",
+        "@smithy/hash-node": "^2.0.15",
+        "@smithy/invalid-dependency": "^2.0.13",
+        "@smithy/middleware-content-length": "^2.0.15",
+        "@smithy/middleware-endpoint": "^2.2.0",
+        "@smithy/middleware-retry": "^2.0.20",
+        "@smithy/middleware-serde": "^2.0.13",
+        "@smithy/middleware-stack": "^2.0.7",
+        "@smithy/node-config-provider": "^2.1.5",
+        "@smithy/node-http-handler": "^2.1.9",
+        "@smithy/protocol-http": "^3.0.9",
+        "@smithy/smithy-client": "^2.1.15",
+        "@smithy/types": "^2.5.0",
+        "@smithy/url-parser": "^2.0.13",
+        "@smithy/util-base64": "^2.0.1",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.19",
+        "@smithy/util-defaults-mode-node": "^2.0.25",
+        "@smithy/util-endpoints": "^1.0.4",
+        "@smithy/util-retry": "^2.0.6",
+        "@smithy/util-utf8": "^2.0.2",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -350,63 +306,63 @@
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.325.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.325.0.tgz",
-      "integrity": "sha512-5ZOScg5EvyLV59mDUxSbL9x10cUbZsoSqvNETGLruyXILHaRHa8WS00wffcDA/dRzKIk9xQwJNwplcWnpT8WUw==",
-      "optional": true,
-      "peer": true,
+      "version": "3.462.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.462.0.tgz",
+      "integrity": "sha512-oO6SVGB9kR0dwc4T/M3++TcioBVv26cEpxZGS4BcKMDxSjkCLqJ/jE37aCNNPGTlCAhnuOAwqGjFqYrsehsI1Q==",
+      "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.310.0",
-        "@aws-sdk/credential-provider-node": "3.325.0",
-        "@aws-sdk/fetch-http-handler": "3.310.0",
-        "@aws-sdk/hash-node": "3.310.0",
-        "@aws-sdk/invalid-dependency": "3.310.0",
-        "@aws-sdk/middleware-content-length": "3.325.0",
-        "@aws-sdk/middleware-endpoint": "3.325.0",
-        "@aws-sdk/middleware-host-header": "3.325.0",
-        "@aws-sdk/middleware-logger": "3.325.0",
-        "@aws-sdk/middleware-recursion-detection": "3.325.0",
-        "@aws-sdk/middleware-retry": "3.325.0",
-        "@aws-sdk/middleware-sdk-sts": "3.325.0",
-        "@aws-sdk/middleware-serde": "3.325.0",
-        "@aws-sdk/middleware-signing": "3.325.0",
-        "@aws-sdk/middleware-stack": "3.325.0",
-        "@aws-sdk/middleware-user-agent": "3.325.0",
-        "@aws-sdk/node-config-provider": "3.310.0",
-        "@aws-sdk/node-http-handler": "3.321.1",
-        "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/smithy-client": "3.325.0",
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/url-parser": "3.310.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-body-length-browser": "3.310.0",
-        "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.325.0",
-        "@aws-sdk/util-defaults-mode-node": "3.325.0",
-        "@aws-sdk/util-endpoints": "3.319.0",
-        "@aws-sdk/util-retry": "3.310.0",
-        "@aws-sdk/util-user-agent-browser": "3.310.0",
-        "@aws-sdk/util-user-agent-node": "3.310.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "fast-xml-parser": "4.1.2",
+        "@aws-sdk/core": "3.451.0",
+        "@aws-sdk/credential-provider-node": "3.460.0",
+        "@aws-sdk/middleware-host-header": "3.460.0",
+        "@aws-sdk/middleware-logger": "3.460.0",
+        "@aws-sdk/middleware-recursion-detection": "3.460.0",
+        "@aws-sdk/middleware-sdk-sts": "3.461.0",
+        "@aws-sdk/middleware-signing": "3.461.0",
+        "@aws-sdk/middleware-user-agent": "3.460.0",
+        "@aws-sdk/region-config-resolver": "3.451.0",
+        "@aws-sdk/types": "3.460.0",
+        "@aws-sdk/util-endpoints": "3.460.0",
+        "@aws-sdk/util-user-agent-browser": "3.460.0",
+        "@aws-sdk/util-user-agent-node": "3.460.0",
+        "@smithy/config-resolver": "^2.0.18",
+        "@smithy/fetch-http-handler": "^2.2.6",
+        "@smithy/hash-node": "^2.0.15",
+        "@smithy/invalid-dependency": "^2.0.13",
+        "@smithy/middleware-content-length": "^2.0.15",
+        "@smithy/middleware-endpoint": "^2.2.0",
+        "@smithy/middleware-retry": "^2.0.20",
+        "@smithy/middleware-serde": "^2.0.13",
+        "@smithy/middleware-stack": "^2.0.7",
+        "@smithy/node-config-provider": "^2.1.5",
+        "@smithy/node-http-handler": "^2.1.9",
+        "@smithy/protocol-http": "^3.0.9",
+        "@smithy/smithy-client": "^2.1.15",
+        "@smithy/types": "^2.5.0",
+        "@smithy/url-parser": "^2.0.13",
+        "@smithy/util-base64": "^2.0.1",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.19",
+        "@smithy/util-defaults-mode-node": "^2.0.25",
+        "@smithy/util-endpoints": "^1.0.4",
+        "@smithy/util-retry": "^2.0.6",
+        "@smithy/util-utf8": "^2.0.2",
+        "fast-xml-parser": "4.2.5",
         "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/config-resolver": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.310.0.tgz",
-      "integrity": "sha512-8vsT+/50lOqfDxka9m/rRt6oxv1WuGZoP8oPMk0Dt+TxXMbAzf4+rejBgiB96wshI1k3gLokYRjSQZn+dDtT8g==",
-      "optional": true,
-      "peer": true,
+    "node_modules/@aws-sdk/core": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.451.0.tgz",
+      "integrity": "sha512-SamWW2zHEf1ZKe3j1w0Piauryl8BQIlej0TBS18A4ACzhjhWXhCs13bO1S88LvPR5mBFXok3XOT6zPOnKDFktw==",
+      "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/util-config-provider": "3.310.0",
-        "@aws-sdk/util-middleware": "3.310.0",
+        "@smithy/smithy-client": "^2.1.15",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -414,15 +370,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-cognito-identity": {
-      "version": "3.325.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.325.0.tgz",
-      "integrity": "sha512-5tTBLfzPu3r/0PNXle9sy6B9gTTtbg8hB9aSON7Xs1XSUDD3MjDQ8HVwIvqtTSTipyXRq8UbEmrWWuZwywinIg==",
-      "optional": true,
-      "peer": true,
+      "version": "3.462.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.462.0.tgz",
+      "integrity": "sha512-oTN5PXFidfadOC+Ar1gZrRkvOTDzk4FZCf47Eqf6Spfm/Z58iQ8GuZ99uh98oQJZlcbYx8hCeuffRLQtPZS20Q==",
+      "dev": true,
       "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.325.0",
-        "@aws-sdk/property-provider": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/client-cognito-identity": "3.462.0",
+        "@aws-sdk/types": "3.460.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/types": "^2.5.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -430,31 +386,34 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.310.0.tgz",
-      "integrity": "sha512-vvIPQpI16fj95xwS7M3D48F7QhZJBnnCgB5lR+b7So+vsG9ibm1mZRVGzVpdxCvgyOhHFbvrby9aalNJmmIP1A==",
-      "optional": true,
-      "peer": true,
+      "version": "3.460.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.460.0.tgz",
+      "integrity": "sha512-WWdaRJFuYRc2Ue9NKDy2NIf8pQRNx/QRVmrsk6EkIID8uWlQIOePk3SWTVV0TZIyPrbfSEaSnJRZoShphJ6PAg==",
+      "dev": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/types": "3.460.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/types": "^2.5.0",
         "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/credential-provider-imds": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.310.0.tgz",
-      "integrity": "sha512-baxK7Zp6dai5AGW01FIW27xS2KAaPUmKLIXv5SvFYsUgXXvNW55im4uG3b+2gA0F7V+hXvVBH08OEqmwW6we5w==",
-      "optional": true,
-      "peer": true,
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.460.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.460.0.tgz",
+      "integrity": "sha512-tLnuLDsGcBRemj8jxt1MkerjwsQlYdwnlfQXvrYOO8qMrbFP2sEjAx165GeCbsjmY/y0w1UFQEV+xRpFg5dxUw==",
+      "dev": true,
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.310.0",
-        "@aws-sdk/property-provider": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/url-parser": "3.310.0",
+        "@aws-sdk/types": "3.460.0",
+        "@smithy/fetch-http-handler": "^2.2.6",
+        "@smithy/node-http-handler": "^2.1.9",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/protocol-http": "^3.0.9",
+        "@smithy/smithy-client": "^2.1.15",
+        "@smithy/types": "^2.5.0",
+        "@smithy/util-stream": "^2.0.20",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -462,20 +421,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.325.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.325.0.tgz",
-      "integrity": "sha512-jvNEHU4zEBbtvf2JqiC2ENb0Y55BurA5X6KVBP1vA3mvn7+zIGH9qD1nAkpvrRelzuorbC5Ey7AmZshR+AugTg==",
-      "optional": true,
-      "peer": true,
+      "version": "3.460.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.460.0.tgz",
+      "integrity": "sha512-1IEUmyaWzt2M3mONO8QyZtPy0f9ccaEjCo48ZQLgptWxUI+Ohga9gPK0mqu1kTJOjv4JJGACYHzLwEnnpltGlA==",
+      "dev": true,
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.310.0",
-        "@aws-sdk/credential-provider-imds": "3.310.0",
-        "@aws-sdk/credential-provider-process": "3.310.0",
-        "@aws-sdk/credential-provider-sso": "3.325.0",
-        "@aws-sdk/credential-provider-web-identity": "3.310.0",
-        "@aws-sdk/property-provider": "3.310.0",
-        "@aws-sdk/shared-ini-file-loader": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/credential-provider-env": "3.460.0",
+        "@aws-sdk/credential-provider-process": "3.460.0",
+        "@aws-sdk/credential-provider-sso": "3.460.0",
+        "@aws-sdk/credential-provider-web-identity": "3.460.0",
+        "@aws-sdk/types": "3.460.0",
+        "@smithy/credential-provider-imds": "^2.0.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/types": "^2.5.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -483,21 +442,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.325.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.325.0.tgz",
-      "integrity": "sha512-SG3F3yywnSzYcG5diErez9ukG8tToQIksedL/pM/gYFJ1zKYH560VJRc7Rkt0yjnl2cPFewazvPoDLBN/5Azbw==",
-      "optional": true,
-      "peer": true,
+      "version": "3.460.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.460.0.tgz",
+      "integrity": "sha512-PbPo92WIgNlF6V4eWKehYGYjTqf0gU9vr09LeQUc3bTm1DJhJw1j+HU/3PfQ8LwTkBQePO7MbJ5A2n6ckMwfMg==",
+      "dev": true,
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.310.0",
-        "@aws-sdk/credential-provider-imds": "3.310.0",
-        "@aws-sdk/credential-provider-ini": "3.325.0",
-        "@aws-sdk/credential-provider-process": "3.310.0",
-        "@aws-sdk/credential-provider-sso": "3.325.0",
-        "@aws-sdk/credential-provider-web-identity": "3.310.0",
-        "@aws-sdk/property-provider": "3.310.0",
-        "@aws-sdk/shared-ini-file-loader": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/credential-provider-env": "3.460.0",
+        "@aws-sdk/credential-provider-ini": "3.460.0",
+        "@aws-sdk/credential-provider-process": "3.460.0",
+        "@aws-sdk/credential-provider-sso": "3.460.0",
+        "@aws-sdk/credential-provider-web-identity": "3.460.0",
+        "@aws-sdk/types": "3.460.0",
+        "@smithy/credential-provider-imds": "^2.0.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/types": "^2.5.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -505,15 +464,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.310.0.tgz",
-      "integrity": "sha512-h73sg6GPMUWC+3zMCbA1nZ2O03nNJt7G96JdmnantiXBwHpRKWW8nBTLzx5uhXn6hTuTaoQRP/P+oxQJKYdMmA==",
-      "optional": true,
-      "peer": true,
+      "version": "3.460.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.460.0.tgz",
+      "integrity": "sha512-ng+0FMc4EaxLAwdttCwf2nzNf4AgcqAHZ8pKXUf8qF/KVkoyTt3UZKW7P2FJI01zxwP+V4yAwVt95PBUKGn4YQ==",
+      "dev": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.310.0",
-        "@aws-sdk/shared-ini-file-loader": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/types": "3.460.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/types": "^2.5.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -521,17 +480,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.325.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.325.0.tgz",
-      "integrity": "sha512-Te7jxJwjVGJAPWN3jCq2xcYrX8d4WkZFIqSIWSmrHqGKgWPc8+QgUkpRQkHaM+4NeNBJadRG1XbJNfu22gjDWA==",
-      "optional": true,
-      "peer": true,
+      "version": "3.460.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.460.0.tgz",
+      "integrity": "sha512-KnrQieOw17+aHEzE3SwfxjeSQ5ZTe2HeAzxkaZF++GxhNul/PkVnLzjGpIuB9bn71T9a2oNfG3peDUA+m2l2kw==",
+      "dev": true,
       "dependencies": {
-        "@aws-sdk/client-sso": "3.325.0",
-        "@aws-sdk/property-provider": "3.310.0",
-        "@aws-sdk/shared-ini-file-loader": "3.310.0",
-        "@aws-sdk/token-providers": "3.325.0",
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/client-sso": "3.460.0",
+        "@aws-sdk/token-providers": "3.460.0",
+        "@aws-sdk/types": "3.460.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/types": "^2.5.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -539,14 +498,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.310.0.tgz",
-      "integrity": "sha512-H4SzuZXILNhK6/IR1uVvsUDZvzc051hem7GLyYghBCu8mU+tq28YhKE8MfSroi6eL2e5Vujloij1OM2EQQkPkw==",
-      "optional": true,
-      "peer": true,
+      "version": "3.460.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.460.0.tgz",
+      "integrity": "sha512-7OeaZgC3HmJZGE0I0ZiKInUMF2LyA0IZiW85AYFnAZzAIfv1cXk/1UnDAoFIQhOZfnUBXivStagz892s480ryw==",
+      "dev": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/types": "3.460.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/types": "^2.5.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -554,111 +513,26 @@
       }
     },
     "node_modules/@aws-sdk/credential-providers": {
-      "version": "3.325.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.325.0.tgz",
-      "integrity": "sha512-PUs8Na+RVnzpX+ZXCA85Im5OMdBuHfLN7FjFCuMuGDqOFFNNTQkqsXZ5RaSOKAYaKafY4e/dTd/zvxzB4o3ijg==",
-      "optional": true,
-      "peer": true,
+      "version": "3.462.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.462.0.tgz",
+      "integrity": "sha512-M5XBK3NPbuDmZPUPlpiKeS0NxLNq/ihpEP0ZjFKwOi2fToXt3x8LqZ0e6o8NDl4UqjHtgEewu8Wwrl4paTmc1A==",
+      "dev": true,
       "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.325.0",
-        "@aws-sdk/client-sso": "3.325.0",
-        "@aws-sdk/client-sts": "3.325.0",
-        "@aws-sdk/credential-provider-cognito-identity": "3.325.0",
-        "@aws-sdk/credential-provider-env": "3.310.0",
-        "@aws-sdk/credential-provider-imds": "3.310.0",
-        "@aws-sdk/credential-provider-ini": "3.325.0",
-        "@aws-sdk/credential-provider-node": "3.325.0",
-        "@aws-sdk/credential-provider-process": "3.310.0",
-        "@aws-sdk/credential-provider-sso": "3.325.0",
-        "@aws-sdk/credential-provider-web-identity": "3.310.0",
-        "@aws-sdk/property-provider": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/fetch-http-handler": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.310.0.tgz",
-      "integrity": "sha512-Bi9vIwzdkw1zMcvi/zGzlWS9KfIEnAq4NNhsnCxbQ4OoIRU9wvU+WGZdBBhxg0ZxZmpp1j1aZhU53lLjA07MHw==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/querystring-builder": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "node_modules/@aws-sdk/hash-node": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.310.0.tgz",
-      "integrity": "sha512-NvE2fhRc8GRwCXBfDehxVAWCmVwVMILliAKVPAEr4yz2CkYs0tqU51S48x23dtna07H4qHtgpeNqVTthcIQOEQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/util-buffer-from": "3.310.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/invalid-dependency": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.310.0.tgz",
-      "integrity": "sha512-1s5RG5rSPXoa/aZ/Kqr5U/7lqpx+Ry81GprQ2bxWqJvWQIJ0IRUwo5pk8XFxbKVr/2a+4lZT/c3OGoBOM1yRRA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "node_modules/@aws-sdk/is-array-buffer": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
-      "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-content-length": {
-      "version": "3.325.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.325.0.tgz",
-      "integrity": "sha512-t38VBKCpNqSKqSu0OfWMJs7cwaRHFGQxIF9lV8JMCM/2lyUpN4JcfuzSTK+MFN2eDZEHp5DiNg8w07GXXusRYg==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-endpoint": {
-      "version": "3.325.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.325.0.tgz",
-      "integrity": "sha512-3CavuOHCKiWUnCtzrUFbhbEP26qIgzzRs5C3vpOJhDUhugBubIWgPGGRLpbnIro+P4XJPwM3pMziNzhKVuSDlQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/middleware-serde": "3.325.0",
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/url-parser": "3.310.0",
-        "@aws-sdk/util-middleware": "3.310.0",
+        "@aws-sdk/client-cognito-identity": "3.462.0",
+        "@aws-sdk/client-sso": "3.460.0",
+        "@aws-sdk/client-sts": "3.462.0",
+        "@aws-sdk/credential-provider-cognito-identity": "3.462.0",
+        "@aws-sdk/credential-provider-env": "3.460.0",
+        "@aws-sdk/credential-provider-http": "3.460.0",
+        "@aws-sdk/credential-provider-ini": "3.460.0",
+        "@aws-sdk/credential-provider-node": "3.460.0",
+        "@aws-sdk/credential-provider-process": "3.460.0",
+        "@aws-sdk/credential-provider-sso": "3.460.0",
+        "@aws-sdk/credential-provider-web-identity": "3.460.0",
+        "@aws-sdk/types": "3.460.0",
+        "@smithy/credential-provider-imds": "^2.0.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/types": "^2.5.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -666,14 +540,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.325.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.325.0.tgz",
-      "integrity": "sha512-IN28gsxcRy4J+FxxCHvzb2NORBx8uMA+h9QYS4BBZfpKVYIZh+mudHgYcdNHWlKXmlTGjhWBNWTeByhzuSKAiA==",
-      "optional": true,
-      "peer": true,
+      "version": "3.460.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.460.0.tgz",
+      "integrity": "sha512-qBeDyuJkEuHe87Xk6unvFO9Zg5j6zM8bQOOZITocTLfu9JN0u5V4GQ/yopvpv+nQHmC/MGr0G7p+kIXMrg/Q2A==",
+      "dev": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/types": "3.460.0",
+        "@smithy/protocol-http": "^3.0.9",
+        "@smithy/types": "^2.5.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -681,13 +555,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.325.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.325.0.tgz",
-      "integrity": "sha512-S8rWgTpN2b/+UDDm+yZMFM6rw1zwO8KT0GAIQbAhB96shyD5eKen/UfihCTB7YMvbD2piebymwJTvxv6bn1VqQ==",
-      "optional": true,
-      "peer": true,
+      "version": "3.460.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.460.0.tgz",
+      "integrity": "sha512-w2AJ6HOJ+Ggx9+VDKuWBHk5S0ZxYEo2EY2IFh0qtCQ1RDix/ur1QEzOOL5vNjHlZKPv/dseIwhgsTCac8UHXbQ==",
+      "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/types": "3.460.0",
+        "@smithy/types": "^2.5.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -695,62 +569,29 @@
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.325.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.325.0.tgz",
-      "integrity": "sha512-2l1ABF7KePsoKz8KaNvD2uxo1zHqkFHK4PL/wW/FbcwOcE08f0R7qX++st/bPpVjXX/j/5vWTnNNgJOIOrZhyw==",
-      "optional": true,
-      "peer": true,
+      "version": "3.460.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.460.0.tgz",
+      "integrity": "sha512-wmzm1/2NzpcCVCAsGqqiTBK+xNyLmQwTOq63rcW6eeq6gYOO0cyTZROOkVRrrsKWPBigrSFFHvDrEvonOMtKAg==",
+      "dev": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/types": "3.460.0",
+        "@smithy/protocol-http": "^3.0.9",
+        "@smithy/types": "^2.5.0",
         "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-retry": {
-      "version": "3.325.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.325.0.tgz",
-      "integrity": "sha512-oQM5AI3vkNQuCakBMgdohOcvRnVYcBBlv+KzCCj07ue9gk0x2dHOZY2pqTQ2CYilRqS/X1PtLogJXoyHP5Wvwg==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/service-error-classification": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/util-middleware": "3.310.0",
-        "@aws-sdk/util-retry": "3.310.0",
-        "tslib": "^2.5.0",
-        "uuid": "^8.3.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-sts": {
-      "version": "3.325.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.325.0.tgz",
-      "integrity": "sha512-deRK1ZuNueQ6OOTEhBZ9bLmjPema/N3cwbtO+tDVwpi7MipjE4EZDXX8WL0xza5YLRnz9kxcHuyfL47vvKgO3A==",
-      "optional": true,
-      "peer": true,
+      "version": "3.461.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.461.0.tgz",
+      "integrity": "sha512-sgNxkwKdJ/NZm7SJZBnbYPkbspmzn3lDyRSJH7PTCvyzDBzY2PB6yS/dfnGkitR+PYwromuOYMha37W4su2SOw==",
+      "dev": true,
       "dependencies": {
-        "@aws-sdk/middleware-signing": "3.325.0",
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-serde": {
-      "version": "3.325.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.325.0.tgz",
-      "integrity": "sha512-QAZYaFfAw1a06Vg39JiYIq0kSJ6EuUPOiKfK/Goj0cBv78lrXWuKdf04UF3U8Rqk/4mamnsTqUSwf4NoKkF0hw==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/middleware-signing": "3.461.0",
+        "@aws-sdk/types": "3.460.0",
+        "@smithy/types": "^2.5.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -758,30 +599,17 @@
       }
     },
     "node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.325.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.325.0.tgz",
-      "integrity": "sha512-SOwPwaCE3vSCGwFzkIlnOUSkeCUzKTyIQnFVjlQkqGuMxMX/iDaQQGaX+HUbuGIuULCEQqjZH4dLKZcor8eVZw==",
-      "optional": true,
-      "peer": true,
+      "version": "3.461.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.461.0.tgz",
+      "integrity": "sha512-aM/7VupHlsgeRG1UZSAQMWJX+2Jam4GG8ZGVAbLfBr9yh9cBwnUUndpUpYI9rU7atA8n+vISr162EbR7WTiFhQ==",
+      "dev": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.310.0",
-        "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/signature-v4": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/util-middleware": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-stack": {
-      "version": "3.325.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.325.0.tgz",
-      "integrity": "sha512-cZWehA4grGvX1IKlY9atJgD0bq3ew7YRJgY7GA6DSgsU7GrZ61Qvi+H7IuGx5AdeAwaTnbnTGN4qCaA2EfxNhA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
+        "@aws-sdk/types": "3.460.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/protocol-http": "^3.0.9",
+        "@smithy/signature-v4": "^2.0.0",
+        "@smithy/types": "^2.5.0",
+        "@smithy/util-middleware": "^2.0.6",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -789,163 +617,31 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.325.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.325.0.tgz",
-      "integrity": "sha512-2aIdGId4o8eIStm1J1aWZwNDf6nvrwg5Nx7BomLAxKZ4lkH8knzXDtxaZR4ElcTsBlBcYxz2gbsrScMyKRDTGA==",
-      "optional": true,
-      "peer": true,
+      "version": "3.460.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.460.0.tgz",
+      "integrity": "sha512-0gBSOCr+RtwRUCSRLn9H3RVnj9ercvk/QKTHIr33CgfEdyZtIGpHWUSs6uqiQydPTRzjCm5SfUa6ESGhRVMM6A==",
+      "dev": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/util-endpoints": "3.319.0",
+        "@aws-sdk/types": "3.460.0",
+        "@aws-sdk/util-endpoints": "3.460.0",
+        "@smithy/protocol-http": "^3.0.9",
+        "@smithy/types": "^2.5.0",
         "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/node-config-provider": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.310.0.tgz",
-      "integrity": "sha512-T/Pp6htc6hq/Cq+MLNDSyiwWCMVF6GqbBbXKVlO5L8rdHx4sq9xPdoPveZhGWrxvkanjA6eCwUp6E0riBOSVng==",
-      "optional": true,
-      "peer": true,
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.451.0.tgz",
+      "integrity": "sha512-3iMf4OwzrFb4tAAmoROXaiORUk2FvSejnHIw/XHvf/jjR4EqGGF95NZP/n/MeFZMizJWVssrwS412GmoEyoqhg==",
+      "dev": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.310.0",
-        "@aws-sdk/shared-ini-file-loader": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/node-http-handler": {
-      "version": "3.321.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.321.1.tgz",
-      "integrity": "sha512-DdQBrtFFDNtzphJIN3s93Vf+qd9LHSzH6WTQRrWoXhTDMHDzSI2Cn+c5KWfk89Nggp/n3+OTwUPQeCiBT5EBuw==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/abort-controller": "3.310.0",
-        "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/querystring-builder": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/property-provider": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.310.0.tgz",
-      "integrity": "sha512-3lxDb0akV6BBzmFe4nLPaoliQbAifyWJhuvuDOu7e8NzouvpQXs0275w9LePhhcgjKAEVXUIse05ZW2DLbxo/g==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/protocol-http": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.310.0.tgz",
-      "integrity": "sha512-fgZ1aw/irQtnrsR58pS8ThKOWo57Py3xX6giRvwSgZDEcxHfVzuQjy9yPuV++v04fdmdtgpbGf8WfvAAJ11yXQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/querystring-builder": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.310.0.tgz",
-      "integrity": "sha512-ZHH8GV/80+pWGo7DzsvwvXR5xVxUHXUvPJPFAkhr6nCf78igdoF8gR10ScFoEKbtEapoNTaZlKHPXxpD8aPG7A==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/util-uri-escape": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/querystring-parser": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.310.0.tgz",
-      "integrity": "sha512-YkIznoP6lsiIUHinx++/lbb3tlMURGGqMpo0Pnn32zYzGrJXA6eC3D0as2EcMjo55onTfuLcIiX4qzXes2MYOA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/service-error-classification": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.310.0.tgz",
-      "integrity": "sha512-PuyC7k3qfIKeH2LCnDwbttMOKq3qAx4buvg0yfnJtQOz6t1AR8gsnAq0CjKXXyfkXwNKWTqCpE6lVNUIkXgsMw==",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/shared-ini-file-loader": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.310.0.tgz",
-      "integrity": "sha512-N0q9pG0xSjQwc690YQND5bofm+4nfUviQ/Ppgan2kU6aU0WUq8KwgHJBto/YEEI+VlrME30jZJnxtOvcZJc2XA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/signature-v4": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.310.0.tgz",
-      "integrity": "sha512-1M60P1ZBNAjCFv9sYW29OF6okktaeibWyW3lMXqzoHF70lHBZh+838iUchznXUA5FLabfn4jBFWMRxlAXJUY2Q==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/util-hex-encoding": "3.310.0",
-        "@aws-sdk/util-middleware": "3.310.0",
-        "@aws-sdk/util-uri-escape": "3.310.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/smithy-client": {
-      "version": "3.325.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.325.0.tgz",
-      "integrity": "sha512-sqDFuhjxd8+Q9qI8MmXe/g1/FgoViwetv14K+bpHK7pGlOIvDyT7TboDNClfgqSLdgTDCEaoC3JRSi9Y5RgbmA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/middleware-stack": "3.325.0",
-        "@aws-sdk/types": "3.310.0",
+        "@smithy/node-config-provider": "^2.1.5",
+        "@smithy/types": "^2.5.0",
+        "@smithy/util-config-provider": "^2.0.0",
+        "@smithy/util-middleware": "^2.0.6",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -953,16 +649,47 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.325.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.325.0.tgz",
-      "integrity": "sha512-h/ecgqXaMwEkUWo+SZJNcOMWJkAknjonWWpK/vQ4uz+qE9rBqRugsIeIiey+Ij7zCtwh6WhtpfCpt5RbxRHe6g==",
-      "optional": true,
-      "peer": true,
+      "version": "3.460.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.460.0.tgz",
+      "integrity": "sha512-EvSIPMI1gXk3gEkdtbZCW+p3Bjmt2gOR1m7ibQD7qLj4l0dKXhp4URgTqB1ExH3S4qUq0M/XSGKbGLZpvunHNg==",
+      "dev": true,
       "dependencies": {
-        "@aws-sdk/client-sso-oidc": "3.325.0",
-        "@aws-sdk/property-provider": "3.310.0",
-        "@aws-sdk/shared-ini-file-loader": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/middleware-host-header": "3.460.0",
+        "@aws-sdk/middleware-logger": "3.460.0",
+        "@aws-sdk/middleware-recursion-detection": "3.460.0",
+        "@aws-sdk/middleware-user-agent": "3.460.0",
+        "@aws-sdk/region-config-resolver": "3.451.0",
+        "@aws-sdk/types": "3.460.0",
+        "@aws-sdk/util-endpoints": "3.460.0",
+        "@aws-sdk/util-user-agent-browser": "3.460.0",
+        "@aws-sdk/util-user-agent-node": "3.460.0",
+        "@smithy/config-resolver": "^2.0.18",
+        "@smithy/fetch-http-handler": "^2.2.6",
+        "@smithy/hash-node": "^2.0.15",
+        "@smithy/invalid-dependency": "^2.0.13",
+        "@smithy/middleware-content-length": "^2.0.15",
+        "@smithy/middleware-endpoint": "^2.2.0",
+        "@smithy/middleware-retry": "^2.0.20",
+        "@smithy/middleware-serde": "^2.0.13",
+        "@smithy/middleware-stack": "^2.0.7",
+        "@smithy/node-config-provider": "^2.1.5",
+        "@smithy/node-http-handler": "^2.1.9",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/protocol-http": "^3.0.9",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/smithy-client": "^2.1.15",
+        "@smithy/types": "^2.5.0",
+        "@smithy/url-parser": "^2.0.13",
+        "@smithy/util-base64": "^2.0.1",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.19",
+        "@smithy/util-defaults-mode-node": "^2.0.25",
+        "@smithy/util-endpoints": "^1.0.4",
+        "@smithy/util-retry": "^2.0.6",
+        "@smithy/util-utf8": "^2.0.2",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -970,149 +697,26 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.310.0.tgz",
-      "integrity": "sha512-j8eamQJ7YcIhw7fneUfs8LYl3t01k4uHi4ZDmNRgtbmbmTTG3FZc2MotStZnp3nZB6vLiPF1o5aoJxWVvkzS6A==",
-      "optional": true,
-      "peer": true,
+      "version": "3.460.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.460.0.tgz",
+      "integrity": "sha512-MyZSWS/FV8Bnux5eD9en7KLgVxevlVrGNEP3X2D7fpnUlLhl0a7k8+OpSI2ozEQB8hIU2DLc/XXTKRerHSefxQ==",
+      "dev": true,
       "dependencies": {
+        "@smithy/types": "^2.5.0",
         "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/url-parser": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.310.0.tgz",
-      "integrity": "sha512-mCLnCaSB9rQvAgx33u0DujLvr4d5yEm/W5r789GblwwQnlNXedVu50QRizMLTpltYWyAUoXjJgQnJHmJMaKXhw==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/querystring-parser": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-base64": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz",
-      "integrity": "sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-body-length-browser": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.310.0.tgz",
-      "integrity": "sha512-sxsC3lPBGfpHtNTUoGXMQXLwjmR0zVpx0rSvzTPAuoVILVsp5AU/w5FphNPxD5OVIjNbZv9KsKTuvNTiZjDp9g==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-body-length-node": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.310.0.tgz",
-      "integrity": "sha512-2tqGXdyKhyA6w4zz7UPoS8Ip+7sayOg9BwHNidiGm2ikbDxm1YrCfYXvCBdwaJxa4hJfRVz+aL9e+d3GqPI9pQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-buffer-from": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
-      "integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-config-provider": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.310.0.tgz",
-      "integrity": "sha512-xIBaYo8dwiojCw8vnUcIL4Z5tyfb1v3yjqyJKJWV/dqKUFOOS0U591plmXbM+M/QkXyML3ypon1f8+BoaDExrg==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.325.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.325.0.tgz",
-      "integrity": "sha512-gcowpXTo8E8N3jxD2KW+csiicJ7HPkhWnpL925xgwe0oq091OpATsKFrBOL18h72VfRWf4FAsR9lVwxSQ78zSA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-defaults-mode-node": {
-      "version": "3.325.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.325.0.tgz",
-      "integrity": "sha512-/5uoOrgNxoUxv3AwsdXjMA3f6KJA6fi69otA0RiINjilCdcbOxq5GI11AFEyRio/+e+imriX4+UYjsguUR+f4g==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/config-resolver": "3.310.0",
-        "@aws-sdk/credential-provider-imds": "3.310.0",
-        "@aws-sdk/node-config-provider": "3.310.0",
-        "@aws-sdk/property-provider": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.319.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.319.0.tgz",
-      "integrity": "sha512-3I64UMoYA2e2++oOUJXRcFtYLpLylnZFRltWfPo1B3dLlf+MIWat9djT+mMus+hW1ntLsvAIVu1hLVePJC0gvw==",
-      "optional": true,
-      "peer": true,
+      "version": "3.460.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.460.0.tgz",
+      "integrity": "sha512-myH6kM5WP4IWULHDHMYf2Q+BCYVGlzqJgiBmO10kQEtJSeAGZZ49eoFFYgKW8ZAYB5VnJ+XhXVB1TRA+vR4l5A==",
+      "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-hex-encoding": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
-      "integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
+        "@aws-sdk/types": "3.460.0",
+        "@smithy/util-endpoints": "^1.0.4",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1123,48 +727,7 @@
       "version": "3.310.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.310.0.tgz",
       "integrity": "sha512-qo2t/vBTnoXpjKxlsC2e1gBrRm80M3bId27r0BRB2VniSSe7bL1mmzM+/HFtujm0iAxtPM+aLEflLJlJeDPg0w==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-middleware": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.310.0.tgz",
-      "integrity": "sha512-FTSUKL/eRb9X6uEZClrTe27QFXUNNp7fxYrPndZwk1hlaOP5ix+MIHBcI7pIiiY/JPfOUmPyZOu+HetlFXjWog==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-retry": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.310.0.tgz",
-      "integrity": "sha512-FwWGhCBLfoivTMUHu1LIn4NjrN9JLJ/aX5aZmbcPIOhZVFJj638j0qDgZXyfvVqBuBZh7M8kGq0Oahy3dp69OA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/service-error-classification": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-uri-escape": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
-      "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
-      "optional": true,
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -1173,26 +736,26 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.310.0.tgz",
-      "integrity": "sha512-yU/4QnHHuQ5z3vsUqMQVfYLbZGYwpYblPiuZx4Zo9+x0PBkNjYMqctdDcrpoH9Z2xZiDN16AmQGK1tix117ZKw==",
-      "optional": true,
-      "peer": true,
+      "version": "3.460.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.460.0.tgz",
+      "integrity": "sha512-FRCzW+TyjKnvxsargPVrjayBfp/rvObYHZyZ2OSqrVw8lkkPCb4e/WZOeIiXZuhdhhoah7wMuo6zGwtFF3bYKg==",
+      "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/types": "3.460.0",
+        "@smithy/types": "^2.5.0",
         "bowser": "^2.11.0",
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.310.0.tgz",
-      "integrity": "sha512-Ra3pEl+Gn2BpeE7KiDGpi4zj7WJXZA5GXnGo3mjbi9+Y3zrbuhJAbdZO3mO/o7xDgMC6ph4xCTbaSGzU6b6EDg==",
-      "optional": true,
-      "peer": true,
+      "version": "3.460.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.460.0.tgz",
+      "integrity": "sha512-+kSoR9ABGpJ5Xc7v0VwpgTQbgyI4zuezC8K4pmKAGZsSsVWg4yxptoy2bDqoFL7qfRlWviMVTkQRMvR4D44WxA==",
+      "dev": true,
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/types": "3.460.0",
+        "@smithy/node-config-provider": "^2.1.5",
+        "@smithy/types": "^2.5.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1207,26 +770,11 @@
         }
       }
     },
-    "node_modules/@aws-sdk/util-utf8": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.310.0.tgz",
-      "integrity": "sha512-DnLfFT8uCO22uOJc0pt0DsSNau1GTisngBCDw8jQuWT5CqogMJu4b/uXmwEqfj8B3GX6Xsz8zOd6JpRlPftQoA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/util-utf8-browser": {
       "version": "3.259.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
       "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
-      "optional": true,
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
       }
@@ -2634,6 +2182,546 @@
       "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
       "dev": true
     },
+    "node_modules/@smithy/abort-controller": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.14.tgz",
+      "integrity": "sha512-zXtteuYLWbSXnzI3O6xq3FYvigYZFW8mdytGibfarLL2lxHto9L3ILtGVnVGmFZa7SDh62l39EnU5hesLN87Fw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^2.6.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/config-resolver": {
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.19.tgz",
+      "integrity": "sha512-JsghnQ5zjWmjEVY8TFOulLdEOCj09SjRLugrHlkPZTIBBm7PQitCFVLThbsKPZQOP7N3ME1DU1nKUc1UaVnBog==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/node-config-provider": "^2.1.6",
+        "@smithy/types": "^2.6.0",
+        "@smithy/util-config-provider": "^2.0.0",
+        "@smithy/util-middleware": "^2.0.7",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.1.2.tgz",
+      "integrity": "sha512-Y62jBWdoLPSYjr9fFvJf+KwTa1EunjVr6NryTEWCnwIY93OJxwV4t0qxjwdPl/XMsUkq79ppNJSEQN6Ohnhxjw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/node-config-provider": "^2.1.6",
+        "@smithy/property-provider": "^2.0.15",
+        "@smithy/types": "^2.6.0",
+        "@smithy/url-parser": "^2.0.14",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-codec": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.0.14.tgz",
+      "integrity": "sha512-g/OU/MeWGfHDygoXgMWfG/Xb0QqDnAGcM9t2FRrVAhleXYRddGOEnfanR5cmHgB9ue52MJsyorqFjckzXsylaA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/crc32": "3.0.0",
+        "@smithy/types": "^2.6.0",
+        "@smithy/util-hex-encoding": "^2.0.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.2.7.tgz",
+      "integrity": "sha512-iSDBjxuH9TgrtMYAr7j5evjvkvgwLY3y+9D547uep+JNkZ1ZT+BaeU20j6I/bO/i26ilCWFImrlXTPsfQtZdIQ==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/protocol-http": "^3.0.10",
+        "@smithy/querystring-builder": "^2.0.14",
+        "@smithy/types": "^2.6.0",
+        "@smithy/util-base64": "^2.0.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@smithy/hash-node": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.16.tgz",
+      "integrity": "sha512-Wbi9A0PacMYUOwjAulQP90Wl3mQ6NDwnyrZQzFjDz+UzjXOSyQMgBrTkUBz+pVoYVlX3DUu24gWMZBcit+wOGg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^2.6.0",
+        "@smithy/util-buffer-from": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.14.tgz",
+      "integrity": "sha512-d8ohpwZo9RzTpGlAfsWtfm1SHBSU7+N4iuZ6MzR10xDTujJJWtmXYHK1uzcr7rggbpUTaWyHpPFgnf91q0EFqQ==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^2.6.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.0.0.tgz",
+      "integrity": "sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.16.tgz",
+      "integrity": "sha512-9ddDia3pp1d3XzLXKcm7QebGxLq9iwKf+J1LapvlSOhpF8EM9SjMeSrMOOFgG+2TfW5K3+qz4IAJYYm7INYCng==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/protocol-http": "^3.0.10",
+        "@smithy/types": "^2.6.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.2.1.tgz",
+      "integrity": "sha512-dVDS7HNJl/wb0lpByXor6whqDbb1YlLoaoWYoelyYzLHioXOE7y/0iDwJWtDcN36/tVCw9EPBFZ3aans84jLpg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/middleware-serde": "^2.0.14",
+        "@smithy/node-config-provider": "^2.1.6",
+        "@smithy/shared-ini-file-loader": "^2.2.5",
+        "@smithy/types": "^2.6.0",
+        "@smithy/url-parser": "^2.0.14",
+        "@smithy/util-middleware": "^2.0.7",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry": {
+      "version": "2.0.21",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.21.tgz",
+      "integrity": "sha512-EZS1EXv1k6IJX6hyu/0yNQuPcPaXwG8SWljQHYueyRbOxmqYgoWMWPtfZj0xRRQ4YtLawQSpBgAeiJltq8/MPw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/node-config-provider": "^2.1.6",
+        "@smithy/protocol-http": "^3.0.10",
+        "@smithy/service-error-classification": "^2.0.7",
+        "@smithy/types": "^2.6.0",
+        "@smithy/util-middleware": "^2.0.7",
+        "@smithy/util-retry": "^2.0.7",
+        "tslib": "^2.5.0",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.14.tgz",
+      "integrity": "sha512-hFi3FqoYWDntCYA2IGY6gJ6FKjq2gye+1tfxF2HnIJB5uW8y2DhpRNBSUMoqP+qvYzRqZ6ntv4kgbG+o3pX57g==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^2.6.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.0.8.tgz",
+      "integrity": "sha512-7/N59j0zWqVEKExJcA14MrLDZ/IeN+d6nbkN8ucs+eURyaDUXWYlZrQmMOd/TyptcQv0+RDlgag/zSTTV62y/Q==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^2.6.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.1.6.tgz",
+      "integrity": "sha512-HLqTs6O78m3M3z1cPLFxddxhEPv5MkVatfPuxoVO3A+cHZanNd/H5I6btcdHy6N2CB1MJ/lihJC92h30SESsBA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/property-provider": "^2.0.15",
+        "@smithy/shared-ini-file-loader": "^2.2.5",
+        "@smithy/types": "^2.6.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.1.10.tgz",
+      "integrity": "sha512-lkALAwtN6odygIM4nB8aHDahINM6WXXjNrZmWQAh0RSossySRT2qa31cFv0ZBuAYVWeprskRk13AFvvLmf1WLw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/abort-controller": "^2.0.14",
+        "@smithy/protocol-http": "^3.0.10",
+        "@smithy/querystring-builder": "^2.0.14",
+        "@smithy/types": "^2.6.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider": {
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.15.tgz",
+      "integrity": "sha512-YbRFBn8oiiC3o1Kn3a4KjGa6k47rCM9++5W9cWqYn9WnkyH+hBWgfJAckuxpyA2Hq6Ys4eFrWzXq6fqHEw7iew==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^2.6.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.10.tgz",
+      "integrity": "sha512-6+tjNk7rXW7YTeGo9qwxXj/2BFpJTe37kTj3EnZCoX/nH+NP/WLA7O83fz8XhkGqsaAhLUPo/bB12vvd47nsmg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^2.6.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.14.tgz",
+      "integrity": "sha512-lQ4pm9vTv9nIhl5jt6uVMPludr6syE2FyJmHsIJJuOD7QPIJnrf9HhUGf1iHh9KJ4CUv21tpOU3X6s0rB6uJ0g==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^2.6.0",
+        "@smithy/util-uri-escape": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.14.tgz",
+      "integrity": "sha512-+cbtXWI9tNtQjlgQg3CA+pvL3zKTAxPnG3Pj6MP89CR3vi3QMmD0SOWoq84tqZDnJCxlsusbgIXk1ngMReXo+A==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^2.6.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/service-error-classification": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.0.7.tgz",
+      "integrity": "sha512-LLxgW12qGz8doYto15kZ4x1rHjtXl0BnCG6T6Wb8z2DI4PT9cJfOSvzbuLzy7+5I24PAepKgFeWHRd9GYy3Z9w==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.2.5.tgz",
+      "integrity": "sha512-LHA68Iu7SmNwfAVe8egmjDCy648/7iJR/fK1UnVw+iAOUJoEYhX2DLgVd5pWllqdDiRbQQzgaHLcRokM+UFR1w==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^2.6.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.0.16.tgz",
+      "integrity": "sha512-ilLY85xS2kZZzTb83diQKYLIYALvart0KnBaKnIRnMBHAGEio5aHSlANQoxVn0VsonwmQ3CnWhnCT0sERD8uTg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/eventstream-codec": "^2.0.14",
+        "@smithy/is-array-buffer": "^2.0.0",
+        "@smithy/types": "^2.6.0",
+        "@smithy/util-hex-encoding": "^2.0.0",
+        "@smithy/util-middleware": "^2.0.7",
+        "@smithy/util-uri-escape": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.1.16.tgz",
+      "integrity": "sha512-Lw67+yQSpLl4YkDLUzI2KgS8TXclXmbzSeOJUmRFS4ueT56B4pw3RZRF/SRzvgyxM/HxgkUan8oSHXCujPDafQ==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/middleware-stack": "^2.0.8",
+        "@smithy/types": "^2.6.0",
+        "@smithy/util-stream": "^2.0.21",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.6.0.tgz",
+      "integrity": "sha512-PgqxJq2IcdMF9iAasxcqZqqoOXBHufEfmbEUdN1pmJrJltT42b0Sc8UiYSWWzKkciIp9/mZDpzYi4qYG1qqg6g==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.14.tgz",
+      "integrity": "sha512-kbu17Y1AFXi5lNlySdDj7ZzmvupyWKCX/0jNZ8ffquRyGdbDZb+eBh0QnWqsSmnZa/ctyWaTf7n4l/pXLExrnw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/querystring-parser": "^2.0.14",
+        "@smithy/types": "^2.6.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.0.1.tgz",
+      "integrity": "sha512-DlI6XFYDMsIVN+GH9JtcRp3j02JEVuWIn/QOZisVzpIAprdsxGveFed0bjbMRCqmIFe8uetn5rxzNrBtIGrPIQ==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-browser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.0.0.tgz",
+      "integrity": "sha512-JdDuS4ircJt+FDnaQj88TzZY3+njZ6O+D3uakS32f2VNnDo3vyEuNdBOh/oFd8Df1zSZOuH1HEChk2AOYDezZg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.1.0.tgz",
+      "integrity": "sha512-/li0/kj/y3fQ3vyzn36NTLGmUwAICb7Jbe/CsWCktW363gh1MOcpEcSO3mJ344Gv2dqz8YJCLQpb6hju/0qOWw==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.0.0.tgz",
+      "integrity": "sha512-/YNnLoHsR+4W4Vf2wL5lGv0ksg8Bmk3GEGxn2vEQt52AQaPSCuaO5PM5VM7lP1K9qHRKHwrPGktqVoAHKWHxzw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-config-provider": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.0.0.tgz",
+      "integrity": "sha512-xCQ6UapcIWKxXHEU4Mcs2s7LcFQRiU3XEluM2WcCjjBtQkUN71Tb+ydGmJFPxMUrW/GWMgQEEGipLym4XG0jZg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.20.tgz",
+      "integrity": "sha512-QJtnbTIl0/BbEASkx1MUFf6EaoWqWW1/IM90N++8NNscePvPf77GheYfpoPis6CBQawUWq8QepTP2QUSAdrVkw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/property-provider": "^2.0.15",
+        "@smithy/smithy-client": "^2.1.16",
+        "@smithy/types": "^2.6.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node": {
+      "version": "2.0.26",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.26.tgz",
+      "integrity": "sha512-lGFPOFCHv1ql019oegYqa54BZH7HREw6EBqjDLbAr0wquMX0BDi2sg8TJ6Eq+JGLijkZbJB73m4+aK8OFAapMg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/config-resolver": "^2.0.19",
+        "@smithy/credential-provider-imds": "^2.1.2",
+        "@smithy/node-config-provider": "^2.1.6",
+        "@smithy/property-provider": "^2.0.15",
+        "@smithy/smithy-client": "^2.1.16",
+        "@smithy/types": "^2.6.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-1.0.5.tgz",
+      "integrity": "sha512-K7qNuCOD5K/90MjHvHm9kJldrfm40UxWYQxNEShMFxV/lCCCRIg8R4uu1PFAxRvPxNpIdcrh1uK6I1ISjDXZJw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/node-config-provider": "^2.1.6",
+        "@smithy/types": "^2.6.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.0.0.tgz",
+      "integrity": "sha512-c5xY+NUnFqG6d7HFh1IFfrm3mGl29lC+vF+geHv4ToiuJCBmIfzx6IeHLg+OgRdPFKDXIw6pvi+p3CsscaMcMA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.0.7.tgz",
+      "integrity": "sha512-tRINOTlf1G9B0ECarFQAtTgMhpnrMPSa+5j4ZEwEawCLfTFTavk6757sxhE4RY5RMlD/I3x+DCS8ZUiR8ho9Pw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^2.6.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.0.7.tgz",
+      "integrity": "sha512-fIe5yARaF0+xVT1XKcrdnHKTJ1Vc4+3e3tLDjCuIcE9b6fkBzzGFY7AFiX4M+vj6yM98DrwkuZeHf7/hmtVp0Q==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/service-error-classification": "^2.0.7",
+        "@smithy/types": "^2.6.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "2.0.21",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.21.tgz",
+      "integrity": "sha512-0BUE16d7n1x7pi1YluXJdB33jOTyBChT0j/BlOkFa9uxfg6YqXieHxjHNuCdJRARa7AZEj32LLLEPJ1fSa4inA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^2.2.7",
+        "@smithy/node-http-handler": "^2.1.10",
+        "@smithy/types": "^2.6.0",
+        "@smithy/util-base64": "^2.0.1",
+        "@smithy/util-buffer-from": "^2.0.0",
+        "@smithy/util-hex-encoding": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-uri-escape": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.0.0.tgz",
+      "integrity": "sha512-ebkxsqinSdEooQduuk9CbKcI+wheijxEb3utGXkCoYQkJnwTnLbH1JXGimJtUkQwNQbsbuYwG2+aFVyZf5TLaw==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.0.2.tgz",
+      "integrity": "sha512-qOiVORSPm6Ce4/Yu6hbSgNHABLP2VMv8QOC3tTDNHHlWY19pPyc++fBTbZPtx6egPXi4HQxKDnMxVxpbtX2GoA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
@@ -3420,8 +3508,7 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
       "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -4635,20 +4722,25 @@
       "dev": true
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
-      "integrity": "sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg==",
-      "optional": true,
-      "peer": true,
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
+      "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
       "dependencies": {
         "strnum": "^1.0.5"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
-      },
-      "funding": {
-        "type": "paypal",
-        "url": "https://paypal.me/naturalintelligence"
       }
     },
     "node_modules/fastq": {
@@ -7894,8 +7986,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
       "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -8296,11 +8387,10 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
-      "optional": true,
-      "peer": true
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "dev": true
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -8536,7 +8626,7 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "devOptional": true,
+      "dev": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     }
   },
   "devDependencies": {
+    "@aws-sdk/credential-providers": "^3.462.0",
     "@iarna/toml": "^2.2.5",
     "@istanbuljs/nyc-config-typescript": "^1.0.2",
     "@microsoft/api-extractor": "^7.35.1",

--- a/test/integration/auth/mongodb_aws.test.ts
+++ b/test/integration/auth/mongodb_aws.test.ts
@@ -1,3 +1,5 @@
+import * as process from 'node:process';
+
 import { expect } from 'chai';
 import * as http from 'http';
 import { performance } from 'perf_hooks';
@@ -5,14 +7,38 @@ import * as sinon from 'sinon';
 
 import { MongoAWSError, type MongoClient, MongoDBAWS, MongoServerError } from '../../mongodb';
 
+function awsSdk() {
+  try {
+    return require('@aws-sdk/credential-providers');
+  } catch {
+    return null;
+  }
+}
+
 describe('MONGODB-AWS', function () {
+  let awsSdkPresent;
   let client: MongoClient;
+
   beforeEach(function () {
     const MONGODB_URI = process.env.MONGODB_URI;
     if (!MONGODB_URI || MONGODB_URI.indexOf('MONGODB-AWS') === -1) {
       this.currentTest.skipReason = 'requires MONGODB_URI to contain MONGODB-AWS auth mechanism';
-      this.skip();
+      return this.skip();
     }
+
+    const { MONGODB_AWS_SDK = 'unset' } = process.env;
+    expect(
+      ['true', 'false'],
+      `Always inform the AWS tests if they run with or without the SDK (MONGODB_AWS_SDK=${MONGODB_AWS_SDK})`
+    ).to.include(MONGODB_AWS_SDK);
+
+    awsSdkPresent = !!awsSdk();
+    expect(
+      awsSdkPresent,
+      MONGODB_AWS_SDK === 'true'
+        ? 'expected aws sdk to be installed'
+        : 'expected aws sdk to not be installed'
+    ).to.be[MONGODB_AWS_SDK];
   });
 
   afterEach(async () => {
@@ -167,13 +193,7 @@ describe('MONGODB-AWS', function () {
 
         const envCheck = () => {
           const { AWS_WEB_IDENTITY_TOKEN_FILE = '' } = process.env;
-          credentialProvider = (() => {
-            try {
-              return require('@aws-sdk/credential-providers');
-            } catch {
-              return null;
-            }
-          })();
+          credentialProvider = awsSdk();
           return AWS_WEB_IDENTITY_TOKEN_FILE.length === 0 || credentialProvider == null;
         };
 

--- a/test/tools/runner/hooks/configuration.js
+++ b/test/tools/runner/hooks/configuration.js
@@ -155,6 +155,7 @@ const testConfigBeforeHook = async function () {
     serverApi: MONGODB_API_VERSION,
     atlas: process.env.ATLAS_CONNECTIVITY != null,
     aws: MONGODB_URI.includes('authMechanism=MONGODB-AWS'),
+    awsSdk: process.env.MONGODB_AWS_SDK,
     azure: MONGODB_URI.includes('PROVIDER_NAME:azure'),
     adl: this.configuration.buildInfo.dataLake
       ? this.configuration.buildInfo.dataLake.version


### PR DESCRIPTION
### Description

#### What is changing?

Track aws sdk in dev deps and skip aws auth tests that do not work without SDK

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

This is to control which version we test with so we can remove vulnerable versions from our matrix

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
