### PR TITLE
chore(NODE-5782): track kerberos as dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "express": "^4.18.2",
         "gcp-metadata": "^5.3.0",
         "js-yaml": "^4.1.0",
+        "kerberos": "^2.1.0",
         "mocha": "^10.2.0",
         "mocha-sinon": "^2.1.2",
         "mongodb-client-encryption": "^6.0.0",
@@ -6308,6 +6309,27 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
       "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "dev": true
+    },
+    "node_modules/kerberos": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/kerberos/-/kerberos-2.1.0.tgz",
+      "integrity": "sha512-HvOl6O6cyEN/8Z4CAocHe/sekJtvt5UrxUdCuu7bXDZ2Hnsy6OpsQbISW+lpm03vrbO2ir+1QQ5Sx/vMEhHnog==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "node-addon-api": "^6.1.0",
+        "prebuild-install": "7.1.1"
+      },
+      "engines": {
+        "node": ">=12.9.0"
+      }
+    },
+    "node_modules/kerberos/node_modules/node-addon-api": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
+      "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
       "dev": true
     },
     "node_modules/kind-of": {

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "express": "^4.18.2",
     "gcp-metadata": "^5.3.0",
     "js-yaml": "^4.1.0",
+    "kerberos": "^2.1.0",
     "mocha": "^10.2.0",
     "mocha-sinon": "^2.1.2",
     "mongodb-client-encryption": "^6.0.0",


### PR DESCRIPTION
### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
