### PR TITLE
test(NODE-5852): Skip transaction unpin spec tests

### DIFF
--- a/test/integration/transactions/transactions.spec.test.js
+++ b/test/integration/transactions/transactions.spec.test.js
@@ -126,7 +126,7 @@ describe('Transactions Spec Legacy Tests', function () {
   function testFilter(spec, configuration) {
     return (
       SKIP_TESTS.indexOf(spec.description) === -1 &&
-      (!gte(configuration.version, '7.1.0') || LATEST_SKIP_TESTS.indexOf(spec.description) === -1)
+      (!gte(configuration.version, '7.9.9') || LATEST_SKIP_TESTS.indexOf(spec.description) === -1)
     );
   }
 

--- a/test/integration/transactions/transactions.spec.test.js
+++ b/test/integration/transactions/transactions.spec.test.js
@@ -90,7 +90,16 @@ const SKIP_TESTS = [
 
   // TODO(NODE-2034): Will be implemented as part of NODE-2034
   'Client side error in command starting transaction',
-  'Client side error when transaction is in progress'
+  'Client side error when transaction is in progress',
+
+  // TODO(NODE-5855): Unskip Transactions Spec Unified Tests mongos-unpin.unpin
+  'unpin after TransientTransactionError error on commit',
+  'unpin on successful abort',
+  'unpin after non-transient error on abort',
+  'unpin after TransientTransactionError error on abort',
+  'unpin when a new transaction is started',
+  'unpin when a non-transaction write operation uses a session',
+  'unpin when a non-transaction read operation uses a session'
 ];
 
 describe('Transactions Spec Legacy Tests', function () {

--- a/test/integration/transactions/transactions.spec.test.js
+++ b/test/integration/transactions/transactions.spec.test.js
@@ -85,7 +85,9 @@ const LATEST_UNIFIED_SKIP_TESTS = [
   'unpin on successful abort',
   'unpin after non-transient error on abort',
   'unpin after TransientTransactionError error on abort',
-  'unpin when a new transaction is started'
+  'unpin when a new transaction is started',
+  'unpin when a non-transaction write operation uses a session',
+  'unpin when a non-transaction read operation uses a session'
 ];
 
 describe('Transactions Spec Unified Tests', function () {

--- a/test/integration/transactions/transactions.spec.test.js
+++ b/test/integration/transactions/transactions.spec.test.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import { gte } from 'semver';
+
 const path = require('path');
 const { expect } = require('chai');
 const { TestRunnerContext, generateTopologyTests } = require('../../tools/spec-runner');
@@ -90,16 +92,15 @@ const SKIP_TESTS = [
 
   // TODO(NODE-2034): Will be implemented as part of NODE-2034
   'Client side error in command starting transaction',
-  'Client side error when transaction is in progress',
+  'Client side error when transaction is in progress'
+];
 
+const LATEST_SKIP_TESTS = [
   // TODO(NODE-5855): Unskip Transactions Spec Unified Tests mongos-unpin.unpin
   'unpin after TransientTransactionError error on commit',
   'unpin on successful abort',
   'unpin after non-transient error on abort',
-  'unpin after TransientTransactionError error on abort',
-  'unpin when a new transaction is started',
-  'unpin when a non-transaction write operation uses a session',
-  'unpin when a non-transaction read operation uses a session'
+  'unpin after TransientTransactionError error on abort'
 ];
 
 describe('Transactions Spec Legacy Tests', function () {
@@ -122,8 +123,11 @@ describe('Transactions Spec Legacy Tests', function () {
     return testContext.setup(this.configuration);
   });
 
-  function testFilter(spec) {
-    return SKIP_TESTS.indexOf(spec.description) === -1;
+  function testFilter(spec, configuration) {
+    return (
+      SKIP_TESTS.indexOf(spec.description) === -1 &&
+      (!gte(configuration.version, '7.1.0') || LATEST_SKIP_TESTS.indexOf(spec.description) === -1)
+    );
   }
 
   generateTopologyTests(testSuites, testContext, testFilter);

--- a/test/integration/transactions/transactions.spec.test.js
+++ b/test/integration/transactions/transactions.spec.test.js
@@ -84,7 +84,8 @@ const LATEST_UNIFIED_SKIP_TESTS = [
   'unpin after TransientTransactionError error on commit',
   'unpin on successful abort',
   'unpin after non-transient error on abort',
-  'unpin after TransientTransactionError error on abort'
+  'unpin after TransientTransactionError error on abort',
+  'unpin when a new transaction is started'
 ];
 
 describe('Transactions Spec Unified Tests', function () {


### PR DESCRIPTION
### Description
Skip transaction unpin tests related to a build failure. 

#### What is changing?
Skip relevant tests. 

##### Is there new documentation needed for these changes?
No.

#### What is the motivation for this change?
Build failure described in NODE-5852

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
