### PR TITLE
feat(NODE-5820): Add async support for createStdioLogger

### DIFF
--- a/src/mongo_logger.ts
+++ b/src/mongo_logger.ts
@@ -1,5 +1,5 @@
 import type { Writable } from 'stream';
-import { inspect } from 'util';
+import { inspect, promisify } from 'util';
 
 import { type Document, EJSON, type EJSONOptions, type ObjectId } from './bson';
 import type { CommandStartedEvent } from './cmap/command_monitoring_events';
@@ -217,10 +217,10 @@ export function createStdioLogger(stream: {
   write: NodeJS.WriteStream['write'];
 }): MongoDBLogWritable {
   return {
-    write: (log: Log): unknown => {
+    write: promisify((log: Log): unknown => {
       stream.write(inspect(log, { compact: true, breakLength: Infinity }), 'utf-8');
       return;
-    }
+    })
   };
 }
 
@@ -281,7 +281,7 @@ export interface Log extends Record<string, any> {
 
 /** @internal */
 export interface MongoDBLogWritable {
-  write(log: Log): void;
+  write(log: Log): PromiseLike<unknown> | any;
 }
 
 function compareSeverity(s0: SeverityLevel, s1: SeverityLevel): 1 | 0 | -1 {

--- a/src/mongo_logger.ts
+++ b/src/mongo_logger.ts
@@ -217,8 +217,8 @@ export function createStdioLogger(stream: {
   write: NodeJS.WriteStream['write'];
 }): MongoDBLogWritable {
   return {
-    write: promisify((log: Log): unknown => {
-      stream.write(inspect(log, { compact: true, breakLength: Infinity }), 'utf-8');
+    write: promisify((log: Log, cb: () => void): unknown => {
+      stream.write(inspect(log, { compact: true, breakLength: Infinity }), 'utf-8', cb);
       return;
     })
   };


### PR DESCRIPTION
### Description
This ticket is a subtask of NODE-4816 (Add error handling to logging). Its testing is contained within the other subtask (NODE-4848), and I ran those tests on this code to ensure they pass separately. 

Promisify `createStdioLogger` so it supports async std i/o ([see here to see more information on async stdio](https://nodejs.org/docs/latest/api/process.html#a-note-on-process-io)).

#### What is changing?
Change write signature (repeat of async write PR)
Wrap write method in createStdioLogger in promisify function

##### Is there new documentation needed for these changes?
After logging is released 

#### What is the motivation for this change?
Async behavior stdio on certain environments.

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
