### PR TITLE
test(NODE-6011): Add modifyCollection helper to UTR

### DIFF
--- a/test/integration/crud/crud.spec.test.js
+++ b/test/integration/crud/crud.spec.test.js
@@ -425,10 +425,6 @@ describe('CRUD spec v1', function () {
   }
 });
 
-// TODO(NODE-5998) - The Node driver UTR does not have a Collection.modifyCollection helper.
-const SKIPPED_TESTS = ['findOneAndUpdate document validation errInfo is accessible'];
 describe('CRUD unified', function () {
-  runUnifiedSuite(loadSpecTests(path.join('crud', 'unified')), ({ description }) =>
-    SKIPPED_TESTS.includes(description) ? `the Node driver does not have a collMod helper.` : false
-  );
+  runUnifiedSuite(loadSpecTests(path.join('crud', 'unified')));
 });

--- a/test/tools/unified-spec-runner/operations.ts
+++ b/test/tools/unified-spec-runner/operations.ts
@@ -896,6 +896,15 @@ operations.set('createSearchIndexes', async ({ entities, operation }) => {
   return collection.createSearchIndexes(models);
 });
 
+operations.set('modifyCollection', async ({ entities, operation }) => {
+  const db = entities.getEntity('db', operation.object);
+  const command = {
+    collMod: operation.arguments?.collection,
+    validator: operation.arguments?.validator
+  };
+  return db.command(command, {});
+});
+
 export async function executeOperationAndCheck(
   operation: OperationDescription,
   entities: EntitiesMap,


### PR DESCRIPTION
### Description
Add `modifyCollection` helper to UTR.

#### What is changing?
UTR can now support operation `modifyCollection`.

##### Is there new documentation needed for these changes?
No.

#### What is the motivation for this change?
To unskip crud spec test. 

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
