### PR TITLE
feat(NODE-6020): upgrade BSON to ^6.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@mongodb-js/saslprep": "^1.1.5",
-        "bson": "^6.4.0",
+        "bson": "^6.5.0",
         "mongodb-connection-string-url": "^3.0.0"
       },
       "devDependencies": {
@@ -3819,9 +3819,9 @@
       }
     },
     "node_modules/bson": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-6.4.0.tgz",
-      "integrity": "sha512-6/gSSEdbkuFlSb+ufj5jUSU4+wo8xQOwm2bDSqwmxiPE17JTpsP63eAwoN8iF8Oy4gJYj+PAL3zdRCTdaw5Y1g==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.5.0.tgz",
+      "integrity": "sha512-DXf1BTAS8vKyR90BO4x5v3rKVarmkdkzwOrnYDFdjAY694ILNDkmA3uRh1xXJEl+C1DAh8XCvAQ+Gh3kzubtpg==",
       "engines": {
         "node": ">=16.20.1"
       }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@mongodb-js/saslprep": "^1.1.5",
-    "bson": "^6.4.0",
+    "bson": "^6.5.0",
     "mongodb-connection-string-url": "^3.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
### Description

#### What is changing?

- Bumps BSON to ^6.5.0

##### Is there new documentation needed for these changes?

No.

#### What is the motivation for this change?

- Keeping BSON upgraded for fixes and feats

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
