### PR TITLE
ci(NODE-5856): move vars to expansions

### DIFF
--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -38,7 +38,7 @@ functions:
           is_patch: ${is_patch}
           project: ${project}
         args:
-        - .evergreen/prepare-shell.sh
+          - .evergreen/prepare-shell.sh
 
     # Load the expansion file to make an evergreen variable with the current unique version
     - command: expansions.update
@@ -448,7 +448,6 @@ functions:
         args:
           - "${PROJECT_DIRECTORY}/.evergreen/run-mongosh-scope-test.sh"
 
-
   "reset aws instance profile":
     - command: shell.exec
       params:
@@ -503,14 +502,14 @@ functions:
           done
 
   "install dependencies":
-    - command: shell.exec
+    - command: subprocess.exec
       type: setup
       params:
         working_dir: "src"
-        script: |
-          ${PREPARE_SHELL}
-          NODE_LTS_VERSION=${NODE_LTS_VERSION} NPM_OPTIONS=${NPM_OPTIONS} NPM_VERSION=${NPM_VERSION}\
-            bash ${PROJECT_DIRECTORY}/.evergreen/install-dependencies.sh
+        binary: bash
+        add_expansions_to_env: true
+        args:
+          - .evergreen/install-dependencies.sh
 
   "install aws-credential-providers":
     - command: shell.exec
@@ -616,16 +615,16 @@ functions:
           bash ${PROJECT_DIRECTORY}/.evergreen/run-ldap-tests.sh
 
   "run data lake tests":
-      - command: shell.exec
-        type: test
-        params:
-          working_dir: src
-          script: |
-            export PROJECT_DIRECTORY="$(pwd)"
-            export MONGODB_URI='mongodb://mhuser:pencil@localhost'
-            export NODE_LTS_VERSION='${NODE_LTS_VERSION}'
+    - command: shell.exec
+      type: test
+      params:
+        working_dir: src
+        script: |
+          export PROJECT_DIRECTORY="$(pwd)"
+          export MONGODB_URI='mongodb://mhuser:pencil@localhost'
+          export NODE_LTS_VERSION='${NODE_LTS_VERSION}'
 
-            bash ${PROJECT_DIRECTORY}/.evergreen/run-data-lake-tests.sh
+          bash ${PROJECT_DIRECTORY}/.evergreen/run-data-lake-tests.sh
 
   "run tls tests":
     - command: shell.exec
@@ -1060,7 +1059,7 @@ functions:
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file:  src/coverage/coverage-final.json
+        local_file: src/coverage/coverage-final.json
         optional: true
         # Upload the coverage report for all tasks in a single build to the same directory.
         # TODO NODE-4707 - change upload directory to ${UPLOAD_BUCKET}
@@ -1107,7 +1106,7 @@ functions:
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file:  src/coverage-report/index.html
+        local_file: src/coverage-report/index.html
         remote_file: mongo-node-driver/${revision}/${version_id}/coverage/index.html
         bucket: mciuploads
         permissions: public-read
@@ -1140,14 +1139,17 @@ tasks:
       - performance
     exec_timeout_secs: 3600
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - { key: NODE_LTS_VERSION, value: v18.16.0 }
+            - { key: NPM_VERSION, value: "9" }
+            - { key: VERSION, value: v6.0-perf }
+            - { key: TOPOLOGY, value: server }
+            - { key: AUTH, value: noauth }
       - func: install dependencies
-        vars:
-          NODE_LTS_VERSION: v18.16.0
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: v6.0-perf
-          TOPOLOGY: server
-          AUTH: noauth
       - func: run spec driver benchmarks
       - command: perf.send
         params:
@@ -1155,6 +1157,11 @@ tasks:
 
   - name: "test-gcpkms-task"
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - { key: NPM_VERSION, value: "9" }
       - func: "install dependencies"
       # Upload node driver to a GCP instance
       - command: subprocess.exec
@@ -1185,17 +1192,20 @@ tasks:
           args:
             - ${DRIVERS_TOOLS}/.evergreen/csfle/gcpkms/run-command.sh
 
-
   - name: "test-gcpkms-fail-task"
     # test-gcpkms-fail-task runs in a non-GCE environment.
     # It is expected to fail to obtain GCE credentials.
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - { key: NPM_VERSION, value: "9" }
+            - { key: VERSION, value: latest }
+            - { key: TOPOLOGY, value: server }
+            - { key: AUTH, value: noauth }
       - func: "install dependencies"
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          TOPOLOGY: server
-          AUTH: noauth
       - command: subprocess.exec
         type: test
         params:
@@ -1205,9 +1215,13 @@ tasks:
           args:
             - src/.evergreen/run-gcp-kms-tests.sh
 
-
   - name: "test-azurekms-task"
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - { key: NPM_VERSION, value: "9" }
       - func: "install dependencies"
       - command: subprocess.exec
         type: setup
@@ -1229,12 +1243,16 @@ tasks:
 
   - name: "test-azurekms-fail-task"
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - { key: NPM_VERSION, value: "9" }
+            - { key: VERSION, value: latest }
+            - { key: TOPOLOGY, value: server }
+            - { key: AUTH, value: noauth }
       - func: "install dependencies"
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          TOPOLOGY: server
-          AUTH: noauth
       - command: subprocess.exec
         type: test
         params:
@@ -1246,6 +1264,11 @@ tasks:
 
   - name: "oidc-auth-test-azure-latest"
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - { key: NPM_VERSION, value: "9" }
       - func: "install dependencies"
       - command: subprocess.exec
         params:
@@ -1257,10 +1280,15 @@ tasks:
             AZUREOIDC_CLIENTID: ${testazureoidc_clientid}
             PROVIDER_NAME: azure
           args:
-          - .evergreen/run-oidc-tests-azure.sh
+            - .evergreen/run-oidc-tests-azure.sh
 
   - name: "test-aws-lambda-deployed"
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - { key: NPM_VERSION, value: "9" }
       - func: "install dependencies"
       - command: ec2.assume_role
         params:
@@ -1279,9 +1307,12 @@ tasks:
 
   - name: test-search-index-helpers
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - { key: NODE_LTS_VERSION, value: "20" }
       - func: install dependencies
-        vars:
-          NODE_LTS_VERSION: 20
       - command: subprocess.exec
         params:
           working_dir: src
@@ -1395,31 +1426,31 @@ task_groups:
 
   - name: testazureoidc_task_group
     setup_group:
-    - func: fetch source
-    - command: shell.exec
-      params:
-        shell: bash
-        script: |-
-          set -o errexit
-          ${PREPARE_SHELL}
-          export AZUREOIDC_CLIENTID="${testazureoidc_clientid}"
-          export AZUREOIDC_TENANTID="${testazureoic_tenantid}"
-          export AZUREOIDC_SECRET="${testazureoidc_secret}"
-          export AZUREOIDC_KEYVAULT=${testazureoidc_keyvault}
-          export AZUREOIDC_DRIVERS_TOOLS="$DRIVERS_TOOLS"
-          export AZUREOIDC_VMNAME_PREFIX="NODE_DRIVER"
-          $DRIVERS_TOOLS/.evergreen/auth_oidc/azure/create-and-setup-vm.sh
+      - func: fetch source
+      - command: shell.exec
+        params:
+          shell: bash
+          script: |-
+            set -o errexit
+            ${PREPARE_SHELL}
+            export AZUREOIDC_CLIENTID="${testazureoidc_clientid}"
+            export AZUREOIDC_TENANTID="${testazureoic_tenantid}"
+            export AZUREOIDC_SECRET="${testazureoidc_secret}"
+            export AZUREOIDC_KEYVAULT=${testazureoidc_keyvault}
+            export AZUREOIDC_DRIVERS_TOOLS="$DRIVERS_TOOLS"
+            export AZUREOIDC_VMNAME_PREFIX="NODE_DRIVER"
+            $DRIVERS_TOOLS/.evergreen/auth_oidc/azure/create-and-setup-vm.sh
     teardown_group:
-    - command: shell.exec
-      params:
-        shell: bash
-        script: |-
-          ${PREPARE_SHELL}
-          $DRIVERS_TOOLS/.evergreen/auth_oidc/azure/delete-vm.sh
+      - command: shell.exec
+        params:
+          shell: bash
+          script: |-
+            ${PREPARE_SHELL}
+            $DRIVERS_TOOLS/.evergreen/auth_oidc/azure/delete-vm.sh
     setup_group_can_fail_task: true
     setup_group_timeout_secs: 1800
     tasks:
-    - oidc-auth-test-azure-latest
+      - oidc-auth-test-azure-latest
 
   - name: test_atlas_task_group
     setup_group:
@@ -1490,7 +1521,7 @@ post:
   - func: "cleanup"
 
 ignore:
-  - '*.md'
+  - "*.md"
 buildvariants:
   - name: performance-tests
     display_name: Performance Test

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -450,14 +450,14 @@ functions:
             chmod +x $i
           done
   install dependencies:
-    - command: shell.exec
+    - command: subprocess.exec
       type: setup
       params:
         working_dir: src
-        script: |
-          ${PREPARE_SHELL}
-          NODE_LTS_VERSION=${NODE_LTS_VERSION} NPM_OPTIONS=${NPM_OPTIONS} NPM_VERSION=${NPM_VERSION}\
-            bash ${PROJECT_DIRECTORY}/.evergreen/install-dependencies.sh
+        binary: bash
+        add_expansions_to_env: true
+        args:
+          - .evergreen/install-dependencies.sh
   install aws-credential-providers:
     - command: shell.exec
       type: setup
@@ -1076,20 +1076,28 @@ tasks:
       - performance
     exec_timeout_secs: 3600
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NODE_LTS_VERSION, value: v18.16.0}
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: v6.0-perf}
+            - {key: TOPOLOGY, value: server}
+            - {key: AUTH, value: noauth}
       - func: install dependencies
