### PR TITLE
feat(NODE-5940): cache the AWS credentials provider in the MONGODB-AWS auth logic

### DIFF
--- a/src/cmap/auth/auth_provider.ts
+++ b/src/cmap/auth/auth_provider.ts
@@ -34,6 +34,10 @@ export class AuthContext {
   }
 }
 
+/**
+ * Provider used during authentication.
+ * @internal
+ */
 export abstract class AuthProvider {
   /**
    * Prepare the handshake document before the initial handshake.

--- a/src/cmap/auth/mongodb_aws.ts
+++ b/src/cmap/auth/mongodb_aws.ts
@@ -1,17 +1,15 @@
-import * as crypto from 'crypto';
 import * as process from 'process';
-import { promisify } from 'util';
 
 import type { Binary, BSONSerializeOptions } from '../../bson';
 import * as BSON from '../../bson';
-import { aws4, getAwsCredentialProvider } from '../../deps';
+import { aws4, type AWSCredentials, getAwsCredentialProvider } from '../../deps';
 import {
   MongoAWSError,
   MongoCompatibilityError,
   MongoMissingCredentialsError,
   MongoRuntimeError
 } from '../../error';
-import { ByteUtils, maxWireVersion, ns, request } from '../../utils';
+import { ByteUtils, maxWireVersion, ns, randomBytes, request } from '../../utils';
 import { type AuthContext, AuthProvider } from './auth_provider';
 import { MongoCredentials } from './mongo_credentials';
 import { AuthMechanism } from './providers';
@@ -57,12 +55,40 @@ interface AWSSaslContinuePayload {
 }
 
 export class MongoDBAWS extends AuthProvider {
-  static credentialProvider: ReturnType<typeof getAwsCredentialProvider> | null = null;
-  randomBytesAsync: (size: number) => Promise<Buffer>;
+  static credentialProvider: ReturnType<typeof getAwsCredentialProvider>;
+  provider?: () => Promise<AWSCredentials>;
 
   constructor() {
     super();
-    this.randomBytesAsync = promisify(crypto.randomBytes);
+    MongoDBAWS.credentialProvider ??= getAwsCredentialProvider();
+
+    let { AWS_STS_REGIONAL_ENDPOINTS = '', AWS_REGION = '' } = process.env;
+    AWS_STS_REGIONAL_ENDPOINTS = AWS_STS_REGIONAL_ENDPOINTS.toLowerCase();
+    AWS_REGION = AWS_REGION.toLowerCase();
+
+    /** The option setting should work only for users who have explicit settings in their environment, the driver should not encode "defaults" */
+    const awsRegionSettingsExist =
+      AWS_REGION.length !== 0 && AWS_STS_REGIONAL_ENDPOINTS.length !== 0;
+
+    /**
+     * If AWS_STS_REGIONAL_ENDPOINTS is set to regional, users are opting into the new behavior of respecting the region settings
+     *
+     * If AWS_STS_REGIONAL_ENDPOINTS is set to legacy, then "old" regions need to keep using the global setting.
+     * Technically the SDK gets this wrong, it reaches out to 'sts.us-east-1.amazonaws.com' when it should be 'sts.amazonaws.com'.
+     * That is not our bug to fix here. We leave that up to the SDK.
+     */
+    const useRegionalSts =
+      AWS_STS_REGIONAL_ENDPOINTS === 'regional' ||
+      (AWS_STS_REGIONAL_ENDPOINTS === 'legacy' && !LEGACY_REGIONS.has(AWS_REGION));
+
+    if ('fromNodeProviderChain' in MongoDBAWS.credentialProvider) {
+      this.provider =
+        awsRegionSettingsExist && useRegionalSts
+          ? MongoDBAWS.credentialProvider.fromNodeProviderChain({
+              clientConfig: { region: AWS_REGION }
+            })
+          : MongoDBAWS.credentialProvider.fromNodeProviderChain();
+    }
   }
 
   override async auth(authContext: AuthContext): Promise<void> {
@@ -83,7 +109,7 @@ export class MongoDBAWS extends AuthProvider {
     }
 
     if (!authContext.credentials.username) {
-      authContext.credentials = await makeTempCredentials(authContext.credentials);
+      authContext.credentials = await makeTempCredentials(authContext.credentials, this.provider);
     }
 
     const { credentials } = authContext;
@@ -101,7 +127,7 @@ export class MongoDBAWS extends AuthProvider {
         : undefined;
 
     const db = credentials.source;
-    const nonce = await this.randomBytesAsync(32);
+    const nonce = await randomBytes(32);
 
     const saslStart = {
       saslStart: 1,
@@ -181,7 +207,10 @@ interface AWSTempCredentials {
   Expiration?: Date;
 }
 
-async function makeTempCredentials(credentials: MongoCredentials): Promise<MongoCredentials> {
+async function makeTempCredentials(
+  credentials: MongoCredentials,
+  provider?: () => Promise<AWSCredentials>
+): Promise<MongoCredentials> {
   function makeMongoCredentialsFromAWSTemp(creds: AWSTempCredentials) {
     if (!creds.AccessKeyId || !creds.SecretAccessKey || !creds.Token) {
       throw new MongoMissingCredentialsError('Could not obtain temporary MONGODB-AWS credentials');
@@ -198,11 +227,31 @@ async function makeTempCredentials(credentials: MongoCredentials): Promise<Mongo
     });
   }
 
-  MongoDBAWS.credentialProvider ??= getAwsCredentialProvider();
-
   // Check if the AWS credential provider from the SDK is present. If not,
   // use the old method.
-  if ('kModuleError' in MongoDBAWS.credentialProvider) {
+  if (provider && !('kModuleError' in MongoDBAWS.credentialProvider)) {
+    /*
+     * Creates a credential provider that will attempt to find credentials from the
+     * following sources (listed in order of precedence):
+     *
+     * - Environment variables exposed via process.env
+     * - SSO credentials from token cache
+     * - Web identity token credentials
+     * - Shared credentials and config ini files
+     * - The EC2/ECS Instance Metadata Service
+     */
+    try {
+      const creds = await provider();
+      return makeMongoCredentialsFromAWSTemp({
+        AccessKeyId: creds.accessKeyId,
+        SecretAccessKey: creds.secretAccessKey,
+        Token: creds.sessionToken,
+        Expiration: creds.expiration
+      });
+    } catch (error) {
+      throw new MongoAWSError(error.message);
+    }
+  } else {
     // If the environment variable AWS_CONTAINER_CREDENTIALS_RELATIVE_URI
     // is set then drivers MUST assume that it was set by an AWS ECS agent
     if (process.env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI) {
@@ -232,54 +281,6 @@ async function makeTempCredentials(credentials: MongoCredentials): Promise<Mongo
     });
 
     return makeMongoCredentialsFromAWSTemp(creds);
-  } else {
-    let { AWS_STS_REGIONAL_ENDPOINTS = '', AWS_REGION = '' } = process.env;
-    AWS_STS_REGIONAL_ENDPOINTS = AWS_STS_REGIONAL_ENDPOINTS.toLowerCase();
-    AWS_REGION = AWS_REGION.toLowerCase();
-
-    /** The option setting should work only for users who have explicit settings in their environment, the driver should not encode "defaults" */
-    const awsRegionSettingsExist =
-      AWS_REGION.length !== 0 && AWS_STS_REGIONAL_ENDPOINTS.length !== 0;
-
-    /**
-     * If AWS_STS_REGIONAL_ENDPOINTS is set to regional, users are opting into the new behavior of respecting the region settings
-     *
-     * If AWS_STS_REGIONAL_ENDPOINTS is set to legacy, then "old" regions need to keep using the global setting.
-     * Technically the SDK gets this wrong, it reaches out to 'sts.us-east-1.amazonaws.com' when it should be 'sts.amazonaws.com'.
-     * That is not our bug to fix here. We leave that up to the SDK.
-     */
-    const useRegionalSts =
-      AWS_STS_REGIONAL_ENDPOINTS === 'regional' ||
-      (AWS_STS_REGIONAL_ENDPOINTS === 'legacy' && !LEGACY_REGIONS.has(AWS_REGION));
-
-    const provider =
-      awsRegionSettingsExist && useRegionalSts
-        ? MongoDBAWS.credentialProvider.fromNodeProviderChain({
-            clientConfig: { region: AWS_REGION }
-          })
-        : MongoDBAWS.credentialProvider.fromNodeProviderChain();
-
-    /*
-     * Creates a credential provider that will attempt to find credentials from the
-     * following sources (listed in order of precedence):
-     *
-     * - Environment variables exposed via process.env
-     * - SSO credentials from token cache
-     * - Web identity token credentials
-     * - Shared credentials and config ini files
-     * - The EC2/ECS Instance Metadata Service
-     */
-    try {
-      const creds = await provider();
-      return makeMongoCredentialsFromAWSTemp({
-        AccessKeyId: creds.accessKeyId,
-        SecretAccessKey: creds.secretAccessKey,
-        Token: creds.sessionToken,
-        Expiration: creds.expiration
-      });
-    } catch (error) {
-      throw new MongoAWSError(error.message);
-    }
   }
 }
 

--- a/src/cmap/auth/scram.ts
+++ b/src/cmap/auth/scram.ts
@@ -1,5 +1,4 @@
 import * as crypto from 'crypto';
-import { promisify } from 'util';
 
 import { Binary, type Document } from '../../bson';
 import { saslprep } from '../../deps';
@@ -8,7 +7,7 @@ import {
   MongoMissingCredentialsError,
   MongoRuntimeError
 } from '../../error';
-import { emitWarning, ns } from '../../utils';
+import { emitWarning, ns, randomBytes } from '../../utils';
 import type { HandshakeDocument } from '../connect';
 import { type AuthContext, AuthProvider } from './auth_provider';
 import type { MongoCredentials } from './mongo_credentials';
@@ -18,11 +17,9 @@ type CryptoMethod = 'sha1' | 'sha256';
 
 class ScramSHA extends AuthProvider {
   cryptoMethod: CryptoMethod;
-  randomBytesAsync: (size: number) => Promise<Buffer>;
   constructor(cryptoMethod: CryptoMethod) {
     super();
     this.cryptoMethod = cryptoMethod || 'sha1';
-    this.randomBytesAsync = promisify(crypto.randomBytes);
   }
 
   override async prepare(
@@ -41,7 +38,7 @@ class ScramSHA extends AuthProvider {
       emitWarning('Warning: no saslprep library specified. Passwords will not be sanitized');
     }
 
-    const nonce = await this.randomBytesAsync(24);
+    const nonce = await randomBytes(24);
     // store the nonce for later use
     authContext.nonce = nonce;
 

--- a/src/cmap/connect.ts
+++ b/src/cmap/connect.ts
@@ -17,14 +17,8 @@ import {
   needsRetryableWriteLabel
 } from '../error';
 import { type Callback, HostAddress, ns } from '../utils';
-import { AuthContext, type AuthProvider } from './auth/auth_provider';
-import { GSSAPI } from './auth/gssapi';
-import { MongoCR } from './auth/mongocr';
-import { MongoDBAWS } from './auth/mongodb_aws';
-import { Plain } from './auth/plain';
+import { AuthContext } from './auth/auth_provider';
 import { AuthMechanism } from './auth/providers';
-import { ScramSHA1, ScramSHA256 } from './auth/scram';
-import { X509 } from './auth/x509';
 import {
   type CommandOptions,
   Connection,
@@ -38,17 +32,6 @@ import {
   MIN_SUPPORTED_SERVER_VERSION,
   MIN_SUPPORTED_WIRE_VERSION
 } from './wire_protocol/constants';
-
-/** @internal */
-export const AUTH_PROVIDERS = new Map<AuthMechanism | string, AuthProvider>([
-  [AuthMechanism.MONGODB_AWS, new MongoDBAWS()],
-  [AuthMechanism.MONGODB_CR, new MongoCR()],
-  [AuthMechanism.MONGODB_GSSAPI, new GSSAPI()],
-  [AuthMechanism.MONGODB_PLAIN, new Plain()],
-  [AuthMechanism.MONGODB_SCRAM_SHA1, new ScramSHA1()],
-  [AuthMechanism.MONGODB_SCRAM_SHA256, new ScramSHA256()],
-  [AuthMechanism.MONGODB_X509, new X509()]
-]);
 
 /** @public */
 export type Stream = Socket | TLSSocket;
@@ -110,7 +93,7 @@ async function performInitialHandshake(
   if (credentials) {
     if (
       !(credentials.mechanism === AuthMechanism.MONGODB_DEFAULT) &&
-      !AUTH_PROVIDERS.get(credentials.mechanism)
+      !options.authProviders.getOrCreateProvider(credentials.mechanism)
     ) {
       throw new MongoInvalidArgumentError(`AuthMechanism '${credentials.mechanism}' not supported`);
     }
@@ -165,7 +148,7 @@ async function performInitialHandshake(
     authContext.response = response;
 
     const resolvedCredentials = credentials.resolveAuthMechanism(response);
-    const provider = AUTH_PROVIDERS.get(resolvedCredentials.mechanism);
+    const provider = options.authProviders.getOrCreateProvider(resolvedCredentials.mechanism);
     if (!provider) {
       throw new MongoInvalidArgumentError(
         `No AuthProvider for ${resolvedCredentials.mechanism} defined.`
@@ -186,6 +169,10 @@ async function performInitialHandshake(
   }
 }
 
+/**
+ * HandshakeDocument used during authentication.
+ * @internal
+ */
 export interface HandshakeDocument extends Document {
   /**
    * @deprecated Use hello instead
@@ -227,7 +214,9 @@ export async function prepareHandshakeDocument(
     if (credentials.mechanism === AuthMechanism.MONGODB_DEFAULT && credentials.username) {
       handshakeDoc.saslSupportedMechs = `${credentials.source}.${credentials.username}`;
 
-      const provider = AUTH_PROVIDERS.get(AuthMechanism.MONGODB_SCRAM_SHA256);
+      const provider = authContext.options.authProviders.getOrCreateProvider(
+        AuthMechanism.MONGODB_SCRAM_SHA256
+      );
       if (!provider) {
         // This auth mechanism is always present.
         throw new MongoInvalidArgumentError(
@@ -236,7 +225,7 @@ export async function prepareHandshakeDocument(
       }
       return provider.prepare(handshakeDoc, authContext);
     }
-    const provider = AUTH_PROVIDERS.get(credentials.mechanism);
+    const provider = authContext.options.authProviders.getOrCreateProvider(credentials.mechanism);
     if (!provider) {
       throw new MongoInvalidArgumentError(`No AuthProvider for ${credentials.mechanism} defined.`);
     }

--- a/src/cmap/connection.ts
+++ b/src/cmap/connection.ts
@@ -23,6 +23,7 @@ import {
   MongoWriteConcernError
 } from '../error';
 import type { ServerApi, SupportedNodeConnectionOptions } from '../mongo_client';
+import { type MongoClientAuthProviders } from '../mongo_client_auth_providers';
 import { type CancellationToken, TypedEventEmitter } from '../mongo_types';
 import type { ReadPreferenceLike } from '../read_preference';
 import { applySession, type ClientSession, updateSessionFromResponse } from '../sessions';
@@ -120,6 +121,8 @@ export interface ConnectionOptions
   /** @internal */
   connectionType?: typeof Connection;
   credentials?: MongoCredentials;
+  /** @internal */
+  authProviders: MongoClientAuthProviders;
   connectTimeoutMS?: number;
   tls: boolean;
   /** @deprecated - Will not be able to turn off in the future. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -200,7 +200,7 @@ export type {
   ResumeToken,
   UpdateDescription
 } from './change_stream';
-export type { AuthContext } from './cmap/auth/auth_provider';
+export type { AuthContext, AuthProvider } from './cmap/auth/auth_provider';
 export type {
   AuthMechanismProperties,
   MongoCredentials,
@@ -217,6 +217,7 @@ export type {
   Response,
   WriteProtocolMessageType
 } from './cmap/commands';
+export type { HandshakeDocument } from './cmap/connect';
 export type { LEGAL_TCP_SOCKET_OPTIONS, LEGAL_TLS_SOCKET_OPTIONS, Stream } from './cmap/connect';
 export type {
   CommandOptions,
@@ -304,6 +305,7 @@ export type {
   SupportedTLSSocketOptions,
   WithSessionCallback
 } from './mongo_client';
+export { MongoClientAuthProviders } from './mongo_client_auth_providers';
 export type {
   Log,
   LogConvertible,

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -16,6 +16,7 @@ import { Db, type DbOptions } from './db';
 import type { AutoEncrypter, AutoEncryptionOptions } from './deps';
 import type { Encrypter } from './encrypter';
 import { MongoInvalidArgumentError } from './error';
+import { MongoClientAuthProviders } from './mongo_client_auth_providers';
 import { MongoLogger, type MongoLoggerOptions } from './mongo_logger';
 import { TypedEventEmitter } from './mongo_types';
 import type { ReadConcern, ReadConcernLevel, ReadConcernLike } from './read_concern';
@@ -293,6 +294,7 @@ export interface MongoClientPrivate {
   bsonOptions: BSONSerializeOptions;
   namespace: MongoDBNamespace;
   hasBeenClosed: boolean;
+  authProviders: MongoClientAuthProviders;
   /**
    * We keep a reference to the sessions that are acquired from the pool.
    * - used to track and close all sessions in client.close() (which is non-standard behavior)
@@ -369,6 +371,7 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> {
       hasBeenClosed: false,
       sessionPool: new ServerSessionPool(this),
       activeSessions: new Set(),
+      authProviders: new MongoClientAuthProviders(),
 
       get options() {
         return client[kOptions];
@@ -765,7 +768,8 @@ export interface MongoOptions
 
   /** @internal */
   connectionType?: typeof Connection;
-
+  /** @internal */
+  authProviders: MongoClientAuthProviders;
   /** @internal */
   encrypter: Encrypter;
   /** @internal */

--- a/src/mongo_client_auth_providers.ts
+++ b/src/mongo_client_auth_providers.ts
@@ -1,0 +1,52 @@
+import { type AuthProvider } from './cmap/auth/auth_provider';
+import { GSSAPI } from './cmap/auth/gssapi';
+import { MongoCR } from './cmap/auth/mongocr';
+import { MongoDBAWS } from './cmap/auth/mongodb_aws';
+import { Plain } from './cmap/auth/plain';
+import { AuthMechanism } from './cmap/auth/providers';
+import { ScramSHA1, ScramSHA256 } from './cmap/auth/scram';
+import { X509 } from './cmap/auth/x509';
+import { MongoInvalidArgumentError } from './error';
+
+/** @internal */
+const AUTH_PROVIDERS = new Map<AuthMechanism | string, () => AuthProvider>([
+  [AuthMechanism.MONGODB_AWS, () => new MongoDBAWS()],
+  [AuthMechanism.MONGODB_CR, () => new MongoCR()],
+  [AuthMechanism.MONGODB_GSSAPI, () => new GSSAPI()],
+  [AuthMechanism.MONGODB_PLAIN, () => new Plain()],
+  [AuthMechanism.MONGODB_SCRAM_SHA1, () => new ScramSHA1()],
+  [AuthMechanism.MONGODB_SCRAM_SHA256, () => new ScramSHA256()],
+  [AuthMechanism.MONGODB_X509, () => new X509()]
+]);
+
+/**
+ * Create a set of providers per client
+ * to avoid sharing the provider's cache between different clients.
+ * @internal
+ */
+export class MongoClientAuthProviders {
+  private existingProviders: Map<AuthMechanism | string, AuthProvider> = new Map();
+
+  /**
+   * Get or create an authentication provider based on the provided mechanism.
+   * We don't want to create all providers at once, as some providers may not be used.
+   * @param name - The name of the provider to get or create.
+   * @returns The provider.
+   * @throws MongoInvalidArgumentError if the mechanism is not supported.
+   * @internal
+   */
+  getOrCreateProvider(name: AuthMechanism | string): AuthProvider {
+    const authProvider = this.existingProviders.get(name);
+    if (authProvider) {
+      return authProvider;
+    }
+
+    const provider = AUTH_PROVIDERS.get(name)?.();
+    if (!provider) {
+      throw new MongoInvalidArgumentError(`authMechanism ${name} not supported`);
+    }
+
+    this.existingProviders.set(name, provider);
+    return provider;
+  }
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,6 +3,7 @@ import type { SrvRecord } from 'dns';
 import * as http from 'http';
 import * as url from 'url';
 import { URL } from 'url';
+import { promisify } from 'util';
 
 import { type Document, ObjectId, resolveBSONOptions } from './bson';
 import type { Connection } from './cmap/connection';
@@ -1317,3 +1318,5 @@ export async function request(
     req.end();
   });
 }
+
+export const randomBytes = promisify(crypto.randomBytes);

--- a/test/integration/auth/mongodb_aws.test.ts
+++ b/test/integration/auth/mongodb_aws.test.ts
@@ -67,6 +67,20 @@ describe('MONGODB-AWS', function () {
       .that.equals('');
   });
 
+  it('should store a MongoDBAWS provider instance per client', async function () {
+    client = this.configuration.newClient(process.env.MONGODB_URI);
+
+    await client
+      .db('aws')
+      .collection('aws_test')
+      .estimatedDocumentCount()
+      .catch(error => error);
+
+    expect(client).to.have.nested.property('s.authProviders');
+    const provider = client.s.authProviders.getOrCreateProvider('MONGODB-AWS');
+    expect(provider).to.be.instanceOf(MongoDBAWS);
+  });
+
   describe('EC2 with missing credentials', () => {
     let client;
 
@@ -190,6 +204,7 @@ describe('MONGODB-AWS', function () {
         let storedEnv;
         let calledArguments;
         let shouldSkip = false;
+        let numberOfFromNodeProviderChainCalls;
 
         const envCheck = () => {
           const { AWS_WEB_IDENTITY_TOKEN_FILE = '' } = process.env;
@@ -204,8 +219,6 @@ describe('MONGODB-AWS', function () {
             return this.skip();
           }
 
-          client = this.configuration.newClient(process.env.MONGODB_URI);
-
           storedEnv = process.env;
           if (test.env.AWS_STS_REGIONAL_ENDPOINTS === undefined) {
             delete process.env.AWS_STS_REGIONAL_ENDPOINTS;
@@ -218,13 +231,17 @@ describe('MONGODB-AWS', function () {
             process.env.AWS_REGION = test.env.AWS_REGION;
           }
 
-          calledArguments = [];
+          numberOfFromNodeProviderChainCalls = 0;
+
           MongoDBAWS.credentialProvider = {
             fromNodeProviderChain(...args) {
               calledArguments = args;
+              numberOfFromNodeProviderChainCalls += 1;
               return credentialProvider.fromNodeProviderChain(...args);
             }
           };
+
+          client = this.configuration.newClient(process.env.MONGODB_URI);
         });
 
         afterEach(() => {
@@ -252,6 +269,18 @@ describe('MONGODB-AWS', function () {
           expect(result).to.be.a('number');
 
           expect(calledArguments).to.deep.equal(test.calledWith);
+        });
+
+        it('fromNodeProviderChain called once', async function () {
+          await client.close();
+          await client.connect();
+          await client
+            .db('aws')
+            .collection('aws_test')
+            .estimatedDocumentCount()
+            .catch(error => error);
+
+          expect(numberOfFromNodeProviderChainCalls).to.be.eql(1);
         });
       });
     }

--- a/test/unit/cmap/connect.test.ts
+++ b/test/unit/cmap/connect.test.ts
@@ -10,6 +10,7 @@ import {
   HostAddress,
   isHello,
   LEGACY_HELLO_COMMAND,
+  MongoClientAuthProviders,
   MongoCredentials,
   MongoNetworkError,
   prepareHandshakeDocument
@@ -45,7 +46,8 @@ describe('Connect Tests', function () {
           source: 'admin',
           mechanism: 'PLAIN',
           mechanismProperties: {}
-        })
+        }),
+        authProviders: new MongoClientAuthProviders()
       };
     });
 
@@ -207,7 +209,9 @@ describe('Connect Tests', function () {
 
   context('prepareHandshakeDocument', () => {
     context('when serverApi.version is present', () => {
-      const options = {};
+      const options = {
+        authProviders: new MongoClientAuthProviders()
+      };
       const authContext = {
         connection: { serverApi: { version: '1' } },
         options
@@ -222,7 +226,9 @@ describe('Connect Tests', function () {
     context('when serverApi is not present', () => {
       const options = {};
       const authContext = {
-        connection: {},
+        connection: {
+          authProviders: new MongoClientAuthProviders()
+        },
         options
       };
 
@@ -235,7 +241,9 @@ describe('Connect Tests', function () {
     context('loadBalanced option', () => {
       context('when loadBalanced is not set as an option', () => {
         it('does not set loadBalanced on the handshake document', async () => {
-          const options = {};
+          const options = {
+            authProviders: new MongoClientAuthProviders()
+          };
           const authContext = {
             connection: {},
             options
@@ -248,7 +256,8 @@ describe('Connect Tests', function () {
       context('when loadBalanced is set to false', () => {
         it('does not set loadBalanced on the handshake document', async () => {
           const options = {
-            loadBalanced: false
+            loadBalanced: false,
+            authProviders: new MongoClientAuthProviders()
           };
           const authContext = {
             connection: {},
@@ -262,7 +271,8 @@ describe('Connect Tests', function () {
       context('when loadBalanced is set to true', () => {
         it('does set loadBalanced on the handshake document', async () => {
           const options = {
-            loadBalanced: true
+            loadBalanced: true,
+            authProviders: new MongoClientAuthProviders()
           };
           const authContext = {
             connection: {},

--- a/test/unit/cmap/connection.test.ts
+++ b/test/unit/cmap/connection.test.ts
@@ -15,6 +15,7 @@ import {
   type HostAddress,
   isHello,
   type MessageStream,
+  MongoClientAuthProviders,
   MongoNetworkError,
   MongoNetworkTimeoutError,
   MongoRuntimeError,
@@ -31,7 +32,8 @@ const connectionOptionsDefaults = {
   monitorCommands: false,
   tls: false,
   metadata: undefined,
-  loadBalanced: false
+  loadBalanced: false,
+  authProviders: new MongoClientAuthProviders()
 };
 
 /**
@@ -446,7 +448,8 @@ describe('new Connection()', function () {
         generation: 1,
         monitorCommands: false,
         metadata: {} as ClientMetadata,
-        loadBalanced: false
+        loadBalanced: false,
+        authProviders: new MongoClientAuthProviders()
       };
       let server;
       let connectOptions;

--- a/test/unit/cmap/connection_pool.test.js
+++ b/test/unit/cmap/connection_pool.test.js
@@ -10,6 +10,7 @@ const { ns, isHello } = require('../../mongodb');
 const { LEGACY_HELLO_COMMAND } = require('../../mongodb');
 const { createTimerSandbox } = require('../timer_sandbox');
 const { topologyWithPlaceholderClient } = require('../../tools/utils');
+const { MongoClientAuthProviders } = require('../../mongodb');
 
 describe('Connection Pool', function () {
   let mockMongod;
@@ -18,6 +19,9 @@ describe('Connection Pool', function () {
       client: {
         mongoLogger: {
           debug: () => null
+        },
+        s: {
+          authProviders: new MongoClientAuthProviders()
         }
       }
     }

--- a/test/unit/index.test.ts
+++ b/test/unit/index.test.ts
@@ -69,6 +69,7 @@ const EXPECTED_EXPORTS = [
   'MongoBulkWriteError',
   'MongoChangeStreamError',
   'MongoClient',
+  'MongoClientAuthProviders',
   'MongoCompatibilityError',
   'MongoCursorExhaustedError',
   'MongoCursorInUseError',

--- a/test/unit/mongo_client.test.js
+++ b/test/unit/mongo_client.test.js
@@ -8,12 +8,17 @@ const { ReadConcern } = require('../mongodb');
 const { WriteConcern } = require('../mongodb');
 const { ReadPreference } = require('../mongodb');
 const { MongoCredentials } = require('../mongodb');
-const { MongoClient, MongoParseError, ServerApiVersion } = require('../mongodb');
+const {
+  MongoClient,
+  MongoParseError,
+  ServerApiVersion,
+  MongoInvalidArgumentError
+} = require('../mongodb');
 const { MongoLogger } = require('../mongodb');
 const sinon = require('sinon');
 const { Writable } = require('stream');
 
-describe('MongoOptions', function () {
+describe('MongoClient', function () {
   it('MongoClient should always freeze public options', function () {
     const client = new MongoClient('mongodb://localhost:27017');
     expect(client.options).to.be.frozen;
@@ -874,6 +879,17 @@ describe('MongoOptions', function () {
     it('assigns the parsed options to the mongoLoggerOptions option', function () {
       const client = new MongoClient('mongodb://localhost:27017');
       expect(client.options).to.have.property('mongoLoggerOptions').to.equal(expectedLoggingObject);
+    });
+  });
+
+  context('getAuthProvider', function () {
+    it('throws MongoInvalidArgumentError if provided authMechanism is not supported', function () {
+      const client = new MongoClient('mongodb://localhost:27017');
+      try {
+        client.s.authProviders.getOrCreateProvider('NOT_SUPPORTED');
+      } catch (error) {
+        expect(error).to.be.an.instanceof(MongoInvalidArgumentError);
+      }
     });
   });
 });

--- a/test/unit/mongo_client.test.js
+++ b/test/unit/mongo_client.test.js
@@ -889,7 +889,9 @@ describe('MongoClient', function () {
         client.s.authProviders.getOrCreateProvider('NOT_SUPPORTED');
       } catch (error) {
         expect(error).to.be.an.instanceof(MongoInvalidArgumentError);
+        return;
       }
+      expect.fail('missed exception');
     });
   });
 });


### PR DESCRIPTION
### Description
Instead of creating a new AWS provider for each authentication, we cache the AWS credentials provider per client.

#### What is changing?
Backporting [NODE-5616](https://jira.mongodb.org/browse/NODE-5616) to 5.x.

##### Is there new documentation needed for these changes?
None

#### What is the motivation for this change?
[NODE-5940](https://jira.mongodb.org/browse/NODE-5940)

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Caching AWS credentials provider per client

Instead of creating a new AWS provider for each authentication, we cache the AWS credentials provider per client to prevent overwhelming the auth endpoint and ensure that cached credentials are not shared with other clients.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
