### PR TITLE
fix(NODE-5993): memory leak in the `Connection` class

### DIFF
--- a/src/cmap/connection.ts
+++ b/src/cmap/connection.ts
@@ -623,7 +623,7 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
    */
   private async *readMany(): AsyncGenerator<OpMsgResponse | OpQueryResponse> {
     try {
-      this.dataEvents = this.dataEvents = onData(this.messageStream);
+      this.dataEvents = onData(this.messageStream);
       for await (const message of this.dataEvents) {
         const response = await decompressResponse(message);
         yield response;

--- a/src/cmap/connection.ts
+++ b/src/cmap/connection.ts
@@ -1,6 +1,5 @@
 import { type Readable, Transform, type TransformCallback } from 'stream';
 import { clearTimeout, setTimeout } from 'timers';
-import { promisify } from 'util';
 
 import type { BSONSerializeOptions, Document, ObjectId } from '../bson';
 import type { AutoEncrypter } from '../client-side-encryption/auto_encrypter';
@@ -182,18 +181,18 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
    * Once connection is established, command logging can log events (if enabled)
    */
   public established: boolean;
+  /** Indicates that the connection (including underlying TCP socket) has been closed. */
+  public closed = false;
 
   private lastUseTime: number;
   private clusterTime: Document | null = null;
+  private error: Error | null = null;
+  private dataEvents: AsyncGenerator<Buffer, void, void> | null = null;
 
   private readonly socketTimeoutMS: number;
   private readonly monitorCommands: boolean;
   private readonly socket: Stream;
-  private readonly controller: AbortController;
-  private readonly signal: AbortSignal;
   private readonly messageStream: Readable;
-  private readonly socketWrite: (buffer: Uint8Array) => Promise<void>;
-  private readonly aborted: Promise<never>;
 
   /** @event */
   static readonly COMMAND_STARTED = COMMAND_STARTED;
@@ -213,6 +212,7 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
   constructor(stream: Stream, options: ConnectionOptions) {
     super();
 
+    this.socket = stream;
     this.id = options.id;
     this.address = streamIdentifier(stream, options);
     this.socketTimeoutMS = options.socketTimeoutMS ?? 0;
@@ -225,39 +225,12 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
     this.generation = options.generation;
     this.lastUseTime = now();
 
-    this.socket = stream;
-
-    // TODO: Remove signal from connection layer
-    this.controller = new AbortController();
-    const { signal } = this.controller;
-    this.signal = signal;
-    const { promise: aborted, reject } = promiseWithResolvers<never>();
-    aborted.then(undefined, () => null); // Prevent unhandled rejection
-    this.signal.addEventListener(
-      'abort',
-      function onAbort() {
-        reject(signal.reason);
-      },
-      { once: true }
-    );
-    this.aborted = aborted;
-
     this.messageStream = this.socket
       .on('error', this.onError.bind(this))
       .pipe(new SizedMessageTransform({ connection: this }))
       .on('error', this.onError.bind(this));
     this.socket.on('close', this.onClose.bind(this));
     this.socket.on('timeout', this.onTimeout.bind(this));
-
-    const socketWrite = promisify(this.socket.write.bind(this.socket));
-    this.socketWrite = async buffer => {
-      return Promise.race([socketWrite(buffer), this.aborted]);
-    };
-  }
-
-  /** Indicates that the connection (including underlying TCP socket) has been closed. */
-  public get closed(): boolean {
-    return this.signal.aborted;
   }
 
   public get hello() {
@@ -357,7 +330,11 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
     }
 
     this.socket.destroy();
-    this.controller.abort(error);
+    if (error) {
+      this.error = error;
+      this.dataEvents?.throw(error).then(undefined, () => null); // squash unhandled rejection
+    }
+    this.closed = true;
     this.emit(Connection.CLOSE);
   }
 
@@ -598,7 +575,7 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
   }
 
   private throwIfAborted() {
-    this.signal.throwIfAborted();
+    if (this.error) throw this.error;
   }
 
   /**
@@ -621,7 +598,18 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
 
     const buffer = Buffer.concat(await finalCommand.toBin());
 
-    return this.socketWrite(buffer);
+    if (this.socket.write(buffer)) return;
+
+    const { promise: drained, resolve, reject } = promiseWithResolvers<void>();
+    const onDrain = () => resolve();
+    const onError = (error: Error) => reject(error);
+
+    this.socket.once('drain', onDrain).once('error', onError);
+    try {
+      return await drained;
+    } finally {
+      this.socket.off('drain', onDrain).off('error', onError);
+    }
   }
 
   /**
@@ -634,13 +622,19 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
    * Note that `for-await` loops call `return` automatically when the loop is exited.
    */
   private async *readMany(): AsyncGenerator<OpMsgResponse | OpQueryResponse> {
-    for await (const message of onData(this.messageStream, { signal: this.signal })) {
-      const response = await decompressResponse(message);
-      yield response;
+    try {
+      this.dataEvents = this.dataEvents = onData(this.messageStream);
+      for await (const message of this.dataEvents) {
+        const response = await decompressResponse(message);
+        yield response;
 
-      if (!response.moreToCome) {
-        return;
+        if (!response.moreToCome) {
+          return;
+        }
       }
+    } finally {
+      this.dataEvents = null;
+      this.throwIfAborted();
     }
   }
 }

--- a/src/cmap/connection.ts
+++ b/src/cmap/connection.ts
@@ -281,7 +281,7 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
     this.lastUseTime = now();
   }
 
-  public onError(error?: Error) {
+  public onError(error: Error) {
     this.cleanup(error);
   }
 
@@ -324,18 +324,14 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
    *
    * This method does nothing if the connection is already closed.
    */
-  private cleanup(error?: Error): void {
+  private cleanup(error: Error): void {
     if (this.closed) {
       return;
     }
 
     this.socket.destroy();
-    if (error) {
-      this.error = error;
-      this.dataEvents?.throw(error).then(undefined, () => null); // squash unhandled rejection
-    } else {
-      this.dataEvents?.return().then(undefined, () => null); // squash unhandled rejection
-    }
+    this.error = error;
+    this.dataEvents?.throw(error).then(undefined, () => null); // squash unhandled rejection
     this.closed = true;
     this.emit(Connection.CLOSE);
   }

--- a/src/cmap/wire_protocol/on_data.ts
+++ b/src/cmap/wire_protocol/on_data.ts
@@ -18,9 +18,7 @@ type PendingPromises = Omit<
  * Returns an AsyncIterator that iterates each 'data' event emitted from emitter.
  * It will reject upon an error event or if the provided signal is aborted.
  */
-export function onData(emitter: EventEmitter, options: { signal: AbortSignal }) {
-  const signal = options.signal;
-
+export function onData(emitter: EventEmitter) {
   // Setup pending events and pending promise lists
   /**
    * When the caller has not yet called .next(), we store the
@@ -89,18 +87,7 @@ export function onData(emitter: EventEmitter, options: { signal: AbortSignal }) 
   emitter.on('data', eventHandler);
   emitter.on('error', errorHandler);
 
-  if (signal.aborted) {
-    // If the signal is aborted, set up the first .next() call to be a rejection
-    queueMicrotask(abortListener);
-  } else {
-    signal.addEventListener('abort', abortListener, { once: true });
-  }
-
   return iterator;
-
-  function abortListener() {
-    errorHandler(signal.reason);
-  }
 
   function eventHandler(value: Buffer) {
     const promise = unconsumedPromises.shift();
@@ -119,7 +106,6 @@ export function onData(emitter: EventEmitter, options: { signal: AbortSignal }) 
     // Adding event handlers
     emitter.off('data', eventHandler);
     emitter.off('error', errorHandler);
-    signal.removeEventListener('abort', abortListener);
     finished = true;
     const doneResult = { value: undefined, done: finished } as const;
 

--- a/src/cmap/wire_protocol/on_data.ts
+++ b/src/cmap/wire_protocol/on_data.ts
@@ -16,7 +16,7 @@ type PendingPromises = Omit<
  * https://nodejs.org/api/events.html#eventsonemitter-eventname-options
  *
  * Returns an AsyncIterator that iterates each 'data' event emitted from emitter.
- * It will reject upon an error event or if the provided signal is aborted.
+ * It will reject upon an error event.
  */
 export function onData(emitter: EventEmitter) {
   // Setup pending events and pending promise lists

--- a/test/integration/connection-monitoring-and-pooling/connection.test.ts
+++ b/test/integration/connection-monitoring-and-pooling/connection.test.ts
@@ -1,7 +1,11 @@
 import { expect } from 'chai';
+import { type EventEmitter, once } from 'events';
+import * as sinon from 'sinon';
+import { setTimeout } from 'timers';
 
 import {
   addContainerMetadata,
+  Binary,
   connect,
   Connection,
   type ConnectionOptions,
@@ -15,7 +19,9 @@ import {
   ServerHeartbeatStartedEvent,
   Topology
 } from '../../mongodb';
+import * as mock from '../../tools/mongodb-mock/index';
 import { skipBrokenAuthTestBeforeEachHook } from '../../tools/runner/hooks/configuration';
+import { getSymbolFrom, sleep } from '../../tools/utils';
 import { assert as test, setupDatabase } from '../shared';
 
 const commonConnectOptions = {
@@ -199,6 +205,84 @@ describe('Connection', function () {
 
       client.connect();
     });
+
+    context(
+      'when a large message is written to the socket',
+      { requires: { topology: 'single', auth: 'disabled' } },
+      () => {
+        let client, mockServer: import('../../tools/mongodb-mock/src/server').MockServer;
+
+        beforeEach(async function () {
+          mockServer = await mock.createServer();
+
+          mockServer
+            .addMessageHandler('insert', req => {
+              setTimeout(() => {
+                req.reply({ ok: 1 });
+              }, 800);
+            })
+            .addMessageHandler('hello', req => {
+              req.reply(Object.assign({}, mock.HELLO));
+            })
+            .addMessageHandler(LEGACY_HELLO_COMMAND, req => {
+              req.reply(Object.assign({}, mock.HELLO));
+            });
+
+          client = new MongoClient(`mongodb://${mockServer.uri()}`, {
+            minPoolSize: 1,
+            maxPoolSize: 1
+          });
+        });
+
+        afterEach(async function () {
+          await client.close();
+          mockServer.destroy();
+          sinon.restore();
+        });
+
+        it('waits for an async drain event because the write was buffered', async () => {
+          const connectionReady = once(client, 'connectionReady');
+          await client.connect();
+          await connectionReady;
+
+          // Get the only connection
+          const pool = [...client.topology.s.servers.values()][0].pool;
+
+          const connections = pool[getSymbolFrom(pool, 'connections')];
+          expect(connections).to.have.lengthOf(1);
+
+          const connection = connections.first();
+          const socket: EventEmitter = connection.socket;
+
+          // Spy on the socket event listeners
+          const addedListeners: string[] = [];
+          const removedListeners: string[] = [];
+          socket
+            .on('removeListener', name => removedListeners.push(name))
+            .on('newListener', name => addedListeners.push(name));
+
+          // Make server sockets block
+          for (const s of mockServer.sockets) s.pause();
+
+          const insert = client
+            .db('test')
+            .collection('test')
+            // Anything above 16Kb should work I think (10mb to be extra sure)
+            .insertOne({ a: new Binary(Buffer.alloc(10 * (2 ** 10) ** 2), 127) });
+
+          // Sleep a bit and unblock server sockets
+          await sleep(10);
+          for (const s of mockServer.sockets) s.resume();
+
+          // Let the operation finish
+          await insert;
+
+          // Ensure that we used the drain event for this write
+          expect(addedListeners).to.deep.equal(['drain', 'error']);
+          expect(removedListeners).to.deep.equal(['drain', 'error']);
+        });
+      }
+    );
 
     context('when connecting with a username and password', () => {
       let utilClient: MongoClient;


### PR DESCRIPTION
### Description

#### What is changing?

- Remove promise wrapping of signal
- Make writing async based on whether or not write returns true
- Remove signal

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

The Connection class stored a promise that would reject when the signal was aborted. This caused a leak that would create new promises unbounded. I've removed the promise wrapping opting for a simpler implementation that only makes writing async if there was buffering. If there was buffering we wait for the drain event and use try/finally to make sure we clean up event listeners.

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fixed memory leak in Connection layer

The Connection class has recently been refactored to operate on our socket operations using promises. An oversight how we made async network operations interruptible made new promises for every operation. We've simplified the approach and corrected the leak.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