-        vars:
-          NODE_LTS_VERSION: v18.16.0
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: v6.0-perf
-          TOPOLOGY: server
-          AUTH: noauth
       - func: run spec driver benchmarks
       - command: perf.send
         params:
           file: src/results.json
   - name: test-gcpkms-task
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
       - func: install dependencies
       - command: subprocess.exec
         type: setup
@@ -1119,12 +1127,16 @@ tasks:
             - ${DRIVERS_TOOLS}/.evergreen/csfle/gcpkms/run-command.sh
   - name: test-gcpkms-fail-task
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: latest}
+            - {key: TOPOLOGY, value: server}
+            - {key: AUTH, value: noauth}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          TOPOLOGY: server
-          AUTH: noauth
       - command: subprocess.exec
         type: test
         params:
@@ -1135,6 +1147,11 @@ tasks:
             - src/.evergreen/run-gcp-kms-tests.sh
   - name: test-azurekms-task
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
       - func: install dependencies
       - command: subprocess.exec
         type: setup
@@ -1155,12 +1172,16 @@ tasks:
             - ${DRIVERS_TOOLS}/.evergreen/csfle/azurekms/run-command.sh
   - name: test-azurekms-fail-task
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: latest}
+            - {key: TOPOLOGY, value: server}
+            - {key: AUTH, value: noauth}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          TOPOLOGY: server
-          AUTH: noauth
       - command: subprocess.exec
         type: test
         params:
@@ -1171,6 +1192,11 @@ tasks:
             - src/.evergreen/run-azure-kms-tests.sh
   - name: oidc-auth-test-azure-latest
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
       - func: install dependencies
       - command: subprocess.exec
         params:
@@ -1185,6 +1211,11 @@ tasks:
             - .evergreen/run-oidc-tests-azure.sh
   - name: test-aws-lambda-deployed
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
       - func: install dependencies
       - command: ec2.assume_role
         params:
@@ -1202,9 +1233,12 @@ tasks:
             AWS_REGION: us-east-1
   - name: test-search-index-helpers
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NODE_LTS_VERSION, value: '20'}
       - func: install dependencies
-        vars:
-          NODE_LTS_VERSION: 20
       - command: subprocess.exec
         params:
           working_dir: src
@@ -1217,14 +1251,16 @@ tasks:
       - latest
       - server
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: latest}
+            - {key: TOPOLOGY, value: server}
+            - {key: AUTH, value: auth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          TOPOLOGY: server
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-latest-replica_set
@@ -1232,14 +1268,16 @@ tasks:
       - latest
       - replica_set
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: latest}
+            - {key: TOPOLOGY, value: replica_set}
+            - {key: AUTH, value: auth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          TOPOLOGY: replica_set
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-latest-sharded_cluster
@@ -1247,14 +1285,16 @@ tasks:
       - latest
       - sharded_cluster
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: latest}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: AUTH, value: auth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          TOPOLOGY: sharded_cluster
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-rapid-server
@@ -1262,14 +1302,16 @@ tasks:
       - rapid
       - server
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: rapid}
+            - {key: TOPOLOGY, value: server}
+            - {key: AUTH, value: auth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: rapid
-          TOPOLOGY: server
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-rapid-replica_set
@@ -1277,14 +1319,16 @@ tasks:
       - rapid
       - replica_set
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: rapid}
+            - {key: TOPOLOGY, value: replica_set}
+            - {key: AUTH, value: auth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: rapid
-          TOPOLOGY: replica_set
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-rapid-sharded_cluster
@@ -1292,14 +1336,16 @@ tasks:
       - rapid
       - sharded_cluster
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: rapid}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: AUTH, value: auth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: rapid
-          TOPOLOGY: sharded_cluster
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-7.0-server
@@ -1307,14 +1353,16 @@ tasks:
       - '7.0'
       - server
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '7.0'}
+            - {key: TOPOLOGY, value: server}
+            - {key: AUTH, value: auth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '7.0'
-          TOPOLOGY: server
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-7.0-replica_set
@@ -1322,14 +1370,16 @@ tasks:
       - '7.0'
       - replica_set
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '7.0'}
+            - {key: TOPOLOGY, value: replica_set}
+            - {key: AUTH, value: auth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '7.0'
-          TOPOLOGY: replica_set
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-7.0-sharded_cluster
@@ -1337,14 +1387,16 @@ tasks:
       - '7.0'
       - sharded_cluster
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '7.0'}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: AUTH, value: auth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '7.0'
-          TOPOLOGY: sharded_cluster
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-6.0-server
@@ -1352,14 +1404,16 @@ tasks:
       - '6.0'
       - server
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '6.0'}
+            - {key: TOPOLOGY, value: server}
+            - {key: AUTH, value: auth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '6.0'
-          TOPOLOGY: server
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-6.0-replica_set
@@ -1367,14 +1421,16 @@ tasks:
       - '6.0'
       - replica_set
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '6.0'}
+            - {key: TOPOLOGY, value: replica_set}
+            - {key: AUTH, value: auth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '6.0'
-          TOPOLOGY: replica_set
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-6.0-sharded_cluster
@@ -1382,14 +1438,16 @@ tasks:
       - '6.0'
       - sharded_cluster
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '6.0'}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: AUTH, value: auth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '6.0'
-          TOPOLOGY: sharded_cluster
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-5.0-server
@@ -1397,14 +1455,16 @@ tasks:
       - '5.0'
       - server
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '5.0'}
+            - {key: TOPOLOGY, value: server}
+            - {key: AUTH, value: auth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '5.0'
-          TOPOLOGY: server
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-5.0-replica_set
@@ -1412,14 +1472,16 @@ tasks:
       - '5.0'
       - replica_set
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '5.0'}
+            - {key: TOPOLOGY, value: replica_set}
+            - {key: AUTH, value: auth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '5.0'
-          TOPOLOGY: replica_set
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-5.0-sharded_cluster
@@ -1427,14 +1489,16 @@ tasks:
       - '5.0'
       - sharded_cluster
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '5.0'}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: AUTH, value: auth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '5.0'
-          TOPOLOGY: sharded_cluster
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-4.4-server
@@ -1442,14 +1506,16 @@ tasks:
       - '4.4'
       - server
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '4.4'}
+            - {key: TOPOLOGY, value: server}
+            - {key: AUTH, value: auth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.4'
-          TOPOLOGY: server
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-4.4-replica_set
@@ -1457,14 +1523,16 @@ tasks:
       - '4.4'
       - replica_set
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '4.4'}
+            - {key: TOPOLOGY, value: replica_set}
+            - {key: AUTH, value: auth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.4'
-          TOPOLOGY: replica_set
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-4.4-sharded_cluster
@@ -1472,14 +1540,16 @@ tasks:
       - '4.4'
       - sharded_cluster
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '4.4'}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: AUTH, value: auth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.4'
-          TOPOLOGY: sharded_cluster
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-4.2-server
@@ -1487,14 +1557,16 @@ tasks:
       - '4.2'
       - server
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '4.2'}
+            - {key: TOPOLOGY, value: server}
+            - {key: AUTH, value: auth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.2'
-          TOPOLOGY: server
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-4.2-replica_set
@@ -1502,14 +1574,16 @@ tasks:
       - '4.2'
       - replica_set
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '4.2'}
+            - {key: TOPOLOGY, value: replica_set}
+            - {key: AUTH, value: auth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.2'
-          TOPOLOGY: replica_set
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-4.2-sharded_cluster
@@ -1517,14 +1591,16 @@ tasks:
       - '4.2'
       - sharded_cluster
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '4.2'}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: AUTH, value: auth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.2'
-          TOPOLOGY: sharded_cluster
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-4.0-server
@@ -1532,14 +1608,16 @@ tasks:
       - '4.0'
       - server
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '4.0'}
+            - {key: TOPOLOGY, value: server}
+            - {key: AUTH, value: auth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.0'
-          TOPOLOGY: server
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-4.0-replica_set
@@ -1547,14 +1625,16 @@ tasks:
       - '4.0'
       - replica_set
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '4.0'}
+            - {key: TOPOLOGY, value: replica_set}
+            - {key: AUTH, value: auth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.0'
-          TOPOLOGY: replica_set
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-4.0-sharded_cluster
@@ -1562,14 +1642,16 @@ tasks:
       - '4.0'
       - sharded_cluster
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '4.0'}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: AUTH, value: auth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.0'
-          TOPOLOGY: sharded_cluster
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-3.6-server
@@ -1577,14 +1659,16 @@ tasks:
       - '3.6'
       - server
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '3.6'}
+            - {key: TOPOLOGY, value: server}
+            - {key: AUTH, value: auth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '3.6'
-          TOPOLOGY: server
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-3.6-replica_set
@@ -1592,14 +1676,16 @@ tasks:
       - '3.6'
       - replica_set
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '3.6'}
+            - {key: TOPOLOGY, value: replica_set}
+            - {key: AUTH, value: auth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '3.6'
-          TOPOLOGY: replica_set
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-3.6-sharded_cluster
@@ -1607,14 +1693,16 @@ tasks:
       - '3.6'
       - sharded_cluster
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '3.6'}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: AUTH, value: auth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '3.6'
-          TOPOLOGY: sharded_cluster
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-latest-server-v1-api
@@ -1623,17 +1711,19 @@ tasks:
       - server
       - v1-api
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: latest}
+            - {key: TOPOLOGY, value: server}
+            - {key: REQUIRE_API_VERSION, value: '1'}
+            - {key: MONGODB_API_VERSION, value: '1'}
+            - {key: AUTH, value: auth}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          TOPOLOGY: server
-          REQUIRE_API_VERSION: '1'
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
-        vars:
-          MONGODB_API_VERSION: '1'
   - name: test-atlas-connectivity
     tags:
       - atlas-connect
