### PR TITLE
feat(NODE-3470): retry selects another mongos

### DIFF
--- a/src/operations/execute_operation.ts
+++ b/src/operations/execute_operation.ts
@@ -247,7 +247,7 @@ async function retryOperation<
   const server = await topology.selectServerAsync(selector, {
     session,
     operationName: operation.commandName,
-    previousServer: previousServer
+    previousServer
   });
 
   if (isWriteOperation && !supportsRetryableWrites(server)) {

--- a/src/operations/execute_operation.ts
+++ b/src/operations/execute_operation.ts
@@ -18,6 +18,7 @@ import {
 import type { MongoClient } from '../mongo_client';
 import { ReadPreference } from '../read_preference';
 import type { Server } from '../sdam/server';
+import type { ServerDescription } from '../sdam/server_description';
 import {
   sameServerSelector,
   secondaryWritableServerSelector,
@@ -183,7 +184,8 @@ export async function executeOperation<
       return await retryOperation(operation, operationError, {
         session,
         topology,
-        selector
+        selector,
+        previousServer: server.description
       });
     }
     throw operationError;
@@ -199,6 +201,7 @@ type RetryOptions = {
   session: ClientSession;
   topology: Topology;
   selector: ReadPreference | ServerSelector;
+  previousServer: ServerDescription;
 };
 
 async function retryOperation<
@@ -207,7 +210,7 @@ async function retryOperation<
 >(
   operation: T,
   originalError: MongoError,
-  { session, topology, selector }: RetryOptions
+  { session, topology, selector, previousServer }: RetryOptions
 ): Promise<TResult> {
   const isWriteOperation = operation.hasAspect(Aspect.WRITE_OPERATION);
   const isReadOperation = operation.hasAspect(Aspect.READ_OPERATION);
@@ -243,7 +246,8 @@ async function retryOperation<
   // select a new server, and attempt to retry the operation
   const server = await topology.selectServerAsync(selector, {
     session,
-    operationName: operation.commandName
+    operationName: operation.commandName,
+    previousServer: previousServer
   });
 
   if (isWriteOperation && !supportsRetryableWrites(server)) {

--- a/src/sdam/server_selection.ts
+++ b/src/sdam/server_selection.ts
@@ -294,7 +294,10 @@ export function readPreferenceServerSelector(readPreference: ReadPreference): Se
     }
 
     if (topologyDescription.type === TopologyType.Sharded) {
-      const selectable = servers.length > 0 ? servers : deprioritized;
+      const filtered = servers.filter(server => {
+        return !deprioritized.includes(server);
+      });
+      const selectable = filtered.length > 0 ? filtered : deprioritized;
       return latencyWindowReducer(topologyDescription, selectable.filter(knownFilter));
     }
 

--- a/src/sdam/server_selection.ts
+++ b/src/sdam/server_selection.ts
@@ -14,7 +14,8 @@ export const MIN_SECONDARY_WRITE_WIRE_VERSION = 13;
 /** @internal */
 export type ServerSelector = (
   topologyDescription: TopologyDescription,
-  servers: ServerDescription[]
+  servers: ServerDescription[],
+  deprioritized?: ServerDescription[]
 ) => ServerDescription[];
 
 /**
@@ -266,7 +267,8 @@ export function readPreferenceServerSelector(readPreference: ReadPreference): Se
 
   return (
     topologyDescription: TopologyDescription,
-    servers: ServerDescription[]
+    servers: ServerDescription[],
+    deprioritized: ServerDescription[] = []
   ): ServerDescription[] => {
     const commonWireVersion = topologyDescription.commonWireVersion;
     if (
@@ -287,11 +289,13 @@ export function readPreferenceServerSelector(readPreference: ReadPreference): Se
       return [];
     }
 
-    if (
-      topologyDescription.type === TopologyType.Single ||
-      topologyDescription.type === TopologyType.Sharded
-    ) {
+    if (topologyDescription.type === TopologyType.Single) {
       return latencyWindowReducer(topologyDescription, servers.filter(knownFilter));
+    }
+
+    if (topologyDescription.type === TopologyType.Sharded) {
+      const selectable = servers.length > 0 ? servers : deprioritized;
+      return latencyWindowReducer(topologyDescription, selectable.filter(knownFilter));
     }
 
     const mode = readPreference.mode;

--- a/test/integration/server-selection/server_selection.prose.sharded_retryable_reads.test.ts
+++ b/test/integration/server-selection/server_selection.prose.sharded_retryable_reads.test.ts
@@ -1,0 +1,161 @@
+import { expect } from 'chai';
+
+import type { CommandFailedEvent, CommandSucceededEvent } from '../../mongodb';
+
+const TEST_METADATA = { requires: { mongodb: '>=4.2.9', topology: 'sharded' } };
+const FAIL_COMMAND = {
+  configureFailPoint: 'failCommand',
+  mode: { times: 1 },
+  data: {
+    failCommands: ['find'],
+    errorCode: 6,
+    closeConnection: true
+  }
+};
+const DISABLE_FAIL_COMMAND = {
+  configureFailPoint: 'failCommand',
+  mode: 'off',
+  data: {
+    failCommands: ['find'],
+    errorCode: 6,
+    closeConnection: true
+  }
+};
+
+describe('Server Selection Sharded Retryable Reads Prose tests', function () {
+  context('Retryable Reads Are Retried on a Different mongos if One is Available', function () {
+    const commandFailedEvents: CommandFailedEvent[] = [];
+    let client;
+    let utilClientOne;
+    let utilClientTwo;
+
+    // This test MUST be executed against a sharded cluster that has at least two
+    // mongos instances.
+    // 1. Ensure that a test is run against a sharded cluster that has at least two
+    //    mongoses. If there are more than two mongoses in the cluster, pick two to
+    //    test against.
+    beforeEach(async function () {
+      const uri = this.configuration.url({
+        monitorCommands: true,
+        useMultipleMongoses: true
+      });
+
+      // 3. Create a client with ``retryReads=true`` that connects to the cluster,
+      //    providing the two selected mongoses as seeds.
+      client = this.configuration.newClient(uri, {
+        monitorCommands: true,
+        retryReads: true
+      });
+      client.on('commandFailed', event => {
+        commandFailedEvents.push(event);
+      });
+      await client.connect();
+      const seeds = client.topology.s.seedlist.map(address => address.toString());
+
+      // 2. Create a client per mongos using the direct connection, and configure the
+      //    following fail points on each mongos::
+      //      {
+      //          configureFailPoint: "failCommand",
+      //          mode: { times: 1 },
+      //          data: {
+      //              failCommands: ["find"],
+      //              errorCode: 6,
+      //              closeConnection: true
+      //          }
+      //      }
+      utilClientOne = this.configuration.newClient(`mongodb://${seeds[0]}`, {
+        directConnection: true
+      });
+      utilClientTwo = this.configuration.newClient(`mongodb://${seeds[1]}`, {
+        directConnection: true
+      });
+      await utilClientOne.db('admin').command(FAIL_COMMAND);
+      await utilClientTwo.db('admin').command(FAIL_COMMAND);
+    });
+
+    afterEach(async function () {
+      await client?.close();
+      await utilClientOne.db('admin').command(DISABLE_FAIL_COMMAND);
+      await utilClientTwo.db('admin').command(DISABLE_FAIL_COMMAND);
+      await utilClientOne?.close();
+      await utilClientTwo?.close();
+    });
+
+    // 4. Enable command monitoring, and execute a ``find`` command that is
+    //    supposed to fail on both mongoses.
+    // 5. Asserts that there were failed command events from each mongos.
+    // 6. Disable the fail points.
+    it('retries on a different mongos', TEST_METADATA, async function () {
+      await client
+        .db('test')
+        .collection('test')
+        .find()
+        .toArray()
+        .catch(() => null);
+      expect(commandFailedEvents[0].address).to.not.equal(commandFailedEvents[1].address);
+    });
+  });
+
+  // 1. Ensure that a test is run against a sharded cluster. If there are multiple
+  // mongoses in the cluster, pick one to test against.
+  context('Retryable Reads Are Retried on the Same mongos if No Others are Available', function () {
+    const commandFailedEvents: CommandFailedEvent[] = [];
+    const commandSucceededEvents: CommandSucceededEvent[] = [];
+    let client;
+    let utilClient;
+
+    beforeEach(async function () {
+      const uri = this.configuration.url({
+        monitorCommands: true
+      });
+
+      // 3. Create a client with ``retryReads=true`` that connects to the cluster,
+      //     providing the selected mongos as the seed.
+      client = this.configuration.newClient(uri, {
+        monitorCommands: true,
+        retryReads: true
+      });
+      client.on('commandFailed', event => {
+        commandFailedEvents.push(event);
+      });
+      client.on('commandSucceeded', event => {
+        commandSucceededEvents.push(event);
+      });
+
+      // 2. Create a client that connects to the mongos using the direct connection,
+      //     and configure the following fail point on the mongos::
+      //       {
+      //           configureFailPoint: "failCommand",
+      //           mode: { times: 1 },
+      //           data: {
+      //               failCommands: ["find"],
+      //               errorCode: 6,
+      //               closeConnection: true
+      //           }
+      //       }
+      utilClient = this.configuration.newClient(uri, {
+        directConnection: true
+      });
+      await utilClient.db('admin').command(FAIL_COMMAND);
+    });
+
+    afterEach(async function () {
+      await client?.close();
+      await utilClient?.db('admin').command(DISABLE_FAIL_COMMAND);
+      await utilClient?.close();
+    });
+
+    // 4. Enable command monitoring, and execute a ``find`` command.
+    // 5. Asserts that there was a failed command and a successful command event.
+    // 6. Disable the fail point.
+    it('retries on the same mongos', TEST_METADATA, async function () {
+      await client
+        .db('test')
+        .collection('test')
+        .find()
+        .toArray()
+        .catch(() => null);
+      expect(commandFailedEvents[0].address).to.equal(commandSucceededEvents[0].address);
+    });
+  });
+});

--- a/test/integration/server-selection/server_selection.prose.sharded_retryable_writes.test.ts
+++ b/test/integration/server-selection/server_selection.prose.sharded_retryable_writes.test.ts
@@ -1,0 +1,159 @@
+import { expect } from 'chai';
+
+import type { CommandFailedEvent, CommandSucceededEvent } from '../../mongodb';
+
+const TEST_METADATA = { requires: { mongodb: '>=4.3.1', topology: 'sharded' } };
+const FAIL_COMMAND = {
+  configureFailPoint: 'failCommand',
+  mode: { times: 1 },
+  data: {
+    failCommands: ['insert'],
+    errorCode: 6,
+    errorLabels: ['RetryableWriteError'],
+    closeConnection: true
+  }
+};
+const DISABLE_FAIL_COMMAND = {
+  configureFailPoint: 'failCommand',
+  mode: 'off',
+  data: {
+    failCommands: ['find'],
+    errorCode: 6,
+    errorLabels: ['RetryableWriteError'],
+    closeConnection: true
+  }
+};
+
+describe('Server Selection Sharded Retryable Writes Prose tests', function () {
+  context(
+    'Test that in a sharded cluster writes are retried on a different mongos if one available',
+    function () {
+      const commandFailedEvents: CommandFailedEvent[] = [];
+      let client;
+      let utilClientOne;
+      let utilClientTwo;
+      // This test MUST be executed against a sharded cluster that has at least two mongos instances.
+      // This test requires MongoDB 4.3.1+ for the errorLabels fail point option.
+      // Ensure that a test is run against a sharded cluster that has at least two mongoses. If there are more than two mongoses in the cluster, pick two to test against.
+      beforeEach(async function () {
+        const uri = this.configuration.url({
+          monitorCommands: true,
+          useMultipleMongoses: true
+        });
+
+        // Create a client with retryWrites=true that connects to the cluster, providing the two selected mongoses as seeds.
+        // Enable command monitoring, and execute a write command that is supposed to fail on both mongoses.
+        client = this.configuration.newClient(uri, {
+          monitorCommands: true,
+          retryWrites: true
+        });
+        client.on('commandFailed', event => {
+          commandFailedEvents.push(event);
+        });
+        await client.connect();
+        const seeds = client.topology.s.seedlist.map(address => address.toString());
+
+        // Create a client per mongos using the direct connection, and configure the following fail point on each mongos:
+        // {
+        //     configureFailPoint: "failCommand",
+        //     mode: { times: 1 },
+        //     data: {
+        //         failCommands: ["insert"],
+        //         errorCode: 6,
+        //         errorLabels: ["RetryableWriteError"],
+        //         closeConnection: true
+        //     }
+        // }
+        utilClientOne = this.configuration.newClient(`mongodb://${seeds[0]}`, {
+          directConnection: true
+        });
+        utilClientTwo = this.configuration.newClient(`mongodb://${seeds[1]}`, {
+          directConnection: true
+        });
+        await utilClientOne.db('admin').command(FAIL_COMMAND);
+        await utilClientTwo.db('admin').command(FAIL_COMMAND);
+      });
+
+      afterEach(async function () {
+        await client?.close();
+        await utilClientOne.db('admin').command(DISABLE_FAIL_COMMAND);
+        await utilClientTwo.db('admin').command(DISABLE_FAIL_COMMAND);
+        await utilClientOne?.close();
+        await utilClientTwo?.close();
+      });
+
+      // Asserts that there were failed command events from each mongos.
+      // Disable the fail points.
+      it('retries on a different mongos', TEST_METADATA, async function () {
+        await client
+          .db('test')
+          .collection('test')
+          .insertOne({ a: 1 })
+          .catch(() => null);
+        expect(commandFailedEvents[0].address).to.not.equal(commandFailedEvents[1].address);
+      });
+    }
+  );
+
+  context(
+    'Test that in a sharded cluster writes are retried on the same mongos if no other is available',
+    function () {
+      // This test MUST be executed against a sharded cluster and requires MongoDB 4.3.1+ for the errorLabels fail point option.
+      // Ensure that a test is run against a sharded cluster. If there are multiple mongoses in the cluster, pick one to test against.
+      const commandFailedEvents: CommandFailedEvent[] = [];
+      const commandSucceededEvents: CommandSucceededEvent[] = [];
+      let client;
+      let utilClient;
+
+      beforeEach(async function () {
+        const uri = this.configuration.url({
+          monitorCommands: true
+        });
+        // Create a client that connects to the mongos using the direct connection, and configure the following fail point on the mongos:
+        // {
+        //     configureFailPoint: "failCommand",
+        //     mode: { times: 1 },
+        //     data: {
+        //         failCommands: ["insert"],
+        //         errorCode: 6,
+        //         errorLabels: ["RetryableWriteError"],
+        //         closeConnection: true
+        //     }
+        // }
+        client = this.configuration.newClient(uri, {
+          monitorCommands: true,
+          retryWrites: true
+        });
+        client.on('commandFailed', event => {
+          commandFailedEvents.push(event);
+        });
+        client.on('commandSucceeded', event => {
+          commandSucceededEvents.push(event);
+        });
+        // Create a client with retryWrites=true that connects to the cluster, providing the selected mongos as the seed.
+        // Enable command monitoring, and execute a write command that is supposed to fail.
+        utilClient = this.configuration.newClient(uri, {
+          directConnection: true
+        });
+        await utilClient.db('admin').command(FAIL_COMMAND);
+      });
+
+      afterEach(async function () {
+        await client?.close();
+        await utilClient?.db('admin').command(DISABLE_FAIL_COMMAND);
+        await utilClient?.close();
+      });
+
+      // Asserts that there was a failed command and a successful command event.
+      // Disable the fail point.
+      it('retries on the same mongos', TEST_METADATA, async function () {
+        await client
+          .db('test')
+          .collection('test')
+          .insert({ a: 1 })
+          .catch(() => null);
+        expect(commandFailedEvents[0].address).to.equal(commandSucceededEvents[0].address);
+      });
+    }
+  );
+});


### PR DESCRIPTION
### Description

When retrying reads and writes on a sharded cluster, will attempt the retry on a different mongos if multiple mongoses are present.

#### What is changing?
- `executeOperation` now keeps track of the previously selected server.
- Server selection will now attempt to exclude the previous server when the topology is sharded and multiple mongoses are present.
- Adds unit tests for server selection and prose tests for retryable reads and writes.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-3470

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### When retrying reads or writes on a sharded cluster, the driver will attempt to select a different mongos for the retry if multiple are present.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
