### PR TITLE
refactor(NODE-5953): move promisifying of randomBytes to utils

### DIFF
--- a/src/cmap/auth/mongodb_aws.ts
+++ b/src/cmap/auth/mongodb_aws.ts
@@ -1,6 +1,4 @@
-import * as crypto from 'crypto';
 import * as process from 'process';
-import { promisify } from 'util';
 
 import type { Binary, BSONSerializeOptions } from '../../bson';
 import * as BSON from '../../bson';
@@ -11,7 +9,7 @@ import {
   MongoMissingCredentialsError,
   MongoRuntimeError
 } from '../../error';
-import { ByteUtils, maxWireVersion, ns, request } from '../../utils';
+import { ByteUtils, maxWireVersion, ns, randomBytes, request } from '../../utils';
 import { type AuthContext, AuthProvider } from './auth_provider';
 import { MongoCredentials } from './mongo_credentials';
 import { AuthMechanism } from './providers';
@@ -59,11 +57,9 @@ interface AWSSaslContinuePayload {
 export class MongoDBAWS extends AuthProvider {
   static credentialProvider: ReturnType<typeof getAwsCredentialProvider>;
   provider?: () => Promise<AWSCredentials>;
-  randomBytesAsync: (size: number) => Promise<Buffer>;
 
   constructor() {
     super();
-    this.randomBytesAsync = promisify(crypto.randomBytes);
     MongoDBAWS.credentialProvider ??= getAwsCredentialProvider();
 
     let { AWS_STS_REGIONAL_ENDPOINTS = '', AWS_REGION = '' } = process.env;
@@ -131,7 +127,7 @@ export class MongoDBAWS extends AuthProvider {
         : undefined;
 
     const db = credentials.source;
-    const nonce = await this.randomBytesAsync(32);
+    const nonce = await randomBytes(32);
 
     const saslStart = {
       saslStart: 1,

--- a/src/cmap/auth/scram.ts
+++ b/src/cmap/auth/scram.ts
@@ -1,6 +1,5 @@
 import { saslprep } from '@mongodb-js/saslprep';
 import * as crypto from 'crypto';
-import { promisify } from 'util';
 
 import { Binary, type Document } from '../../bson';
 import {
@@ -8,7 +7,7 @@ import {
   MongoMissingCredentialsError,
   MongoRuntimeError
 } from '../../error';
-import { ns } from '../../utils';
+import { ns, randomBytes } from '../../utils';
 import type { HandshakeDocument } from '../connect';
 import { type AuthContext, AuthProvider } from './auth_provider';
 import type { MongoCredentials } from './mongo_credentials';
@@ -18,11 +17,10 @@ type CryptoMethod = 'sha1' | 'sha256';
 
 class ScramSHA extends AuthProvider {
   cryptoMethod: CryptoMethod;
-  randomBytesAsync: (size: number) => Promise<Buffer>;
+
   constructor(cryptoMethod: CryptoMethod) {
     super();
     this.cryptoMethod = cryptoMethod || 'sha1';
-    this.randomBytesAsync = promisify(crypto.randomBytes);
   }
 
   override async prepare(
@@ -35,7 +33,7 @@ class ScramSHA extends AuthProvider {
       throw new MongoMissingCredentialsError('AuthContext must provide credentials.');
     }
 
-    const nonce = await this.randomBytesAsync(24);
+    const nonce = await randomBytes(24);
     // store the nonce for later use
     authContext.nonce = nonce;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,6 +4,7 @@ import * as http from 'http';
 import { clearTimeout, setTimeout } from 'timers';
 import * as url from 'url';
 import { URL } from 'url';
+import { promisify } from 'util';
 
 import { type Document, ObjectId, resolveBSONOptions } from './bson';
 import type { Connection } from './cmap/connection';
@@ -1292,3 +1293,5 @@ export function promiseWithResolvers<T>() {
   });
   return { promise, resolve, reject } as const;
 }
+
+export const randomBytes = promisify(crypto.randomBytes);


### PR DESCRIPTION
### Description
Move promisifying of `randomBytes` to utils.ts to make it module-scoped function and to reuse everywhere else.

##### Is there new documentation needed for these changes?
None

#### What is the motivation for this change?
Technical debt leftover from [NODE-5616](https://jira.mongodb.org/browse/NODE-5616)

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
