### PR TITLE
fix(NODE-5839): support for multibyte code-points in stringifyWithMaxLen

### DIFF
--- a/src/mongo_logger.ts
+++ b/src/mongo_logger.ts
@@ -425,7 +425,11 @@ export function stringifyWithMaxLen(
   } else if (typeof value === 'function') {
     strToTruncate = value.toString();
   } else {
-    strToTruncate = EJSON.stringify(value, options);
+    try {
+      strToTruncate = EJSON.stringify(value, options);
+    } catch (e) {
+      strToTruncate = `Extended JSON serialization failed with: ${e.message}`;
+    }
   }
 
   // handle truncation that occurs in the middle of multi-byte codepoints

--- a/src/mongo_logger.ts
+++ b/src/mongo_logger.ts
@@ -423,7 +423,7 @@ export function stringifyWithMaxLen(
   if (typeof value === 'string') {
     strToTruncate = value;
   } else if (typeof value === 'function') {
-    strToTruncate = value.toString();
+    strToTruncate = value.name;
   } else {
     try {
       strToTruncate = EJSON.stringify(value, options);

--- a/test/integration/command-logging-and-monitoring/command_logging_and_monitoring.prose.test.ts
+++ b/test/integration/command-logging-and-monitoring/command_logging_and_monitoring.prose.test.ts
@@ -156,7 +156,7 @@ describe('Command Logging and Monitoring Prose Tests', function () {
     });
   });
 
-  context.skip('Truncation with multi-byte codepoints', function () {
+  context('Truncation with multi-byte codepoints', function () {
     /*
     A specific test case is not provided here due to the allowed variations in truncation logic
      as well as varying extended JSON whitespace usage.
@@ -216,11 +216,11 @@ describe('Command Logging and Monitoring Prose Tests', function () {
       );
 
       // multi-byte codepoint in middle of truncated string
-      expect(insertManyCommandStarted?.command.charCodeAt(maxDocLength - 1)).to.equal(
-        firstByteChar
-      );
-      expect(insertManyCommandStarted?.command.charCodeAt(maxDocLength - 1)).to.equal(
+      expect(insertManyCommandStarted?.command.charCodeAt(maxDocLength - 2)).to.equal(
         secondByteChar
+      );
+      expect(insertManyCommandStarted?.command.charCodeAt(maxDocLength - 3)).to.equal(
+        firstByteChar
       );
 
       const insertManyCommandSucceeded = writable.buffer[1];
@@ -230,5 +230,5 @@ describe('Command Logging and Monitoring Prose Tests', function () {
         maxDocLength + ELLIPSES_LENGTH
       );
     });
-  }).skipReason = 'todo(NODE-5839)';
+  });
 });

--- a/test/unit/mongo_logger.test.ts
+++ b/test/unit/mongo_logger.test.ts
@@ -1290,8 +1290,8 @@ describe('class MongoLogger', async function () {
 
           context('when maxDocumentLength > 1', function () {
             it('should round down maxDocLength to previous codepoint', function () {
-              const randomString = `random ${multiByteCodePoint}random random${multiByteCodePoint}${multiByteCodePoint}`;
               const randomStringMinusACodePoint = `random ${multiByteCodePoint}random random${multiByteCodePoint}`;
+              const randomString = `${randomStringMinusACodePoint}${multiByteCodePoint}`;
               expect(
                 stringifyWithMaxLen(randomString, randomString.length - 1, { relaxed: true })
               ).to.equal(`${randomStringMinusACodePoint}...`);


### PR DESCRIPTION
### Description
Support truncation of multibyte codepoints through `stringifyWithMaxLen` into well-formed strings. (round down to the nearest codepoint).

#### What is changing?

- Add codepoint check before truncation
- If maxDocLength = 1, and maxDocLength--, return ' '
- Un-skipped prose test #3 for command logging
- No longer wrap lone strings in an extra quotation while stringifying for logger (makes stringification confusing to read and is unnecessary) 

##### Is there new documentation needed for these changes?
No

#### What is the motivation for this change?
Prose test #3 command logging (see kickoff)

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