@@ -1651,13 +1741,16 @@ tasks:
       - sharded_cluster
       - load_balancer
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '5.0'}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: AUTH, value: auth}
+            - {key: LOAD_BALANCER, value: 'true'}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '5.0'
-          TOPOLOGY: sharded_cluster
-          AUTH: auth
-          LOAD_BALANCER: 'true'
       - func: start-load-balancer
       - func: run-lb-tests
       - func: stop-load-balancer
@@ -1667,13 +1760,16 @@ tasks:
       - sharded_cluster
       - load_balancer
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '6.0'}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: AUTH, value: auth}
+            - {key: LOAD_BALANCER, value: 'true'}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '6.0'
-          TOPOLOGY: sharded_cluster
-          AUTH: auth
-          LOAD_BALANCER: 'true'
       - func: start-load-balancer
       - func: run-lb-tests
       - func: stop-load-balancer
@@ -1683,13 +1779,16 @@ tasks:
       - sharded_cluster
       - load_balancer
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: latest}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: AUTH, value: auth}
+            - {key: LOAD_BALANCER, value: 'true'}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          TOPOLOGY: sharded_cluster
-          AUTH: auth
-          LOAD_BALANCER: 'true'
       - func: start-load-balancer
       - func: run-lb-tests
       - func: stop-load-balancer
@@ -1713,938 +1812,1160 @@ tasks:
       - replica_set
       - oidc
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: latest}
+            - {key: TOPOLOGY, value: replica_set}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-oidc.json}
       - func: install dependencies
       - func: bootstrap oidc
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          TOPOLOGY: replica_set
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-oidc.json
       - func: setup oidc roles
       - func: run oidc tests aws
   - name: test-socks5
     tags: []
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: latest}
+            - {key: TOPOLOGY, value: replica_set}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          TOPOLOGY: replica_set
       - func: bootstrap kms servers
       - func: run socks5 tests
   - name: test-socks5-csfle
     tags:
       - socks5-csfle
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: latest}
+            - {key: TOPOLOGY, value: replica_set}
+            - {key: TEST_SOCKS5_CSFLE, value: 'true'}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          TOPOLOGY: replica_set
       - func: bootstrap kms servers
       - func: run socks5 tests
-        vars:
-          TEST_SOCKS5_CSFLE: 'true'
   - name: test-socks5-tls
     tags: []
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: SSL, value: ssl}
+            - {key: VERSION, value: latest}
+            - {key: TOPOLOGY, value: replica_set}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          SSL: ssl
-          VERSION: latest
-          TOPOLOGY: replica_set
       - func: run socks5 tests
-        vars:
-          SSL: ssl
   - name: test-zstd-compression
     tags:
       - latest
       - zstd
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: latest}
+            - {key: TOPOLOGY, value: replica_set}
+            - {key: AUTH, value: auth}
+            - {key: COMPRESSOR, value: zstd}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          TOPOLOGY: replica_set
-          AUTH: auth
-          COMPRESSOR: zstd
       - func: run-compression-tests
   - name: test-snappy-compression
     tags:
       - latest
       - snappy
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: latest}
+            - {key: TOPOLOGY, value: replica_set}
+            - {key: AUTH, value: auth}
+            - {key: COMPRESSOR, value: snappy}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          TOPOLOGY: replica_set
-          AUTH: auth
-          COMPRESSOR: snappy
       - func: run-compression-tests
   - name: test-tls-support-latest
     tags:
       - tls-support
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: latest}
+            - {key: SSL, value: ssl}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          SSL: ssl
-          TOPOLOGY: server
       - func: run tls tests
   - name: test-tls-support-6.0
     tags:
       - tls-support
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '6.0'}
+            - {key: SSL, value: ssl}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '6.0'
-          SSL: ssl
-          TOPOLOGY: server
       - func: run tls tests
   - name: test-tls-support-5.0
     tags:
       - tls-support
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '5.0'}
+            - {key: SSL, value: ssl}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '5.0'
-          SSL: ssl
-          TOPOLOGY: server
       - func: run tls tests
   - name: test-tls-support-4.4
     tags:
       - tls-support
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '4.4'}
+            - {key: SSL, value: ssl}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.4'
-          SSL: ssl
-          TOPOLOGY: server
       - func: run tls tests
   - name: test-tls-support-4.2
     tags:
       - tls-support
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '4.2'}
+            - {key: SSL, value: ssl}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.2'
-          SSL: ssl
-          TOPOLOGY: server
       - func: run tls tests
   - name: aws-latest-auth-test-run-aws-auth-test-with-regular-aws-credentials
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: latest}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with regular aws credentials
   - name: aws-latest-auth-test-run-aws-auth-test-with-assume-role-credentials
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: latest}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with assume role credentials
   - name: aws-latest-auth-test-run-aws-auth-test-with-aws-EC2-credentials
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: latest}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with aws EC2 credentials
   - name: aws-latest-auth-test-run-aws-auth-test-with-aws-credentials-as-environment-variables
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: latest}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with aws credentials as environment variables
   - name: aws-latest-auth-test-run-aws-auth-test-with-aws-credentials-and-session-token-as-environment-variables
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: latest}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with aws credentials and session token as environment variables
   - name: aws-latest-auth-test-run-aws-ECS-auth-test
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: latest}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws ECS auth test
   - name: aws-latest-auth-test-run-aws-auth-test-AssumeRoleWithWebIdentity-with-AWS_ROLE_SESSION_NAME-unset
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: latest}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test AssumeRoleWithWebIdentity with AWS_ROLE_SESSION_NAME unset
   - name: aws-latest-auth-test-run-aws-auth-test-AssumeRoleWithWebIdentity-with-AWS_ROLE_SESSION_NAME-set
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: latest}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test AssumeRoleWithWebIdentity with AWS_ROLE_SESSION_NAME set
   - name: aws-latest-auth-test-run-aws-auth-test-with-regular-aws-credentials-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: latest}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with regular aws credentials
   - name: aws-latest-auth-test-run-aws-auth-test-with-assume-role-credentials-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: latest}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with assume role credentials
   - name: aws-latest-auth-test-run-aws-auth-test-with-aws-EC2-credentials-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: latest}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with aws EC2 credentials
   - name: aws-latest-auth-test-run-aws-auth-test-with-aws-credentials-as-environment-variables-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: latest}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with aws credentials as environment variables
   - name: >-
       aws-latest-auth-test-run-aws-auth-test-with-aws-credentials-and-session-token-as-environment-variables-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: latest}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with aws credentials and session token as environment variables
   - name: aws-latest-auth-test-run-aws-ECS-auth-test-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: latest}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws ECS auth test
   - name: >-
       aws-latest-auth-test-run-aws-auth-test-AssumeRoleWithWebIdentity-with-AWS_ROLE_SESSION_NAME-unset-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: latest}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test AssumeRoleWithWebIdentity with AWS_ROLE_SESSION_NAME unset
   - name: >-
       aws-latest-auth-test-run-aws-auth-test-AssumeRoleWithWebIdentity-with-AWS_ROLE_SESSION_NAME-set-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: latest}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test AssumeRoleWithWebIdentity with AWS_ROLE_SESSION_NAME set
   - name: aws-6.0-auth-test-run-aws-auth-test-with-regular-aws-credentials
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '6.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '6.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with regular aws credentials
   - name: aws-6.0-auth-test-run-aws-auth-test-with-assume-role-credentials
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '6.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '6.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with assume role credentials
   - name: aws-6.0-auth-test-run-aws-auth-test-with-aws-EC2-credentials
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '6.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '6.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with aws EC2 credentials
   - name: aws-6.0-auth-test-run-aws-auth-test-with-aws-credentials-as-environment-variables
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '6.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '6.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with aws credentials as environment variables
   - name: aws-6.0-auth-test-run-aws-auth-test-with-aws-credentials-and-session-token-as-environment-variables
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '6.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '6.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with aws credentials and session token as environment variables
   - name: aws-6.0-auth-test-run-aws-ECS-auth-test
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '6.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '6.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws ECS auth test
   - name: aws-6.0-auth-test-run-aws-auth-test-AssumeRoleWithWebIdentity-with-AWS_ROLE_SESSION_NAME-unset
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '6.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '6.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test AssumeRoleWithWebIdentity with AWS_ROLE_SESSION_NAME unset
   - name: aws-6.0-auth-test-run-aws-auth-test-AssumeRoleWithWebIdentity-with-AWS_ROLE_SESSION_NAME-set
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '6.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '6.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test AssumeRoleWithWebIdentity with AWS_ROLE_SESSION_NAME set
   - name: aws-6.0-auth-test-run-aws-auth-test-with-regular-aws-credentials-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '6.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '6.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with regular aws credentials
   - name: aws-6.0-auth-test-run-aws-auth-test-with-assume-role-credentials-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '6.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '6.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with assume role credentials
   - name: aws-6.0-auth-test-run-aws-auth-test-with-aws-EC2-credentials-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '6.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '6.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with aws EC2 credentials
   - name: aws-6.0-auth-test-run-aws-auth-test-with-aws-credentials-as-environment-variables-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '6.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '6.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with aws credentials as environment variables
   - name: >-
       aws-6.0-auth-test-run-aws-auth-test-with-aws-credentials-and-session-token-as-environment-variables-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '6.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '6.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with aws credentials and session token as environment variables
   - name: aws-6.0-auth-test-run-aws-ECS-auth-test-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '6.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '6.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws ECS auth test
   - name: >-
       aws-6.0-auth-test-run-aws-auth-test-AssumeRoleWithWebIdentity-with-AWS_ROLE_SESSION_NAME-unset-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '6.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '6.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test AssumeRoleWithWebIdentity with AWS_ROLE_SESSION_NAME unset
   - name: aws-6.0-auth-test-run-aws-auth-test-AssumeRoleWithWebIdentity-with-AWS_ROLE_SESSION_NAME-set-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '6.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '6.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test AssumeRoleWithWebIdentity with AWS_ROLE_SESSION_NAME set
   - name: aws-5.0-auth-test-run-aws-auth-test-with-regular-aws-credentials
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '5.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '5.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with regular aws credentials
   - name: aws-5.0-auth-test-run-aws-auth-test-with-assume-role-credentials
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '5.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '5.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with assume role credentials
   - name: aws-5.0-auth-test-run-aws-auth-test-with-aws-EC2-credentials
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '5.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '5.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with aws EC2 credentials
   - name: aws-5.0-auth-test-run-aws-auth-test-with-aws-credentials-as-environment-variables
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '5.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '5.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with aws credentials as environment variables
   - name: aws-5.0-auth-test-run-aws-auth-test-with-aws-credentials-and-session-token-as-environment-variables
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '5.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '5.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with aws credentials and session token as environment variables
   - name: aws-5.0-auth-test-run-aws-ECS-auth-test
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '5.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '5.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws ECS auth test
   - name: aws-5.0-auth-test-run-aws-auth-test-AssumeRoleWithWebIdentity-with-AWS_ROLE_SESSION_NAME-unset
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '5.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '5.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test AssumeRoleWithWebIdentity with AWS_ROLE_SESSION_NAME unset
   - name: aws-5.0-auth-test-run-aws-auth-test-AssumeRoleWithWebIdentity-with-AWS_ROLE_SESSION_NAME-set
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '5.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '5.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test AssumeRoleWithWebIdentity with AWS_ROLE_SESSION_NAME set
   - name: aws-5.0-auth-test-run-aws-auth-test-with-regular-aws-credentials-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '5.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '5.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with regular aws credentials
   - name: aws-5.0-auth-test-run-aws-auth-test-with-assume-role-credentials-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '5.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '5.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with assume role credentials
   - name: aws-5.0-auth-test-run-aws-auth-test-with-aws-EC2-credentials-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '5.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '5.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with aws EC2 credentials
   - name: aws-5.0-auth-test-run-aws-auth-test-with-aws-credentials-as-environment-variables-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '5.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '5.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with aws credentials as environment variables
   - name: >-
       aws-5.0-auth-test-run-aws-auth-test-with-aws-credentials-and-session-token-as-environment-variables-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '5.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '5.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with aws credentials and session token as environment variables
   - name: aws-5.0-auth-test-run-aws-ECS-auth-test-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '5.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '5.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws ECS auth test
   - name: >-
       aws-5.0-auth-test-run-aws-auth-test-AssumeRoleWithWebIdentity-with-AWS_ROLE_SESSION_NAME-unset-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '5.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '5.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test AssumeRoleWithWebIdentity with AWS_ROLE_SESSION_NAME unset
   - name: aws-5.0-auth-test-run-aws-auth-test-AssumeRoleWithWebIdentity-with-AWS_ROLE_SESSION_NAME-set-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '5.0'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '5.0'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test AssumeRoleWithWebIdentity with AWS_ROLE_SESSION_NAME set
   - name: aws-4.4-auth-test-run-aws-auth-test-with-regular-aws-credentials
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '4.4'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.4'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with regular aws credentials
   - name: aws-4.4-auth-test-run-aws-auth-test-with-assume-role-credentials
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '4.4'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.4'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with assume role credentials
   - name: aws-4.4-auth-test-run-aws-auth-test-with-aws-EC2-credentials
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '4.4'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.4'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with aws EC2 credentials
   - name: aws-4.4-auth-test-run-aws-auth-test-with-aws-credentials-as-environment-variables
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '4.4'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.4'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with aws credentials as environment variables
   - name: aws-4.4-auth-test-run-aws-auth-test-with-aws-credentials-and-session-token-as-environment-variables
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '4.4'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.4'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with aws credentials and session token as environment variables
   - name: aws-4.4-auth-test-run-aws-ECS-auth-test
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '4.4'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.4'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws ECS auth test
   - name: aws-4.4-auth-test-run-aws-auth-test-AssumeRoleWithWebIdentity-with-AWS_ROLE_SESSION_NAME-unset
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '4.4'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.4'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test AssumeRoleWithWebIdentity with AWS_ROLE_SESSION_NAME unset
   - name: aws-4.4-auth-test-run-aws-auth-test-AssumeRoleWithWebIdentity-with-AWS_ROLE_SESSION_NAME-set
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '4.4'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: install aws-credential-providers
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.4'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test AssumeRoleWithWebIdentity with AWS_ROLE_SESSION_NAME set
   - name: aws-4.4-auth-test-run-aws-auth-test-with-regular-aws-credentials-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '4.4'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.4'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with regular aws credentials
   - name: aws-4.4-auth-test-run-aws-auth-test-with-assume-role-credentials-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '4.4'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.4'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with assume role credentials
   - name: aws-4.4-auth-test-run-aws-auth-test-with-aws-EC2-credentials-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '4.4'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.4'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with aws EC2 credentials
   - name: aws-4.4-auth-test-run-aws-auth-test-with-aws-credentials-as-environment-variables-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '4.4'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.4'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with aws credentials as environment variables
   - name: >-
       aws-4.4-auth-test-run-aws-auth-test-with-aws-credentials-and-session-token-as-environment-variables-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '4.4'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.4'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test with aws credentials and session token as environment variables
   - name: aws-4.4-auth-test-run-aws-ECS-auth-test-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '4.4'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.4'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws ECS auth test
   - name: >-
       aws-4.4-auth-test-run-aws-auth-test-AssumeRoleWithWebIdentity-with-AWS_ROLE_SESSION_NAME-unset-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '4.4'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.4'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test AssumeRoleWithWebIdentity with AWS_ROLE_SESSION_NAME unset
   - name: aws-4.4-auth-test-run-aws-auth-test-AssumeRoleWithWebIdentity-with-AWS_ROLE_SESSION_NAME-set-no-peer-dependencies
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '4.4'}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.4'
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run aws auth test AssumeRoleWithWebIdentity with AWS_ROLE_SESSION_NAME set
@@ -2652,64 +2973,78 @@ tasks:
     tags:
       - run-unit-tests
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NODE_LTS_VERSION, value: '16'}
+            - {key: NPM_VERSION, value: '9'}
       - func: install dependencies
