### PR TITLE
fix(NODE-5971): attach `v` to createIndexes command when `version` is specified

### DIFF
--- a/src/operations/indexes.ts
+++ b/src/operations/indexes.ts
@@ -204,7 +204,7 @@ function constructIndexDescriptionMap(indexSpec: IndexSpecification): Map<string
 function resolveIndexDescription(
   description: IndexDescription
 ): Omit<ResolvedIndexDescription, 'key'> {
-  const validProvidedOptions = Object.entries({ ...description }).filter(([optionName]) =>
+  const validProvidedOptions = Object.entries(description).filter(([optionName]) =>
     VALID_INDEX_OPTIONS.has(optionName)
   );
 

--- a/src/operations/indexes.ts
+++ b/src/operations/indexes.ts
@@ -249,7 +249,7 @@ export class CreateIndexesOperation extends CommandOperation<string[]> {
       // Ensure the key is a Map to preserve index key ordering
       const key =
         userIndex.key instanceof Map ? userIndex.key : new Map(Object.entries(userIndex.key));
-      const name = userIndex.name != null ? userIndex.name : Array.from(key).flat().join('_');
+      const name = userIndex.name ?? Array.from(key).flat().join('_');
       const validIndexOptions = resolveIndexDescription(userIndex);
       return {
         ...validIndexOptions,

--- a/test/integration/index_management.test.ts
+++ b/test/integration/index_management.test.ts
@@ -8,7 +8,7 @@ import {
   type MongoClient,
   MongoServerError
 } from '../mongodb';
-import { assert as test, setupDatabase } from './shared';
+import { assert as test, filterForCommands, setupDatabase } from './shared';
 
 describe('Indexes', function () {
   let client: MongoClient;
@@ -158,6 +158,82 @@ describe('Indexes', function () {
           .to.deep.equal([['age', 1]]);
       });
     });
+  });
+
+  describe('Collection.createIndex()', function () {
+    const started: CommandStartedEvent[] = [];
+    beforeEach(() => {
+      started.length = 0;
+      client.on('commandStarted', filterForCommands('createIndexes', started));
+    });
+
+    context('when version is not specified as an option', function () {
+      it('does not attach `v` to the command', async () => {
+        await collection.createIndex({ age: 1 });
+        const { command } = started[0];
+        expect(command).to.exist;
+        expect(command.indexes[0]).not.to.have.property('v');
+      });
+    });
+
+    context('when version is specified as an option', function () {
+      it('attaches `v` to the command with the value of `version`', async () => {
+        await collection.createIndex({ age: 1 }, { version: 1 });
+        const { command } = started[0];
+        expect(command).to.exist;
+        expect(command.indexes[0]).to.have.property('v', 1);
+      });
+    });
+  });
+
+  describe('Collection.createIndexes()', function () {
+    const started: CommandStartedEvent[] = [];
+    beforeEach(() => {
+      started.length = 0;
+      client.on('commandStarted', filterForCommands('createIndexes', started));
+    });
+
+    context('when version is not specified as an option', function () {
+      it('does not attach `v` to the command', async () => {
+        await collection.createIndexes([{ key: { age: 1 } }]);
+        const { command } = started[0];
+        expect(command).to.exist;
+        expect(command.indexes[0]).not.to.have.property('v');
+      });
+    });
+
+    context('when version is specified as an option', function () {
+      it('does not attach `v` to the command', async () => {
+        await collection.createIndexes([{ key: { age: 1 } }], { version: 1 });
+        const { command } = started[0];
+        expect(command).to.exist;
+        expect(command.indexes[0]).not.to.have.property('v', 1);
+      });
+    });
+
+    context('when version is provided in the index description and the options', function () {
+      it('the value in the description takes precedence', async () => {
+        await collection.createIndexes([{ key: { age: 1 }, version: 1 }], { version: 0 });
+        const { command } = started[0];
+        expect(command).to.exist;
+        expect(command.indexes[0]).to.have.property('v', 1);
+      });
+    });
+
+    context(
+      'when version is provided in some of the index descriptions and the options',
+      function () {
+        it('does not specify a version from the `version` provided in the options', async () => {
+          await collection.createIndexes([{ key: { age: 1 }, version: 1 }, { key: { date: 1 } }], {
+            version: 0
+          });
+          const { command } = started[0];
+          expect(command).to.exist;
+          expect(command.indexes[0]).to.have.property('v', 1);
+          expect(command.indexes[1]).not.to.have.property('v');
+        });
+      }
+    );
   });
 
   describe('Collection.indexExists()', function () {


### PR DESCRIPTION
### Description

#### What is changing?

`createIndex` and `createIndexes` now support specifying an index version with the `version` option.

One note is that `createIndexes()` requires that users specify the `version` as a part of their index specification - a `version` provided as a part of the options is ignored.  This behavior is consistent with other index options provided to `createIndexes`.

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

(release highlight left empty since `v` is an undocumented feature, no need for it to appear in our release notes)
### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
