### PR TITLE
fix(NODE-5840): heartbeat duration includes socket creation

### DIFF
--- a/src/cmap/connect.ts
+++ b/src/cmap/connect.ts
@@ -16,7 +16,7 @@ import {
   MongoRuntimeError,
   needsRetryableWriteLabel
 } from '../error';
-import { type Callback, HostAddress, ns } from '../utils';
+import { HostAddress, ns, promiseWithResolvers } from '../utils';
 import { AuthContext, type AuthProvider } from './auth/auth_provider';
 import { GSSAPI } from './auth/gssapi';
 import { MongoCR } from './auth/mongocr';
@@ -55,27 +55,26 @@ export const AUTH_PROVIDERS = new Map<AuthMechanism | string, AuthProvider>([
 /** @public */
 export type Stream = Socket | TLSSocket;
 
-export function connect(options: ConnectionOptions, callback: Callback<Connection>): void {
-  makeConnection({ ...options, existingSocket: undefined }, (err, socket) => {
-    if (err || !socket) {
-      return callback(err);
-    }
+export async function connect(options: ConnectionOptions): Promise<Connection> {
+  let connection: Connection | null = null;
+  try {
+    const socket = await makeSocket(options);
+    connection = makeConnection(options, socket);
+    await performInitialHandshake(connection, options);
+    return connection;
+  } catch (error) {
+    connection?.destroy({ force: false });
+    throw error;
+  }
+}
 
-    let ConnectionType = options.connectionType ?? Connection;
-    if (options.autoEncrypter) {
-      ConnectionType = CryptoConnection;
-    }
+export function makeConnection(options: ConnectionOptions, socket: Stream): Connection {
+  let ConnectionType = options.connectionType ?? Connection;
+  if (options.autoEncrypter) {
+    ConnectionType = CryptoConnection;
+  }
 
-    const connection = new ConnectionType(socket, options);
-
-    performInitialHandshake(connection, options).then(
-      () => callback(undefined, connection),
-      error => {
-        connection.destroy({ force: false });
-        callback(error);
-      }
-    );
-  });
+  return new ConnectionType(socket, options);
 }
 
 function checkSupportedServer(hello: Document, options: ConnectionOptions) {
@@ -103,7 +102,7 @@ function checkSupportedServer(hello: Document, options: ConnectionOptions) {
   return new MongoCompatibilityError(message);
 }
 
-async function performInitialHandshake(
+export async function performInitialHandshake(
   conn: Connection,
   options: ConnectionOptions
 ): Promise<void> {
@@ -329,11 +328,7 @@ function parseSslOptions(options: MakeConnectionOptions): TLSConnectionOpts {
   return result;
 }
 
-const SOCKET_ERROR_EVENT_LIST = ['error', 'close', 'timeout', 'parseError'] as const;
-type ErrorHandlerEventName = (typeof SOCKET_ERROR_EVENT_LIST)[number] | 'cancel';
-const SOCKET_ERROR_EVENTS = new Set(SOCKET_ERROR_EVENT_LIST);
-
-function makeConnection(options: MakeConnectionOptions, _callback: Callback<Stream>) {
+export async function makeSocket(options: MakeConnectionOptions): Promise<Stream> {
   const useTLS = options.tls ?? false;
   const noDelay = options.noDelay ?? true;
   const connectTimeoutMS = options.connectTimeoutMS ?? 30000;
@@ -341,23 +336,13 @@ function makeConnection(options: MakeConnectionOptions, _callback: Callback<Stre
   const existingSocket = options.existingSocket;
 
   let socket: Stream;
-  const callback: Callback<Stream> = function (err, ret) {
-    if (err && socket) {
-      socket.destroy();
-    }
-
-    _callback(err, ret);
-  };
 
   if (options.proxyHost != null) {
     // Currently, only Socks5 is supported.
-    return makeSocks5Connection(
-      {
-        ...options,
-        connectTimeoutMS // Should always be present for Socks5
-      },
-      callback
-    );
+    return makeSocks5Connection({
+      ...options,
+      connectTimeoutMS // Should always be present for Socks5
+    });
   }
 
   if (useTLS) {
@@ -379,47 +364,41 @@ function makeConnection(options: MakeConnectionOptions, _callback: Callback<Stre
   socket.setTimeout(connectTimeoutMS);
   socket.setNoDelay(noDelay);
 
-  const connectEvent = useTLS ? 'secureConnect' : 'connect';
-  let cancellationHandler: (err: Error) => void;
-  function errorHandler(eventName: ErrorHandlerEventName) {
-    return (err: Error) => {
-      SOCKET_ERROR_EVENTS.forEach(event => socket.removeAllListeners(event));
-      if (cancellationHandler && options.cancellationToken) {
-        options.cancellationToken.removeListener('cancel', cancellationHandler);
-      }
+  let cancellationHandler: ((err: Error) => void) | null = null;
 
-      socket.removeListener(connectEvent, connectHandler);
-      callback(connectionFailureError(eventName, err));
-    };
-  }
-
-  function connectHandler() {
-    SOCKET_ERROR_EVENTS.forEach(event => socket.removeAllListeners(event));
-    if (cancellationHandler && options.cancellationToken) {
-      options.cancellationToken.removeListener('cancel', cancellationHandler);
-    }
-
-    if ('authorizationError' in socket) {
-      if (socket.authorizationError && rejectUnauthorized) {
-        // TODO(NODE-5192): wrap this with a MongoError subclass
-        return callback(socket.authorizationError);
-      }
-    }
-
-    socket.setTimeout(0);
-    callback(undefined, socket);
-  }
-
-  SOCKET_ERROR_EVENTS.forEach(event => socket.once(event, errorHandler(event)));
-  if (options.cancellationToken) {
-    cancellationHandler = errorHandler('cancel');
-    options.cancellationToken.once('cancel', cancellationHandler);
-  }
-
+  const { promise: connectedSocket, resolve, reject } = promiseWithResolvers<Stream>();
   if (existingSocket) {
-    process.nextTick(connectHandler);
+    resolve(socket);
   } else {
-    socket.once(connectEvent, connectHandler);
+    const connectEvent = useTLS ? 'secureConnect' : 'connect';
+    socket
+      .once(connectEvent, () => resolve(socket))
+      .once('error', error => reject(error))
+      .once('timeout', () => reject(connectionFailureError('timeout')))
+      .once('close', () => reject(connectionFailureError('close')));
+
+    if (options.cancellationToken != null) {
+      cancellationHandler = () => reject(connectionFailureError('cancel'));
+      options.cancellationToken.once('cancel', cancellationHandler);
+    }
+  }
+
+  try {
+    socket = await connectedSocket;
+    return socket;
+  } catch (error) {
+    socket.destroy();
+    if ('authorizationError' in socket && socket.authorizationError != null && rejectUnauthorized) {
+      // TODO(NODE-5192): wrap this with a MongoError subclass
+      throw socket.authorizationError;
+    }
+    throw error;
+  } finally {
+    socket.setTimeout(0);
+    socket.removeAllListeners();
+    if (cancellationHandler != null) {
+      options.cancellationToken?.removeListener('cancel', cancellationHandler);
+    }
   }
 }
 
@@ -435,78 +414,71 @@ function loadSocks() {
   return socks;
 }
 
-function makeSocks5Connection(options: MakeConnectionOptions, callback: Callback<Stream>) {
+async function makeSocks5Connection(options: MakeConnectionOptions): Promise<Stream> {
   const hostAddress = HostAddress.fromHostPort(
     options.proxyHost ?? '', // proxyHost is guaranteed to set here
     options.proxyPort ?? 1080
   );
 
   // First, connect to the proxy server itself:
-  makeConnection(
-    {
+  const rawSocket = await makeSocket({
+    ...options,
+    hostAddress,
+    tls: false,
+    proxyHost: undefined
+  });
+
+  const destination = parseConnectOptions(options) as net.TcpNetConnectOpts;
+  if (typeof destination.host !== 'string' || typeof destination.port !== 'number') {
+    throw new MongoInvalidArgumentError('Can only make Socks5 connections to TCP hosts');
+  }
+
+  socks ??= loadSocks();
+
+  try {
+    // Then, establish the Socks5 proxy connection:
+    const { socket } = await socks.SocksClient.createConnection({
+      existing_socket: rawSocket,
+      timeout: options.connectTimeoutMS,
+      command: 'connect',
+      destination: {
+        host: destination.host,
+        port: destination.port
+      },
+      proxy: {
+        // host and port are ignored because we pass existing_socket
+        host: 'iLoveJavaScript',
+        port: 0,
+        type: 5,
+        userId: options.proxyUsername || undefined,
+        password: options.proxyPassword || undefined
+      }
+    });
+
+    // Finally, now treat the resulting duplex stream as the
+    // socket over which we send and receive wire protocol messages:
+    return await makeSocket({
       ...options,
-      hostAddress,
-      tls: false,
+      existingSocket: socket,
       proxyHost: undefined
-    },
-    (err, rawSocket) => {
-      if (err || !rawSocket) {
-        return callback(err);
-      }
-
-      const destination = parseConnectOptions(options) as net.TcpNetConnectOpts;
-      if (typeof destination.host !== 'string' || typeof destination.port !== 'number') {
-        return callback(
-          new MongoInvalidArgumentError('Can only make Socks5 connections to TCP hosts')
-        );
-      }
-
-      try {
-        socks ??= loadSocks();
-      } catch (error) {
-        return callback(error);
-      }
-
-      // Then, establish the Socks5 proxy connection:
-      socks.SocksClient.createConnection({
-        existing_socket: rawSocket,
-        timeout: options.connectTimeoutMS,
-        command: 'connect',
-        destination: {
-          host: destination.host,
-          port: destination.port
-        },
-        proxy: {
-          // host and port are ignored because we pass existing_socket
-          host: 'iLoveJavaScript',
-          port: 0,
-          type: 5,
-          userId: options.proxyUsername || undefined,
-          password: options.proxyPassword || undefined
-        }
-      }).then(
-        ({ socket }) => {
-          // Finally, now treat the resulting duplex stream as the
-          // socket over which we send and receive wire protocol messages:
-          makeConnection(
-            {
-              ...options,
-              existingSocket: socket,
-              proxyHost: undefined
-            },
-            callback
-          );
-        },
-        error => callback(connectionFailureError('error', error))
-      );
-    }
-  );
+    });
+  } catch (error) {
+    throw connectionFailureError('error', error);
+  }
 }
 
-function connectionFailureError(type: ErrorHandlerEventName, err: Error) {
+function connectionFailureError(type: 'error', cause: Error): MongoNetworkError;
+function connectionFailureError(
+  type: 'error' | 'close' | 'timeout' | 'cancel',
+  cause?: Error
+): MongoNetworkError;
+function connectionFailureError(
+  type: 'error' | 'close' | 'timeout' | 'cancel',
+  cause?: Error
+): MongoNetworkError {
   switch (type) {
     case 'error':
-      return new MongoNetworkError(MongoError.buildErrorMessage(err), { cause: err });
+      return new MongoNetworkError(MongoError.buildErrorMessage(cause), { cause });
     case 'timeout':
       return new MongoNetworkTimeoutError('connection timed out');
     case 'close':

--- a/src/cmap/connect.ts
+++ b/src/cmap/connect.ts
@@ -468,10 +468,7 @@ async function makeSocks5Connection(options: MakeConnectionOptions): Promise<Str
 }
 
 function connectionFailureError(type: 'error', cause: Error): MongoNetworkError;
-function connectionFailureError(
-  type: 'error' | 'close' | 'timeout' | 'cancel',
-  cause?: Error
-): MongoNetworkError;
+function connectionFailureError(type: 'close' | 'timeout' | 'cancel'): MongoNetworkError;
 function connectionFailureError(
   type: 'error' | 'close' | 'timeout' | 'cancel',
   cause?: Error

--- a/src/cmap/connect.ts
+++ b/src/cmap/connect.ts
@@ -373,7 +373,7 @@ export async function makeSocket(options: MakeConnectionOptions): Promise<Stream
     const connectEvent = useTLS ? 'secureConnect' : 'connect';
     socket
       .once(connectEvent, () => resolve(socket))
-      .once('error', error => reject(error))
+      .once('error', error => reject(connectionFailureError('error', error)))
       .once('timeout', () => reject(connectionFailureError('timeout')))
       .once('close', () => reject(connectionFailureError('close')));
 

--- a/src/error.ts
+++ b/src/error.ts
@@ -109,8 +109,8 @@ export interface ErrorDescription extends Document {
   errInfo?: Document;
 }
 
-function isAggregateError(e: Error): e is Error & { errors: Error[] } {
-  return 'errors' in e && Array.isArray(e.errors);
+function isAggregateError(e: unknown): e is Error & { errors: Error[] } {
+  return e != null && typeof e === 'object' && 'errors' in e && Array.isArray(e.errors);
 }
 
 /**
@@ -150,7 +150,7 @@ export class MongoError extends Error {
   }
 
   /** @internal */
-  static buildErrorMessage(e: Error | string): string {
+  static buildErrorMessage(e: unknown): string {
     if (typeof e === 'string') {
       return e;
     }
@@ -160,7 +160,9 @@ export class MongoError extends Error {
         : e.errors.map(({ message }) => message).join(', ');
     }
 
-    return e.message;
+    return e != null && typeof e === 'object' && 'message' in e && typeof e.message === 'string'
+      ? e.message
+      : 'empty error message';
   }
 
   override get name(): string {

--- a/src/sdam/monitor.ts
+++ b/src/sdam/monitor.ts
@@ -358,8 +358,13 @@ function checkServer(monitor: Monitor, callback: Callback<Document | null>) {
     const socket = await makeSocket(monitor.connectOptions);
     const connection = makeConnection(monitor.connectOptions, socket);
     start = now();
-    await performInitialHandshake(connection, monitor.connectOptions);
-    return connection;
+    try {
+      await performInitialHandshake(connection, monitor.connectOptions);
+      return connection;
+    } catch (error) {
+      connection.destroy({ force: false });
+      throw error;
+    }
   })().then(
     connection => {
       if (isInCloseState(monitor)) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -492,9 +492,9 @@ export function now(): number {
 }
 
 /** @internal */
-export function calculateDurationInMs(started: number): number {
+export function calculateDurationInMs(started: number | undefined): number {
   if (typeof started !== 'number') {
-    throw new MongoInvalidArgumentError('Numeric value required to calculate duration');
+    return -1;
   }
 
   const elapsed = now() - started;

--- a/test/integration/connection-monitoring-and-pooling/connection.test.ts
+++ b/test/integration/connection-monitoring-and-pooling/connection.test.ts
@@ -35,7 +35,7 @@ describe('Connection', function () {
     it('should execute a command against a server', {
       metadata: { requires: { apiVersion: false, topology: '!load-balanced' } },
       test: async function () {
-        const connectOptions: Partial<ConnectionOptions> = {
+        const connectOptions: ConnectionOptions = {
           connectionType: Connection,
           ...this.configuration.options,
           metadata: makeClientMetadata({ driverInfo: {} })
@@ -43,7 +43,7 @@ describe('Connection', function () {
 
         let conn;
         try {
-          conn = await promisify(connect)(connectOptions as any as ConnectionOptions);
+          conn = await connect(connectOptions);
           const hello = await conn?.command(ns('admin.$cmd'), { [LEGACY_HELLO_COMMAND]: 1 });
           expect(hello).to.have.property('ok', 1);
         } finally {
@@ -55,7 +55,7 @@ describe('Connection', function () {
     it('should emit command monitoring events', {
       metadata: { requires: { apiVersion: false, topology: '!load-balanced' } },
       test: async function () {
-        const connectOptions: Partial<ConnectionOptions> = {
+        const connectOptions: ConnectionOptions = {
           connectionType: Connection,
           ...this.configuration.options,
           monitorCommands: true,
@@ -64,7 +64,7 @@ describe('Connection', function () {
 
         let conn;
         try {
-          conn = await promisify(connect)(connectOptions as any as ConnectionOptions);
+          conn = await connect(connectOptions);
 
           const events: any[] = [];
           conn.on('commandStarted', event => events.push(event));

--- a/test/integration/connection-monitoring-and-pooling/connection.test.ts
+++ b/test/integration/connection-monitoring-and-pooling/connection.test.ts
@@ -1,5 +1,3 @@
-import { promisify } from 'node:util';
-
 import { expect } from 'chai';
 
 import {

--- a/test/integration/connection-monitoring-and-pooling/connection.test.ts
+++ b/test/integration/connection-monitoring-and-pooling/connection.test.ts
@@ -4,6 +4,7 @@ import {
   connect,
   Connection,
   type ConnectionOptions,
+  HostAddress,
   LEGACY_HELLO_COMMAND,
   makeClientMetadata,
   MongoClient,
@@ -14,6 +15,16 @@ import {
 } from '../../mongodb';
 import { skipBrokenAuthTestBeforeEachHook } from '../../tools/runner/hooks/configuration';
 import { assert as test, setupDatabase } from '../shared';
+
+const commonConnectOptions = {
+  id: 1,
+  generation: 1,
+  monitorCommands: false,
+  tls: false,
+  loadBalanced: false,
+  // Will be overridden by configuration options
+  hostAddress: HostAddress.fromString('127.0.0.1:1')
+};
 
 describe('Connection', function () {
   beforeEach(
@@ -34,6 +45,7 @@ describe('Connection', function () {
       metadata: { requires: { apiVersion: false, topology: '!load-balanced' } },
       test: async function () {
         const connectOptions: ConnectionOptions = {
+          ...commonConnectOptions,
           connectionType: Connection,
           ...this.configuration.options,
           metadata: makeClientMetadata({ driverInfo: {} })
@@ -54,6 +66,7 @@ describe('Connection', function () {
       metadata: { requires: { apiVersion: false, topology: '!load-balanced' } },
       test: async function () {
         const connectOptions: ConnectionOptions = {
+          ...commonConnectOptions,
           connectionType: Connection,
           ...this.configuration.options,
           monitorCommands: true,

--- a/test/tools/runner/hooks/configuration.js
+++ b/test/tools/runner/hooks/configuration.js
@@ -94,7 +94,11 @@ const testSkipBeforeEachHook = async function () {
   }
 };
 
-// TODO: NODE-3891 - fix tests that are broken with auth enabled and remove this hook
+/**
+ * TODO: NODE-3891 - fix tests that are broken with auth enabled and remove this hook
+ * @param {{ skippedTests: string[] }} skippedTests - define list of tests to skip
+ * @returns
+ */
 const skipBrokenAuthTestBeforeEachHook = function ({ skippedTests } = { skippedTests: [] }) {
   return function () {
     if (process.env.AUTH === 'auth' && skippedTests.includes(this.currentTest.title)) {

--- a/test/unit/cmap/connect.test.ts
+++ b/test/unit/cmap/connect.test.ts
@@ -1,5 +1,4 @@
 import { expect } from 'chai';
-import { promisify } from 'util';
 
 import {
   CancellationToken,

--- a/test/unit/cmap/connection.test.ts
+++ b/test/unit/cmap/connection.test.ts
@@ -1,18 +1,9 @@
 import { expect } from 'chai';
 import * as sinon from 'sinon';
-import { promisify } from 'util';
 
-import {
-  connect as driverConnectCb,
-  Connection,
-  isHello,
-  MongoNetworkTimeoutError,
-  ns
-} from '../../mongodb';
+import { connect, Connection, isHello, MongoNetworkTimeoutError, ns } from '../../mongodb';
 import * as mock from '../../tools/mongodb-mock/index';
 import { getSymbolFrom } from '../../tools/utils';
-
-const connect = promisify(driverConnectCb);
 
 const connectionOptionsDefaults = {
   id: 0,


### PR DESCRIPTION
### Description

#### What is changing?

- Refactor connect to be async
- Rename and refactor makeConnection -> makeSocket
- Add makeConnection function
- Refactor monitor to record start time after socket is created, before handshake
- socket failures set heartbeat failed duration to -1 
- Refactor tests using callback style connect
- Test duration does not include socket creation by artificially delaying it

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

The duration field of hb started and failed should match the definition in the spec.

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fixed heartbeat duration including socket creation

The ServerHeartbeatSucceeded and ServerHeartbeatFailed event have a duration property that represents the time it took to perform the `hello` handshake with MongoDB. The Monitor responsible for issuing heartbeats mistakenly included the time it took to create the socket in this field, which inflates the value with the time it takes to perform a DNS lookup, TCP, and TLS handshakes.

<!-- RELEASE_HIGHLIGHT_END -->

### Double-check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
