### PR TITLE
fix(NODE-5818): Add feature flagging to server selection logging

### DIFF
--- a/src/mongo_logger.ts
+++ b/src/mongo_logger.ts
@@ -222,7 +222,7 @@ export function createStdioLogger(stream: {
     write: promisify((log: Log, cb: (error?: Error) => void): unknown => {
       stream.write(inspect(log, { compact: true, breakLength: Infinity }), 'utf-8', cb);
       return;
-    })
+    }
   };
 }
 

--- a/src/mongo_logger.ts
+++ b/src/mongo_logger.ts
@@ -222,7 +222,7 @@ export function createStdioLogger(stream: {
     write: promisify((log: Log, cb: (error?: Error) => void): unknown => {
       stream.write(inspect(log, { compact: true, breakLength: Infinity }), 'utf-8', cb);
       return;
-    }
+    })
   };
 }
 

--- a/src/sdam/topology.ts
+++ b/src/sdam/topology.ts
@@ -569,7 +569,7 @@ export class Topology extends TypedEventEmitter<TopologyEvents> {
 
     options = { serverSelectionTimeoutMS: this.s.serverSelectionTimeoutMS, ...options };
     if (
-      this.client.mongoLogger?.willLog(SeverityLevel.DEBUG, MongoLoggableComponent.SERVER_SELECTION)
+      this.client.mongoLogger?.willLog(MongoLoggableComponent.SERVER_SELECTION, SeverityLevel.DEBUG)
     ) {
       this.client.mongoLogger?.debug(
         MongoLoggableComponent.SERVER_SELECTION,
@@ -584,8 +584,8 @@ export class Topology extends TypedEventEmitter<TopologyEvents> {
     if (isSharded && transaction && transaction.server) {
       if (
         this.client.mongoLogger?.willLog(
-          SeverityLevel.DEBUG,
-          MongoLoggableComponent.SERVER_SELECTION
+          MongoLoggableComponent.SERVER_SELECTION,
+          SeverityLevel.DEBUG
         )
       ) {
         this.client.mongoLogger?.debug(
@@ -624,8 +624,8 @@ export class Topology extends TypedEventEmitter<TopologyEvents> {
       );
       if (
         this.client.mongoLogger?.willLog(
-          SeverityLevel.DEBUG,
-          MongoLoggableComponent.SERVER_SELECTION
+          MongoLoggableComponent.SERVER_SELECTION,
+          SeverityLevel.DEBUG
         )
       ) {
         this.client.mongoLogger?.debug(
@@ -916,8 +916,8 @@ function drainWaitQueue(queue: List<ServerSelectionRequest>, err?: MongoDriverEr
       if (err) {
         if (
           waitQueueMember.mongoLogger?.willLog(
-            SeverityLevel.DEBUG,
-            MongoLoggableComponent.SERVER_SELECTION
+            MongoLoggableComponent.SERVER_SELECTION,
+            SeverityLevel.DEBUG
           )
         ) {
           waitQueueMember.mongoLogger?.debug(
@@ -970,8 +970,8 @@ function processWaitQueue(topology: Topology) {
       waitQueueMember.timeoutController.clear();
       if (
         topology.client.mongoLogger?.willLog(
-          SeverityLevel.DEBUG,
-          MongoLoggableComponent.SERVER_SELECTION
+          MongoLoggableComponent.SERVER_SELECTION,
+          SeverityLevel.DEBUG
         )
       ) {
         topology.client.mongoLogger?.debug(
@@ -993,8 +993,8 @@ function processWaitQueue(topology: Topology) {
       if (!waitQueueMember.waitingLogged) {
         if (
           topology.client.mongoLogger?.willLog(
-            SeverityLevel.INFORMATIONAL,
-            MongoLoggableComponent.SERVER_SELECTION
+            MongoLoggableComponent.SERVER_SELECTION,
+            SeverityLevel.INFORMATIONAL
           )
         ) {
           topology.client.mongoLogger?.info(
@@ -1033,8 +1033,8 @@ function processWaitQueue(topology: Topology) {
       );
       if (
         topology.client.mongoLogger?.willLog(
-          SeverityLevel.DEBUG,
-          MongoLoggableComponent.SERVER_SELECTION
+          MongoLoggableComponent.SERVER_SELECTION,
+          SeverityLevel.DEBUG
         )
       ) {
         topology.client.mongoLogger?.debug(
@@ -1059,8 +1059,8 @@ function processWaitQueue(topology: Topology) {
 
     if (
       topology.client.mongoLogger?.willLog(
-        SeverityLevel.DEBUG,
-        MongoLoggableComponent.SERVER_SELECTION
+        MongoLoggableComponent.SERVER_SELECTION,
+        SeverityLevel.DEBUG
       )
     ) {
       topology.client.mongoLogger?.debug(


### PR DESCRIPTION
### Description
Add feature flagging to server selection logging, so that event instances are only created when `willLog` returns `true` for the logging configuration.

#### **EVG Perf Analysis Results**

Upon comparing the perf results of NODE-5818's changes to the commit before server selection logging was merged ([b93d405](https://evergreen.mongodb.com/task/mongo_node_driver_next_performance_tests_run_spec_benchmark_tests_node_18_server_6.0_b93d405275c3a8ce6b1eba0af335ffb2a309e34e_24_01_03_17_07_24), there are no significant regressions through this commit. 
Both commits were rerun at the same time to ensure no ci changes influence the results.

Here is the [Spreadsheet Link](https://docs.google.com/spreadsheets/d/1L_tlp-n5-tUFVuSAQrmIdC0aqMNvFsPLKqV8my-ACE8/edit#gid=0).

#### What is changing?
Same as above.

##### Is there new documentation needed for these changes?
No.

#### What is the motivation for this change?
Before: (Due to server selection logging merge [NODE-4687](https://jira.mongodb.org/browse/NODE-4687))
findOne - 6% throughput reduction
runCommand - 9% throughput reduction
smallDocInsertOne - 6.5% throughput reduction

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
