### PR TITLE
feat(NODE-5967): container and Kubernetes awareness in client metadata

### DIFF
--- a/src/cmap/connect.ts
+++ b/src/cmap/connect.ts
@@ -25,7 +25,6 @@ import {
   type ConnectionOptions,
   CryptoConnection
 } from './connection';
-import { addContainerMetadata } from './handshake/client_metadata';
 import {
   MAX_SUPPORTED_SERVER_VERSION,
   MAX_SUPPORTED_WIRE_VERSION,
@@ -197,7 +196,7 @@ export async function prepareHandshakeDocument(
   const options = authContext.options;
   const compressors = options.compressors ? options.compressors : [];
   const { serverApi } = authContext.connection;
-  const clientMetadata = await addContainerMetadata(options.metadata);
+  const clientMetadata = await options.extendedMetadata;
 
   const handshakeDoc: HandshakeDocument = {
     [serverApi?.version ? 'hello' : LEGACY_HELLO_COMMAND]: 1,

--- a/src/cmap/connect.ts
+++ b/src/cmap/connect.ts
@@ -25,7 +25,7 @@ import {
   type ConnectionOptions,
   CryptoConnection
 } from './connection';
-import type { ClientMetadata } from './handshake/client_metadata';
+import { addContainerMetadata } from './handshake/client_metadata';
 import {
   MAX_SUPPORTED_SERVER_VERSION,
   MAX_SUPPORTED_WIRE_VERSION,
@@ -180,7 +180,7 @@ export interface HandshakeDocument extends Document {
   ismaster?: boolean;
   hello?: boolean;
   helloOk?: boolean;
-  client: ClientMetadata;
+  client: Document;
   compression: string[];
   saslSupportedMechs?: string;
   loadBalanced?: boolean;
@@ -197,11 +197,12 @@ export async function prepareHandshakeDocument(
   const options = authContext.options;
   const compressors = options.compressors ? options.compressors : [];
   const { serverApi } = authContext.connection;
+  const clientMetadata = await addContainerMetadata(options.metadata);
 
   const handshakeDoc: HandshakeDocument = {
     [serverApi?.version ? 'hello' : LEGACY_HELLO_COMMAND]: 1,
     helloOk: true,
-    client: options.metadata,
+    client: clientMetadata,
     compression: compressors
   };
 

--- a/src/cmap/connection.ts
+++ b/src/cmap/connection.ts
@@ -133,6 +133,8 @@ export interface ConnectionOptions
   socketTimeoutMS?: number;
   cancellationToken?: CancellationToken;
   metadata: ClientMetadata;
+  /** @internal */
+  extendedMetadata: Promise<Document>;
 }
 
 /** @internal */

--- a/src/cmap/handshake/client_metadata.ts
+++ b/src/cmap/handshake/client_metadata.ts
@@ -157,20 +157,15 @@ export function makeClientMetadata(options: MakeClientMetadataOptions): ClientMe
   return metadataDocument.toObject() as ClientMetadata;
 }
 
-let isDocker: boolean;
-let dockerPromise: Promise<void>;
+let dockerPromise: Promise<boolean>;
 /** @internal */
 async function getContainerMetadata() {
   const containerMetadata: Record<string, any> = {};
-  if (isDocker == null) {
-    dockerPromise ??= fs.access('/.dockerenv');
-    try {
-      await dockerPromise;
-      isDocker = true;
-    } catch {
-      isDocker = false;
-    }
-  }
+  dockerPromise ??= fs.access('/.dockerenv').then(
+    () => true,
+    () => false
+  );
+  const isDocker = await dockerPromise;
 
   const { KUBERNETES_SERVICE_HOST = '' } = process.env;
   const isKubernetes = KUBERNETES_SERVICE_HOST.length > 0 ? true : false;

--- a/src/cmap/handshake/client_metadata.ts
+++ b/src/cmap/handshake/client_metadata.ts
@@ -1,7 +1,8 @@
+import { promises as fs } from 'fs';
 import * as os from 'os';
 import * as process from 'process';
 
-import { BSON, Int32 } from '../../bson';
+import { BSON, type Document, Int32 } from '../../bson';
 import { MongoInvalidArgumentError } from '../../error';
 import type { MongoOptions } from '../../mongo_client';
 
@@ -71,13 +72,13 @@ export class LimitedSizeDocument {
     return true;
   }
 
-  toObject(): ClientMetadata {
+  toObject(): Document {
     return BSON.deserialize(BSON.serialize(this.document), {
       promoteLongs: false,
       promoteBuffers: false,
       promoteValues: false,
       useBigInt64: false
-    }) as ClientMetadata;
+    });
   }
 }
 
@@ -153,7 +154,62 @@ export function makeClientMetadata(options: MakeClientMetadataOptions): ClientMe
     }
   }
 
-  return metadataDocument.toObject();
+  return metadataDocument.toObject() as ClientMetadata;
+}
+
+let isDocker: boolean;
+let dockerPromise: Promise<void>;
+/** @internal */
+async function getContainerMetadata() {
+  const containerMetadata: Record<string, any> = {};
+  if (isDocker == null) {
+    dockerPromise ??= fs.access('/.dockerenv');
+    try {
+      await dockerPromise;
+      isDocker = true;
+    } catch {
+      isDocker = false;
+    }
+  }
+
+  const { KUBERNETES_SERVICE_HOST = '' } = process.env;
+  const isKubernetes = KUBERNETES_SERVICE_HOST.length > 0 ? true : false;
+
+  if (isDocker) containerMetadata.runtime = 'docker';
+  if (isKubernetes) containerMetadata.orchestrator = 'kubernetes';
+
+  return containerMetadata;
+}
+
+/**
+ * @internal
+ * Re-add each metadata value.
+ * Attempt to add new env container metadata, but keep old data if it does not fit.
+ */
+export async function addContainerMetadata(originalMetadata: ClientMetadata) {
+  const containerMetadata = await getContainerMetadata();
+  if (Object.keys(containerMetadata).length === 0) return originalMetadata;
+
+  const extendedMetadata = new LimitedSizeDocument(512);
+
+  const extendedEnvMetadata = { ...originalMetadata?.env, container: containerMetadata };
+
+  for (const [key, val] of Object.entries(originalMetadata)) {
+    if (key !== 'env') {
+      extendedMetadata.ifItFitsItSits(key, val);
+    } else {
+      if (!extendedMetadata.ifItFitsItSits('env', extendedEnvMetadata)) {
+        // add in old data if newer / extended metadata does not fit
+        extendedMetadata.ifItFitsItSits('env', val);
+      }
+    }
+  }
+
+  if (!('env' in originalMetadata)) {
+    extendedMetadata.ifItFitsItSits('env', extendedEnvMetadata);
+  }
+
+  return extendedMetadata.toObject();
 }
 
 /**

--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -6,7 +6,7 @@ import { URLSearchParams } from 'url';
 import type { Document } from './bson';
 import { MongoCredentials } from './cmap/auth/mongo_credentials';
 import { AUTH_MECHS_AUTH_SRC_EXTERNAL, AuthMechanism } from './cmap/auth/providers';
-import { makeClientMetadata } from './cmap/handshake/client_metadata';
+import { addContainerMetadata, makeClientMetadata } from './cmap/handshake/client_metadata';
 import { Compressor, type CompressorName } from './cmap/wire_protocol/compression';
 import { Encrypter } from './encrypter';
 import {
@@ -550,6 +550,9 @@ export function parseOptions(
   );
 
   mongoOptions.metadata = makeClientMetadata(mongoOptions);
+  mongoOptions.extendedMetadata = addContainerMetadata(mongoOptions.metadata).catch(() => {
+    /* rejections will be handled later */
+  });
 
   return mongoOptions;
 }

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -757,6 +757,8 @@ export interface MongoOptions
   writeConcern: WriteConcern;
   dbName: string;
   metadata: ClientMetadata;
