### PR TITLE
test(NODE-5938): sync retryable writes spec tests

### DIFF
--- a/test/spec/retryable-writes/unified/bulkWrite-serverErrors.json
+++ b/test/spec/retryable-writes/unified/bulkWrite-serverErrors.json
@@ -3,9 +3,15 @@
   "schemaVersion": "1.0",
   "runOnRequirements": [
     {
-      "minServerVersion": "3.6",
+      "minServerVersion": "4.0",
       "topologies": [
         "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topologies": [
+        "sharded"
       ]
     }
   ],
@@ -55,16 +61,7 @@
       "description": "BulkWrite succeeds after retryable writeConcernError in first batch",
       "runOnRequirements": [
         {
-          "minServerVersion": "4.0",
-          "topologies": [
-            "replicaset"
-          ]
-        },
-        {
-          "minServerVersion": "4.1.7",
-          "topologies": [
-            "sharded-replicaset"
-          ]
+          "minServerVersion": "4.3.1"
         }
       ],
       "operations": [

--- a/test/spec/retryable-writes/unified/bulkWrite-serverErrors.yml
+++ b/test/spec/retryable-writes/unified/bulkWrite-serverErrors.yml
@@ -3,8 +3,10 @@ description: "retryable-writes bulkWrite serverErrors"
 schemaVersion: "1.0"
 
 runOnRequirements:
-  - minServerVersion: "3.6"
+  - minServerVersion: "4.0"
     topologies: [ replicaset ]
+  - minServerVersion: "4.1.7"
+    topologies: [ sharded ]
 
 createEntities:
   - client:
@@ -30,10 +32,7 @@ initialData:
 tests:
   - description: "BulkWrite succeeds after retryable writeConcernError in first batch"
     runOnRequirements:
-      - minServerVersion: "4.0"
-        topologies: [ replicaset ]
-      - minServerVersion: "4.1.7"
-        topologies: [ sharded-replicaset ]
+      - minServerVersion: "4.3.1" # failCommand errorLabels option
     operations:
       - name: failPoint
         object: testRunner

--- a/test/spec/retryable-writes/unified/insertOne-serverErrors.json
+++ b/test/spec/retryable-writes/unified/insertOne-serverErrors.json
@@ -3,9 +3,15 @@
   "schemaVersion": "1.0",
   "runOnRequirements": [
     {
-      "minServerVersion": "3.6",
+      "minServerVersion": "4.0",
       "topologies": [
         "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topologies": [
+        "sharded"
       ]
     }
   ],
@@ -55,16 +61,7 @@
       "description": "InsertOne succeeds after retryable writeConcernError",
       "runOnRequirements": [
         {
-          "minServerVersion": "4.0",
-          "topologies": [
-            "replicaset"
-          ]
-        },
-        {
-          "minServerVersion": "4.1.7",
-          "topologies": [
-            "sharded-replicaset"
-          ]
+          "minServerVersion": "4.3.1"
         }
       ],
       "operations": [

--- a/test/spec/retryable-writes/unified/insertOne-serverErrors.yml
+++ b/test/spec/retryable-writes/unified/insertOne-serverErrors.yml
@@ -3,8 +3,10 @@ description: "retryable-writes insertOne serverErrors"
 schemaVersion: "1.0"
 
 runOnRequirements:
-  - minServerVersion: "3.6"
+  - minServerVersion: "4.0"
     topologies: [ replicaset ]
+  - minServerVersion: "4.1.7"
+    topologies: [ sharded ]
 
 createEntities:
   - client:
@@ -30,10 +32,7 @@ initialData:
 tests:
   - description: "InsertOne succeeds after retryable writeConcernError"
     runOnRequirements:
-      - minServerVersion: "4.0"
-        topologies: [ replicaset ]
-      - minServerVersion: "4.1.7"
-        topologies: [ sharded-replicaset ]
+      - minServerVersion: "4.3.1" # failCommand errorLabels option
     operations:
       - name: failPoint
         object: testRunner

--- a/test/spec/unified-test-format/valid-pass/poc-retryable-writes.json
+++ b/test/spec/unified-test-format/valid-pass/poc-retryable-writes.json
@@ -1,14 +1,6 @@
 {
   "description": "poc-retryable-writes",
   "schemaVersion": "1.0",
-  "runOnRequirements": [
-    {
-      "minServerVersion": "3.6",
-      "topologies": [
-        "replicaset"
-      ]
-    }
-  ],
   "createEntities": [
     {
       "client": {
@@ -79,6 +71,14 @@
   "tests": [
     {
       "description": "FindOneAndUpdate is committed on first attempt",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6",
+          "topologies": [
+            "replicaset"
+          ]
+        }
+      ],
       "operations": [
         {
           "name": "failPoint",
@@ -132,6 +132,14 @@
     },
     {
       "description": "FindOneAndUpdate is not committed on first attempt",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6",
+          "topologies": [
+            "replicaset"
+          ]
+        }
+      ],
       "operations": [
         {
           "name": "failPoint",
@@ -188,6 +196,14 @@
     },
     {
       "description": "FindOneAndUpdate is never committed",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6",
+          "topologies": [
+            "replicaset"
+          ]
+        }
+      ],
       "operations": [
         {
           "name": "failPoint",
@@ -245,15 +261,10 @@
       "description": "InsertMany succeeds after PrimarySteppedDown",
       "runOnRequirements": [
         {
-          "minServerVersion": "4.0",
+          "minServerVersion": "4.3.1",
           "topologies": [
-            "replicaset"
-          ]
-        },
-        {
-          "minServerVersion": "4.1.7",
-          "topologies": [
-            "sharded-replicaset"
+            "replicaset",
+            "sharded"
           ]
         }
       ],
@@ -345,7 +356,7 @@
         {
           "minServerVersion": "4.1.7",
           "topologies": [
-            "sharded-replicaset"
+            "sharded"
           ]
         }
       ],
@@ -406,15 +417,10 @@
       "description": "InsertOne fails after multiple retryable writeConcernErrors",
       "runOnRequirements": [
         {
-          "minServerVersion": "4.0",
+          "minServerVersion": "4.3.1",
           "topologies": [
-            "replicaset"
-          ]
-        },
-        {
-          "minServerVersion": "4.1.7",
-          "topologies": [
-            "sharded-replicaset"
+            "replicaset",
+            "sharded"
           ]
         }
       ],
@@ -432,6 +438,9 @@
               "data": {
                 "failCommands": [
                   "insert"
+                ],
+                "errorLabels": [
+                  "RetryableWriteError"
                 ],
                 "writeConcernError": {
                   "code": 91,

--- a/test/spec/unified-test-format/valid-pass/poc-retryable-writes.yml
+++ b/test/spec/unified-test-format/valid-pass/poc-retryable-writes.yml
@@ -2,10 +2,6 @@ description: "poc-retryable-writes"
 
 schemaVersion: "1.0"
 
-runOnRequirements:
-  - minServerVersion: "3.6"
-    topologies: [ replicaset ]
-
 createEntities:
   - client:
       id: &client0 client0
@@ -42,6 +38,9 @@ initialData:
 
 tests:
   - description: "FindOneAndUpdate is committed on first attempt"
+    runOnRequirements: &onPrimaryTransactionalWrite_requirements
+      - minServerVersion: "3.6"
+        topologies: [ replicaset ]
     operations:
       - name: failPoint
         object: testRunner
@@ -65,6 +64,7 @@ tests:
           - { _id: 2, x: 22 }
 
   - description: "FindOneAndUpdate is not committed on first attempt"
+    runOnRequirements: *onPrimaryTransactionalWrite_requirements
     operations:
       - name: failPoint
         object: testRunner
@@ -89,6 +89,7 @@ tests:
           - { _id: 2, x: 22 }
 
   - description: "FindOneAndUpdate is never committed"
+    runOnRequirements: *onPrimaryTransactionalWrite_requirements
     operations:
       - name: failPoint
         object: testRunner
@@ -113,13 +114,9 @@ tests:
           - { _id: 2, x: 22 }
 
   - description: "InsertMany succeeds after PrimarySteppedDown"
-    runOnRequirements: &failCommand_requirements
-      - minServerVersion: "4.0"
-        topologies: [ replicaset ]
-      - minServerVersion: "4.1.7"
-        # Original test uses "sharded", but retryable writes requires a sharded
-        # cluster backed by replica sets
-        topologies: [ sharded-replicaset ]
+    runOnRequirements:
+      - minServerVersion: "4.3.1" # failCommand errorLabels option
+        topologies: [ replicaset, sharded ]
     operations:
       - name: failPoint
         object: testRunner
@@ -131,7 +128,7 @@ tests:
             data:
               failCommands: [ insert ]
               errorCode: 189 # PrimarySteppedDown
-              errorLabels: [  RetryableWriteError ]
+              errorLabels: [ RetryableWriteError ]
       - name: insertMany
         object: *collection0
         arguments:
@@ -153,7 +150,11 @@ tests:
           - { _id: 4, x: 44 }
 
   - description: "InsertOne fails after connection failure when retryWrites option is false"
-    runOnRequirements: *failCommand_requirements
+    runOnRequirements: # failCommand
+      - minServerVersion: "4.0"
+        topologies: [ replicaset ]
+      - minServerVersion: "4.1.7"
+        topologies: [ sharded ]
     operations:
       - name: failPoint
         object: testRunner
@@ -181,7 +182,9 @@ tests:
           - { _id: 2, x: 22 }
 
   - description: "InsertOne fails after multiple retryable writeConcernErrors"
-    runOnRequirements: *failCommand_requirements
+    runOnRequirements:
+      - minServerVersion: "4.3.1" # failCommand errorLabels option
+        topologies: [ replicaset, sharded ]
     operations:
       - name: failPoint
         object: testRunner
@@ -192,6 +195,7 @@ tests:
             mode: { times: 2 }
             data:
               failCommands: [ insert ]
+              errorLabels: [ RetryableWriteError ]
               writeConcernError:
                 code: 91 # ShutdownInProgress
                 errmsg: "Replication is being shut down"

--- a/test/tools/unified-spec-runner/unified-utils.ts
+++ b/test/tools/unified-spec-runner/unified-utils.ts
@@ -41,19 +41,6 @@ export async function topologySatisfies(
 
   let skipReason;
 
-  if (r.minServerVersion) {
-    const minVersion = patchVersion(r.minServerVersion);
-    ok &&= semverGte(config.version, minVersion);
-    if (!ok && skipReason == null) {
-      skipReason = `requires mongodb version greater than ${minVersion}`;
-    }
-  }
-  if (r.maxServerVersion) {
-    const maxVersion = patchVersion(r.maxServerVersion);
-    ok &&= semverLte(config.version, maxVersion);
-    if (!ok && skipReason == null) skipReason = `requires mongodb version less than ${maxVersion}`;
-  }
-
   if (r.topologies) {
     const topologyType = {
       Single: 'single',
@@ -80,6 +67,19 @@ export async function topologySatisfies(
         skipReason = `requires ${r.topologies} but discovered a ${topologyType} topology`;
       }
     }
+  }
+
+  if (r.minServerVersion) {
+    const minVersion = patchVersion(r.minServerVersion);
+    ok &&= semverGte(config.version, minVersion);
+    if (!ok && skipReason == null) {
+      skipReason = `requires mongodb version greater than ${minVersion}`;
+    }
+  }
+  if (r.maxServerVersion) {
+    const maxVersion = patchVersion(r.maxServerVersion);
+    ok &&= semverLte(config.version, maxVersion);
+    if (!ok && skipReason == null) skipReason = `requires mongodb version less than ${maxVersion}`;
   }
 
   if (r.serverParameters) {

--- a/test/tools/unified-spec-runner/unified-utils.ts
+++ b/test/tools/unified-spec-runner/unified-utils.ts
@@ -146,12 +146,16 @@ export async function topologySatisfies(
 }
 
 export async function isAnyRequirementSatisfied(ctx, requirements, client) {
+  const skipTarget = ctx.currentTest || ctx.test;
+  const skipReasons = [];
   for (const requirement of requirements) {
     const met = await topologySatisfies(ctx, requirement, client);
     if (met) {
       return true;
     }
+    skipReasons.push(skipTarget.skipReason);
   }
+  skipTarget.skipReason = skipReasons.join(' OR ');
   return false;
 }
 


### PR DESCRIPTION
### Description
NODE-5797/DRIVERS-2799

#### What is changing?

* Synced the following tests to latest compatible with DRIVERS-2799; the resulting files include changes from DRIVERS-2609, DRIVERS-2799, and DRIVERS-2802:
  * retryable-writes/unified/insertOne-serverErrors
    * spec@5fc23f4 (DRIVERS-2802)
  * retryable-writes/unified/bulkWrite-serverErrors
    * latest spec
  * unified-test-format/valid-pass/poc-retryable-writes
    * latest spec
  * *Note: The NODE tickets corresponding to DRIVERS-2609 and DRIVERS-2802 were updated to reflect that the above tests have already been updated.*
* Cleaned up `skipReason` logic to provide a more accurate message when skipping tests:
  * Topology now takes precedence over server version (i.e., if neither the topology nor the server requirements are met, the skip will be attributed to the topology mismatch instead of the server version mismatch)
  * An aggregate `skipReason` is now displayed when none of multiple sets of requirements are met instead of only displaying the first unmet requirement
    * Example: `requires mongodb version greater than 4.0.0 OR requires sharded but discovered a replicaset topology`

##### Is there new documentation needed for these changes?
No

#### What is the motivation for this change?
Spec compliance

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [N/A] Changes are covered by tests
- [N/A] New TODOs have a related JIRA ticket