-        vars:
-          NODE_LTS_VERSION: 16
-          NPM_VERSION: 9
       - func: run unit tests
   - name: run-lint-checks
     tags:
       - run-lint-checks
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NODE_LTS_VERSION, value: '16'}
+            - {key: NPM_VERSION, value: '9'}
       - func: install dependencies
-        vars:
-          NODE_LTS_VERSION: 16
-          NPM_VERSION: 9
       - func: run lint checks
   - name: check-types-typescript-next
     tags:
       - check-types-typescript-next
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NODE_LTS_VERSION, value: '16'}
+            - {key: NPM_VERSION, value: '9'}
+            - {key: TS_VERSION, value: next}
       - func: install dependencies
-        vars:
-          NODE_LTS_VERSION: 16
-          NPM_VERSION: 9
       - func: check types
-        vars:
-          TS_VERSION: next
   - name: compile-driver-typescript-current
     tags:
       - compile-driver-typescript-current
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NODE_LTS_VERSION, value: '16'}
+            - {key: NPM_VERSION, value: '9'}
+            - {key: TS_VERSION, value: current}
       - func: install dependencies
-        vars:
-          NODE_LTS_VERSION: 16
-          NPM_VERSION: 9
       - func: compile driver
-        vars:
-          TS_VERSION: current
   - name: check-types-typescript-current
     tags:
       - check-types-typescript-current
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NODE_LTS_VERSION, value: '16'}
+            - {key: NPM_VERSION, value: '9'}
+            - {key: TS_VERSION, value: current}
       - func: install dependencies
-        vars:
-          NODE_LTS_VERSION: 16
-          NPM_VERSION: 9
       - func: check types
-        vars:
-          TS_VERSION: current
   - name: check-types-typescript-4.1.6
     tags:
       - check-types-typescript-4.1.6
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NODE_LTS_VERSION, value: '16'}
+            - {key: NPM_VERSION, value: '9'}
+            - {key: TS_VERSION, value: 4.1.6}
       - func: install dependencies
-        vars:
-          NODE_LTS_VERSION: 16
-          NPM_VERSION: 9
       - func: check types
-        vars:
-          TS_VERSION: 4.1.6
   - name: download-and-merge-coverage
     tags: []
     commands:
@@ -2723,112 +3058,120 @@ tasks:
     tags:
       - run-custom-dependency-tests
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NODE_LTS_VERSION, value: '16'}
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '5.0'}
+            - {key: TOPOLOGY, value: replica_set}
+            - {key: CSFLE_GIT_REF, value: 974a4614f8c1c3786e5e39fa63568d83f4f69ebd}
       - func: install dependencies
-        vars:
-          NODE_LTS_VERSION: 16
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '5.0'
-          TOPOLOGY: replica_set
       - func: bootstrap kms servers
       - func: run custom csfle tests
-        vars:
-          CSFLE_GIT_REF: 974a4614f8c1c3786e5e39fa63568d83f4f69ebd
   - name: run-custom-csfle-tests-5.0-master
     tags:
       - run-custom-dependency-tests
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NODE_LTS_VERSION, value: '16'}
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '5.0'}
+            - {key: TOPOLOGY, value: replica_set}
+            - {key: CSFLE_GIT_REF, value: master}
       - func: install dependencies
-        vars:
-          NODE_LTS_VERSION: 16
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '5.0'
-          TOPOLOGY: replica_set
       - func: bootstrap kms servers
       - func: run custom csfle tests
-        vars:
-          CSFLE_GIT_REF: master
   - name: run-custom-csfle-tests-rapid-pinned-commit
     tags:
       - run-custom-dependency-tests
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NODE_LTS_VERSION, value: '16'}
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: rapid}
+            - {key: TOPOLOGY, value: replica_set}
+            - {key: CSFLE_GIT_REF, value: 974a4614f8c1c3786e5e39fa63568d83f4f69ebd}
       - func: install dependencies