+  /** @internal */
+  extendedMetadata: Promise<Document>;
   /**
    * @deprecated This option will be removed in the next major version.
    */

--- a/src/sdam/topology.ts
+++ b/src/sdam/topology.ts
@@ -143,6 +143,7 @@ export interface TopologyOptions extends BSONSerializeOptions, ServerOptions {
   directConnection: boolean;
   loadBalanced: boolean;
   metadata: ClientMetadata;
+  extendedMetadata: Promise<Document>;
   /** MongoDB server API version */
   serverApi?: ServerApi;
   [featureFlag: symbol]: any;

--- a/test/integration/connection-monitoring-and-pooling/connection.test.ts
+++ b/test/integration/connection-monitoring-and-pooling/connection.test.ts
@@ -95,7 +95,8 @@ describe('Connection', function () {
         const connectOptions: Partial<ConnectionOptions> = {
           connectionType: Connection,
           ...this.configuration.options,
-          metadata: makeClientMetadata({ driverInfo: {} })
+          metadata: makeClientMetadata({ driverInfo: {} }),
+          extendedMetadata: addContainerMetadata(makeClientMetadata({ driverInfo: {} }))
         };
 
         connect(connectOptions as any as ConnectionOptions, (err, conn) => {

--- a/test/integration/connection-monitoring-and-pooling/connection.test.ts
+++ b/test/integration/connection-monitoring-and-pooling/connection.test.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 
 import {
+  addContainerMetadata,
   connect,
   Connection,
   type ConnectionOptions,
@@ -36,7 +37,8 @@ describe('Connection', function () {
         const connectOptions: Partial<ConnectionOptions> = {
           connectionType: Connection,
           ...this.configuration.options,
-          metadata: makeClientMetadata({ driverInfo: {} })
+          metadata: makeClientMetadata({ driverInfo: {} }),
+          extendedMetadata: addContainerMetadata(makeClientMetadata({ driverInfo: {} }))
         };
 
         connect(connectOptions as any as ConnectionOptions, (err, conn) => {
@@ -60,7 +62,8 @@ describe('Connection', function () {
           connectionType: Connection,
           monitorCommands: true,
           ...this.configuration.options,
-          metadata: makeClientMetadata({ driverInfo: {} })
+          metadata: makeClientMetadata({ driverInfo: {} }),
+          extendedMetadata: addContainerMetadata(makeClientMetadata({ driverInfo: {} }))
         };
 
         connect(connectOptions as any as ConnectionOptions, (err, conn) => {

--- a/test/tools/cmap_spec_runner.ts
+++ b/test/tools/cmap_spec_runner.ts
@@ -4,6 +4,7 @@ import { clearTimeout, setTimeout } from 'timers';
 import { promisify } from 'util';
 
 import {
+  addContainerMetadata,
   CMAP_EVENTS,
   type Connection,
   ConnectionPool,
@@ -371,6 +372,7 @@ async function runCmapTest(test: CmapTest, threadContext: ThreadContext) {
   }
 
   const metadata = makeClientMetadata({ appName: poolOptions.appName, driverInfo: {} });
+  const extendedMetadata = addContainerMetadata(metadata);
   delete poolOptions.appName;
 
   const operations = test.operations;
@@ -382,7 +384,12 @@ async function runCmapTest(test: CmapTest, threadContext: ThreadContext) {
   const mainThread = threadContext.getThread(MAIN_THREAD_KEY);
   mainThread.start();
 
-  threadContext.createPool({ ...poolOptions, metadata, minPoolSizeCheckFrequencyMS });
+  threadContext.createPool({
+    ...poolOptions,
+    metadata,
+    extendedMetadata,
+    minPoolSizeCheckFrequencyMS
+  });
   // yield control back to the event loop so that the ConnectionPoolCreatedEvent
   // has a chance to be fired before any synchronously-emitted events from
   // the queued operations

--- a/test/unit/cmap/connection_pool.test.js
+++ b/test/unit/cmap/connection_pool.test.js
@@ -22,6 +22,9 @@ describe('Connection Pool', function () {
         },
         s: {
           authProviders: new MongoClientAuthProviders()
+        },
+        options: {
+          extendedMetadata: {}
         }
       }
     }


### PR DESCRIPTION
**Note:** This PR's description and changes are  almost identical to the one on the 6.x branch (NODE-5968).

### Description
Track user usage of containers on 5.x branch.

#### What is changing?
When kubernetes is in `process.env`, we add a  `{orchestrator: 'kubernetes'}` field to the `client.env` field of the handshake document (if this does not make the document exceed 512 bytes).

When '/.dockerenv' exists, we add a  `{runtime: 'docker'}` field to the `client.env` field of the handshake document (if this does not make the document exceed 512 bytes).

Note: We do not unit test docker, but I tested our logic for detecting docker on an EVG Host, ran Docker and detection succeeds for both root and non-root user cases.

##### Is there new documentation needed for these changes?
No, non-user facing change. 

#### What is the motivation for this change?
Product wants to track user usage of docker and kubernetes.

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->
### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Container and Kubernetes Awareness

The Node.js driver now keeps track of container metadata in the `client.env.container` field of the handshake document. 

If space allows, the following metadata will be included in `client.env.container`:

```
env?: { 
  container?: {
    orchestrator?: 'kubernetes' // if process.env.KUBERNETES_SERVICE_HOST is set
    runtime?: 'docker' // if the '/.dockerenv' file exists
  } 
}
```

Note: If neither Kubernetes nor Docker is present, `client.env` will not have the `container` property.

<!-- RELEASE_HIGHLIGHT_END -->
<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket