### PR TITLE
test(NODE-6024): sync skip rangePreview tests on server 8.0+

### DIFF
--- a/test/integration/client-side-encryption/client_side_encryption.prose.22.range_explicit_encryption.test.ts
+++ b/test/integration/client-side-encryption/client_side_encryption.prose.22.range_explicit_encryption.test.ts
@@ -2,6 +2,7 @@ import { EJSON } from 'bson';
 import { expect } from 'chai';
 import { readFile } from 'fs/promises';
 import { join } from 'path';
+import * as semver from 'semver';
 
 import { Decimal128, type Document, Double, Long, type MongoClient } from '../../../src';
 /* eslint-disable @typescript-eslint/no-restricted-imports */
@@ -125,6 +126,14 @@ const readEncryptedFieldsFile = (dataType: string): Promise<string> =>
 
 describe('Range Explicit Encryption', function () {
   installNodeDNSWorkaroundHooks();
+
+  beforeEach(async function () {
+    if (semver.gte('7.999.999', this.configuration.version)) {
+      if (this.currentTest)
+        this.currentTest.skipReason = 'TODO(NODE-5908): skip rangePreview tests on server 8.0+';
+      return this.currentTest?.skip();
+    }
+  });
 
   let clientEncryption;
   let keyId;

--- a/test/integration/client-side-encryption/client_side_encryption.prose.22.range_explicit_encryption.test.ts
+++ b/test/integration/client-side-encryption/client_side_encryption.prose.22.range_explicit_encryption.test.ts
@@ -128,7 +128,7 @@ describe('Range Explicit Encryption', function () {
   installNodeDNSWorkaroundHooks();
 
   beforeEach(async function () {
-    if (semver.gte('7.999.999', this.configuration.version)) {
+    if (semver.gte(this.configuration.version, '7.999.999')) {
       if (this.currentTest)
         this.currentTest.skipReason = 'TODO(NODE-5908): skip rangePreview tests on server 8.0+';
       return this.currentTest?.skip();

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-MissingKey.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-MissingKey.json
@@ -54,7 +54,7 @@
   "key_vault_data": [],
   "tests": [
     {
-      "description": "FLE2 encrypt fails with mising key",
+      "description": "FLE2 encrypt fails with missing key",
       "clientOptions": {
         "autoEncryptOpts": {
           "kmsProviders": {
@@ -85,7 +85,7 @@
       ]
     },
     {
-      "description": "FLE2 decrypt fails with mising key",
+      "description": "FLE2 decrypt fails with missing key",
       "clientOptions": {
         "autoEncryptOpts": {
           "kmsProviders": {

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-MissingKey.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-MissingKey.yml
@@ -19,7 +19,7 @@ data: [
 encrypted_fields: {'fields': [{'keyId': {'$binary': {'base64': 'EjRWeBI0mHYSNBI0VniQEg==', 'subType': '04'}}, 'path': 'encryptedIndexed', 'bsonType': 'string', 'queries': {'queryType': 'equality', 'contention': {'$numberLong': '0'}}}, {'keyId': {'$binary': {'base64': 'q83vqxI0mHYSNBI0VniQEg==', 'subType': '04'}}, 'path': 'encryptedUnindexed', 'bsonType': 'string'}]}
 key_vault_data: []
 tests:
-  - description: "FLE2 encrypt fails with mising key"
+  - description: "FLE2 encrypt fails with missing key"
     clientOptions:
       autoEncryptOpts:
         kmsProviders:
@@ -30,7 +30,7 @@ tests:
           document: { _id: 1, encryptedIndexed: "123" }
         result:
           errorContains: "not all keys requested were satisfied"
-  - description: "FLE2 decrypt fails with mising key"
+  - description: "FLE2 decrypt fails with missing key"
     clientOptions:
       autoEncryptOpts:
         kmsProviders:

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Date-Aggregate.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Date-Aggregate.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Date-Aggregate.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Date-Aggregate.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Date-Correctness.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Date-Correctness.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Date-Correctness.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Date-Correctness.yml
@@ -7,6 +7,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Date-Delete.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Date-Delete.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Date-Delete.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Date-Delete.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Date-FindOneAndUpdate.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Date-FindOneAndUpdate.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Date-FindOneAndUpdate.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Date-FindOneAndUpdate.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Date-InsertFind.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Date-InsertFind.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Date-InsertFind.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Date-InsertFind.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Date-Update.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Date-Update.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Date-Update.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Date-Update.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-Aggregate.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-Aggregate.json
@@ -4,7 +4,8 @@
       "minServerVersion": "7.0.0",
       "topology": [
         "replicaset"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-Aggregate.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-Aggregate.yml
@@ -6,6 +6,8 @@ runOn:
     # FLE 2 Encrypted collections are not supported on standalone.
     # Tests for Decimal (without precision) must only run against a replica set. Decimal (without precision) queries are expected to take a long time and may exceed the default mongos timeout.
     topology: [ "replicaset" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-Correctness.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-Correctness.json
@@ -4,7 +4,8 @@
       "minServerVersion": "7.0.0",
       "topology": [
         "replicaset"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-Correctness.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-Correctness.yml
@@ -8,6 +8,8 @@ runOn:
     # FLE 2 Encrypted collections are not supported on standalone.
     # Tests for Decimal (without precision) must only run against a replica set. Decimal (without precision) queries are expected to take a long time and may exceed the default mongos timeout.
     topology: [ "replicaset" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-Delete.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-Delete.json
@@ -4,7 +4,8 @@
       "minServerVersion": "7.0.0",
       "topology": [
         "replicaset"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-Delete.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-Delete.yml
@@ -6,6 +6,8 @@ runOn:
     # FLE 2 Encrypted collections are not supported on standalone.
     # Tests for Decimal (without precision) must only run against a replica set. Decimal (without precision) queries are expected to take a long time and may exceed the default mongos timeout.
     topology: [ "replicaset" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-FindOneAndUpdate.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-FindOneAndUpdate.json
@@ -4,7 +4,8 @@
       "minServerVersion": "7.0.0",
       "topology": [
         "replicaset"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-FindOneAndUpdate.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-FindOneAndUpdate.yml
@@ -6,6 +6,8 @@ runOn:
     # FLE 2 Encrypted collections are not supported on standalone.
     # Tests for Decimal (without precision) must only run against a replica set. Decimal (without precision) queries are expected to take a long time and may exceed the default mongos timeout.
     topology: [ "replicaset" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-InsertFind.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-InsertFind.json
@@ -4,7 +4,8 @@
       "minServerVersion": "7.0.0",
       "topology": [
         "replicaset"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-InsertFind.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-InsertFind.yml
@@ -6,6 +6,8 @@ runOn:
     # FLE 2 Encrypted collections are not supported on standalone.
     # Tests for Decimal (without precision) must only run against a replica set. Decimal (without precision) queries are expected to take a long time and may exceed the default mongos timeout.
     topology: [ "replicaset" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-Update.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-Update.json
@@ -4,7 +4,8 @@
       "minServerVersion": "7.0.0",
       "topology": [
         "replicaset"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-Update.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-Update.yml
@@ -6,6 +6,8 @@ runOn:
     # FLE 2 Encrypted collections are not supported on standalone.
     # Tests for Decimal (without precision) must only run against a replica set. Decimal (without precision) queries are expected to take a long time and may exceed the default mongos timeout.
     topology: [ "replicaset" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-Aggregate.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-Aggregate.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-Aggregate.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-Aggregate.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-Correctness.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-Correctness.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-Correctness.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-Correctness.yml
@@ -7,6 +7,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-Delete.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-Delete.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-Delete.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-Delete.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-FindOneAndUpdate.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-FindOneAndUpdate.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-FindOneAndUpdate.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-FindOneAndUpdate.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-InsertFind.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-InsertFind.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-InsertFind.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-InsertFind.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-Update.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-Update.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-Update.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-Update.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Double-Aggregate.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Double-Aggregate.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Double-Aggregate.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Double-Aggregate.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Double-Correctness.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Double-Correctness.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Double-Correctness.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Double-Correctness.yml
@@ -7,6 +7,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Double-Delete.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Double-Delete.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Double-Delete.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Double-Delete.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Double-FindOneAndUpdate.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Double-FindOneAndUpdate.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Double-FindOneAndUpdate.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Double-FindOneAndUpdate.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Double-InsertFind.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Double-InsertFind.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Double-InsertFind.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Double-InsertFind.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Double-Update.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Double-Update.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Double-Update.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Double-Update.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-Aggregate.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-Aggregate.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-Aggregate.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-Aggregate.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-Correctness.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-Correctness.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-Correctness.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-Correctness.yml
@@ -7,6 +7,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-Delete.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-Delete.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-Delete.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-Delete.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-FindOneAndUpdate.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-FindOneAndUpdate.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-FindOneAndUpdate.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-FindOneAndUpdate.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-InsertFind.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-InsertFind.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-InsertFind.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-InsertFind.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-Update.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-Update.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-Update.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-Update.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Int-Aggregate.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Int-Aggregate.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Int-Aggregate.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Int-Aggregate.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Int-Correctness.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Int-Correctness.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Int-Correctness.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Int-Correctness.yml
@@ -7,6 +7,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Int-Delete.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Int-Delete.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Int-Delete.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Int-Delete.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Int-FindOneAndUpdate.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Int-FindOneAndUpdate.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Int-FindOneAndUpdate.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Int-FindOneAndUpdate.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Int-InsertFind.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Int-InsertFind.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Int-InsertFind.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Int-InsertFind.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Int-Update.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Int-Update.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Int-Update.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Int-Update.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Long-Aggregate.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Long-Aggregate.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Long-Aggregate.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Long-Aggregate.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Long-Correctness.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Long-Correctness.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Long-Correctness.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Long-Correctness.yml
@@ -7,6 +7,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Long-Delete.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Long-Delete.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Long-Delete.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Long-Delete.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Long-FindOneAndUpdate.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Long-FindOneAndUpdate.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Long-FindOneAndUpdate.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Long-FindOneAndUpdate.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Long-InsertFind.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Long-InsertFind.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Long-InsertFind.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Long-InsertFind.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Long-Update.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Long-Update.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Long-Update.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-Long-Update.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-WrongType.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-WrongType.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-WrongType.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Range-WrongType.yml
@@ -7,6 +7,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/test/spec/client-side-encryption/tests/legacy/getMore.json
+++ b/test/spec/client-side-encryption/tests/legacy/getMore.json
@@ -216,7 +216,10 @@
           "command_started_event": {
             "command": {
               "getMore": {
-                "$$type": "long"
+                "$$type": [
+                  "int",
+                  "long"
+                ]
               },
               "collection": "default",
               "batchSize": 2

--- a/test/spec/client-side-encryption/tests/legacy/getMore.yml
+++ b/test/spec/client-side-encryption/tests/legacy/getMore.yml
@@ -48,7 +48,7 @@ tests:
           command_name: find
       - command_started_event:
           command:
-            getMore: { $$type: "long" }
+            getMore: { $$type: [ int, long ] }
             collection: *collection_name
             batchSize: 2
           command_name: getMore


### PR DESCRIPTION
### Description

#### What is changing?

NODE-6026

- Synced skip rangePreview tests on server 8.0+
- Synced getMore.yml in fle tests
  - The just added int or long as the type for cursor id instead of just long
- Synced fle2v2-MissingKey.yml one of the test names was spell checked
- Skipped prose test 22 

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

- Clear the server latest failures

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
