### PR TITLE
test(NODE-5962): gossip cluster time in utr

### DIFF
--- a/test/integration/transactions-convenient-api/transactions-convenient-api.spec.test.ts
+++ b/test/integration/transactions-convenient-api/transactions-convenient-api.spec.test.ts
@@ -5,19 +5,8 @@ import { runUnifiedSuite } from '../../tools/unified-spec-runner/runner';
 
 const SKIPPED_TESTS = [
   'callback succeeds after multiple connection errors',
-  'callback is not retried after non-transient error',
   'callback is not retried after non-transient error (DuplicateKeyError)',
-  'withTransaction succeeds if callback aborts',
-  'unpin after transient error within a transaction',
-  'withTransaction succeeds if callback commits',
-  'withTransaction still succeeds if callback aborts and runs extra op',
-  'withTransaction still succeeds if callback commits and runs extra op',
-  'withTransaction commits after callback returns (second transaction)',
-  'withTransaction commits after callback returns',
-  'withTransaction and no transaction options set',
-  'withTransaction inherits transaction options from defaultTransactionOptions',
-  'withTransaction explicit transaction options override defaultTransactionOptions',
-  'withTransaction explicit transaction options'
+  'withTransaction succeeds if callback aborts'
 ];
 
 describe('Transactions Convenient API Spec Unified Tests', function () {
@@ -33,7 +22,7 @@ describe('Transactions Convenient API Spec Unified Tests', function () {
 
   runUnifiedSuite(loadSpecTests(path.join('transactions-convenient-api', 'unified')), test => {
     return SKIPPED_TESTS.includes(test.description)
-      ? 'TODO(NODE-5855/DRIVERS-2816): Skipping failing transaction tests'
+      ? 'TODO(NODE-5855): Skipping failing transaction tests'
       : false;
   });
 });

--- a/test/tools/unified-spec-runner/entities.ts
+++ b/test/tools/unified-spec-runner/entities.ts
@@ -7,6 +7,7 @@ import {
   ChangeStream,
   ClientEncryption,
   ClientSession,
+  type ClusterTime,
   Collection,
   type CommandFailedEvent,
   type CommandStartedEvent,
@@ -556,6 +557,7 @@ export class EntitiesMap<E = Entity> extends Map<string, E> {
 
   static async createEntities(
     config: TestConfiguration,
+    clusterTime: ClusterTime | null,
     entities?: EntityDescription[],
     entityMap?: EntitiesMap
   ): Promise<EntitiesMap> {
@@ -627,6 +629,10 @@ export class EntitiesMap<E = Entity> extends Map<string, E> {
           }
         }
         const session = client.startSession(options);
+        // Advance the session cluster time. See DRIVERS-2816.
+        if (clusterTime) {
+          session.advanceClusterTime(clusterTime);
+        }
         map.set(entity.session.id, session);
       } else if ('bucket' in entity) {
         const db = map.getEntity('db', entity.bucket.database);

--- a/test/tools/unified-spec-runner/operations.ts
+++ b/test/tools/unified-spec-runner/operations.ts
@@ -45,7 +45,7 @@ operations.set('createEntities', async ({ entities, operation, testConfig }) => 
   if (!operation.arguments?.entities) {
     throw new Error('encountered createEntities operation without entities argument');
   }
-  await EntitiesMap.createEntities(testConfig, operation.arguments.entities!, entities);
+  await EntitiesMap.createEntities(testConfig, null, operation.arguments.entities!, entities);
 });
 
 operations.set('abortTransaction', async ({ entities, operation }) => {

--- a/test/tools/unified-spec-runner/runner.ts
+++ b/test/tools/unified-spec-runner/runner.ts
@@ -113,9 +113,6 @@ async function runUnifiedTest(
       return ctx.skip();
     }
 
-    const ping = await utilClient.db().admin().command({ ping: 1 });
-    const clusterTime = ping.$clusterTime;
-
     // If initialData is specified, for each collectionData therein the test runner MUST drop the
     // collection and insert the specified documents (if any) using a "majority" write concern. If no
     // documents are specified, the test runner MUST create the collection with a "majority" write concern.
@@ -162,6 +159,9 @@ async function runUnifiedTest(
         }
       }
     }
+
+    const ping = await utilClient.db().admin().command({ ping: 1 });
+    const clusterTime = ping.$clusterTime;
 
     trace('createEntities');
     entities = await EntitiesMap.createEntities(

--- a/test/tools/unified-spec-runner/runner.ts
+++ b/test/tools/unified-spec-runner/runner.ts
@@ -113,6 +113,9 @@ async function runUnifiedTest(
       return ctx.skip();
     }
 
+    const ping = await utilClient.db().admin().command({ ping: 1 });
+    const clusterTime = ping.$clusterTime;
+
     // If initialData is specified, for each collectionData therein the test runner MUST drop the
     // collection and insert the specified documents (if any) using a "majority" write concern. If no
     // documents are specified, the test runner MUST create the collection with a "majority" write concern.
@@ -161,7 +164,11 @@ async function runUnifiedTest(
     }
 
     trace('createEntities');
-    entities = await EntitiesMap.createEntities(ctx.configuration, unifiedSuite.createEntities);
+    entities = await EntitiesMap.createEntities(
+      ctx.configuration,
+      clusterTime,
+      unifiedSuite.createEntities
+    );
 
     // Workaround for SERVER-39704:
     // test runners MUST execute a non-transactional distinct command on


### PR DESCRIPTION
### Description

Gossip the cluster time in the unified test runner.

#### What is changing?
- Pings the server on the util client to get the current cluster time.
- Sets the cluster time on all sessions that get created in the entities map.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-5962/DRIVERS-2816

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