-        vars:
-          NODE_LTS_VERSION: 16
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: rapid
-          TOPOLOGY: replica_set
       - func: bootstrap kms servers
       - func: run custom csfle tests
-        vars:
-          CSFLE_GIT_REF: 974a4614f8c1c3786e5e39fa63568d83f4f69ebd
   - name: run-custom-csfle-tests-rapid-master
     tags:
       - run-custom-dependency-tests
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NODE_LTS_VERSION, value: '16'}
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: rapid}
+            - {key: TOPOLOGY, value: replica_set}
+            - {key: CSFLE_GIT_REF, value: master}
       - func: install dependencies
-        vars:
-          NODE_LTS_VERSION: 16
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: rapid
-          TOPOLOGY: replica_set
       - func: bootstrap kms servers
       - func: run custom csfle tests
-        vars:
-          CSFLE_GIT_REF: master
   - name: run-custom-csfle-tests-latest-pinned-commit
     tags:
       - run-custom-dependency-tests
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NODE_LTS_VERSION, value: '16'}
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: latest}
+            - {key: TOPOLOGY, value: replica_set}
+            - {key: CSFLE_GIT_REF, value: 974a4614f8c1c3786e5e39fa63568d83f4f69ebd}
       - func: install dependencies
-        vars:
-          NODE_LTS_VERSION: 16
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          TOPOLOGY: replica_set
       - func: bootstrap kms servers
       - func: run custom csfle tests
-        vars:
-          CSFLE_GIT_REF: 974a4614f8c1c3786e5e39fa63568d83f4f69ebd
   - name: run-custom-csfle-tests-latest-master
     tags:
       - run-custom-dependency-tests
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NODE_LTS_VERSION, value: '16'}
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: latest}
+            - {key: TOPOLOGY, value: replica_set}
+            - {key: CSFLE_GIT_REF, value: master}
       - func: install dependencies
-        vars:
-          NODE_LTS_VERSION: 16
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          TOPOLOGY: replica_set
       - func: bootstrap kms servers
       - func: run custom csfle tests
-        vars:
-          CSFLE_GIT_REF: master
   - name: test-latest-server-noauth
     tags:
       - latest
       - server
       - noauth
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: latest}
+            - {key: TOPOLOGY, value: server}
+            - {key: AUTH, value: noauth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          TOPOLOGY: server
-          AUTH: noauth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-latest-replica_set-noauth
@@ -2837,14 +3180,16 @@ tasks:
       - replica_set
       - noauth
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: latest}
+            - {key: TOPOLOGY, value: replica_set}
+            - {key: AUTH, value: noauth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          TOPOLOGY: replica_set
-          AUTH: noauth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-latest-sharded_cluster-noauth
@@ -2853,14 +3198,16 @@ tasks:
       - sharded_cluster
       - noauth
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: latest}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: AUTH, value: noauth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          TOPOLOGY: sharded_cluster
-          AUTH: noauth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-rapid-server-noauth
@@ -2869,14 +3216,16 @@ tasks:
       - server
       - noauth
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: rapid}
+            - {key: TOPOLOGY, value: server}
+            - {key: AUTH, value: noauth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: rapid
-          TOPOLOGY: server
-          AUTH: noauth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-rapid-replica_set-noauth
@@ -2885,14 +3234,16 @@ tasks:
       - replica_set
       - noauth
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: rapid}
+            - {key: TOPOLOGY, value: replica_set}
+            - {key: AUTH, value: noauth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: rapid
-          TOPOLOGY: replica_set
-          AUTH: noauth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-rapid-sharded_cluster-noauth
@@ -2901,14 +3252,16 @@ tasks:
       - sharded_cluster
       - noauth
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: rapid}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: AUTH, value: noauth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: rapid
-          TOPOLOGY: sharded_cluster
-          AUTH: noauth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-7.0-server-noauth
@@ -2917,14 +3270,16 @@ tasks:
       - server
       - noauth
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '7.0'}
+            - {key: TOPOLOGY, value: server}
+            - {key: AUTH, value: noauth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '7.0'
-          TOPOLOGY: server
-          AUTH: noauth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-7.0-replica_set-noauth
@@ -2933,14 +3288,16 @@ tasks:
       - replica_set
       - noauth
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '7.0'}
+            - {key: TOPOLOGY, value: replica_set}
+            - {key: AUTH, value: noauth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '7.0'
-          TOPOLOGY: replica_set
-          AUTH: noauth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-7.0-sharded_cluster-noauth
@@ -2949,14 +3306,16 @@ tasks:
       - sharded_cluster
       - noauth
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '7.0'}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: AUTH, value: noauth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '7.0'
-          TOPOLOGY: sharded_cluster
-          AUTH: noauth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-6.0-server-noauth
@@ -2965,14 +3324,16 @@ tasks:
       - server
       - noauth
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '6.0'}
+            - {key: TOPOLOGY, value: server}
+            - {key: AUTH, value: noauth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '6.0'
-          TOPOLOGY: server
-          AUTH: noauth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-6.0-replica_set-noauth
@@ -2981,14 +3342,16 @@ tasks:
       - replica_set
       - noauth
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '6.0'}
+            - {key: TOPOLOGY, value: replica_set}
+            - {key: AUTH, value: noauth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '6.0'
-          TOPOLOGY: replica_set
-          AUTH: noauth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-6.0-sharded_cluster-noauth
@@ -2997,14 +3360,16 @@ tasks:
       - sharded_cluster
       - noauth
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '6.0'}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: AUTH, value: noauth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '6.0'
-          TOPOLOGY: sharded_cluster
-          AUTH: noauth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-5.0-server-noauth
@@ -3013,14 +3378,16 @@ tasks:
       - server
       - noauth
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '5.0'}
+            - {key: TOPOLOGY, value: server}
+            - {key: AUTH, value: noauth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '5.0'
-          TOPOLOGY: server
-          AUTH: noauth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-5.0-replica_set-noauth
@@ -3029,14 +3396,16 @@ tasks:
       - replica_set
       - noauth
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '5.0'}
+            - {key: TOPOLOGY, value: replica_set}
+            - {key: AUTH, value: noauth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '5.0'
-          TOPOLOGY: replica_set
-          AUTH: noauth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-5.0-sharded_cluster-noauth
@@ -3045,14 +3414,16 @@ tasks:
       - sharded_cluster
       - noauth
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '5.0'}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: AUTH, value: noauth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '5.0'
-          TOPOLOGY: sharded_cluster
-          AUTH: noauth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-4.4-server-noauth
@@ -3061,14 +3432,16 @@ tasks:
       - server
       - noauth
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '4.4'}
+            - {key: TOPOLOGY, value: server}
+            - {key: AUTH, value: noauth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.4'
-          TOPOLOGY: server
-          AUTH: noauth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-4.4-replica_set-noauth
@@ -3077,14 +3450,16 @@ tasks:
       - replica_set
       - noauth
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '4.4'}
+            - {key: TOPOLOGY, value: replica_set}
+            - {key: AUTH, value: noauth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.4'
-          TOPOLOGY: replica_set
-          AUTH: noauth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-4.4-sharded_cluster-noauth
@@ -3093,14 +3468,16 @@ tasks:
       - sharded_cluster
       - noauth
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '4.4'}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: AUTH, value: noauth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.4'
-          TOPOLOGY: sharded_cluster
-          AUTH: noauth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-4.2-server-noauth
@@ -3109,14 +3486,16 @@ tasks:
       - server
       - noauth
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '4.2'}
+            - {key: TOPOLOGY, value: server}
+            - {key: AUTH, value: noauth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.2'
-          TOPOLOGY: server
-          AUTH: noauth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-4.2-replica_set-noauth
@@ -3125,14 +3504,16 @@ tasks:
       - replica_set
       - noauth
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '4.2'}
+            - {key: TOPOLOGY, value: replica_set}
+            - {key: AUTH, value: noauth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.2'
-          TOPOLOGY: replica_set
-          AUTH: noauth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-4.2-sharded_cluster-noauth
@@ -3141,14 +3522,16 @@ tasks:
       - sharded_cluster
       - noauth
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '4.2'}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: AUTH, value: noauth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.2'
-          TOPOLOGY: sharded_cluster
-          AUTH: noauth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-4.0-server-noauth
@@ -3157,14 +3540,16 @@ tasks:
       - server
       - noauth
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '4.0'}
+            - {key: TOPOLOGY, value: server}
+            - {key: AUTH, value: noauth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.0'
-          TOPOLOGY: server
-          AUTH: noauth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-4.0-replica_set-noauth
@@ -3173,14 +3558,16 @@ tasks:
       - replica_set
       - noauth
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '4.0'}
+            - {key: TOPOLOGY, value: replica_set}
+            - {key: AUTH, value: noauth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.0'
-          TOPOLOGY: replica_set
-          AUTH: noauth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-4.0-sharded_cluster-noauth
@@ -3189,14 +3576,16 @@ tasks:
       - sharded_cluster
       - noauth
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '4.0'}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: AUTH, value: noauth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.0'
-          TOPOLOGY: sharded_cluster
-          AUTH: noauth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-3.6-server-noauth
@@ -3205,14 +3594,16 @@ tasks:
       - server
       - noauth
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '3.6'}
+            - {key: TOPOLOGY, value: server}
+            - {key: AUTH, value: noauth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '3.6'
-          TOPOLOGY: server
-          AUTH: noauth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-3.6-replica_set-noauth
@@ -3221,14 +3612,16 @@ tasks:
       - replica_set
       - noauth
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '3.6'}
+            - {key: TOPOLOGY, value: replica_set}
+            - {key: AUTH, value: noauth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '3.6'
-          TOPOLOGY: replica_set
-          AUTH: noauth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-3.6-sharded_cluster-noauth
@@ -3237,14 +3630,16 @@ tasks:
       - sharded_cluster
       - noauth
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: '3.6'}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: AUTH, value: noauth}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '3.6'
-          TOPOLOGY: sharded_cluster
-          AUTH: noauth
       - func: bootstrap kms servers
       - func: run tests
   - name: test-lambda-example
