### PR TITLE
fix(NODE-5901): propagate errors to transformed stream in cursor

### DIFF
--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -337,7 +337,7 @@ export abstract class AbstractCursor<
       const transform = options.transform;
       const readable = new ReadableCursorStream(this);
 
-      return readable.pipe(
+      const transformedStream = readable.pipe(
         new Transform({
           objectMode: true,
           highWaterMark: 1,
@@ -351,6 +351,12 @@ export abstract class AbstractCursor<
           }
         })
       );
+
+      // Bubble errors to transformed stream, because otherwise no way
+      // to handle this error.
+      readable.on('error', err => transformedStream.emit('error', err));
+
+      return transformedStream;
     }
 
     return new ReadableCursorStream(this);


### PR DESCRIPTION
### Description

Right now, any query error when using cursor `stream()` with `transform` option leads to an uncatchable error. Consider the following script: the following script throws an uncaught "Sort exceeded memory limit" even though there's an `on('error')` handler.

```javascript
const mongodb = require('mongodb');
const { Transform } = require('stream');
  

async function run() { 
  const client = await mongodb.MongoClient.connect('mongodb://localhost:27017/test');
  const numDocs = 10000;
  const db = client.db();
  
  const count = await db.collection('tests').countDocuments();
  if (count < numDocs) {
    const numToCreate = numDocs - count;
    console.log(`begin creating ${numToCreate} docs`);
    for (let i = 0; i < iterations; i++) {
      await db.collection('tests').insertOne({ studentId: ('' + i).repeat(5000) });
      console.log(i);
    }
  }
  
  const transform = new Transform({
    transform(data, encoding, callback) {
      callback(null, data);
    },
  });
  
  console.log('run query');
  const stream = db.collection('tests').find().sort({ studentId: -1 }).stream({ transform });
  stream.on('data', () => { console.log('Doc', ++i); });
  // Currently doesn't catch the error
  stream.on('error', err => console.log('Caught', err));
  stream.on('end', () => console.log('Done'));
}

run();

```

#### What is changing?

Propagate errors from query stream to transformed stream

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

Because the original query stream isn't returned when you set `transform` option, there's no way to catch errors that occur.

[Some more reading here](https://blog.logrocket.com/working-node-js-streams/). In theory, we could use [Node's new `stream.pipeline()`](https://nodejs.org/api/stream.html#streampipelinestreams-options) function for this, but TypeScript complains about `stream.pipeline([readable, transformedStream])`.

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Errors on cursor transform streams are now properly propagated.

These were previously swallowed and now will be emitted on the `error` event:

```ts
const transform = new Transform({
  transform(data, encoding, callback) {
    callback(null, data);
  },
});
const stream = db.collection('tests').find().sort({ studentId: -1 }).stream({ transform });
stream.on('error', err => {
  // The error will properly be emitted here.
});
```

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [X] Ran `npm run check:lint` script
- [X] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [X] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
