### PR TITLE
refactor(NODE-5809): remove executeOperation callback overload and maybeCallback

### DIFF
--- a/src/bulk/common.ts
+++ b/src/bulk/common.ts
@@ -579,23 +579,18 @@ function executeCommands(
   }
 
   try {
-    if (isInsertBatch(batch)) {
-      executeOperation(
-        bulkOperation.s.collection.client,
-        new InsertOperation(bulkOperation.s.namespace, batch.operations, finalOptions),
-        resultHandler
-      );
-    } else if (isUpdateBatch(batch)) {
-      executeOperation(
-        bulkOperation.s.collection.client,
-        new UpdateOperation(bulkOperation.s.namespace, batch.operations, finalOptions),
-        resultHandler
-      );
-    } else if (isDeleteBatch(batch)) {
-      executeOperation(
-        bulkOperation.s.collection.client,
-        new DeleteOperation(bulkOperation.s.namespace, batch.operations, finalOptions),
-        resultHandler
+    const operation = isInsertBatch(batch)
+      ? new InsertOperation(bulkOperation.s.namespace, batch.operations, finalOptions)
+      : isUpdateBatch(batch)
+      ? new UpdateOperation(bulkOperation.s.namespace, batch.operations, finalOptions)
+      : isDeleteBatch(batch)
+      ? new DeleteOperation(bulkOperation.s.namespace, batch.operations, finalOptions)
+      : null;
+
+    if (operation != null) {
+      executeOperation(bulkOperation.s.collection.client, operation).then(
+        result => resultHandler(undefined, result),
+        error => resultHandler(error)
       );
     }
   } catch (err) {

--- a/src/operations/execute_operation.ts
+++ b/src/operations/execute_operation.ts
@@ -57,7 +57,6 @@ export interface ExecutionResult {
  *
  * The expectation is that this function:
  * - Connects the MongoClient if it has not already been connected
- *   - This amounts to creating and starting the Monitors, something that serverSelection could also do
  * - Creates a session if none is provided and cleans up the session it creates
  * - Selects a server based on readPreference or various factors
  * - Retries an operation if it fails for certain errors, see {@link retryOperation}

--- a/src/operations/execute_operation.ts
+++ b/src/operations/execute_operation.ts
@@ -51,15 +51,22 @@ export interface ExecutionResult {
  * @internal
  *
  * @remarks
- * This method reduces large amounts of duplication in the entire codebase by providing
- * a single point for determining whether callbacks or promises should be used. Additionally
- * it allows for a single point of entry to provide features such as implicit sessions, which
+ * Allows for a single point of entry to provide features such as implicit sessions, which
  * are required by the Driver Sessions specification in the event that a ClientSession is
- * not provided
+ * not provided.
  *
- * @param topology - The topology to execute this operation on
+ * The expectation is that this function:
+ * - Connects the MongoClient if it has not already been connected
+ *   - This amounts to creating and starting the Monitors, something that serverSelection could also do
+ * - Creates a session if none is provided and cleans up the session it creates
+ * - Selects a server based on readPreference or various factors
+ * - Retries an operation if it fails for certain errors, see {@link retryOperation}
+ *
+ * @typeParam T - The operation's type
+ * @typeParam TResult - The type of the operation's result, calculated from T
+ *
+ * @param client - The MongoClient to execute this operation with
  * @param operation - The operation to execute
- * @param callback - The command result callback
  */
 export async function executeOperation<
   T extends AbstractOperation<TResult>,

--- a/src/operations/execute_operation.ts
+++ b/src/operations/execute_operation.ts
@@ -25,7 +25,7 @@ import {
 } from '../sdam/server_selection';
 import type { Topology } from '../sdam/topology';
 import type { ClientSession } from '../sessions';
-import { type Callback, maybeCallback, supportsRetryableWrites } from '../utils';
+import { supportsRetryableWrites } from '../utils';
 import { AbstractOperation, Aspect } from './operation';
 
 const MMAPv1_RETRY_WRITES_ERROR_CODE = MONGODB_ERROR_CODES.IllegalOperation;
@@ -61,26 +61,7 @@ export interface ExecutionResult {
  * @param operation - The operation to execute
  * @param callback - The command result callback
  */
-export function executeOperation<
-  T extends AbstractOperation<TResult>,
-  TResult = ResultTypeFromOperation<T>
->(client: MongoClient, operation: T): Promise<TResult>;
-export function executeOperation<
-  T extends AbstractOperation<TResult>,
-  TResult = ResultTypeFromOperation<T>
->(client: MongoClient, operation: T, callback: Callback<TResult>): void;
-export function executeOperation<
-  T extends AbstractOperation<TResult>,
-  TResult = ResultTypeFromOperation<T>
->(client: MongoClient, operation: T, callback?: Callback<TResult>): Promise<TResult> | void;
-export function executeOperation<
-  T extends AbstractOperation<TResult>,
-  TResult = ResultTypeFromOperation<T>
->(client: MongoClient, operation: T, callback?: Callback<TResult>): Promise<TResult> | void {
-  return maybeCallback(() => executeOperationAsync(client, operation), callback);
-}
-
-async function executeOperationAsync<
+export async function executeOperation<
   T extends AbstractOperation<TResult>,
   TResult = ResultTypeFromOperation<T>
 >(client: MongoClient, operation: T): Promise<TResult> {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -331,30 +331,6 @@ export function* makeCounter(seed = 0): Generator<number> {
 }
 
 /**
- * Helper for handling legacy callback support.
- */
-export function maybeCallback<T>(promiseFn: () => Promise<T>, callback: null): Promise<T>;
-export function maybeCallback<T>(
-  promiseFn: () => Promise<T>,
-  callback?: Callback<T>
-): Promise<T> | void;
-export function maybeCallback<T>(
-  promiseFn: () => Promise<T>,
-  callback?: Callback<T> | null
-): Promise<T> | void {
-  const promise = promiseFn();
-  if (callback == null) {
-    return promise;
-  }
-
-  promise.then(
-    result => callback(undefined, result),
-    error => callback(error)
-  );
-  return;
-}
-
-/**
  * Synchronously Generate a UUIDv4
  * @internal
  */

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -14,7 +14,6 @@ import {
   LEGACY_HELLO_COMMAND,
   List,
   matchesParentDomain,
-  maybeCallback,
   MongoDBCollectionNamespace,
   MongoDBNamespace,
   MongoRuntimeError,
@@ -849,96 +848,6 @@ describe('driver utils', function () {
         expect(ha).to.have.property('socketPath', undefined);
         expect(ha).to.have.property('host', 'iLoveJavascript.sock'.toLowerCase());
         expect(ha).to.have.property('port', 27017);
-      });
-    });
-  });
-
-  describe('maybeCallback()', () => {
-    it('should accept two arguments', () => {
-      expect(maybeCallback).to.have.lengthOf(2);
-    });
-
-    describe('when handling an error case', () => {
-      it('should pass the error to the callback provided', done => {
-        const superPromiseRejection = Promise.reject(new Error('fail'));
-        const result = maybeCallback(
-          () => superPromiseRejection,
-          (error, result) => {
-            try {
-              expect(result).to.not.exist;
-              expect(error).to.be.instanceOf(Error);
-              return done();
-            } catch (assertionError) {
-              return done(assertionError);
-            }
-          }
-        );
-        expect(result).to.be.undefined;
-      });
-
-      it('should return the rejected promise to the caller when no callback is provided', async () => {
-        const superPromiseRejection = Promise.reject(new Error('fail'));
-        const returnedPromise = maybeCallback(() => superPromiseRejection, undefined);
-        expect(returnedPromise).to.equal(superPromiseRejection);
-        // @ts-expect-error: There is no overload to change the return type not be nullish,
-        // and we do not want to add one in fear of making it too easy to neglect adding the callback argument
-        const thrownError = await returnedPromise.catch(error => error);
-        expect(thrownError).to.be.instanceOf(Error);
-      });
-
-      it('should not modify a rejection error promise', async () => {
-        class MyError extends Error {}
-        const driverError = Object.freeze(new MyError());
-        const rejection = Promise.reject(driverError);
-        // @ts-expect-error: There is no overload to change the return type not be nullish,
-        // and we do not want to add one in fear of making it too easy to neglect adding the callback argument
-        const thrownError = await maybeCallback(() => rejection, undefined).catch(error => error);
-        expect(thrownError).to.be.equal(driverError);
-      });
-
-      it('should not modify a rejection error when passed to callback', done => {
-        class MyError extends Error {}
-        const driverError = Object.freeze(new MyError());
-        const rejection = Promise.reject(driverError);
-        maybeCallback(
-          () => rejection,
-          error => {
-            try {
-              expect(error).to.exist;
-              expect(error).to.equal(driverError);
-              done();
-            } catch (assertionError) {
-              done(assertionError);
-            }
-          }
-        );
-      });
-    });
-
-    describe('when handling a success case', () => {
-      it('should pass the result and undefined error to the callback provided', done => {
-        const superPromiseSuccess = Promise.resolve(2);
-
-        const result = maybeCallback(
-          () => superPromiseSuccess,
-          (error, result) => {
-            try {
-              expect(error).to.be.undefined;
-              expect(result).to.equal(2);
-              done();
-            } catch (assertionError) {
-              done(assertionError);
-            }
-          }
-        );
-        expect(result).to.be.undefined;
-      });
-
-      it('should return the resolved promise to the caller when no callback is provided', async () => {
-        const superPromiseSuccess = Promise.resolve(2);
-        const result = maybeCallback(() => superPromiseSuccess);
-        expect(result).to.equal(superPromiseSuccess);
-        expect(await result).to.equal(2);
       });
     });
   });


### PR DESCRIPTION
### Description

#### What is changing?

- Move .then/.catch chain into callers
- Remove maybeCallback
- Improve docs over executeOperation

##### Is there new documentation needed for these changes?

No.

#### What is the motivation for this change?

This change is effectively a no-op, but it removes the overloads advertized by executeOperation that are no longer used making future changes to executeOperation easier to make.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
