### PR TITLE
chore(NODE-5842): skip windows tls url settings failure

### DIFF
--- a/test/manual/tls_support.test.ts
+++ b/test/manual/tls_support.test.ts
@@ -1,3 +1,5 @@
+import * as process from 'node:process';
+
 import { expect } from 'chai';
 import { promises as fs } from 'fs';
 
@@ -31,6 +33,16 @@ describe('TLS Support', function () {
     'should connect with tls via client options',
     makeConnectionTest(CONNECTION_STRING, tlsSettings)
   );
+
+  beforeEach(function () {
+    if (
+      this.currentTest?.title === 'should connect with tls via url options' &&
+      process.platform === 'win32'
+    ) {
+      this.currentTest.skipReason = 'TODO(NODE-5803): Un-skip Windows TLS tests via URL';
+      return this.skip();
+    }
+  });
 
   it(
     'should connect with tls via url options',


### PR DESCRIPTION
### Description

#### What is changing?

- Skip flaky windows URL settings TLS test

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

Tracking the fix at NODE-5803

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
