### PR TITLE
fix(NODE-5985): throw Nodejs' certificate expired error when TLS fails to connect instead of `CERT_HAS_EXPIRED`

### DIFF
--- a/src/cmap/connect.ts
+++ b/src/cmap/connect.ts
@@ -375,10 +375,6 @@ export async function makeSocket(options: MakeConnectionOptions): Promise<Stream
     return socket;
   } catch (error) {
     socket.destroy();
-    if ('authorizationError' in socket && socket.authorizationError != null && rejectUnauthorized) {
-      // TODO(NODE-5192): wrap this with a MongoError subclass
-      throw socket.authorizationError;
-    }
     throw error;
   } finally {
     socket.setTimeout(0);

--- a/src/cmap/connect.ts
+++ b/src/cmap/connect.ts
@@ -319,7 +319,6 @@ export async function makeSocket(options: MakeConnectionOptions): Promise<Stream
   const useTLS = options.tls ?? false;
   const noDelay = options.noDelay ?? true;
   const connectTimeoutMS = options.connectTimeoutMS ?? 30000;
-  const rejectUnauthorized = options.rejectUnauthorized ?? true;
   const existingSocket = options.existingSocket;
 
   let socket: Stream;


### PR DESCRIPTION
### Description

#### What is changing?

When enabled, `rejectUnauthorized` configures Node's TLS API to reject / error when its unable to verify the certificates of the server.  This is enabled by default.  When the option is enabled and Node is unabled to verify the certificates of the server, an error event is emitted.  In our connect logic, this means the `connect` promise rejects.

Prior to https://github.com/mongodb/node-mongodb-native/pull/3973, the code removed in this PR was in the connect handler (called on successful TLS connection).  This was dead code because we will never receive an error that is triggered by `rejectUnauthorized` and successfully connect.  When https://github.com/mongodb/node-mongodb-native/pull/3973 refactored `connect()` to be async, we moved this logic into the `catch` block instead of the `try` block, so that it _did_ run when an error occurred during TLS connection.

The code throws `socket.authorizationError` instead of the caught error, which is a string value (https://nodejs.org/api/tls.html#tlssocketauthorizationerror).  As a result, instead of throwing the error Nodejs gave us, we throw the authorization error property from the socket.

##### Is there new documentation needed for these changes?

No.

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

Driver `6.3.0` included an internal refactor to the driver's TLS connection logic that introduced logic that intercepted TLS connection errors.  In certain situations, the driver would erroneously throw the TLS socket's `authorizationError` property instead of the error thrown from Nodejs' TLS API.

This was observable in two ways:

- The error message for TLS connection issues changed.  For example, instead of `certificate has expired`, the driver threw an error with the message `CERT_HAS_EXPIRED`
- The error thrown from the driver had a `cause` property set to a string instead of an error.

The driver now correctly propagates TLS errors.

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