@@ -3252,26 +3647,32 @@ tasks:
       - latest
       - lambda
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: rapid}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: rapid
-          TOPOLOGY: server
       - func: run lambda handler example tests
   - name: test-lambda-aws-auth-example
     tags:
       - latest
       - lambda
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: rapid}
+            - {key: AUTH, value: auth}
+            - {key: ORCHESTRATION_FILE, value: auth-aws.json}
+            - {key: TOPOLOGY, value: server}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: rapid
-          AUTH: auth
-          ORCHESTRATION_FILE: auth-aws.json
-          TOPOLOGY: server
       - func: add aws auth variables to file
       - func: setup aws env
       - func: run lambda handler example tests with aws auth
@@ -3280,106 +3681,120 @@ tasks:
       - latest
       - sharded_cluster
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: latest}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: AUTH, value: auth}
+            - {key: TEST_NPM_SCRIPT, value: check:csfle}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: latest
-          TOPOLOGY: sharded_cluster
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
-        vars:
-          TEST_NPM_SCRIPT: check:csfle
   - name: test-rapid-csfle-mongocryptd
     tags:
       - rapid
       - sharded_cluster
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: rapid}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: AUTH, value: auth}
+            - {key: TEST_NPM_SCRIPT, value: check:csfle}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: rapid
-          TOPOLOGY: sharded_cluster
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
-        vars:
-          TEST_NPM_SCRIPT: check:csfle
   - name: test-7.0-csfle-mongocryptd
     tags:
       - '7.0'
       - sharded_cluster
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '7.0'}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: AUTH, value: auth}
+            - {key: TEST_NPM_SCRIPT, value: check:csfle}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '7.0'
-          TOPOLOGY: sharded_cluster
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
-        vars:
-          TEST_NPM_SCRIPT: check:csfle
   - name: test-6.0-csfle-mongocryptd
     tags:
       - '6.0'
       - sharded_cluster
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '6.0'}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: AUTH, value: auth}
+            - {key: TEST_NPM_SCRIPT, value: check:csfle}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '6.0'
-          TOPOLOGY: sharded_cluster
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
-        vars:
-          TEST_NPM_SCRIPT: check:csfle
   - name: test-5.0-csfle-mongocryptd
     tags:
       - '5.0'
       - sharded_cluster
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '5.0'}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: AUTH, value: auth}
+            - {key: TEST_NPM_SCRIPT, value: check:csfle}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '5.0'
-          TOPOLOGY: sharded_cluster
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
-        vars:
-          TEST_NPM_SCRIPT: check:csfle
   - name: test-4.4-csfle-mongocryptd
     tags:
       - '4.4'
       - sharded_cluster
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '4.4'}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: AUTH, value: auth}
+            - {key: TEST_NPM_SCRIPT, value: check:csfle}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.4'
-          TOPOLOGY: sharded_cluster
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
-        vars:
-          TEST_NPM_SCRIPT: check:csfle
   - name: test-4.2-csfle-mongocryptd
     tags:
       - '4.2'
       - sharded_cluster
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '4.2'}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: AUTH, value: auth}
+            - {key: TEST_NPM_SCRIPT, value: check:csfle}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
-        vars:
-          VERSION: '4.2'
-          TOPOLOGY: sharded_cluster
-          AUTH: auth
       - func: bootstrap kms servers
       - func: run tests
-        vars:
-          TEST_NPM_SCRIPT: check:csfle
   - name: run-mongosh-browser-runtime-electron
     tags:
       - run-mongosh-integration-tests
@@ -4059,11 +4474,11 @@ buildvariants:
       - run-mongosh-service-provider-server
       - compile-mongosh
       - verify-mongosh-scopes
-  - name: ubuntu1804-test-mongodb-aws
+  - name: ubuntu2004-test-mongodb-aws
     display_name: MONGODB-AWS Auth test
-    run_on: ubuntu1804-large
+    run_on: ubuntu2004-small
     expansions:
-      NODE_LTS_VERSION: 16
+      NODE_LTS_VERSION: 20
     tasks:
       - aws-latest-auth-test-run-aws-auth-test-with-regular-aws-credentials
       - aws-latest-auth-test-run-aws-auth-test-with-assume-role-credentials

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -40,30 +40,38 @@ const OPERATING_SYSTEMS = [
 }));
 
 // TODO: NODE-3060: enable skipped tests on windows except oidc (not supported)
-const WINDOWS_SKIP_TAGS = new Set(['atlas-connect', 'auth', 'load_balancer', 'socks5-csfle', 'oidc']);
+const WINDOWS_SKIP_TAGS = new Set([
+  'atlas-connect',
+  'auth',
+  'load_balancer',
+  'socks5-csfle',
+  'oidc'
+]);
 
 const TASKS = [];
 const SINGLETON_TASKS = [];
