### PR TITLE
feat(NODE-5717): make ExceededTimeLimit retryable reads error

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -1145,14 +1145,12 @@ const RETRYABLE_READ_ERROR_CODES = new Set<number>([
   MONGODB_ERROR_CODES.InterruptedAtShutdown,
   MONGODB_ERROR_CODES.InterruptedDueToReplStateChange,
   MONGODB_ERROR_CODES.NotPrimaryNoSecondaryOk,
-  MONGODB_ERROR_CODES.NotPrimaryOrSecondary
+  MONGODB_ERROR_CODES.NotPrimaryOrSecondary,
+  MONGODB_ERROR_CODES.ExceededTimeLimit
 ]);
 
 // see: https://github.com/mongodb/specifications/blob/master/source/retryable-writes/retryable-writes.rst#terms
-const RETRYABLE_WRITE_ERROR_CODES = new Set<number>([
-  ...RETRYABLE_READ_ERROR_CODES,
-  MONGODB_ERROR_CODES.ExceededTimeLimit
-]);
+const RETRYABLE_WRITE_ERROR_CODES = new Set<number>([...RETRYABLE_READ_ERROR_CODES]);
 
 export function needsRetryableWriteLabel(error: Error, maxWireVersion: number): boolean {
   // pre-4.4 server, then the driver adds an error label for every valid case

--- a/src/error.ts
+++ b/src/error.ts
@@ -1150,7 +1150,7 @@ const RETRYABLE_READ_ERROR_CODES = new Set<number>([
 ]);
 
 // see: https://github.com/mongodb/specifications/blob/master/source/retryable-writes/retryable-writes.rst#terms
-const RETRYABLE_WRITE_ERROR_CODES = new Set<number>([...RETRYABLE_READ_ERROR_CODES]);
+const RETRYABLE_WRITE_ERROR_CODES = RETRYABLE_READ_ERROR_CODES;
 
 export function needsRetryableWriteLabel(error: Error, maxWireVersion: number): boolean {
   // pre-4.4 server, then the driver adds an error label for every valid case

--- a/test/spec/retryable-reads/unified/exceededTimeLimit.json
+++ b/test/spec/retryable-reads/unified/exceededTimeLimit.json
@@ -1,0 +1,147 @@
+{
+  "description": "ExceededTimeLimit is a retryable read",
+  "schemaVersion": "1.3",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "4.0",
+      "topologies": [
+        "single",
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topologies": [
+        "sharded",
+        "load-balanced"
+      ]
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": false,
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "retryable-reads-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "exceededtimelimit-test"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "exceededtimelimit-test",
+      "databaseName": "retryable-reads-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        },
+        {
+          "_id": 2,
+          "x": 22
+        },
+        {
+          "_id": 3,
+          "x": 33
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "Find succeeds on second attempt after ExceededTimeLimit",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "find"
+                ],
+                "errorCode": 262
+              }
+            }
+          }
+        },
+        {
+          "name": "find",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
+            }
+          },
+          "object": "collection0",
+          "expectResult": [
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "exceededtimelimit-test",
+                  "filter": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  }
+                },
+                "commandName": "find",
+                "databaseName": "retryable-reads-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "exceededtimelimit-test",
+                  "filter": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  }
+                },
+                "commandName": "find",
+                "databaseName": "retryable-reads-tests"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/retryable-reads/unified/exceededTimeLimit.yml
+++ b/test/spec/retryable-reads/unified/exceededTimeLimit.yml
@@ -1,0 +1,68 @@
+description: "ExceededTimeLimit is a retryable read"
+
+schemaVersion: "1.3"
+
+runOnRequirements:
+  - minServerVersion: "4.0"
+    topologies: [single, replicaset]
+  - minServerVersion: "4.1.7"
+    topologies: [sharded, load-balanced]
+
+createEntities:
+  - client:
+      id: &client0 client0
+      # Ensure the `configureFailpoint` and `find` commands are run on the same mongos
+      useMultipleMongoses: false
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name "retryable-reads-tests"
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name "exceededtimelimit-test"
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1, x: 11 }
+      - { _id: 2, x: 22 }
+      - { _id: 3, x: 33 }
+
+tests:
+  - description: "Find succeeds on second attempt after ExceededTimeLimit"
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+              failCommands: [ "find" ]
+              errorCode: 262 # ExceededTimeLimit
+      - name: find
+        arguments:
+          filter: { _id: { $gt: 1 } }
+        object: *collection0
+        expectResult:
+          - { _id: 2, x: 22 }
+          - { _id: 3, x: 33 }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                find: *collection0Name
+                filter: { _id: { $gt: 1 } }
+              commandName: find
+              databaseName: *database0Name
+          - commandStartedEvent:
+              command:
+                find: *collection0Name
+                filter: { _id: { $gt: 1 } }
+              commandName: find
+              databaseName: *database0Name


### PR DESCRIPTION
### Description
- Add ExceededTimeLimit to RETRYABLE_READ_ERROR_CODES
- Sync spec tests: https://github.com/mongodb/specifications/commit/5786a46a59cdfeebab36edf6672cdf6f23dd636c

#### What is changing?
Previously ExceededTimeLimit related only to retryable writes errors. Now it belongs both to RETRYABLE_WRITE_ERROR_CODES and RETRYABLE_READ_ERROR_CODES arrays.

##### Is there new documentation needed for these changes?
None

#### What is the motivation for this change?
[NODE-5717](https://jira.mongodb.org/browse/NODE-5717)

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### ExceededTimeLimit was added to the list of error codes that should be retried

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
