### PR TITLE
refactor(NODE-5964): clean up prepareHandshakeDocument

### DIFF
--- a/test/unit/mongo_client.test.js
+++ b/test/unit/mongo_client.test.js
@@ -1196,7 +1196,9 @@ describe('MongoClient', function () {
         client.s.authProviders.getOrCreateProvider('NOT_SUPPORTED');
       } catch (error) {
         expect(error).to.be.an.instanceof(MongoInvalidArgumentError);
+        return;
       }
+      expect.fail('missed exception');
     });
   });
 });


### PR DESCRIPTION
### Description
We don't need to pass `authProviders` to `prepareHandshakeDocument()`, because it can read `ConnectionOptions` from `AuthContext`.

##### Is there new documentation needed for these changes?
None

#### What is the motivation for this change?
[NODE-5964](https://jira.mongodb.org/browse/NODE-5964)

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
