### PR TITLE
test(NODE-5992): fix env var restoration in tests

### DIFF
--- a/test/integration/auth/mongodb_aws.test.ts
+++ b/test/integration/auth/mongodb_aws.test.ts
@@ -88,15 +88,17 @@ describe('MONGODB-AWS', function () {
   });
 
   describe('with missing aws token', () => {
-    let awsSessionToken;
+    let awsSessionToken: string | undefined;
 
-    beforeEach(function () {
+    beforeEach(() => {
       awsSessionToken = process.env.AWS_SESSION_TOKEN;
       delete process.env.AWS_SESSION_TOKEN;
     });
 
-    afterEach(async () => {
-      process.env.AWS_SESSION_TOKEN = awsSessionToken;
+    afterEach(() => {
+      if (awsSessionToken != null) {
+        process.env.AWS_SESSION_TOKEN = awsSessionToken;
+      }
     });
 
     it('should not throw an exception when aws token is missing', async function () {


### PR DESCRIPTION
### Description
Without this fix, if AWS_SESSION_TOKEN does not exist, afterEach would set it to "undefined".

#### What is changing?
Reset AWS_SESSION_TOKEN only when `awsSessionToken != null`.

##### Is there new documentation needed for these changes?
None

#### What is the motivation for this change?
[NODE-5992](https://jira.mongodb.org/browse/NODE-5992)

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
