### PR TITLE
test(NODE-5823): CSOT unified runner changes

### DIFF
--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -1090,6 +1090,9 @@ export const OPTIONS = {
     target: 'tls',
     type: 'boolean'
   },
+  timeoutMS: {
+    type: 'uint'
+  },
   tls: {
     type: 'boolean'
   },

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -118,7 +118,7 @@ export type SupportedNodeConnectionOptions = SupportedTLSConnectionOptions &
 export interface MongoClientOptions extends BSONSerializeOptions, SupportedNodeConnectionOptions {
   /** Specifies the name of the replica set, if the mongod is a member of a replica set. */
   replicaSet?: string;
-  /** @experimental */
+  /** @internal This option is in development and currently has no behaviour. */
   timeoutMS?: number;
   /** Enables or disables TLS/SSL for the connection. */
   tls?: boolean;

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -118,6 +118,8 @@ export type SupportedNodeConnectionOptions = SupportedTLSConnectionOptions &
 export interface MongoClientOptions extends BSONSerializeOptions, SupportedNodeConnectionOptions {
   /** Specifies the name of the replica set, if the mongod is a member of a replica set. */
   replicaSet?: string;
+  /** @experimental */
+  timeoutMS?: number;
   /** Enables or disables TLS/SSL for the connection. */
   tls?: boolean;
   /** A boolean to enable or disables TLS/SSL for the connection. (The ssl option is equivalent to the tls option.) */


### PR DESCRIPTION
### Description

Implements unified test runner changes for the CSOT unified tests to run.

#### What is changing?

Implements the following operations:
- `listDatabaseNames`
- `listCollectionNames`
- `count`
- `listIndexNames`
- `dropIndexes`
- `drop`

Updates `find` to work on both a collection or gridfs bucket.

Patch for enabled CSOT unified tests on all topologies: https://spruce.mongodb.com/version/65a7fe30e3c33167dda24b5d/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-5823

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
