### PR TITLE
fix(NODE-5945): make AWS session token optional

### DIFF
--- a/src/cmap/auth/mongodb_aws.ts
+++ b/src/cmap/auth/mongodb_aws.ts
@@ -116,6 +116,7 @@ export class MongoDBAWS extends AuthProvider {
 
     const accessKeyId = credentials.username;
     const secretAccessKey = credentials.password;
+    // Allow the user to specify an AWS session token for authentication with temporary credentials.
     const sessionToken = credentials.mechanismProperties.AWS_SESSION_TOKEN;
 
     // If all three defined, include sessionToken, else include username and pass, else no credentials
@@ -129,6 +130,8 @@ export class MongoDBAWS extends AuthProvider {
     const db = credentials.source;
     const nonce = await randomBytes(32);
 
+    // All messages between MongoDB clients and servers are sent as BSON objects
+    // in the payload field of saslStart and saslContinue.
     const saslStart = {
       saslStart: 1,
       mechanism: 'MONGODB-AWS',
@@ -212,7 +215,8 @@ async function makeTempCredentials(
   provider?: () => Promise<AWSCredentials>
 ): Promise<MongoCredentials> {
   function makeMongoCredentialsFromAWSTemp(creds: AWSTempCredentials) {
-    if (!creds.AccessKeyId || !creds.SecretAccessKey || !creds.Token) {
+    // The AWS session token (creds.Token) may or may not be set.
+    if (!creds.AccessKeyId || !creds.SecretAccessKey) {
       throw new MongoMissingCredentialsError('Could not obtain temporary MONGODB-AWS credentials');
     }
 

--- a/test/integration/auth/mongodb_aws.test.ts
+++ b/test/integration/auth/mongodb_aws.test.ts
@@ -81,6 +81,35 @@ describe('MONGODB-AWS', function () {
     expect(provider).to.be.instanceOf(MongoDBAWS);
   });
 
+  describe('with missing aws token', () => {
+    let awsSessionToken;
+
+    beforeEach(function () {
+      awsSessionToken = process.env.AWS_SESSION_TOKEN;
+      delete process.env.AWS_SESSION_TOKEN;
+    });
+
+    afterEach(async () => {
+      process.env.AWS_SESSION_TOKEN = awsSessionToken;
+    });
+
+    it('should not throw an exception when aws token is missing', async function () {
+      client = this.configuration.newClient(process.env.MONGODB_URI);
+
+      const result = await client
+        .db('aws')
+        .collection('aws_test')
+        .estimatedDocumentCount()
+        .catch(error => error);
+
+      // We check only for the MongoMissingCredentialsError
+      // and do check for the MongoServerError as the error or numeric result
+      // that can be returned depending on different types of environments
+      // getting credentials from different sources.
+      expect(result).to.not.be.instanceOf(MongoMissingCredentialsError);
+    });
+  });
+
   describe('EC2 with missing credentials', () => {
     let client;
 

--- a/test/integration/auth/mongodb_aws.test.ts
+++ b/test/integration/auth/mongodb_aws.test.ts
@@ -5,7 +5,13 @@ import * as http from 'http';
 import { performance } from 'perf_hooks';
 import * as sinon from 'sinon';
 
-import { MongoAWSError, type MongoClient, MongoDBAWS, MongoServerError } from '../../mongodb';
+import {
+  MongoAWSError,
+  type MongoClient,
+  MongoDBAWS,
+  MongoMissingCredentialsError,
+  MongoServerError
+} from '../../mongodb';
 
 function awsSdk() {
   try {

--- a/test/integration/auth/mongodb_aws.test.ts
+++ b/test/integration/auth/mongodb_aws.test.ts
@@ -88,15 +88,17 @@ describe('MONGODB-AWS', function () {
   });
 
   describe('with missing aws token', () => {
-    let awsSessionToken;
+    let awsSessionToken: string | undefined;
 
-    beforeEach(function () {
+    beforeEach(() => {
       awsSessionToken = process.env.AWS_SESSION_TOKEN;
       delete process.env.AWS_SESSION_TOKEN;
     });
 
-    afterEach(async () => {
-      process.env.AWS_SESSION_TOKEN = awsSessionToken;
+    afterEach(() => {
+      if (awsSessionToken != null) {
+        process.env.AWS_SESSION_TOKEN = awsSessionToken;
+      }
     });
 
     it('should not throw an exception when aws token is missing', async function () {


### PR DESCRIPTION
### Description
Backport optional AWS session token [fix](https://github.com/mongodb/node-mongodb-native/pull/4002).

#### What is changing?
Do not throw the `MongoMissingCredentialsError('Could not obtain temporary MONGODB-AWS credentials')` exception when the AWS token is missing.

##### Is there new documentation needed for these changes?
None

#### What is the motivation for this change?
[NODE-5945](https://jira.mongodb.org/browse/NODE-5945)

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### The AWS token is now optional
Users may provide an `AWS_SESSION_TOKEN` as a client option or AWS configuration in addition to a username and password. But if the token is not provided, the driver won't throw an exception and let AWS SDK handle the request.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
