### PR TITLE
feat(NODE-5978): upgrade BSON to ^6.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@mongodb-js/saslprep": "^1.1.0",
-        "bson": "^6.3.0",
+        "bson": "^6.4.0",
         "mongodb-connection-string-url": "^3.0.0"
       },
       "devDependencies": {
@@ -3819,9 +3819,9 @@
       }
     },
     "node_modules/bson": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-6.3.0.tgz",
-      "integrity": "sha512-balJfqwwTBddxfnidJZagCBPP/f48zj9Sdp3OJswREOgsJzHiQSaOIAtApSgDQFYgHqAvFkp53AFSqjMDZoTFw==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.4.0.tgz",
+      "integrity": "sha512-6/gSSEdbkuFlSb+ufj5jUSU4+wo8xQOwm2bDSqwmxiPE17JTpsP63eAwoN8iF8Oy4gJYj+PAL3zdRCTdaw5Y1g==",
       "engines": {
         "node": ">=16.20.1"
       }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@mongodb-js/saslprep": "^1.1.0",
-    "bson": "^6.3.0",
+    "bson": "^6.4.0",
     "mongodb-connection-string-url": "^3.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
### Description

#### What is changing?

Upgrading to the latest BSON

##### Is there new documentation needed for these changes?

No.

#### What is the motivation for this change?

New BSON new me

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

BSON has had a number of performance increases in the last two releases (6.3.0 and 6.4.0). Small basic latin (ASCII) only strings, small memory allocations (ObjectId and Decimal128) and numeric parsing operations (int32, doubles, and longs) have all had optimizations applied to them. 

For details check out the release notes here: [BSON 6.3.0](https://github.com/mongodb/js-bson/releases/tag/v6.3.0) and [BSON 6.4.0](https://github.com/mongodb/js-bson/releases/tag/v6.4.0) :racehorse:

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
