### PR TITLE
docs(NODE-5721): thrown error expectations in withTransaction

### DIFF
--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -446,6 +446,15 @@ export class ClientSession extends TypedEventEmitter<ClientSessionEvents> {
    *
    * Checkout a descriptive example here:
    * @see https://www.mongodb.com/blog/post/quick-start-nodejs--mongodb--how-to-implement-transactions
+   * 
+   * If a command inside this function fails:
+   * - It may cause the transaction on the server to be aborted. 
+   * - This situation is normally handled transparently by the driver. 
+   * - However, if the application catches such an error and does not re-raise it, the driver will not be able to determine whether the transaction was aborted or not. 
+   * - The driver will then retry the transaction indefinitely.
+   * 
+   * To avoid this situation, the application must not silently handle errors within this function.
+   * If the application needs to handle errors within, it must await all operations such that if an operation is rejected, the rejection becomes the rejection of the function passed into withTransaction.
    *
    * @param fn - callback to run within a transaction
    * @param options - optional settings for the transaction

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -446,15 +446,15 @@ export class ClientSession extends TypedEventEmitter<ClientSessionEvents> {
    *
    * Checkout a descriptive example here:
    * @see https://www.mongodb.com/blog/post/quick-start-nodejs--mongodb--how-to-implement-transactions
-   * 
+   *
    * If a command inside this function fails:
-   * - It may cause the transaction on the server to be aborted. 
-   * - This situation is normally handled transparently by the driver. 
-   * - However, if the application catches such an error and does not re-raise it, the driver will not be able to determine whether the transaction was aborted or not. 
+   * - It may cause the transaction on the server to be aborted.
+   * - This situation is normally handled transparently by the driver.
+   * - However, if the application catches such an error and does not re-raise it, the driver will not be able to determine whether the transaction was aborted or not.
    * - The driver will then retry the transaction indefinitely.
-   * 
+   *
    * To avoid this situation, the application must not silently handle errors within this function.
-   * If the application needs to handle errors within, it must await all operations such that if an operation is rejected, the rejection becomes the rejection of the function passed into withTransaction.
+   * If the application needs to handle errors within, it must await all operations such that if an operation is rejected it becomes the rejection of the callback function passed into withTransaction.
    *
    * @param fn - callback to run within a transaction
    * @param options - optional settings for the transaction

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -438,22 +438,21 @@ export class ClientSession extends TypedEventEmitter<ClientSessionEvents> {
    * **IMPORTANT:** This method requires the function passed in to return a Promise. That promise must be made by `await`-ing all operations in such a way that rejections are propagated to the returned promise.
    *
    * @remarks
-   * This function:
-   * - If all operations successfully complete and the `commitTransaction` operation is successful, then this function will return the result of the provided function.
-   * - If the transaction is unable to complete or an error is thrown from within the provided function, then this function will throw an error.
+   * - If all operations successfully complete and the `commitTransaction` operation is successful, then the provided function will return the result of the provided function.
+   * - If the transaction is unable to complete or an error is thrown from within the provided function, then the provided function will throw an error.
    *   - If the transaction is manually aborted within the provided function it will not throw.
-   * - May be called multiple times if the driver needs to attempt to retry the operations.
+   * - If the driver needs to attempt to retry the operations, the provided function may be called multiple times.
    *
    * Checkout a descriptive example here:
    * @see https://www.mongodb.com/blog/post/quick-start-nodejs--mongodb--how-to-implement-transactions
    *
-   * If a command inside this function fails:
+   * If a command inside withTransaction fails:
    * - It may cause the transaction on the server to be aborted.
    * - This situation is normally handled transparently by the driver.
    * - However, if the application catches such an error and does not rethrow it, the driver will not be able to determine whether the transaction was aborted or not.
    * - The driver will then retry the transaction indefinitely.
    *
-   * To avoid this situation, the application must not silently handle errors within this function.
+   * To avoid this situation, the application must not silently handle errors within the provided function.
    * If the application needs to handle errors within, it must await all operations such that if an operation is rejected it becomes the rejection of the callback function passed into withTransaction.
    *
    * @param fn - callback to run within a transaction

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -435,7 +435,7 @@ export class ClientSession extends TypedEventEmitter<ClientSessionEvents> {
   /**
    * Starts a transaction and runs a provided function, ensuring the commitTransaction is always attempted when all operations run in the function have completed.
    *
-   * **IMPORTANT:** This method requires the function passed in to return a Promise. That promise must be made by await-ing all operations in such a way that rejections are propagated to the returned promise.
+   * **IMPORTANT:** This method requires the function passed in to return a Promise. That promise must be made by `await`-ing all operations in such a way that rejections are propagated to the returned promise.
    *
    * @remarks
    * This function:

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -435,7 +435,7 @@ export class ClientSession extends TypedEventEmitter<ClientSessionEvents> {
   /**
    * Starts a transaction and runs a provided function, ensuring the commitTransaction is always attempted when all operations run in the function have completed.
    *
-   * **IMPORTANT:** This method requires the user to return a Promise, and `await` all operations.
+   * **IMPORTANT:** This method requires the function passed in to return a Promise. That promise must be made by await-ing all operations in such a way that rejections are propagated to the returned promise.
    *
    * @remarks
    * This function:
@@ -450,7 +450,7 @@ export class ClientSession extends TypedEventEmitter<ClientSessionEvents> {
    * If a command inside this function fails:
    * - It may cause the transaction on the server to be aborted.
    * - This situation is normally handled transparently by the driver.
-   * - However, if the application catches such an error and does not re-raise it, the driver will not be able to determine whether the transaction was aborted or not.
+   * - However, if the application catches such an error and does not rethrow it, the driver will not be able to determine whether the transaction was aborted or not.
    * - The driver will then retry the transaction indefinitely.
    *
    * To avoid this situation, the application must not silently handle errors within this function.


### PR DESCRIPTION
### Description
Add API docs to `withTransaction` function to aid users with error handling in the case that the command passed into the transaction fails, and the transaction goes into an infinite loop.

#### What is changing?
Descriptive API doc with error handling steps is added to `withTransaction`

##### Is there new documentation needed for these changes?
Yes, I've added "Docs Changes Needed" to the ticket description, asking the docs team to update this [page](https://www.mongodb.com/docs/drivers/node/current/fundamentals/transactions/#convenient-transaction-api).

#### What is the motivation for this change?
Help users with error handling after this infinite loop case was discovered.


### Add error handling information to `withTransaction` API docs
The `withTransaction` function API docs now contain more information on how to avoid an application entering an infinite loop in the event that a failed command aborts the transaction and causes the transaction to be retried.


### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
