### PR TITLE
chore(NODE-5903): add newline to stdio logging

### DIFF
--- a/src/mongo_logger.ts
+++ b/src/mongo_logger.ts
@@ -220,7 +220,8 @@ export function createStdioLogger(stream: {
 }): MongoDBLogWritable {
   return {
     write: promisify((log: Log, cb: (error?: Error) => void): unknown => {
-      stream.write(inspect(log, { compact: true, breakLength: Infinity }), 'utf-8', cb);
+      const logLine = inspect(log, { compact: true, breakLength: Infinity });
+      stream.write(`${logLine}\n`, 'utf-8', cb);
       return;
     })
   };

--- a/test/unit/connection_string.test.ts
+++ b/test/unit/connection_string.test.ts
@@ -896,7 +896,8 @@ describe('Connection String', function () {
         });
         const log: Log = { t: new Date(), c: 'ConnectionStringStdErr', s: 'error' };
         client.options.mongoLoggerOptions.logDestination.write(log);
-        expect(stderrStub.write).calledWith(inspect(log, { breakLength: Infinity, compact: true }));
+        const logLine = inspect(log, { breakLength: Infinity, compact: true });
+        expect(stderrStub.write).calledWith(`${logLine}\n`);
       });
     });
 
@@ -907,7 +908,8 @@ describe('Connection String', function () {
         });
         const log: Log = { t: new Date(), c: 'ConnectionStringStdOut', s: 'error' };
         client.options.mongoLoggerOptions.logDestination.write(log);
-        expect(stdoutStub.write).calledWith(inspect(log, { breakLength: Infinity, compact: true }));
+        const logLine = inspect(log, { breakLength: Infinity, compact: true });
+        expect(stdoutStub.write).calledWith(`${logLine}\n`);
       });
     });
 

--- a/test/unit/mongo_client.test.js
+++ b/test/unit/mongo_client.test.js
@@ -852,9 +852,8 @@ describe('MongoClient', function () {
             });
             const log = { t: new Date(), c: 'constructorStdErr', s: 'error' };
             client.options.mongoLoggerOptions.logDestination.write(log);
-            expect(stderrStub.write).calledWith(
-              inspect(log, { breakLength: Infinity, compact: true })
-            );
+            const logLine = inspect(log, { breakLength: Infinity, compact: true });
+            expect(stderrStub.write).calledWith(`${logLine}\n`);
           });
         });
 
@@ -882,9 +881,8 @@ describe('MongoClient', function () {
             });
             const log = { t: new Date(), c: 'constructorStdOut', s: 'error' };
             client.options.mongoLoggerOptions.logDestination.write(log);
-            expect(stdoutStub.write).calledWith(
-              inspect(log, { breakLength: Infinity, compact: true })
-            );
+            const logLine = inspect(log, { breakLength: Infinity, compact: true });
+            expect(stdoutStub.write).calledWith(`${logLine}\n`);
           });
         });
 
@@ -939,9 +937,8 @@ describe('MongoClient', function () {
           });
           const log = { t: new Date(), c: 'constructorStdErr', s: 'error' };
           client.options.mongoLoggerOptions.logDestination.write(log);
-          expect(stderrStub.write).calledWith(
-            inspect(log, { breakLength: Infinity, compact: true })
-          );
+          const logLine = inspect(log, { breakLength: Infinity, compact: true });
+          expect(stderrStub.write).calledWith(`${logLine}\n`);
         });
       });
     });

--- a/test/unit/mongo_logger.test.ts
+++ b/test/unit/mongo_logger.test.ts
@@ -443,9 +443,8 @@ describe('class MongoLogger', async function () {
                 const log: Log = { t: new Date(), c: 'command', s: 'error' };
                 options.logDestination.write(log);
 
-                expect(stderrStub.write).to.have.been.calledOnceWith(
-                  inspect(log, { breakLength: Infinity, compact: true })
-                );
+                const logLine = inspect(log, { breakLength: Infinity, compact: true });
+                expect(stderrStub.write).to.have.been.calledOnceWith(`${logLine}\n`);
               });
             }
           }