+
+/**
+ * @param {Record<string, any>} expansions - keys become expansion names and values are stringified and become expansion value.
+ * @returns {{command: 'expansions.update'; type: 'setup'; params: { updates: Array<{key: string, value: string}> } }}
+ */
+function updateExpansions(expansions) {
+  const updates = Object.entries(expansions).map(([key, value]) => ({ key, value: `${value}` }));
+  return {
+    command: 'expansions.update',
+    type: 'setup',
+    params: { updates }
+  };
+}
 
 function makeTask({ mongoVersion, topology, tags = [], auth = 'auth' }) {
   return {
     name: `test-${mongoVersion}-${topology}${auth === 'noauth' ? '-noauth' : ''}`,
     tags: [mongoVersion, topology, ...tags],
     commands: [
-      { 
-        func: 'install dependencies',
-        vars: {
-          NPM_VERSION: 9
-        }
-      },
-      {
-        func: 'bootstrap mongo-orchestration',
-        vars: {
-          VERSION: mongoVersion,
-          TOPOLOGY: topology,
-          AUTH: auth
-        }
-      },
+      updateExpansions({ NPM_VERSION: 9, VERSION: mongoVersion, TOPOLOGY: topology, AUTH: auth }),
+      { func: 'install dependencies' },
+      { func: 'bootstrap mongo-orchestration' },
       { func: 'bootstrap kms servers' },
       { func: 'run tests' }
     ]
@@ -91,23 +99,17 @@ BASE_TASKS.push({
   name: `test-latest-server-v1-api`,
   tags: ['latest', 'server', 'v1-api'],
   commands: [
+    updateExpansions({
+      VERSION: 'latest',
+      TOPOLOGY: 'server',
+      REQUIRE_API_VERSION: '1',
+      MONGODB_API_VERSION: '1',
+      AUTH: 'auth'
+    }),
     { func: 'install dependencies' },
-    {
-      func: 'bootstrap mongo-orchestration',
-      vars: {
-        VERSION: 'latest',
-        TOPOLOGY: 'server',
-        REQUIRE_API_VERSION: '1',
-        AUTH: 'auth'
-      }
-    },
+    { func: 'bootstrap mongo-orchestration' },
     { func: 'bootstrap kms servers' },
-    {
-      func: 'run tests',
-      vars: {
-        MONGODB_API_VERSION: '1'
-      }
-    }
+    { func: 'run tests' }
   ]
 });
 
@@ -131,16 +133,14 @@ TASKS.push(
       name: 'test-5.0-load-balanced',
       tags: ['latest', 'sharded_cluster', 'load_balancer'],
       commands: [
+        updateExpansions({
+          VERSION: '5.0',
+          TOPOLOGY: 'sharded_cluster',
+          AUTH: 'auth',
+          LOAD_BALANCER: 'true'
+        }),
         { func: 'install dependencies' },
-        {
-          func: 'bootstrap mongo-orchestration',
-          vars: {
-            VERSION: '5.0',
-            TOPOLOGY: 'sharded_cluster',
-            AUTH: 'auth',
-            LOAD_BALANCER: 'true'
-          }
-        },
+        { func: 'bootstrap mongo-orchestration' },
         { func: 'start-load-balancer' },
         { func: 'run-lb-tests' },
         { func: 'stop-load-balancer' }
@@ -150,16 +150,14 @@ TASKS.push(
       name: 'test-6.0-load-balanced',
       tags: ['latest', 'sharded_cluster', 'load_balancer'],
       commands: [
+        updateExpansions({
+          VERSION: '6.0',
+          TOPOLOGY: 'sharded_cluster',
+          AUTH: 'auth',
+          LOAD_BALANCER: 'true'
+        }),
         { func: 'install dependencies' },
-        {
-          func: 'bootstrap mongo-orchestration',
-          vars: {
-            VERSION: '6.0',
-            TOPOLOGY: 'sharded_cluster',
-            AUTH: 'auth',
-            LOAD_BALANCER: 'true'
-          }
-        },
+        { func: 'bootstrap mongo-orchestration' },
         { func: 'start-load-balancer' },
         { func: 'run-lb-tests' },
         { func: 'stop-load-balancer' }
@@ -169,16 +167,14 @@ TASKS.push(
       name: 'test-latest-load-balanced',
       tags: ['latest', 'sharded_cluster', 'load_balancer'],
       commands: [
+        updateExpansions({
+          VERSION: 'latest',
+          TOPOLOGY: 'sharded_cluster',
+          AUTH: 'auth',
+          LOAD_BALANCER: 'true'
+        }),
         { func: 'install dependencies' },
-        {
-          func: 'bootstrap mongo-orchestration',
-          vars: {
-            VERSION: 'latest',
-            TOPOLOGY: 'sharded_cluster',
-            AUTH: 'auth',
-            LOAD_BALANCER: 'true'
-          }
-        },
+        { func: 'bootstrap mongo-orchestration' },
         { func: 'start-load-balancer' },
         { func: 'run-lb-tests' },
         { func: 'stop-load-balancer' }
@@ -198,17 +194,15 @@ TASKS.push(
       name: 'test-auth-oidc',
       tags: ['latest', 'replica_set', 'oidc'],
       commands: [
+        updateExpansions({
+          VERSION: 'latest',
+          TOPOLOGY: 'replica_set',
+          AUTH: 'auth',
+          ORCHESTRATION_FILE: 'auth-oidc.json'
+        }),
         { func: 'install dependencies' },
         { func: 'bootstrap oidc' },
-        {
-          func: 'bootstrap mongo-orchestration',
-          vars: {
-            VERSION: 'latest',
-            TOPOLOGY: 'replica_set',
-            AUTH: 'auth',
-            ORCHESTRATION_FILE: 'auth-oidc.json'
-          }
-        },
+        { func: 'bootstrap mongo-orchestration' },
         { func: 'setup oidc roles' },
         { func: 'run oidc tests aws' }
       ]
@@ -217,14 +211,12 @@ TASKS.push(
       name: 'test-socks5',
       tags: [],
       commands: [
+        updateExpansions({
+          VERSION: 'latest',
+          TOPOLOGY: 'replica_set'
+        }),
         { func: 'install dependencies' },
-        {
-          func: 'bootstrap mongo-orchestration',
-          vars: {
-            VERSION: 'latest',
-            TOPOLOGY: 'replica_set'
-          }
-        },
+        { func: 'bootstrap mongo-orchestration' },
         { func: 'bootstrap kms servers' },
         { func: 'run socks5 tests' }
       ]
@@ -233,37 +225,29 @@ TASKS.push(
       name: 'test-socks5-csfle',
       tags: ['socks5-csfle'],
       commands: [
+        updateExpansions({
+          VERSION: 'latest',
+          TOPOLOGY: 'replica_set',
+          TEST_SOCKS5_CSFLE: 'true'
+        }),
         { func: 'install dependencies' },
-        {
-          func: 'bootstrap mongo-orchestration',
-          vars: {
-            VERSION: 'latest',
-            TOPOLOGY: 'replica_set'
-          }
-        },
+        { func: 'bootstrap mongo-orchestration' },
         { func: 'bootstrap kms servers' },
-        {
-          func: 'run socks5 tests',
-          vars: {
-            TEST_SOCKS5_CSFLE: 'true'
-          }
-        }
+        { func: 'run socks5 tests' }
       ]
     },
     {
       name: 'test-socks5-tls',
       tags: [],
       commands: [
+        updateExpansions({
+          SSL: 'ssl',
+          VERSION: 'latest',
+          TOPOLOGY: 'replica_set'
+        }),
         { func: 'install dependencies' },
-        {
-          func: 'bootstrap mongo-orchestration',
-          vars: {
-            SSL: 'ssl',
-            VERSION: 'latest',
-            TOPOLOGY: 'replica_set'
-          }
-        },
-        { func: 'run socks5 tests', vars: { SSL: 'ssl' } }
+        { func: 'bootstrap mongo-orchestration' },
+        { func: 'run socks5 tests' }
       ]
     }
   ]
@@ -274,16 +258,14 @@ for (const compressor of ['zstd', 'snappy']) {
     name: `test-${compressor}-compression`,
     tags: ['latest', compressor],
     commands: [
+      updateExpansions({
+        VERSION: 'latest',
+        TOPOLOGY: 'replica_set',
+        AUTH: 'auth',
+        COMPRESSOR: compressor
+      }),
       { func: 'install dependencies' },
-      {
-        func: 'bootstrap mongo-orchestration',
-        vars: {
-          VERSION: 'latest',
-          TOPOLOGY: 'replica_set',
-          AUTH: 'auth',
-          COMPRESSOR: compressor
-        }
-      },
+      { func: 'bootstrap mongo-orchestration' },
       { func: 'run-compression-tests' }
     ]
   });
@@ -295,19 +277,13 @@ AWS_LAMBDA_HANDLER_TASKS.push({
   name: 'test-lambda-example',
   tags: ['latest', 'lambda'],
   commands: [
-    {
-      func: 'install dependencies',
-      vars: {
-        NPM_VERSION: 9
-      }
-    },
-    {
-      func: 'bootstrap mongo-orchestration',
-      vars: {
-        VERSION: 'rapid',
-        TOPOLOGY: 'server'
-      }
-    },
+    updateExpansions({
+      NPM_VERSION: 9,
+      VERSION: 'rapid',
+      TOPOLOGY: 'server'
+    }),
+    { func: 'install dependencies' },
+    { func: 'bootstrap mongo-orchestration' },
     { func: 'run lambda handler example tests' }
   ]
 });
@@ -317,16 +293,15 @@ AWS_LAMBDA_HANDLER_TASKS.push({
   name: 'test-lambda-aws-auth-example',
   tags: ['latest', 'lambda'],
   commands: [
+    updateExpansions({
+      NPM_VERSION: 9,
+      VERSION: 'rapid',
+      AUTH: 'auth',
+      ORCHESTRATION_FILE: 'auth-aws.json',
+      TOPOLOGY: 'server'
+    }),
     { func: 'install dependencies' },
-    {
-      func: 'bootstrap mongo-orchestration',
-      vars: {
-        VERSION: 'rapid',
-        AUTH: 'auth',
-        ORCHESTRATION_FILE: 'auth-aws.json',
-        TOPOLOGY: 'server'
-      }
-    },
+    { func: 'bootstrap mongo-orchestration' },
     { func: 'add aws auth variables to file' },
     { func: 'setup aws env' },
     { func: 'run lambda handler example tests with aws auth' }
@@ -338,17 +313,15 @@ for (const VERSION of TLS_VERSIONS) {
     name: `test-tls-support-${VERSION}`,
     tags: ['tls-support'],
     commands: [
+      updateExpansions({
+        VERSION,
+        SSL: 'ssl',
+        TOPOLOGY: 'server'
+        // TODO: NODE-3891 - fix tests broken when AUTH enabled
+        // AUTH: 'auth'
+      }),
       { func: 'install dependencies' },
-      {
-        func: 'bootstrap mongo-orchestration',
-        vars: {
-          VERSION,
-          SSL: 'ssl',
-          TOPOLOGY: 'server'
-          // TODO: NODE-3891 - fix tests broken when AUTH enabled
-          // AUTH: 'auth'
-        }
-      },
+      { func: 'bootstrap mongo-orchestration' },
       { func: 'run tls tests' }
     ]
   });
@@ -372,17 +345,15 @@ for (const VERSION of AWS_AUTH_VERSIONS) {
   const awsTasks = awsFuncs.map(fn => ({
     name: name(fn.func),
     commands: [
+      updateExpansions({
+        VERSION,
+        AUTH: 'auth',
+        ORCHESTRATION_FILE: 'auth-aws.json',
+        TOPOLOGY: 'server'
+      }),
       { func: 'install dependencies' },
       { func: 'install aws-credential-providers' },
-      {
-        func: 'bootstrap mongo-orchestration',
-        vars: {
-          VERSION: VERSION,
-          AUTH: 'auth',
-          ORCHESTRATION_FILE: 'auth-aws.json',
-          TOPOLOGY: 'server'
-        }
-      },
+      { func: 'bootstrap mongo-orchestration' },
       { func: 'add aws auth variables to file' },
       { func: 'setup aws env' },
       { ...fn }
@@ -392,16 +363,14 @@ for (const VERSION of AWS_AUTH_VERSIONS) {
   const awsNoPeerDependenciesTasks = awsFuncs.map(fn => ({
     name: `${name(fn.func)}-no-peer-dependencies`,
     commands: [
+      updateExpansions({
+        VERSION: VERSION,
+        AUTH: 'auth',
+        ORCHESTRATION_FILE: 'auth-aws.json',
+        TOPOLOGY: 'server'
+      }),
       { func: 'install dependencies' },
-      {
-        func: 'bootstrap mongo-orchestration',
-        vars: {
-          VERSION: VERSION,
-          AUTH: 'auth',
-          ORCHESTRATION_FILE: 'auth-aws.json',
-          TOPOLOGY: 'server'
-        }
-      },
+      { func: 'bootstrap mongo-orchestration' },
       { func: 'add aws auth variables to file' },
       { func: 'setup aws env' },
       { ...fn }
@@ -436,7 +405,9 @@ for (const {
   });
 
   for (const NODE_LTS_VERSION of testedNodeVersions) {
-    const nodeLTSCodeName = versions.find(({ versionNumber }) => versionNumber === NODE_LTS_VERSION).codeName;
+    const nodeLTSCodeName = versions.find(
+      ({ versionNumber }) => versionNumber === NODE_LTS_VERSION
+    ).codeName;
     const nodeLtsDisplayName = `Node${NODE_LTS_VERSION}`;
     const name = `${osName}-${NODE_LTS_VERSION >= 20 ? nodeLtsDisplayName : nodeLTSCodeName}`;
     const display_name = `${osDisplayName} ${nodeLtsDisplayName}`;
@@ -468,33 +439,27 @@ for (const {
 }
 
 // Running CSFLE tests with mongocryptd
-const MONGOCRYPTD_CSFLE_TASKS = MONGODB_VERSIONS
-  .filter(mongoVersion => ['latest', 'rapid'].includes(mongoVersion)
-    || semver.gte(`${mongoVersion}.0`, '4.2.0'))
-  .map((mongoVersion) => {
-    return {
-      name: `test-${mongoVersion}-csfle-mongocryptd`,
-      tags: [mongoVersion, 'sharded_cluster'],
-      commands: [
-        { func: 'install dependencies' },
-        {
-          func: 'bootstrap mongo-orchestration',
-          vars: {
-            VERSION: mongoVersion,
-            TOPOLOGY: 'sharded_cluster',
-            AUTH: 'auth'
-          }
-        },
-        { func: 'bootstrap kms servers' },
-        {
-          func: 'run tests',
-          vars: {
-            TEST_NPM_SCRIPT: 'check:csfle'
-          }
-        }
-      ]
-    }
-  });
+const MONGOCRYPTD_CSFLE_TASKS = MONGODB_VERSIONS.filter(
+  mongoVersion =>
+    ['latest', 'rapid'].includes(mongoVersion) || semver.gte(`${mongoVersion}.0`, '4.2.0')
+).map(mongoVersion => {
+  return {
+    name: `test-${mongoVersion}-csfle-mongocryptd`,
+    tags: [mongoVersion, 'sharded_cluster'],
+    commands: [
+      updateExpansions({
+        VERSION: mongoVersion,
+        TOPOLOGY: 'sharded_cluster',
+        AUTH: 'auth',
+        TEST_NPM_SCRIPT: 'check:csfle'
+      }),
+      { func: 'install dependencies' },
+      { func: 'bootstrap mongo-orchestration' },
+      { func: 'bootstrap kms servers' },
+      { func: 'run tests' }
+    ]
+  };
+});
 
 for (const nodeVersion of [LOWEST_LTS, LATEST_LTS]) {
   const name = `rhel8-node${nodeVersion}-test-csfle-mongocryptd`;
@@ -509,8 +474,7 @@ for (const nodeVersion of [LOWEST_LTS, LATEST_LTS]) {
       NODE_LTS_VERSION: LOWEST_LTS,
       NPM_VERSION: 9
     },
-    tasks:
-      MONGOCRYPTD_CSFLE_TASKS.map(task => task.name)
+    tasks: MONGOCRYPTD_CSFLE_TASKS.map(task => task.name)
   });
 }
 
@@ -532,13 +496,11 @@ SINGLETON_TASKS.push(
       name: 'run-unit-tests',
       tags: ['run-unit-tests'],
       commands: [
-        {
-          func: 'install dependencies',
-          vars: {
-            NODE_LTS_VERSION: LOWEST_LTS,
-            NPM_VERSION: 9
-          }
-        },
+        updateExpansions({
+          NODE_LTS_VERSION: LOWEST_LTS,
+          NPM_VERSION: 9
+        }),
+        { func: 'install dependencies' },
         { func: 'run unit tests' }
       ]
     },
@@ -546,20 +508,17 @@ SINGLETON_TASKS.push(
       name: 'run-lint-checks',
       tags: ['run-lint-checks'],
       commands: [
-        {
-          func: 'install dependencies',
-          vars: {
-            NODE_LTS_VERSION: LOWEST_LTS,
-            NPM_VERSION: 9
-          }
-        },
+        updateExpansions({
+          NODE_LTS_VERSION: LOWEST_LTS,
+          NPM_VERSION: 9
+        }),
+        { func: 'install dependencies' },
         { func: 'run lint checks' }
       ]
     },
     ...Array.from(makeTypescriptTasks())
   ]
 );
-
 
 function* makeTypescriptTasks() {
   for (const TS_VERSION of ['next', 'current', '4.1.6']) {
@@ -569,19 +528,13 @@ function* makeTypescriptTasks() {
         name: `compile-driver-typescript-${TS_VERSION}`,
         tags: [`compile-driver-typescript-${TS_VERSION}`],
         commands: [
-          {
-            func: 'install dependencies',
-            vars: {
-              NODE_LTS_VERSION: LOWEST_LTS,
-              NPM_VERSION: 9
-            }
-          },
-          {
-            func: 'compile driver',
-            vars: {
-              TS_VERSION
-            }
-          }
+          updateExpansions({
+            NODE_LTS_VERSION: LOWEST_LTS,
+            NPM_VERSION: 9,
+            TS_VERSION
+          }),
+          { func: 'install dependencies' },
+          { func: 'compile driver' }
         ]
       };
     }
@@ -590,19 +543,13 @@ function* makeTypescriptTasks() {
       name: `check-types-typescript-${TS_VERSION}`,
       tags: [`check-types-typescript-${TS_VERSION}`],
       commands: [
-        {
-          func: 'install dependencies',
-          vars: {
-            NODE_LTS_VERSION: LOWEST_LTS,
-            NPM_VERSION: 9
-          }
-        },
-        {
-          func: 'check types',
-          vars: {
-            TS_VERSION
-          }
-        }
+        updateExpansions({
+          NODE_LTS_VERSION: LOWEST_LTS,
+          NPM_VERSION: 9,
+          TS_VERSION
+        }),
+        { func: 'install dependencies' },
+        { func: 'check types' }
       ]
     };
   }
@@ -610,13 +557,11 @@ function* makeTypescriptTasks() {
     name: 'run-typescript-next',
     tags: ['run-typescript-next'],
     commands: [
-      {
-        func: 'install dependencies',
-        vars: {
-          NODE_LTS_VERSION: LOWEST_LTS,
-          NPM_VERSION: 9
-        }
-      },
+      updateExpansions({
+        NODE_LTS_VERSION: LOWEST_LTS,
+        NPM_VERSION: 9
+      }),
+      { func: 'install dependencies' },
       { func: 'run typescript next' }
     ]
   };
@@ -649,11 +594,11 @@ BUILD_VARIANTS.push({
 
 // special case for MONGODB-AWS authentication
 BUILD_VARIANTS.push({
-  name: 'ubuntu1804-test-mongodb-aws',
+  name: 'ubuntu2004-test-mongodb-aws',
   display_name: 'MONGODB-AWS Auth test',
-  run_on: UBUNTU_OS,
+  run_on: UBUNTU_20_OS,
   expansions: {
-    NODE_LTS_VERSION: LOWEST_LTS
+    NODE_LTS_VERSION: LATEST_LTS
   },
   tasks: AWS_AUTH_TASKS
 });
@@ -668,32 +613,21 @@ for (const version of ['5.0', 'rapid', 'latest']) {
       name: `run-custom-csfle-tests-${version}-${ref === 'master' ? ref : 'pinned-commit'}`,
       tags: ['run-custom-dependency-tests'],
       commands: [
-        {
-          func: 'install dependencies',
-          vars: {
-            NODE_LTS_VERSION: LOWEST_LTS,
-            NPM_VERSION: 9
-          }
-        },
-        {
-          func: 'bootstrap mongo-orchestration',
-          vars: {
-            VERSION: version,
-            TOPOLOGY: 'replica_set'
-          }
-        },
+        updateExpansions({
+          NODE_LTS_VERSION: LOWEST_LTS,
+          NPM_VERSION: 9,
+          VERSION: version,
+          TOPOLOGY: 'replica_set',
+          CSFLE_GIT_REF: ref
+        }),
+        { func: 'install dependencies' },
+        { func: 'bootstrap mongo-orchestration' },
         { func: 'bootstrap kms servers' },
-        {
-          func: 'run custom csfle tests',
-          vars: {
-            CSFLE_GIT_REF: ref
-          }
-        }
+        { func: 'run custom csfle tests' }
       ]
     });
   }
 }
-
 
 const coverageTask = {
   name: 'download and merge coverage'.split(' ').join('-'),
@@ -783,9 +717,7 @@ BUILD_VARIANTS.push({
 
 // TODO(NODE-4575): unskip zstd and snappy on node 16
 for (const variant of BUILD_VARIANTS.filter(
-  variant =>
-    variant.expansions &&
-    [16, 18, 20].includes(variant.expansions.NODE_LTS_VERSION)
+  variant => variant.expansions && [16, 18, 20].includes(variant.expansions.NODE_LTS_VERSION)
 )) {
   variant.tasks = variant.tasks.filter(
     name => !['test-zstd-compression', 'test-snappy-compression'].includes(name)
@@ -813,6 +745,6 @@ fileData.buildvariants = (fileData.buildvariants || []).concat(BUILD_VARIANTS);
 
 fs.writeFileSync(
   `${__dirname}/config.yml`,
-  yaml.dump(fileData, { lineWidth: 120, noRefs: true }),
+  yaml.dump(fileData, { lineWidth: 120, noRefs: true, flowLevel: 7, condenseFlow: false }),
   'utf8'
 );


### PR DESCRIPTION
### Description

Updates the Evergreen configurations to add expansions to the environment due to recent Evergreen config changes.

#### What is changing?

Cherry-picks https://github.com/mongodb/node-mongodb-native/commit/33933ba119df7a50ae48517c374de83ea2d19abf into the 6.0 branch and fixes all the merge conflicts and makes necessary npm version adjustments.

The base issue here was that the `AUTH` environment variable was getting improperly defaulted to "noauth" in the Evergreen runs when authentication was required and mongo orchestration had set up the clusters with auth enabled and auth URIs.

The failure for authentication (NODE-5856) on the POC unified spec tests for retryable reads was 3.6 replica set specific. Those tests are now passing shown here: https://spruce.mongodb.com/task/node_mongodb_native_6.0_rhel80_large_node_latest_test_3.6_replica_set_patch_4df671e5d0a9b8bbb6c0568e30b235acfb5c3605_65b977aa2a60ede95a3dfa12_24_01_30_22_26_52?execution=0&sortBy=STATUS&sortDir=ASC

The failure for authentication and ping (NODE-5857) was present on all variants, now passing also. See: https://spruce.mongodb.com/task/node_mongodb_native_6.0_rhel80_large_node_latest_test_3.6_replica_set_patch_4df671e5d0a9b8bbb6c0568e30b235acfb5c3605_65b977aa2a60ede95a3dfa12_24_01_30_22_26_52?execution=0&sortBy=STATUS&sortDir=ASC

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-5856/NODE-5857

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
