### PR TITLE
chore(NODE-5972): specify TS 5.0 in package.json and package-lock 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "source-map-support": "^0.5.21",
         "ts-node": "^10.9.2",
         "tsd": "^0.30.6",
-        "typescript": "^5.0.4",
+        "typescript": "5.0",
         "typescript-cached-transpile": "^0.0.6",
         "v8-heapsnapshot": "^1.3.1",
         "yargs": "^17.7.2"
@@ -1617,6 +1617,19 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@microsoft/api-extractor/node_modules/typescript": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@microsoft/api-extractor/node_modules/yallist": {
@@ -9317,16 +9330,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=12.20"
       }
     },
     "node_modules/typescript-cached-transpile": {

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "source-map-support": "^0.5.21",
     "ts-node": "^10.9.2",
     "tsd": "^0.30.6",
-    "typescript": "^5.0.4",
+    "typescript": "5.0",
     "typescript-cached-transpile": "^0.0.6",
     "v8-heapsnapshot": "^1.3.1",
     "yargs": "^17.7.2"


### PR DESCRIPTION
### Description

#### What is changing?

https://github.com/mongodb/node-mongodb-native/commit/eb5e2ab762548571102d35d2ea7b516039a8aa71 accidentally included TS@5.3.3 in the package-lock file.  This was allowed because our version specification for Typescript was ^5.0.0.  

This had the unintended side-effect of breaking our API docs.

I specified in the package.json that TS must be a 5.0.x version for now, which fixes doc generation as well.

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
