### PR TITLE
feat(NODE-4848): Add runtime error handling to logging

### DIFF
--- a/src/mongo_logger.ts
+++ b/src/mongo_logger.ts
@@ -421,11 +421,9 @@ export function stringifyWithMaxLen(
     strToTruncate =
       typeof value !== 'function'
         ? EJSON.stringify(value, options)
-        : value.name !== ''
-        ? value.name
-        : 'anonymous function';
+        : 'ReadPreference function';
   } catch (e) {
-    strToTruncate = `... ESJON failed : Error ${e.message}`;
+    strToTruncate = `Extended JSON serialization failed with: ${e.message}`;
   }
 
   return maxDocumentLength !== 0 && strToTruncate.length > maxDocumentLength
@@ -463,7 +461,7 @@ function attachCommandFields(
   log.commandName = commandEvent.commandName;
   log.requestId = commandEvent.requestId;
   log.driverConnectionId = commandEvent.connectionId;
-  const { host, port } = HostAddress.fromString(commandEvent.address ?? '').toHostPort();
+  const { host, port } = HostAddress.fromString(commandEvent.address).toHostPort();
   log.serverHost = host;
   log.serverPort = port;
   if (commandEvent?.serviceId) {
@@ -476,7 +474,7 @@ function attachCommandFields(
 }
 
 function attachConnectionFields(log: Record<string, any>, event: any) {
-  const { host, port } = HostAddress.fromString(event.address ?? '').toHostPort();
+  const { host, port } = HostAddress.fromString(event.address).toHostPort();
   log.serverHost = host;
   log.serverPort = port;
 
@@ -498,7 +496,7 @@ function attachServerHeartbeatFields(
   const { awaited, connectionId } = serverHeartbeatEvent;
   log.awaited = awaited;
   log.driverConnectionId = serverHeartbeatEvent.connectionId;
-  const { host, port } = HostAddress.fromString(connectionId ?? '').toHostPort();
+  const { host, port } = HostAddress.fromString(connectionId).toHostPort();
   log.serverHost = host;
   log.serverPort = port;
   return log;

--- a/src/mongo_logger.ts
+++ b/src/mongo_logger.ts
@@ -219,7 +219,7 @@ export function createStdioLogger(stream: {
   write: NodeJS.WriteStream['write'];
 }): MongoDBLogWritable {
   return {
-    write: promisify((log: Log, cb: () => void): unknown => {
+    write: promisify((log: Log, cb: (error?: Error) => void): unknown => {
       stream.write(inspect(log, { compact: true, breakLength: Infinity }), 'utf-8', cb);
       return;
     })
@@ -418,10 +418,7 @@ export function stringifyWithMaxLen(
   let strToTruncate = '';
 
   try {
-    strToTruncate =
-      typeof value !== 'function'
-        ? EJSON.stringify(value, options)
-        : 'ReadPreference function';
+    strToTruncate = typeof value !== 'function' ? EJSON.stringify(value, options) : value.name;
   } catch (e) {
     strToTruncate = `Extended JSON serialization failed with: ${e.message}`;
   }

--- a/src/sdam/server_selection.ts
+++ b/src/sdam/server_selection.ts
@@ -22,14 +22,15 @@ export type ServerSelector = (
  * Returns a server selector that selects for writable servers
  */
 export function writableServerSelector(): ServerSelector {
-  return (
+  return function writableServer(
     topologyDescription: TopologyDescription,
     servers: ServerDescription[]
-  ): ServerDescription[] =>
-    latencyWindowReducer(
+  ): ServerDescription[] {
+    return latencyWindowReducer(
       topologyDescription,
       servers.filter((s: ServerDescription) => s.isWritable)
     );
+  };
 }
 
 /**
@@ -37,10 +38,10 @@ export function writableServerSelector(): ServerSelector {
  * if it is in a state that it can have commands sent to it.
  */
 export function sameServerSelector(description?: ServerDescription): ServerSelector {
-  return (
+  return function sameServerSelector(
     topologyDescription: TopologyDescription,
     servers: ServerDescription[]
-  ): ServerDescription[] => {
+  ): ServerDescription[] {
     if (!description) return [];
     // Filter the servers to match the provided description only if
     // the type is not unknown.
@@ -265,11 +266,11 @@ export function readPreferenceServerSelector(readPreference: ReadPreference): Se
     throw new MongoInvalidArgumentError('Invalid read preference specified');
   }
 
-  return (
+  return function readPreferenceServers(
     topologyDescription: TopologyDescription,
     servers: ServerDescription[],
     deprioritized: ServerDescription[] = []
-  ): ServerDescription[] => {
+  ): ServerDescription[] {
     const commonWireVersion = topologyDescription.commonWireVersion;
     if (
       commonWireVersion &&

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -171,7 +171,7 @@ export function applyRetryableWrites<T extends HasRetryableWrites>(target: T, db
  * @param value - An object that could be a promise
  * @returns true if the provided value is a Promise
  */
-export function isPromiseLike<T = any>(value?: unknown): value is Promise<T> {
+export function isPromiseLike<T = any>(value?: unknown): value is PromiseLike<T> {
   return (
     value != null &&
     typeof value === 'object' &&

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -171,7 +171,7 @@ export function applyRetryableWrites<T extends HasRetryableWrites>(target: T, db
  * @param value - An object that could be a promise
  * @returns true if the provided value is a Promise
  */
-export function isPromiseLike<T = any>(value?: unknown): value is PromiseLike<T> {
+export function isPromiseLike<T = unknown>(value?: unknown): value is PromiseLike<T> {
   return (
     value != null &&
     typeof value === 'object' &&

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -171,7 +171,10 @@ export function applyRetryableWrites<T extends HasRetryableWrites>(target: T, db
  * @param value - An object that could be a promise
  * @returns true if the provided value is a Promise
  */
-export function isPromiseLike<T = any>(value?: PromiseLike<T> | void): value is Promise<T> {
+export function isPromiseLike<T = any>(
+  value?: PromiseLike<T> | void | unknown
+): value is Promise<T> {
+  // @ts-expect-error since value exists, value.then check is valid ts
   return !!value && typeof value.then === 'function';
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -171,11 +171,13 @@ export function applyRetryableWrites<T extends HasRetryableWrites>(target: T, db
  * @param value - An object that could be a promise
  * @returns true if the provided value is a Promise
  */
-export function isPromiseLike<T = any>(
-  value?: PromiseLike<T> | void | unknown
-): value is Promise<T> {
-  // @ts-expect-error since value exists, value.then check is valid ts
-  return !!value && typeof value.then === 'function';
+export function isPromiseLike<T = any>(value?: unknown): value is Promise<T> {
+  return (
+    value != null &&
+    typeof value === 'object' &&
+    'then' in value &&
+    typeof value.then === 'function'
+  );
 }
 
 /**

--- a/test/unit/mongo_logger.test.ts
+++ b/test/unit/mongo_logger.test.ts
@@ -21,7 +21,6 @@ import {
   CONNECTION_READY,
   createStdioLogger,
   DEFAULT_MAX_DOCUMENT_LENGTH,
-  defaultLogTransform,
   type Log,
   type MongoDBLogWritable,
   MongoLogger,
@@ -57,7 +56,7 @@ describe('meta tests for BufferingStream', function () {
   });
 });
 
-describe('class MongoLogger', async function () {
+describe.only('class MongoLogger', async function () {
   describe('#constructor()', function () {
     it('assigns each property from the options object onto the logging class', function () {
       const componentSeverities: MongoLoggerOptions['componentSeverities'] = {
@@ -1330,15 +1329,6 @@ describe('class MongoLogger', async function () {
             'anonymous function'
           );
         });
-      });
-    });
-  });
-
-  describe('defaultLogTransform', function () {
-    context('when provided a Loggable Event with invalid host-port', function () {
-      // this is an important case to consider, because in the case of an undefined address, the HostAddress.toString() function will throw
-      it('should not throw and output empty host string instead', function () {
-        expect(defaultLogTransform({ name: 'connectionCreated' }).serverHost).to.equal('');
       });
     });
   });

--- a/test/unit/mongo_logger.test.ts
+++ b/test/unit/mongo_logger.test.ts
@@ -19,11 +19,14 @@ import {
   CONNECTION_POOL_CREATED,
   CONNECTION_POOL_READY,
   CONNECTION_READY,
+  createStdioLogger,
   DEFAULT_MAX_DOCUMENT_LENGTH,
+  defaultLogTransform,
   type Log,
   type MongoDBLogWritable,
   MongoLogger,
   type MongoLoggerOptions,
+  parseSeverityFromString,
   SeverityLevel,
   stringifyWithMaxLen
 } from '../mongodb';
@@ -1227,6 +1230,12 @@ describe('class MongoLogger', function () {
             });
           });
         });
+
+        context('when invalid severity is passed into parseSeverityFromString', function () {
+          it('should not throw', function () {
+            expect(parseSeverityFromString('notARealSeverityLevel')).to.equal(null);
+          });
+        });
       });
     }
   });
@@ -1274,6 +1283,135 @@ describe('class MongoLogger', function () {
           expect(() => {
             EJSON.parse(stringifyWithMaxLen(smallDoc, DEFAULT_MAX_DOCUMENT_LENGTH));
           }).to.not.throw();
+        });
+      });
+
+      context('EJSON stringify invalid inputs', function () {
+        const errorInputs = [
+          {
+            name: 'Map with non-string keys',
+            input: new Map([
+              [1, 'one'],
+              [2, 'two'],
+              [3, 'three']
+            ])
+          },
+          {
+            name: 'Object with invalid _bsontype',
+            input: { _bsontype: 'i will never be a real bson type' }
+          }
+        ];
+        for (let i = 0; i < errorInputs.length; i++) {
+          context(`when value is ${errorInputs[i].name}`, function () {
+            it('should output default error message, with no error thrown', function () {
+              expect(
+                stringifyWithMaxLen(errorInputs[i].input, DEFAULT_MAX_DOCUMENT_LENGTH)
+              ).to.equal('... ESJON failed : Error ...');
+            });
+          });
+        }
+      });
+
+      context('when given anonymous function as input', function () {
+        it('should output default error message', function () {
+          expect(stringifyWithMaxLen((v: number) => v + 1, DEFAULT_MAX_DOCUMENT_LENGTH)).to.equal(
+            'anonymous function'
+          );
+        });
+      });
+    });
+  });
+
+  describe('defaultLogTransform', function () {
+    context('when provided a Loggable Event with invalid host-port', function () {
+      // this is an important case to consider, because in the case of an undefined address, the HostAddress.toString() function will throw
+      it('should not throw and output empty host string instead', function () {
+        expect(defaultLogTransform({ name: 'connectionCreated' }).serverHost).to.equal('');
+      });
+    });
+  });
+
+  describe('log', function () {
+    context('stream failure handling', function () {
+      const componentSeverities: MongoLoggerOptions['componentSeverities'] = {
+        default: 'error'
+      } as any;
+      context('when stream is not stderr', function () {
+        let stderrStub;
+
+        beforeEach(function () {
+          stderrStub = sinon.stub(process.stderr);
+        });
+
+        afterEach(function () {
+          sinon.restore();
+        });
+
+        context('when stream user defined stream and stream.write throws', function () {
+          it('should catch error, not crash application, warn user, and start writing to stderr', function () {
+            const stream = {
+              write(_log) {
+                throw Error('This writable always throws');
+              }
+            };
+            const logger = new MongoLogger({
+              componentSeverities,
+              maxDocumentLength: 1000,
+              logDestination: stream
+            });
+            // print random message at the debug level
+            logger.debug('random message');
+            let stderrStubCall = stderrStub.write.getCall(0).args[0];
+            stderrStubCall = stderrStubCall.slice(stderrStubCall.search('c:'));
+            expect(stderrStubCall).to.equal(
+              `c: 'client', s: 'error', message: 'User input for mongodbLogPath is now invalid. Now logging to stderr.', error: 'This writable always throws' }`
+            );
+            logger.debug('random message 2');
+            const stderrStubCall2 = stderrStub.write.getCall(1);
+            expect(stderrStubCall2).to.not.be.null;
+          });
+        });
+
+        context('when stream is stdout and stdout.write throws', function () {
+          it('should catch error, not crash application, warn user, and start writing to stderr', function () {
+            sinon.stub(process.stdout, 'write').throws(new Error('I am stdout and do not work'));
+            // print random message at the debug level
+            const logger = new MongoLogger({
+              componentSeverities,
+              maxDocumentLength: 1000,
+              logDestination: createStdioLogger(process.stdout)
+            });
+            logger.debug('random message');
+            let stderrStubCall = stderrStub.write.getCall(0).args[0];
+            stderrStubCall = stderrStubCall.slice(stderrStubCall.search('c:'));
+            expect(stderrStubCall).to.equal(
+              `c: 'client', s: 'error', message: 'User input for mongodbLogPath is now invalid. Now logging to stderr.', error: 'I am stdout and do not work' }`
+            );
+            logger.debug('random message 2');
+            const stderrStubCall2 = stderrStub.write.getCall(1);
+            expect(stderrStubCall2).to.not.be.null;
+          });
+        });
+      });
+
+      context('when stream is stderr', function () {
+        context('when stderr.write throws', function () {
+          beforeEach(function () {
+            sinon.stub(process.stderr, 'write').throws(new Error('fake stderr failure'));
+          });
+          afterEach(function () {
+            sinon.restore();
+          });
+
+          it('should not throw error', function () {
+            // print random message at the debug level
+            const logger = new MongoLogger({
+              componentSeverities,
+              maxDocumentLength: 1000,
+              logDestination: createStdioLogger(process.stderr)
+            });
+            expect(() => logger.debug('random message')).to.not.throw(Error);
+          });
         });
       });
     });

--- a/test/unit/mongo_logger.test.ts
+++ b/test/unit/mongo_logger.test.ts
@@ -56,7 +56,7 @@ describe('meta tests for BufferingStream', function () {
   });
 });
 
-describe.only('class MongoLogger', async function () {
+describe('class MongoLogger', async function () {
   describe('#constructor()', function () {
     it('assigns each property from the options object onto the logging class', function () {
       const componentSeverities: MongoLoggerOptions['componentSeverities'] = {
@@ -1315,32 +1315,39 @@ describe.only('class MongoLogger', async function () {
         for (const errorInput of errorInputs) {
           context(`when value is ${errorInput.name}`, function () {
             it('should output default error message, with no error thrown', function () {
-              expect(stringifyWithMaxLen(errorInput.input, 25)).to.equal(
-                '... ESJON failed : Error ...'
+              expect(stringifyWithMaxLen(errorInput.input, 40)).to.equal(
+                'Extended JSON serialization failed with:...'
               );
             });
           });
         }
       });
 
-      context('when given anonymous function as input', function () {
-        it('should output default error message', function () {
-          expect(stringifyWithMaxLen((v: number) => v + 1, DEFAULT_MAX_DOCUMENT_LENGTH)).to.equal(
-            'anonymous function'
-          );
+      context('when given function as input', function () {
+        it('should output function.name', function () {
+          expect(
+            stringifyWithMaxLen(function randomFunc() {
+              return 1;
+            }, DEFAULT_MAX_DOCUMENT_LENGTH)
+          ).to.equal('randomFunc');
         });
       });
     });
   });
 
   describe('log', async function () {
-    const componentSeverities: MongoLoggerOptions['componentSeverities'] = {
-      command: 'trace',
-      topology: 'trace',
-      serverSelection: 'trace',
-      connection: 'trace',
-      client: 'trace'
-    } as any;
+    let componentSeverities: MongoLoggerOptions['componentSeverities'];
+
+    beforeEach(function () {
+      componentSeverities = {
+        command: 'trace',
+        topology: 'trace',
+        serverSelection: 'trace',
+        connection: 'trace',
+        client: 'trace'
+      } as any;
+    });
+
     describe('sync stream failure handling', function () {
       context('when stream is not stderr', function () {
         let stderrStub;

--- a/test/unit/mongo_logger.test.ts
+++ b/test/unit/mongo_logger.test.ts
@@ -67,7 +67,8 @@ describe('class MongoLogger', async function () {
       const logger = new MongoLogger({
         componentSeverities,
         maxDocumentLength: 10,
-        logDestination: stream
+        logDestination: stream,
+        logDestinationIsStdErr: false
       });
 
       expect(logger).to.have.property('componentSeverities', componentSeverities);
@@ -85,7 +86,8 @@ describe('class MongoLogger', async function () {
         } as { buffer: any[]; write: (log: Log) => void };
         const logger = new MongoLogger({
           componentSeverities: { command: 'error' } as any,
-          logDestination
+          logDestination,
+          logDestinationIsStdErr: false
         } as any);
 
         logger.error('command', 'Hello world!');
@@ -105,7 +107,8 @@ describe('class MongoLogger', async function () {
 
         const logger = new MongoLogger({
           componentSeverities: { command: 'error' } as any,
-          logDestination
+          logDestination,
+          logDestinationIsStdErr: false
         } as any);
 
         logger.error('command', 'Hello world!');
@@ -648,7 +651,8 @@ describe('class MongoLogger', async function () {
             componentSeverities: {
               topology: 'off'
             } as any,
-            logDestination: stream
+            logDestination: stream,
+            logDestinationIsStdErr: false
           } as any);
 
           logger[severityLevel]('topology', 'message');
@@ -662,7 +666,8 @@ describe('class MongoLogger', async function () {
               componentSeverities: {
                 command: severityLevel
               } as any,
-              logDestination: stream
+              logDestination: stream,
+              logDestinationIsStdErr: false
             } as any);
 
             for (let i = index + 1; i < severities.length; i++) {
@@ -681,7 +686,8 @@ describe('class MongoLogger', async function () {
               componentSeverities: {
                 command: severityLevel
               } as any,
-              logDestination: stream
+              logDestination: stream,
+              logDestinationIsStdErr: false
             } as any);
 
             // Calls all severity logging methods with a level less than or equal to what severityLevel
@@ -706,7 +712,8 @@ describe('class MongoLogger', async function () {
             const stream = new BufferingStream();
             const logger = new MongoLogger({
               componentSeverities: { command: severityLevel } as any,
-              logDestination: stream
+              logDestination: stream,
+              logDestinationIsStdErr: false
             } as any);
 
             logger[severityLevel]('command', obj);
@@ -722,7 +729,8 @@ describe('class MongoLogger', async function () {
             const stream = new BufferingStream();
             const logger = new MongoLogger({
               componentSeverities: { command: severityLevel } as any,
-              logDestination: stream
+              logDestination: stream,
+              logDestinationIsStdErr: false
             } as any);
 
             logger[severityLevel]('command', obj);
@@ -742,7 +750,8 @@ describe('class MongoLogger', async function () {
             const stream = new BufferingStream();
             const logger = new MongoLogger({
               componentSeverities: { command: severityLevel } as any,
-              logDestination: stream
+              logDestination: stream,
+              logDestinationIsStdErr: false
             } as any);
 
             logger[severityLevel]('command', obj);
@@ -760,7 +769,8 @@ describe('class MongoLogger', async function () {
             const stream = new BufferingStream();
             const logger = new MongoLogger({
               componentSeverities: { command: severityLevel } as any,
-              logDestination: stream
+              logDestination: stream,
+              logDestinationIsStdErr: false
             } as any);
 
             logger[severityLevel]('command', message);
@@ -780,7 +790,8 @@ describe('class MongoLogger', async function () {
                 command: 'trace',
                 connection: 'trace'
               } as any,
-              logDestination: stream
+              logDestination: stream,
+              logDestinationIsStdErr: false
             } as any);
           });
 
@@ -1358,7 +1369,8 @@ describe('class MongoLogger', async function () {
             const logger = new MongoLogger({
               componentSeverities,
               maxDocumentLength: 1000,
-              logDestination: stream
+              logDestination: stream,
+              logDestinationIsStdErr: false
             });
             // print random message at the debug level
             logger.debug('random message');
@@ -1397,7 +1409,8 @@ describe('class MongoLogger', async function () {
             const logger = new MongoLogger({
               componentSeverities,
               maxDocumentLength: 1000,
-              logDestination: stream
+              logDestination: stream,
+              logDestinationIsStdErr: false
             });
             // print random message at the debug level
             logger.debug('random message');
@@ -1428,7 +1441,8 @@ describe('class MongoLogger', async function () {
             const logger = new MongoLogger({
               componentSeverities,
               maxDocumentLength: 1000,
-              logDestination: createStdioLogger(process.stdout, 'stdout')
+              logDestination: createStdioLogger(process.stdout),
+              logDestinationIsStdErr: false
             });
             logger.debug('random message');
             // manually wait for promise to resolve (takes extra time with promisify)
@@ -1459,7 +1473,8 @@ describe('class MongoLogger', async function () {
             const logger = new MongoLogger({
               componentSeverities,
               maxDocumentLength: 1000,
-              logDestination: createStdioLogger(process.stderr, 'stderr')
+              logDestination: createStdioLogger(process.stderr),
+              logDestinationIsStdErr: true
             });
             expect(() => logger.debug('random message')).to.not.throw(Error);
             expect(Object.keys(logger.componentSeverities).every(key => key === SeverityLevel.OFF));
@@ -1483,7 +1498,8 @@ describe('class MongoLogger', async function () {
         const logger = new MongoLogger({
           componentSeverities,
           maxDocumentLength: 1000,
-          logDestination: stream
+          logDestination: stream,
+          logDestinationIsStdErr: false
         });
 
         logger.debug('longer timeout');


### PR DESCRIPTION
### Note for Reviewers
Look at changes commit by commit to easily separate async and sync changes

### Description
This ticket is a subtask of [NODE-4816](https://jira.mongodb.org/browse/NODE-4816) (Add Error Handling to the Logger).
Essentially, these changes ensure that the logger does not crash the user's application at runtime, at any point after options are parsed.

#### What is changing?
Add support for runtime error handling (ensure no constructors for loggers throw unless given type errors, log.write, stringifyWithMaxLen, defaultLogTransform).

Add async support for log.write function

See all unit tests defined under runtime error handling in [Kickoff Document](https://docs.google.com/document/d/1gDJ9vpVdH7BalRxEvzC_UZz-gIYOLSTU7HTqSoa18FA/edit#heading=h.7t9v3ahij9a1), and under mongodbLogPath stream handling (since some of this must be done at runtime).

Note: There are no changes to any of the constructors of `LoggableEvent` classes or calls to emitAndLog / variants because no `LoggableEvent` constructors have any explicit errors thrown. In addition, no arguments to `LoggableEvent` constructors are ever invalid at the time of construction. 

##### Is there new documentation needed for these changes?
After NODE-5672 (Release Logger)

#### What is the motivation for this change?
To ensure we don't crash the user's application through the logger.

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
