### PR TITLE
test(NODE-5862): skip transaction unpin TransientTransactionErrors spec tests

### DIFF
--- a/test/integration/transactions/transactions.spec.test.js
+++ b/test/integration/transactions/transactions.spec.test.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const { gte } = require('semver');
-
 const path = require('path');
 const { expect } = require('chai');
 const { TestRunnerContext, generateTopologyTests } = require('../../tools/spec-runner');
@@ -80,7 +78,7 @@ class TransactionsRunnerContext extends TestRunnerContext {
   }
 }
 
-const LATEST_UNIFIED_SKIP_TESTS = [
+const UNIFIED_SKIP_TESTS = [
   'unpin after TransientTransactionError error on commit',
   'unpin on successful abort',
   'unpin after non-transient error on abort',
@@ -91,8 +89,8 @@ const LATEST_UNIFIED_SKIP_TESTS = [
 ];
 
 describe('Transactions Spec Unified Tests', function () {
-  runUnifiedSuite(loadSpecTests(path.join('transactions', 'unified')), (test, ctx) =>
-    gte(ctx.version, '8.0.0') && LATEST_UNIFIED_SKIP_TESTS.includes(test.description)
+  runUnifiedSuite(loadSpecTests(path.join('transactions', 'unified')), test =>
+    UNIFIED_SKIP_TESTS.includes(test.description)
       ? 'TODO(NODE-5855): Unskip Transactions Spec Unified Tests mongos-unpin.unpin'
       : false
   );

--- a/test/integration/transactions/transactions.spec.test.js
+++ b/test/integration/transactions/transactions.spec.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import { gte } from 'semver';
+const { gte } = require('semver');
 
 const path = require('path');
 const { expect } = require('chai');

--- a/test/integration/transactions/transactions.spec.test.js
+++ b/test/integration/transactions/transactions.spec.test.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import { gte } from 'semver';
+
 const path = require('path');
 const { expect } = require('chai');
 const { TestRunnerContext, generateTopologyTests } = require('../../tools/spec-runner');
@@ -78,11 +80,25 @@ class TransactionsRunnerContext extends TestRunnerContext {
   }
 }
 
+const LATEST_UNIFIED_SKIP_TESTS = [
+  'unpin after TransientTransactionError error on commit',
+  'unpin on successful abort',
+  'unpin after non-transient error on abort',
+  'unpin after TransientTransactionError error on abort',
+  'unpin when a new transaction is started',
+  'unpin when a non-transaction write operation uses a session',
+  'unpin when a non-transaction read operation uses a session'
+];
+
 describe('Transactions Spec Unified Tests', function () {
-  runUnifiedSuite(loadSpecTests(path.join('transactions', 'unified')));
+  runUnifiedSuite(loadSpecTests(path.join('transactions', 'unified')), (test, ctx) =>
+    gte(ctx.version, '8.0.0') && LATEST_UNIFIED_SKIP_TESTS.includes(test.description)
+      ? 'TODO(NODE-5855): Unskip Transactions Spec Unified Tests mongos-unpin.unpin'
+      : false
+  );
 });
 
-const SKIP_TESTS = [
+const LEGACY_SKIP_TESTS = [
   // TODO(NODE-3943): Investigate these commit test failures
   // OLD COMMENT: commitTransaction retry seems to be swallowed by mongos in these two cases
   'commitTransaction retry fails on new mongos',
@@ -97,7 +113,7 @@ describe('Transactions Spec Legacy Tests', function () {
   const testContext = new TransactionsRunnerContext();
   if (process.env.SERVERLESS) {
     // TODO(NODE-3550): these tests should pass on serverless but currently fail
-    SKIP_TESTS.push(
+    LEGACY_SKIP_TESTS.push(
       'abortTransaction only performs a single retry',
       'abortTransaction does not retry after Interrupted',
       'abortTransaction does not retry after WriteConcernError Interrupted',
@@ -114,7 +130,7 @@ describe('Transactions Spec Legacy Tests', function () {
   });
 
   function testFilter(spec) {
-    return SKIP_TESTS.indexOf(spec.description) === -1;
+    return LEGACY_SKIP_TESTS.indexOf(spec.description) === -1;
   }
 
   generateTopologyTests(testSuites, testContext, testFilter);


### PR DESCRIPTION
### Description
Skip transaction unpin `TransientTransactionError` tests on the 5.x branch, so that the build failures do not clutter the CI.

#### What is changing?
Skip relevant tests on 5.x

##### Is there new documentation needed for these changes?
No.

#### What is the motivation for this change?
Build failure described in NODE-5852
For 5.x, we are skipping all versions (not just latest like on 6.x) to clear CI.

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
