### PR TITLE
fix(NODE-5609): node driver omits base64 padding in sasl-continue command

### DIFF
--- a/src/cmap/auth/scram.ts
+++ b/src/cmap/auth/scram.ts
@@ -212,7 +212,7 @@ function parsePayload(payload: Binary) {
   const dict: Document = {};
   const parts = payloadStr.split(',');
   for (let i = 0; i < parts.length; i++) {
-    const valueParts = parts[i].split('=');
+    const valueParts = (parts[i].match(/^([^=]*)=(.*)$/) ?? []).slice(1);
     dict[valueParts[0]] = valueParts[1];
   }
   return dict;


### PR DESCRIPTION
### Description
Ensure that we don't strip padded "=" from saslStart responses that are passed to saslContinue.

#### What is changing?
We replace the existing parsing using `split` that kills trailing “=”s with `regex` parsing that preserves trailing “=”s.

##### Is there new documentation needed for these changes?
None

#### What is the motivation for this change?
[NODE-5609](https://jira.mongodb.org/browse/NODE-5609)

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### The base64 padding is now preserved in the saslContinue command
The authentication was rejected by the saslContinue command from mongosh due to missing "=" padding from the client. We fixed the way we parse payload to preserve trailing "="s.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
