### PR TITLE
test(NODE-5643): sync connection string spec tests

### DIFF
--- a/test/spec/connection-string/invalid-uris.json
+++ b/test/spec/connection-string/invalid-uris.json
@@ -163,15 +163,6 @@
       "options": null
     },
     {
-      "description": "Missing delimiting slash between hosts and options",
-      "uri": "mongodb://example.com?w=1",
-      "valid": false,
-      "warning": null,
-      "hosts": null,
-      "auth": null,
-      "options": null
-    },
-    {
       "description": "Incomplete key value pair for option",
       "uri": "mongodb://example.com/?w",
       "valid": false,

--- a/test/spec/connection-string/invalid-uris.yml
+++ b/test/spec/connection-string/invalid-uris.yml
@@ -144,14 +144,6 @@ tests:
         auth: ~
         options: ~
     -
-        description: "Missing delimiting slash between hosts and options"
-        uri: "mongodb://example.com?w=1"
-        valid: false
-        warning: ~
-        hosts: ~
-        auth: ~
-        options: ~
-    -
         description: "Incomplete key value pair for option"
         uri: "mongodb://example.com/?w"
         valid: false

--- a/test/spec/connection-string/valid-options.json
+++ b/test/spec/connection-string/valid-options.json
@@ -20,6 +20,23 @@
       "options": {
         "authmechanism": "MONGODB-CR"
       }
+    },
+    {
+      "description": "Missing delimiting slash between hosts and options",
+      "uri": "mongodb://example.com?tls=true",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "example.com",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": {
+        "tls": true
+      }
     }
   ]
 }

--- a/test/spec/connection-string/valid-options.yml
+++ b/test/spec/connection-string/valid-options.yml
@@ -15,3 +15,16 @@ tests:
             db: "admin"
         options:
             authmechanism: "MONGODB-CR"
+    -
+        description: "Missing delimiting slash between hosts and options"
+        uri: "mongodb://example.com?tls=true"
+        valid: true
+        warning: false
+        hosts:
+            -
+                type: "hostname"
+                host: "example.com"
+                port: ~
+        auth: ~
+        options:
+              tls: true

--- a/test/spec/connection-string/valid-unix_socket-absolute.json
+++ b/test/spec/connection-string/valid-unix_socket-absolute.json
@@ -31,6 +31,21 @@
       "options": null
     },
     {
+      "description": "Unix domain socket (mixed case)",
+      "uri": "mongodb://%2Ftmp%2FMongoDB-27017.sock",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "unix",
+          "host": "/tmp/MongoDB-27017.sock",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
       "description": "Unix domain socket (absolute path with spaces in path)",
       "uri": "mongodb://%2Ftmp%2F %2Fmongodb-27017.sock",
       "valid": true,

--- a/test/spec/connection-string/valid-unix_socket-absolute.yml
+++ b/test/spec/connection-string/valid-unix_socket-absolute.yml
@@ -24,6 +24,18 @@ tests:
         auth: ~
         options: ~
     -
+        description: "Unix domain socket (mixed case)"
+        uri: "mongodb://%2Ftmp%2FMongoDB-27017.sock"
+        valid: true
+        warning: false
+        hosts:
+            -
+                type: "unix"
+                host: "/tmp/MongoDB-27017.sock"
+                port: ~
+        auth: ~
+        options: ~
+    -
         description: "Unix domain socket (absolute path with spaces in path)"
         uri: "mongodb://%2Ftmp%2F %2Fmongodb-27017.sock"
         valid: true

--- a/test/spec/connection-string/valid-unix_socket-relative.json
+++ b/test/spec/connection-string/valid-unix_socket-relative.json
@@ -31,6 +31,21 @@
       "options": null
     },
     {
+      "description": "Unix domain socket (mixed case)",
+      "uri": "mongodb://rel%2FMongoDB-27017.sock",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "unix",
+          "host": "rel/MongoDB-27017.sock",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
       "description": "Unix domain socket (relative path with spaces)",
       "uri": "mongodb://rel%2F %2Fmongodb-27017.sock",
       "valid": true,

--- a/test/spec/connection-string/valid-unix_socket-relative.yml
+++ b/test/spec/connection-string/valid-unix_socket-relative.yml
@@ -24,6 +24,18 @@ tests:
         auth: ~
         options: ~
     -
+        description: "Unix domain socket (mixed case)"
+        uri: "mongodb://rel%2FMongoDB-27017.sock"
+        valid: true
+        warning: false
+        hosts:
+            -
+                type: "unix"
+                host: "rel/MongoDB-27017.sock"
+                port: ~
+        auth: ~
+        options: ~
+    -
         description: "Unix domain socket (relative path with spaces)"
         uri: "mongodb://rel%2F %2Fmongodb-27017.sock"
         valid: true

--- a/test/spec/connection-string/valid-warnings.json
+++ b/test/spec/connection-string/valid-warnings.json
@@ -63,6 +63,36 @@
       "options": {
         "wtimeoutms": 10
       }
+    },
+    {
+      "description": "Empty integer option values are ignored",
+      "uri": "mongodb://localhost/?maxIdleTimeMS=",
+      "valid": true,
+      "warning": true,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "localhost",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Empty boolean option value are ignored",
+      "uri": "mongodb://localhost/?journal=",
+      "valid": true,
+      "warning": true,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "localhost",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
     }
   ]
 }

--- a/test/spec/connection-string/valid-warnings.yml
+++ b/test/spec/connection-string/valid-warnings.yml
@@ -49,3 +49,27 @@ tests:
         auth: ~
         options:
             wtimeoutms: 10
+    -
+        description: "Empty integer option values are ignored"
+        uri: "mongodb://localhost/?maxIdleTimeMS="
+        valid: true
+        warning: true
+        hosts:
+            -
+                type: "hostname"
+                host: "localhost"
+                port: ~
+        auth: ~
+        options: ~
+    -
+        description: "Empty boolean option value are ignored"
+        uri: "mongodb://localhost/?journal="
+        valid: true
+        warning: true
+        hosts:
+            -
+                type: "hostname"
+                host: "localhost"
+                port: ~
+        auth: ~
+        options: ~

--- a/test/unit/connection_string.spec.test.ts
+++ b/test/unit/connection_string.spec.test.ts
@@ -4,9 +4,6 @@ import { loadSpecTests } from '../spec';
 import { executeUriValidationTest } from '../tools/uri_spec_runner';
 
 const skipTests = [
-  // TODO(NODE-3919): fix to match expected behavior
-  'Missing delimiting slash between hosts and options',
-
   // TODO(NODE-3914): Fix; note that wtimeoutms will be deprecated via DRIVERS-555 (NODE-3078)
   'Deprecated (or unknown) options are ignored if replacement exists'
 ];


### PR DESCRIPTION
### Description

Syncs connection string spec tests to latest.

#### What is changing?

- Syncs the connection string spec tests to the most recent in the specifications repo.
- Note the DRIVERS ticket only mentions 2 tests, but I figured to see if going to latest on all would pass and the other changes did. This then covers NODE-5753 as well
- Unskipped NODE-3919 test as it passes now, and that ticket was already closed.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-5643/NODE-5753/DRIVERS-2679/DRIVERS-2770

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
