### PR TITLE
refactor(no-story): don't store directConnection on the connection pool and stream description

### DIFF
--- a/src/cmap/connection.ts
+++ b/src/cmap/connection.ts
@@ -85,6 +85,8 @@ export interface CommandOptions extends BSONSerializeOptions {
   willRetryWrite?: boolean;
 
   writeConcern?: WriteConcern;
+
+  directConnection?: boolean;
 }
 
 /** @public */
@@ -123,8 +125,6 @@ export interface ConnectionOptions
   extendedMetadata: Promise<Document>;
   /** @internal */
   mongoLogger?: MongoLogger | undefined;
-  /** @internal */
-  directConnection: boolean;
 }
 
 /** @internal */
@@ -281,10 +281,6 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
     return this.description.loadBalanced;
   }
 
-  public get directConnection(): boolean {
-    return this.description.directConnection;
-  }
-
   public get idleTime(): number {
     return calculateDurationInMs(this.lastUseTime);
   }
@@ -408,7 +404,7 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
         !isSharded(this) &&
         !this.description.loadBalanced &&
         this.supportsOpMsg &&
-        this.description.directConnection === true &&
+        options.directConnection === true &&
         readPreference?.mode === 'primary'
       ) {
         // For mongos and load balancers with 'primary' mode, drivers MUST NOT set $readPreference.

--- a/src/cmap/connection_pool.ts
+++ b/src/cmap/connection_pool.ts
@@ -100,8 +100,6 @@ export interface ConnectionPoolOptions extends Omit<ConnectionOptions, 'id' | 'g
   waitQueueTimeoutMS: number;
   /** If we are in load balancer mode. */
   loadBalanced: boolean;
-  /**  @internal If topology contains only a single server of any type. */
-  directConnection: boolean;
   /** @internal */
   minPoolSizeCheckFrequencyMS?: number;
 }
@@ -635,8 +633,7 @@ export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
       generation: this[kGeneration],
       cancellationToken: this[kCancellationToken],
       mongoLogger: this.mongoLogger,
-      authProviders: this[kServer].topology.client.s.authProviders,
-      directConnection: this[kServer].topology.client.options.directConnection === true
+      authProviders: this[kServer].topology.client.s.authProviders
     };
 
     this[kPending]++;

--- a/src/cmap/stream_description.ts
+++ b/src/cmap/stream_description.ts
@@ -17,7 +17,6 @@ export interface StreamDescriptionOptions {
   compressors?: CompressorName[];
   logicalSessionTimeoutMinutes?: number;
   loadBalanced: boolean;
-  directConnection: boolean;
 }
 
 /** @public */
@@ -33,7 +32,6 @@ export class StreamDescription {
   compressor?: CompressorName;
   logicalSessionTimeoutMinutes?: number;
   loadBalanced: boolean;
-  directConnection: boolean;
 
   __nodejs_mock_server__?: boolean;
 
@@ -57,7 +55,6 @@ export class StreamDescription {
         ? options.compressors
         : [];
     this.serverConnectionId = null;
-    this.directConnection = !!options?.directConnection;
   }
 
   receiveResponse(response: Document | null): void {

--- a/src/sdam/server.ts
+++ b/src/sdam/server.ts
@@ -290,7 +290,10 @@ export class Server extends TypedEventEmitter<ServerEvents> {
     }
 
     // Clone the options
-    const finalOptions = Object.assign({}, options, { wireProtocolCommand: false });
+    const finalOptions = Object.assign({}, options, {
+      wireProtocolCommand: false,
+      directConnection: this.topology.s.options.directConnection
+    });
 
     // There are cases where we need to flag the read preference not to get sent in
     // the command, such as pre-5.0 servers attempting to perform an aggregate write


### PR DESCRIPTION
### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
