### PR TITLE
fix(NODE-5790): type error with $addToSet in bulkWrite

### DIFF
--- a/src/bulk/common.ts
+++ b/src/bulk/common.ts
@@ -85,8 +85,12 @@ export interface ReplaceOneModel<TSchema extends Document = Document> {
 export interface UpdateOneModel<TSchema extends Document = Document> {
   /** The filter to limit the updated documents. */
   filter: Filter<TSchema>;
-  /** A document or pipeline containing update operators. */
-  update: UpdateFilter<TSchema> | UpdateFilter<TSchema>[];
+  /**
+   * The modifications to apply. The value can be either:
+   * UpdateFilter<TSchema> - A document that contains update operator expressions,
+   * Document[] - an aggregation pipeline.
+   */
+  update: UpdateFilter<TSchema> | Document[];
   /** A set of filters specifying to which array elements an update should apply. */
   arrayFilters?: Document[];
   /** Specifies a collation. */
@@ -101,8 +105,12 @@ export interface UpdateOneModel<TSchema extends Document = Document> {
 export interface UpdateManyModel<TSchema extends Document = Document> {
   /** The filter to limit the updated documents. */
   filter: Filter<TSchema>;
-  /** A document or pipeline containing update operators. */
-  update: UpdateFilter<TSchema> | UpdateFilter<TSchema>[];
+  /**
+   * The modifications to apply. The value can be either:
+   * UpdateFilter<TSchema> - A document that contains update operator expressions,
+   * Document[] - an aggregation pipeline.
+   */
+  update: UpdateFilter<TSchema> | Document[];
   /** A set of filters specifying to which array elements an update should apply. */
   arrayFilters?: Document[];
   /** Specifies a collation. */

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -344,13 +344,17 @@ export class Collection<TSchema extends Document = Document> {
   /**
    * Update a single document in a collection
    *
+   * The value of `update` can be either:
+   * - UpdateFilter<TSchema> - A document that contains update operator expressions,
+   * - Document[] - an aggregation pipeline.
+   *
    * @param filter - The filter used to select the document to update
-   * @param update - The update operations to be applied to the document
+   * @param update - The modifications to apply
    * @param options - Optional settings for the command
    */
   async updateOne(
     filter: Filter<TSchema>,
-    update: UpdateFilter<TSchema> | Partial<TSchema>,
+    update: UpdateFilter<TSchema> | Document[],
     options?: UpdateOptions
   ): Promise<UpdateResult<TSchema>> {
     return executeOperation(
@@ -390,13 +394,17 @@ export class Collection<TSchema extends Document = Document> {
   /**
    * Update multiple documents in a collection
    *
-   * @param filter - The filter used to select the documents to update
-   * @param update - The update operations to be applied to the documents
+   * The value of `update` can be either:
+   * - UpdateFilter<TSchema> - A document that contains update operator expressions,
+   * - Document[] - an aggregation pipeline.
+   *
+   * @param filter - The filter used to select the document to update
+   * @param update - The modifications to apply
    * @param options - Optional settings for the command
    */
   async updateMany(
     filter: Filter<TSchema>,
-    update: UpdateFilter<TSchema>,
+    update: UpdateFilter<TSchema> | Document[],
     options?: UpdateOptions
   ): Promise<UpdateResult<TSchema>> {
     return executeOperation(

--- a/src/mongo_types.ts
+++ b/src/mongo_types.ts
@@ -237,7 +237,11 @@ export type SetFields<TSchema> = ({
   readonly [key in KeysOfAType<TSchema, ReadonlyArray<any> | undefined>]?:
     | OptionalId<Flatten<TSchema[key]>>
     | AddToSetOperators<Array<OptionalId<Flatten<TSchema[key]>>>>;
-} & NotAcceptedFields<TSchema, ReadonlyArray<any> | undefined>) & {
+} & IsAny<
+  TSchema[keyof TSchema],
+  object,
+  NotAcceptedFields<TSchema, ReadonlyArray<any> | undefined>
+>) & {
   readonly [key: string]: AddToSetOperators<any> | any;
 };
 

--- a/test/types/community/collection/bulkWrite.test-d.ts
+++ b/test/types/community/collection/bulkWrite.test-d.ts
@@ -1,6 +1,6 @@
 import { expectError } from 'tsd';
 
-import { MongoClient, ObjectId } from '../../../mongodb';
+import { type Collection, type Document, MongoClient, ObjectId } from '../../../mongodb';
 
 // TODO(NODE-3347): Improve these tests to use more expect assertions
 
@@ -297,3 +297,197 @@ collectionType.bulkWrite([
     }
   }
 ]);
+
+{
+  // NODE-5647 - Type error with $addToSet in bulkWrite
+  interface TestDocument {
+    readonly myId: number;
+    readonly mySet: number[];
+    readonly myAny: any;
+  }
+  const collection = undefined as unknown as Collection<TestDocument>;
+  expectError(
+    collection.bulkWrite([
+      {
+        updateOne: {
+          filter: { myId: 0 },
+          update: {
+            $addToSet: { mySet: 'value of other type' }
+          }
+        }
+      }
+    ])
+  );
+  collection.bulkWrite([
+    {
+      updateOne: {
+        filter: { myId: 0 },
+        update: {
+          $addToSet: { mySet: 0 }
+        }
+      }
+    }
+  ]);
+  collection.bulkWrite([
+    {
+      updateOne: {
+        filter: { myId: 0 },
+        update: {
+          $addToSet: { myAny: 1 }
+        }
+      }
+    }
+  ]);
+  collection.bulkWrite([
+    {
+      updateOne: {
+        filter: { myId: 0 },
+        update: [
+          {
+            $addToSet: { myAny: 0 }
+          }
+        ]
+      }
+    }
+  ]);
+  expectError(
+    collection.bulkWrite([
+      {
+        updateMany: {
+          filter: { myId: 0 },
+          update: {
+            $addToSet: { mySet: 'value of other type' }
+          }
+        }
+      }
+    ])
+  );
+  collection.bulkWrite([
+    {
+      updateMany: {
+        filter: { myId: 0 },
+        update: {
+          $addToSet: { mySet: 0 }
+        }
+      }
+    }
+  ]);
+  collection.bulkWrite([
+    {
+      updateMany: {
+        filter: { myId: 0 },
+        update: {
+          $addToSet: { myAny: 1 }
+        }
+      }
+    }
+  ]);
+  collection.bulkWrite([
+    {
+      updateMany: {
+        filter: { myId: 0 },
+        update: [
+          {
+            $addToSet: { mySet: 0 }
+          }
+        ]
+      }
+    }
+  ]);
+
+  interface IndexSingatureTestDocument extends Document {
+    readonly myId: number;
+    readonly mySet: number[];
+  }
+  const indexSingatureCollection = undefined as unknown as Collection<IndexSingatureTestDocument>;
+  indexSingatureCollection.bulkWrite([
+    {
+      updateOne: {
+        filter: { myId: 0 },
+        update: {
+          $addToSet: { mySet: 0 }
+        }
+      }
+    }
+  ]);
+  indexSingatureCollection.bulkWrite([
+    {
+      updateOne: {
+        filter: { myId: 0 },
+        update: [
+          {
+            $addToSet: { mySet: 0 }
+          }
+        ]
+      }
+    }
+  ]);
+  indexSingatureCollection.bulkWrite([
+    {
+      updateMany: {
+        filter: { myId: 0 },
+        update: {
+          $addToSet: { mySet: 0 }
+        }
+      }
+    }
+  ]);
+  indexSingatureCollection.bulkWrite([
+    {
+      updateMany: {
+        filter: { myId: 0 },
+        update: [
+          {
+            $addToSet: { mySet: 0 }
+          }
+        ]
+      }
+    }
+  ]);
+
+  const collectionOfAnyType = undefined as unknown as Collection<any>;
+  collectionOfAnyType.bulkWrite([
+    {
+      updateOne: {
+        filter: { myId: 0 },
+        update: {
+          $addToSet: { mySet: 0 }
+        }
+      }
+    }
+  ]);
+  collectionOfAnyType.bulkWrite([
+    {
+      updateOne: {
+        filter: { myId: 0 },
+        update: [
+          {
+            $addToSet: { mySet: 0 }
+          }
+        ]
+      }
+    }
+  ]);
+  collectionOfAnyType.bulkWrite([
+    {
+      updateMany: {
+        filter: { myId: 0 },
+        update: {
+          $addToSet: { mySet: 0 }
+        }
+      }
+    }
+  ]);
+  collectionOfAnyType.bulkWrite([
+    {
+      updateMany: {
+        filter: { myId: 0 },
+        update: [
+          {
+            $addToSet: { mySet: 0 }
+          }
+        ]
+      }
+    }
+  ]);
+}

--- a/test/types/community/collection/updateX.test-d.ts
+++ b/test/types/community/collection/updateX.test-d.ts
@@ -439,3 +439,66 @@ export async function testPushWithId(): Promise<void> {
     collectionWithSchema.updateMany({}, {})
   );
 }
+
+{
+  // NODE-5647 - Type error with $addToSet in bulkWrite
+  interface TestDocument {
+    readonly myId: number;
+    readonly mySet: number[];
+    readonly myAny: any;
+  }
+  const collection = undefined as unknown as Collection<TestDocument>;
+  expectError(collection.updateOne({ myId: 0 }, { $addToSet: { mySet: 'value of other type' } }));
+  collection.updateOne({ myId: 0 }, { $addToSet: { mySet: 0 } });
+  collection.updateOne({ myId: 0 }, { $addToSet: { myAny: 1 } });
+  collection.updateOne({ myId: 0 }, [
+    {
+      $addToSet: { mySet: 0 }
+    }
+  ]);
+  expectError(collection.updateMany({ myId: 0 }, { $addToSet: { mySet: 'value of other type' } }));
+  collection.updateMany({ myId: 0 }, { $addToSet: { mySet: 0 } });
+  collection.updateMany({ myId: 0 }, { $addToSet: { myAny: 1 } });
+  collection.updateMany({ myId: 0 }, [
+    {
+      $addToSet: { mySet: 0 }
+    }
+  ]);
+
+  interface IndexSingatureTestDocument extends Document {
+    readonly myId: number;
+    readonly mySet: number[];
+    readonly myAny: any;
+  }
+  const indexSingatureCollection = undefined as unknown as Collection<IndexSingatureTestDocument>;
+  indexSingatureCollection.updateOne({ myId: 0 }, { $addToSet: { mySet: 0 } });
+  indexSingatureCollection.updateOne({ myId: 0 }, { $addToSet: { myAny: 1 } });
+  indexSingatureCollection.updateOne({ myId: 0 }, [
+    {
+      $addToSet: { mySet: 0 }
+    }
+  ]);
+  indexSingatureCollection.updateMany({ myId: 0 }, { $addToSet: { mySet: 0 } });
+  indexSingatureCollection.updateMany({ myId: 0 }, { $addToSet: { myAny: 1 } });
+  indexSingatureCollection.updateMany({ myId: 0 }, [
+    {
+      $addToSet: { mySet: 0 }
+    }
+  ]);
+
+  const collectionOfAnyType = undefined as unknown as Collection<any>;
+  collectionOfAnyType.updateOne({ myId: 0 }, { $addToSet: { mySet: 0 } });
+  collectionOfAnyType.updateOne({ myId: 0 }, { $addToSet: { myAny: 1 } });
+  collectionOfAnyType.updateOne({ myId: 0 }, [
+    {
+      $addToSet: { mySet: 0 }
+    }
+  ]);
+  collectionOfAnyType.updateMany({ myId: 0 }, { $addToSet: { mySet: 0 } });
+  collectionOfAnyType.updateMany({ myId: 0 }, { $addToSet: { myAny: 1 } });
+  collectionOfAnyType.updateMany({ myId: 0 }, [
+    {
+      $addToSet: { mySet: 0 }
+    }
+  ]);
+}


### PR DESCRIPTION
### Description
Backporting https://github.com/mongodb/node-mongodb-native/pull/3953 to 5x.

#### What is changing?
We update types to fix the error with $addToSet in bulkWrite.

##### Is there new documentation needed for these changes?
None

#### What is the motivation for this change?
[NODE-5647](https://jira.mongodb.org/browse/NODE-5647)
[NODE-4664](https://jira.mongodb.org/browse/NODE-4664)

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

### The type error is fixed for fields of `any` type in update commands.
Extending collection interfaces from `Document`/`any` type or specifying fields of `any` type doesn't cause a type error anymore.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
