### PR TITLE
feat(NODE-4686): Add log messages to CLAM spec

### DIFF
--- a/src/cmap/connection.ts
+++ b/src/cmap/connection.ts
@@ -141,7 +141,8 @@ export interface ConnectionOptions
   socketTimeoutMS?: number;
   cancellationToken?: CancellationToken;
   metadata: ClientMetadata;
-  mongoLogger: MongoLogger | undefined;
+  /** @internal  */
+  mongoLogger?: MongoLogger | undefined;
 }
 
 /** @internal */

--- a/src/cmap/connection.ts
+++ b/src/cmap/connection.ts
@@ -726,8 +726,8 @@ function write(
 
   // if command monitoring is enabled we need to modify the callback here
   if (
-    conn.hello &&
-    (conn.monitorCommands || conn.mongoLogger?.willLog(SeverityLevel.DEBUG, conn.component))
+    conn.monitorCommands ||
+    (conn.hello && conn.mongoLogger?.willLog(SeverityLevel.DEBUG, conn.component))
   ) {
     conn.emitAndLogCommand(
       conn.monitorCommands,

--- a/src/cmap/connection_pool.ts
+++ b/src/cmap/connection_pool.ts
@@ -699,7 +699,8 @@ export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
       ...this.options,
       id: this[kConnectionCounter].next().value,
       generation: this[kGeneration],
-      cancellationToken: this[kCancellationToken]
+      cancellationToken: this[kCancellationToken],
+      mongoLogger: this[kServer].topology.client.mongoLogger
     };
 
     this[kPending]++;

--- a/src/cmap/stream_description.ts
+++ b/src/cmap/stream_description.ts
@@ -32,7 +32,7 @@ export class StreamDescription {
   compressor?: CompressorName;
   logicalSessionTimeoutMinutes?: number;
   loadBalanced: boolean;
-  serverConnectionId: number | '<monitor' | undefined;
+  serverConnectionId: number | '<monitor>' | undefined;
 
   __nodejs_mock_server__?: boolean;
 

--- a/src/cmap/stream_description.ts
+++ b/src/cmap/stream_description.ts
@@ -32,6 +32,7 @@ export class StreamDescription {
   compressor?: CompressorName;
   logicalSessionTimeoutMinutes?: number;
   loadBalanced: boolean;
+  serverConnectionId: number | '<monitor' | undefined;
 
   __nodejs_mock_server__?: boolean;
 
@@ -51,6 +52,7 @@ export class StreamDescription {
       options && options.compressors && Array.isArray(options.compressors)
         ? options.compressors
         : [];
+    this.serverConnectionId = undefined;
   }
 
   receiveResponse(response: Document | null): void {
@@ -72,5 +74,7 @@ export class StreamDescription {
     if (response.compression) {
       this.compressor = this.compressors.filter(c => response.compression?.includes(c))[0];
     }
+
+    this.serverConnectionId = response.connectionId;
   }
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -46,8 +46,11 @@ export const CONNECTION_CHECKED_OUT = 'connectionCheckedOut' as const;
 /** @internal */
 export const CONNECTION_CHECKED_IN = 'connectionCheckedIn' as const;
 export const CLUSTER_TIME_RECEIVED = 'clusterTimeReceived' as const;
+/** @internal */
 export const COMMAND_STARTED = 'commandStarted' as const;
+/** @internal */
 export const COMMAND_SUCCEEDED = 'commandSucceeded' as const;
+/** @internal */
 export const COMMAND_FAILED = 'commandFailed' as const;
 export const SERVER_HEARTBEAT_STARTED = 'serverHeartbeatStarted' as const;
 export const SERVER_HEARTBEAT_SUCCEEDED = 'serverHeartbeatSucceeded' as const;

--- a/src/index.ts
+++ b/src/index.ts
@@ -294,6 +294,9 @@ export type { StreamDescription, StreamDescriptionOptions } from './cmap/stream_
 export type { CompressorName } from './cmap/wire_protocol/compression';
 export type { CollectionOptions, CollectionPrivate, ModifyResult } from './collection';
 export type {
+  COMMAND_FAILED,
+  COMMAND_STARTED,
+  COMMAND_SUCCEEDED,
   CONNECTION_CHECK_OUT_FAILED,
   CONNECTION_CHECK_OUT_STARTED,
   CONNECTION_CHECKED_IN,
@@ -356,6 +359,9 @@ export type {
   LogComponentSeveritiesClientOptions,
   LogConvertible,
   Loggable,
+  LoggableCommandFailedEvent,
+  LoggableCommandStartedEvent,
+  LoggableCommandSucceededEvent,
   LoggableEvent,
   MongoDBLogWritable,
   MongoLoggableComponent,

--- a/src/mongo_logger.ts
+++ b/src/mongo_logger.ts
@@ -1,12 +1,7 @@
-import { EJSON, Document, ObjectId, EJSONOptions } from 'bson';
+import { type Document, EJSON, type EJSONOptions, type ObjectId } from 'bson';
 import type { Writable } from 'stream';
 import { inspect } from 'util';
 
-import type {
-  CommandFailedEvent,
-  CommandStartedEvent,
-  CommandSucceededEvent
-} from './cmap/command_monitoring_events';
 import type {
   ConnectionCheckedInEvent,
   ConnectionCheckedOutEvent,

--- a/src/mongo_types.ts
+++ b/src/mongo_types.ts
@@ -412,6 +412,25 @@ export class TypedEventEmitter<Events extends EventsDescription> extends EventEm
     this.emit(event, ...args);
     if (this.component) this.mongoLogger?.debug(this.component, args[0]);
   }
+  protected emitAndLogCommand<EventKey extends keyof Events>(
+    event: EventKey | symbol,
+    serverConnectionId?: number | '<monitor>',
+    ...args: Parameters<Events[EventKey]>
+  ): void {
+    this.emit(event, ...args);
+    if (this.component) {
+      const loggableHeartbeatEvent:
+        | LoggableServerHeartbeatFailedEvent
+        | LoggableServerHeartbeatSucceededEvent
+        | LoggableServerHeartbeatStartedEvent = {
+        topologyId: topologyId,
+        serverConnectionId: serverConnectionId ?? null,
+        ...args[0]
+      };
+      this.mongoLogger?.debug(this.component, loggableHeartbeatEvent);
+    }
+  }
+  
 }
 
 /** @public */

--- a/src/mongo_types.ts
+++ b/src/mongo_types.ts
@@ -423,7 +423,7 @@ export class TypedEventEmitter<Events extends EventsDescription> extends EventEm
     monitorCommands: boolean,
     event: EventKey | symbol,
     serverConnectionId: number | '<monitor>' | undefined,
-    databaseName?: string,
+    databaseName: string,
     ...args: Parameters<Events[EventKey]>
   ): void {
     if (monitorCommands) {

--- a/test/integration/command-logging-and-monitoring/command_logging_and_monitoring.spec.test.ts
+++ b/test/integration/command-logging-and-monitoring/command_logging_and_monitoring.spec.test.ts
@@ -11,7 +11,7 @@ import { runUnifiedSuite } from '../../tools/unified-spec-runner/runner';
 // the server. There's nothing we can change here.
 const SKIP = ['A successful unordered bulk write with an unacknowledged write concern'];
 
-describe('Command Logging and Monitoring Spec', function () {
+describe.only('Command Logging and Monitoring Spec', function () {
   describe('Command Monitoring Spec (unified)', () => {
     runUnifiedSuite(
       loadSpecTests(path.join('command-logging-and-monitoring', 'monitoring')),
@@ -23,6 +23,17 @@ describe('Command Logging and Monitoring Spec', function () {
   });
 
   describe('Command Logging Spec', () => {
-    runUnifiedSuite(loadSpecTests(path.join('command-logging-and-monitoring', 'logging')));
+    const tests = loadSpecTests(path.join('command-logging-and-monitoring', 'logging'));
+    runUnifiedSuite(tests, test => {
+      if (
+        [
+          'Failed bulkWrite operation: log messages have operationIds',
+          'Successful bulkWrite operation: log messages have operationIds'
+        ].includes(test.description)
+      ) {
+        return 'not applicable: operationId not supported';
+      }
+      return false;
+    });
   });
 });

--- a/test/integration/command-logging-and-monitoring/command_logging_and_monitoring.spec.test.ts
+++ b/test/integration/command-logging-and-monitoring/command_logging_and_monitoring.spec.test.ts
@@ -22,7 +22,7 @@ describe('Command Logging and Monitoring Spec', function () {
     );
   });
 
-  describe.only('Command Logging Spec', () => {
+  describe('Command Logging Spec', () => {
     const tests = loadSpecTests(path.join('command-logging-and-monitoring', 'logging'));
     runUnifiedSuite(tests, test => {
       if (

--- a/test/integration/command-logging-and-monitoring/command_logging_and_monitoring.spec.test.ts
+++ b/test/integration/command-logging-and-monitoring/command_logging_and_monitoring.spec.test.ts
@@ -22,7 +22,7 @@ describe('Command Logging and Monitoring Spec', function () {
     );
   });
 
-  describe.skip('Command Logging Spec', () => {
+  describe('Command Logging Spec', () => {
     runUnifiedSuite(loadSpecTests(path.join('command-logging-and-monitoring', 'logging')));
-  }).skipReason = 'TODO(NODE-4686): Unskip these tests';
+  });
 });

--- a/test/integration/command-logging-and-monitoring/command_logging_and_monitoring.spec.test.ts
+++ b/test/integration/command-logging-and-monitoring/command_logging_and_monitoring.spec.test.ts
@@ -11,7 +11,7 @@ import { runUnifiedSuite } from '../../tools/unified-spec-runner/runner';
 // the server. There's nothing we can change here.
 const SKIP = ['A successful unordered bulk write with an unacknowledged write concern'];
 
-describe.only('Command Logging and Monitoring Spec', function () {
+describe('Command Logging and Monitoring Spec', function () {
   describe('Command Monitoring Spec (unified)', () => {
     runUnifiedSuite(
       loadSpecTests(path.join('command-logging-and-monitoring', 'monitoring')),
@@ -22,13 +22,13 @@ describe.only('Command Logging and Monitoring Spec', function () {
     );
   });
 
-  describe('Command Logging Spec', () => {
+  describe.only('Command Logging Spec', () => {
     const tests = loadSpecTests(path.join('command-logging-and-monitoring', 'logging'));
     runUnifiedSuite(tests, test => {
       if (
         [
-          'Failed bulkWrite operation: log messages have operationIds',
-          'Successful bulkWrite operation: log messages have operationIds'
+          'Successful bulk write command log messages include operationIds',
+          'Failed bulk write command log message includes operationId'
         ].includes(test.description)
       ) {
         return 'not applicable: operationId not supported';

--- a/test/tools/unified-spec-runner/match.ts
+++ b/test/tools/unified-spec-runner/match.ts
@@ -596,6 +596,9 @@ export function compareLogs(
   actual: ExpectedLogMessage[],
   entities: EntitiesMap
 ): void {
+  console.log('ACTUAL: ', actual);
+  console.log('EXPECTED: ', expected);
+
   expect(actual).to.have.lengthOf(expected.length);
 
   for (const [index, actualLog] of actual.entries()) {


### PR DESCRIPTION
### Description
Add logging to CLAM events, un-skip + add support for CLAM logging spec tests, and add in prose tests.

#### What is changing?
CLAM logging messages will be enabled when loggingClientOptions for component `MongoLoggableComponent.COMMAND >= SeverityLevel.DEBUG`.

NOTE:
-  Command logging is enabled separate from command monitoring, and the command logging messages contain additional fields than command monitoring, resulting in the need for the additional `emitAndLogCommand` method.
- More context can be found within the [kickoff](https://docs.google.com/document/d/1t8Of6gEbpbhpD3wIyS3qPIGr5YroRTtdQHXw524D1O4/edit). 

##### Is there new documentation needed for these changes?
Not until logging is released (NODE-5762)

#### What is the motivation for this change?
To allow users to see CLAM events through logging. 

#### TODO: 
 once all comments are resolved, update all changes made to the `Connection` class to also be in the `ModernConnection` class

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
