### PR TITLE
test(DRIVERS-2812): sdam load balancer tests in serverless

### DIFF
--- a/test/integration/load-balancers/load_balancers.spec.test.js
+++ b/test/integration/load-balancers/load_balancers.spec.test.js
@@ -25,12 +25,6 @@ const filter = ({ description }) => {
     return 'TODO(DRIVERS-1847): Skipped pending a decision made on DRIVERS-1847';
   }
 
-  if (description === 'errors during the initial connection hello are ignored') {
-    // This test is skipped because it assumes drivers attempt connections on the first operation,
-    // but Node has a connect() method that is called before the first operation is ever run.
-    return 'TODO(NODE-2149): Refactor connect()';
-  }
-
   if (
     process.env.AUTH === 'auth' &&
     [


### PR DESCRIPTION
### Description

Unskips one load balancer test that was part of the two described in DRIVERS-2812. The other was already running and passing.

#### What is changing?

- Unskips the last of the two load balancer tests described in the drivers ticket.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

DRIVERS-2812

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
