### PR TITLE
feat(NODE-5885): upgrade BSON to `^6.3.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@mongodb-js/saslprep": "^1.1.0",
-        "bson": "^6.2.0",
+        "bson": "^6.3.0",
         "mongodb-connection-string-url": "^3.0.0"
       },
       "devDependencies": {
@@ -3627,9 +3627,9 @@
       }
     },
     "node_modules/bson": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-6.2.0.tgz",
-      "integrity": "sha512-ID1cI+7bazPDyL9wYy9GaQ8gEEohWvcUl/Yf0dIdutJxnmInEEyCsb4awy/OiBfall7zBA179Pahi3vCdFze3Q==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.3.0.tgz",
+      "integrity": "sha512-balJfqwwTBddxfnidJZagCBPP/f48zj9Sdp3OJswREOgsJzHiQSaOIAtApSgDQFYgHqAvFkp53AFSqjMDZoTFw==",
       "engines": {
         "node": ">=16.20.1"
       }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@mongodb-js/saslprep": "^1.1.0",
-    "bson": "^6.2.0",
+    "bson": "^6.3.0",
     "mongodb-connection-string-url": "^3.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
### Description

#### What is changing?

Upgrade next driver version to the latest BSON release

##### Is there new documentation needed for these changes?

No.

#### What is the motivation for this change?

New BSON new me

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### BSON ^6.3.0 Adopted

BSON 6.3.0 introduces an optimization to parsing basic latin (ASCII) strings under 20 bytes. This can have a big impact on the time it takes to parse BSON keys. 

Check out the release notes here: [BSON short basic latin string parsing performance improved! 🐎 ](https://github.com/mongodb/js-bson/releases/tag/v6.3.0)


<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