@@ -465,9 +464,8 @@ describe('class MongoLogger', async function () {
                 const log: Log = { t: new Date(), c: 'command', s: 'error' };
                 options.logDestination.write(log);
 
-                expect(stderrStub.write).to.have.been.calledOnceWith(
-                  inspect(log, { breakLength: Infinity, compact: true })
-                );
+                const logLine = inspect(log, { breakLength: Infinity, compact: true });
+                expect(stderrStub.write).to.have.been.calledOnceWith(`${logLine}\n`);
               });
             }
           }
@@ -512,9 +510,8 @@ describe('class MongoLogger', async function () {
                   const log: Log = { t: new Date(), c: 'command', s: 'error' };
                   options.logDestination.write(log);
 
-                  expect(stderrStub.write).to.have.been.calledOnceWith(
-                    inspect(log, { breakLength: Infinity, compact: true })
-                  );
+                  const logLine = inspect(log, { breakLength: Infinity, compact: true });
+                  expect(stderrStub.write).to.have.been.calledOnceWith(`${logLine}\n`);
                 });
               }
             }
@@ -536,9 +533,8 @@ describe('class MongoLogger', async function () {
                     const log: Log = { t: new Date(), c: 'command', s: 'error' };
                     options.logDestination.write(log);
 
-                    expect(stderrStub.write).to.have.been.calledOnceWith(
-                      inspect(log, { breakLength: Infinity, compact: true })
-                    );
+                    const logLine = inspect(log, { breakLength: Infinity, compact: true });
+                    expect(stderrStub.write).to.have.been.calledOnceWith(`${logLine}\n`);
                   });
                 }
               }
@@ -1399,9 +1395,8 @@ describe('class MongoLogger', async function () {
             logger.debug('client', 'random message');
             let stderrStubCall = stderrStub.write.getCall(0).args[0];
             stderrStubCall = stderrStubCall.slice(stderrStubCall.search('c:'));
-            expect(stderrStubCall).to.equal(
-              `c: 'client', s: 'error', message: 'User input for mongodbLogPath is now invalid. Logging is halted.', error: 'This writable always throws' }`
-            );
+            const expectedLogLine1 = `c: 'client', s: 'error', message: 'User input for mongodbLogPath is now invalid. Logging is halted.', error: 'This writable always throws' }`;
+            expect(stderrStubCall).to.equal(`${expectedLogLine1}\n`);
 
             // logging is halted
             logger.debug('client', 'random message 2');
@@ -1450,9 +1445,8 @@ describe('class MongoLogger', async function () {
             // stderr now contains the error message
             let stderrStubCall = stderrStub.write.getCall(0).args[0];
             stderrStubCall = stderrStubCall.slice(stderrStubCall.search('c:'));
-            expect(stderrStubCall).to.equal(
-              `c: 'client', s: 'error', message: 'User input for mongodbLogPath is now invalid. Logging is halted.', error: 'This writable always throws, but only after at least 500ms' }`
-            );
+            const expectedLogLine1 = `c: 'client', s: 'error', message: 'User input for mongodbLogPath is now invalid. Logging is halted.', error: 'This writable always throws, but only after at least 500ms' }`;
+            expect(stderrStubCall).to.equal(`${expectedLogLine1}\n`);
 
             // no more logging in the future
             logger.debug('client', 'random message 2');
@@ -1480,7 +1474,7 @@ describe('class MongoLogger', async function () {
             let stderrStubCall = stderrStub.write.getCall(0).args[0];
             stderrStubCall = stderrStubCall.slice(stderrStubCall.search('c:'));
             expect(stderrStubCall).to.equal(
-              `c: 'client', s: 'error', message: 'User input for mongodbLogPath is now invalid. Logging is halted.', error: 'I am stdout and do not work' }`
+              `c: 'client', s: 'error', message: 'User input for mongodbLogPath is now invalid. Logging is halted.', error: 'I am stdout and do not work' }\n`
             );
 
             // logging is halted


### PR DESCRIPTION
### Description

#### What is changing?
Added newline to create stdio logger.
Updated stdio logging tests to expect newline.

##### Is there new documentation needed for these changes?
No.

#### What is the motivation for this change?
To ensure all stdio logs are not just on one line.

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
