### PR TITLE
fix(NODE-6010): Avoid triple-emitting close events

### DIFF
--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -940,7 +940,9 @@ class ReadableCursorStream extends Readable {
         //       working on 4.4 servers because the error emitted on failover was "interrupted at
         //       shutdown" while on 5.0+ it is "The server is in quiesce mode and will shut down".
         //       See NODE-4475.
-        return this.destroy(err);
+        if (!this._cursor.isDead) {
+          return this.destroy(err);
+        }
       }
     );
   }


### PR DESCRIPTION
### Description

If you kill and then restart the underlying replica set in the following script, you'll see that the `close` event is emitted 3 times:

```javascript
'use strict';
  
const { MongoClient } = require('mongodb');

void async function main() {
  const uri = 'mongodb://127.0.0.1:27017,127.0.0.1:27018/mongoose_test';
  const client = new MongoClient(uri, { useNewUrlParser: true, useUnifiedTopology: true });
  await client.connect();

  const db = client.db();
  const collection = db.collection('people');

  let resumeAfter = null;
  let changeStream = collection.watch();
  addChangeStreamListeners(changeStream);

  function addChangeStreamListeners(changeStream) {
    changeStream.on('change', data => console.log(new Date(), data));
    changeStream.on('resumeTokenChanged', data => {
      console.log(new Date(), 'resumeTokenChanged', data);
      resumeAfter = data._data;
    });
    changeStream.on('error', data => console.log(new Date(), 'error', data));
    changeStream.on('close', async data => {
      console.log(new Date(), 'close', data, new Error().stack);
      changeStream = collection.watch([], { resumeAfter });
      addChangeStreamListeners(changeStream);
    });
  }

  while (true) {
    await new Promise(resolve => setTimeout(resolve, 8000));
    // Insert a doc, will trigger the change stream handler above
    console.log(new Date(), 'Inserting doc');
    await collection.insertOne({ name: 'Axl Rose' });
    console.log(new Date(), 'Inserted doc');
  }
}();
```

First time because abstract cursor `next()` cleans up the cursor: https://github.com/mongodb/node-mongodb-native/blob/31f1eed293f96d9e2f9d64a07088700c522ec860/src/cursor/abstract_cursor.ts#L737-L743, which emits 'close' here: https://github.com/mongodb/node-mongodb-native/blob/31f1eed293f96d9e2f9d64a07088700c522ec860/src/cursor/abstract_cursor.ts#L846

2nd time because `ReadableCursorStream` calls `destroy()`: https://github.com/mongodb/node-mongodb-native/blob/31f1eed293f96d9e2f9d64a07088700c522ec860/src/cursor/abstract_cursor.ts#L943, which calls `close()` on the already closed cursor: https://github.com/mongodb/node-mongodb-native/blob/31f1eed293f96d9e2f9d64a07088700c522ec860/src/cursor/abstract_cursor.ts#L895

3rd time because `destroy` triggers an 'error' event for reasons that I haven't quite been able to figure out

This PR makes it so that only 1 'close' event is emitted, and it looks like all it does is prevent an extra unnecessary `close()` call?

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
