### PR TITLE
docs(NODE-5933): remove find-and-modify warning about defaults

### DIFF
--- a/src/operations/find_and_modify.ts
+++ b/src/operations/find_and_modify.ts
@@ -53,7 +53,6 @@ export interface FindOneAndReplaceOptions extends CommandOperationOptions {
   let?: Document;
   /**
    * Return the ModifyResult instead of the modified document. Defaults to true
-   * but will default to false in the next major version.
    */
   includeResultMetadata?: boolean;
 }
@@ -78,7 +77,6 @@ export interface FindOneAndUpdateOptions extends CommandOperationOptions {
   let?: Document;
   /**
    * Return the ModifyResult instead of the modified document. Defaults to true
-   * but will default to false in the next major version.
    */
   includeResultMetadata?: boolean;
 }

--- a/src/operations/find_and_modify.ts
+++ b/src/operations/find_and_modify.ts
@@ -76,7 +76,7 @@ export interface FindOneAndUpdateOptions extends CommandOperationOptions {
   /** Map of parameter names and values that can be accessed using $$var (requires MongoDB 5.0). */
   let?: Document;
   /**
-   * Return the ModifyResult instead of the modified document. Defaults to true
+   * Return the ModifyResult instead of the modified document. Defaults to false
    */
   includeResultMetadata?: boolean;
 }

--- a/src/operations/find_and_modify.ts
+++ b/src/operations/find_and_modify.ts
@@ -52,7 +52,7 @@ export interface FindOneAndReplaceOptions extends CommandOperationOptions {
   /** Map of parameter names and values that can be accessed using $$var (requires MongoDB 5.0). */
   let?: Document;
   /**
-   * Return the ModifyResult instead of the modified document. Defaults to true
+   * Return the ModifyResult instead of the modified document. Defaults to false
    */
   includeResultMetadata?: boolean;
 }


### PR DESCRIPTION
### Description

#### What is changing?

The previous version of the documentation (5.x) also had the lines that are removed in this commit. However, after testing and verifying, the default behavior is as-if the property "includeResultMetadata" was set to false.

##### Is there new documentation needed for these changes?

The change is documentation 

#### What is the motivation for this change?

Incorrect documentation 

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
