### PR TITLE
chore(NODE-6037): use metadata for skip logic and remove async from context block

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,13 +10,15 @@
     "@typescript-eslint",
     "prettier",
     "unused-imports",
-    "tsdoc"
+    "tsdoc",
+    "mocha"
   ],
   "extends": [
     "eslint:recommended",
     "plugin:@typescript-eslint/eslint-recommended",
     "plugin:@typescript-eslint/recommended",
     "plugin:prettier/recommended"
+    // "plugin:mocha/recommended"
   ],
   "env": {
     "node": true,
@@ -112,6 +114,7 @@
         ]
       }
     ],
+    "mocha/no-async-describe": "error",
     "no-restricted-syntax": [
       "error",
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "eslint": "^8.56.0",
         "eslint-config-prettier": "^8.10.0",
         "eslint-plugin-import": "^2.29.1",
+        "eslint-plugin-mocha": "^10.4.1",
         "eslint-plugin-prettier": "^4.2.1",
         "eslint-plugin-simple-import-sort": "^10.0.0",
         "eslint-plugin-tsdoc": "^0.2.17",
@@ -4749,6 +4750,23 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/eslint-plugin-mocha": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-10.4.1.tgz",
+      "integrity": "sha512-G85ALUgKaLzuEuHhoW3HVRgPTmia6njQC3qCG6CEvA8/Ja9PDZnRZOuzekMki+HaViEQXINuYsmhp5WR5/4MfA==",
+      "dev": true,
+      "dependencies": {
+        "eslint-utils": "^3.0.0",
+        "globals": "^13.24.0",
+        "rambda": "^7.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
     "node_modules/eslint-plugin-prettier": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz",
@@ -4836,6 +4854,33 @@
       },
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/eslint-utils": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^2.0.0"
+      },
+      "engines": {
+        "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=5"
+      }
+    },
+    "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/eslint-visitor-keys": {
@@ -5523,9 +5568,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "13.23.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.23.0.tgz",
-      "integrity": "sha512-XAmF0RjlrjY23MA51q3HltdlGxUpXPvg0GioKiD9X6HD28iMjo2dKC8Vqwm7lne4GNr78+RHTfliktR6ZH09wA==",
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -7938,6 +7983,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/rambda": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/rambda/-/rambda-7.5.0.tgz",
+      "integrity": "sha512-y/M9weqWAH4iopRd7EHDEQQvpFPHj1AA3oHozE9tfITHUtTR7Z9PSlIRRG2l1GuW7sefC1cXFfIcF+cgnShdBA==",
+      "dev": true
     },
     "node_modules/randombytes": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "eslint": "^8.56.0",
     "eslint-config-prettier": "^8.10.0",
     "eslint-plugin-import": "^2.29.1",
+    "eslint-plugin-mocha": "^10.4.1",
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-simple-import-sort": "^10.0.0",
     "eslint-plugin-tsdoc": "^0.2.17",

--- a/test/atlas/drivers_atlas_testing.test.ts
+++ b/test/atlas/drivers_atlas_testing.test.ts
@@ -1,6 +1,6 @@
 import { runUnifiedSuite } from '../tools/unified-spec-runner/runner';
 
-describe('Node Driver Atlas Testing', async function () {
+describe('Node Driver Atlas Testing', function () {
   // Astrolabe can, well, take some time. In some cases up to 800s to
   // reconfigure clusters.
   this.timeout(0);

--- a/test/integration/client-side-encryption/client_side_encryption.prose.22.range_explicit_encryption.test.ts
+++ b/test/integration/client-side-encryption/client_side_encryption.prose.22.range_explicit_encryption.test.ts
@@ -25,7 +25,9 @@ const metaData: MongoDBMetadataUI = {
 
     // The Range Explicit Encryption tests require MongoDB server 7.0+ for QE v2.
     // The tests must not run against a standalone.
-    mongodb: '>=7.0.0',
+    //
+    // `rangePreview` is not supported on 8.0+ servers.
+    mongodb: '>=7.0.0 <8.0.0',
     topology: '!single'
   }
 };
@@ -127,14 +129,6 @@ const readEncryptedFieldsFile = (dataType: string): Promise<string> =>
 describe('Range Explicit Encryption', function () {
   installNodeDNSWorkaroundHooks();
 
-  beforeEach(async function () {
-    if (semver.gte(this.configuration.version, '7.999.999')) {
-      if (this.currentTest)
-        this.currentTest.skipReason = 'TODO(NODE-5908): skip rangePreview tests on server 8.0+';
-      return this.currentTest?.skip();
-    }
-  });
-
   let clientEncryption;
   let keyId;
   let keyVaultClient;
@@ -145,7 +139,7 @@ describe('Range Explicit Encryption', function () {
   let encryptedTwoHundred;
   let compareNumericValues;
   for (const { type: dataType, rangeOptions, factory } of dataTypes) {
-    context(`datatype ${dataType}`, async function () {
+    context(`datatype ${dataType}`, function () {
       beforeEach(async function () {
         compareNumericValues = function (value: unknown, expected: number): void {
           if (dataType === 'DoubleNoPrecision' || dataType === 'DoublePrecision') {

--- a/test/integration/client-side-encryption/client_side_encryption.prose.22.range_explicit_encryption.test.ts
+++ b/test/integration/client-side-encryption/client_side_encryption.prose.22.range_explicit_encryption.test.ts
@@ -2,7 +2,6 @@ import { EJSON } from 'bson';
 import { expect } from 'chai';
 import { readFile } from 'fs/promises';
 import { join } from 'path';
-import * as semver from 'semver';
 
 import { Decimal128, type Document, Double, Long, type MongoClient } from '../../../src';
 /* eslint-disable @typescript-eslint/no-restricted-imports */

--- a/test/integration/crud/abstract_operation.test.ts
+++ b/test/integration/crud/abstract_operation.test.ts
@@ -5,8 +5,8 @@ import { executeOperation, Long, Server } from '../../mongodb';
 import * as mongodb from '../../mongodb';
 import { topologyWithPlaceholderClient } from '../../tools/utils';
 
-describe('abstract operation', async function () {
-  describe('command name getter', async function () {
+describe('abstract operation', function () {
+  describe('command name getter', function () {
     interface AbstractOperationSubclasses {
       subclassCreator: () => mongodb.AbstractOperation;
       subclassType: any;
@@ -312,7 +312,7 @@ describe('abstract operation', async function () {
     });
 
     for (const { subclassCreator, subclassType, correctCommandName } of subclassArray) {
-      context(`when subclass is ${subclassType.name}`, async function () {
+      context(`when subclass is ${subclassType.name}`, function () {
         it(`operation.commandName equals correct string`, async function () {
           const subclassInstance = subclassCreator();
           expect(subclassInstance.commandName).to.equal(correctCommandName);

--- a/test/integration/node-specific/bson-options/use_bigint_64.test.ts
+++ b/test/integration/node-specific/bson-options/use_bigint_64.test.ts
@@ -28,7 +28,7 @@ describe('useBigInt64 option', function () {
     }
   });
 
-  describe('when not provided to client', async function () {
+  describe('when not provided to client', function () {
     beforeEach(async function () {
       client = await this.configuration.newClient().connect();
     });
@@ -92,7 +92,7 @@ describe('useBigInt64 option', function () {
     });
   });
 
-  describe('when set to true at collection level', async function () {
+  describe('when set to true at collection level', function () {
     let res: WithId<BSON.Document> | null;
     beforeEach(async function () {
       client = await this.configuration.newClient().connect();
@@ -110,7 +110,7 @@ describe('useBigInt64 option', function () {
     });
   });
 
-  describe('when set to false at collection level', async function () {
+  describe('when set to false at collection level', function () {
     let res: WithId<BSON.Document> | null;
     beforeEach(async function () {
       client = await this.configuration.newClient().connect();

--- a/test/unit/cmap/connect.test.ts
+++ b/test/unit/cmap/connect.test.ts
@@ -224,7 +224,7 @@ describe('Connect Tests', function () {
           expect(handshakeDocument.client.env).to.not.have.property('name');
         });
 
-        context('when 512 byte size limit is exceeded', async () => {
+        context('when 512 byte size limit is exceeded', () => {
           it(`should not 'env' property in client`, async () => {
             // make metadata = 507 bytes, so it takes up entire LimitedSizeDocument
             const longAppName = 's'.repeat(493);
@@ -274,7 +274,7 @@ describe('Connect Tests', function () {
           expect(handshakeDocument.client.env.name).to.equal('aws.lambda');
         });
 
-        context('when 512 byte size limit is exceeded', async () => {
+        context('when 512 byte size limit is exceeded', () => {
           it(`should not have 'container' property in client.env`, async () => {
             // make metadata = 507 bytes, so it takes up entire LimitedSizeDocument
             const longAppName = 's'.repeat(447);

--- a/test/unit/commands.test.ts
+++ b/test/unit/commands.test.ts
@@ -172,7 +172,7 @@ describe('class OpCompressedRequest', () => {
     });
   });
 
-  context('toBin()', async () => {
+  context('toBin()', () => {
     for (const protocol of [OpMsgRequest, OpQueryRequest]) {
       context(`when ${protocol.name} is used`, () => {
         let msg;

--- a/test/unit/mongo_logger.test.ts
+++ b/test/unit/mongo_logger.test.ts
@@ -57,7 +57,7 @@ describe('meta tests for BufferingStream', function () {
   });
 });
 
-describe('class MongoLogger', async function () {
+describe('class MongoLogger', function () {
   describe('#constructor()', function () {
     it('assigns each property from the options object onto the logging class', function () {
       const componentSeverities: MongoLoggerOptions['componentSeverities'] = {
@@ -1353,7 +1353,7 @@ describe('class MongoLogger', async function () {
     });
   });
 
-  describe('log', async function () {
+  describe('log', function () {
     let componentSeverities: MongoLoggerOptions['componentSeverities'];
 
     beforeEach(function () {
@@ -1407,7 +1407,7 @@ describe('class MongoLogger', async function () {
         });
       });
     });
-    describe('async stream failure handling', async function () {
+    describe('async stream failure handling', function () {
       context('when stream is not stderr', function () {
         let stderrStub;
 
@@ -1419,7 +1419,7 @@ describe('class MongoLogger', async function () {
           sinon.restore();
         });
 
-        context('when stream user defined stream and stream.write throws async', async function () {
+        context('when stream user defined stream and stream.write throws async', function () {
           it('should catch error, not crash application, warn user, and start writing to stderr', async function () {
             const stream = {
               async write(_log) {
@@ -1456,7 +1456,7 @@ describe('class MongoLogger', async function () {
           });
         });
 
-        context('when stream is stdout and stdout.write throws', async function () {
+        context('when stream is stdout and stdout.write throws', function () {
           it('should catch error, not crash application, warn user, and start writing to stderr', async function () {
             sinon.stub(process.stdout, 'write').throws(new Error('I am stdout and do not work'));
             // print random message at the debug level
@@ -1509,7 +1509,7 @@ describe('class MongoLogger', async function () {
         });
       });
     });
-    context('when async stream has multiple logs with different timeouts', async function () {
+    context('when async stream has multiple logs with different timeouts', function () {
       it('should preserve their order', async function () {
         const stream = {
           buffer: [],

--- a/test/unit/sdam/server_selection.test.ts
+++ b/test/unit/sdam/server_selection.test.ts
@@ -17,7 +17,7 @@ import {
 import * as mock from '../../tools/mongodb-mock/index';
 import { topologyWithPlaceholderClient } from '../../tools/utils';
 
-describe('server selection', async function () {
+describe('server selection', function () {
   const primary = new ServerDescription('127.0.0.1:27017', {
     setName: 'test',
     isWritablePrimary: true,
@@ -610,7 +610,7 @@ describe('server selection', async function () {
     });
   });
 
-  describe('server selection logging feature flagging', async function () {
+  describe('server selection logging feature flagging', function () {
     let mockServer;
     let topology;
     let address;


### PR DESCRIPTION
### Description

#### What is changing?

- Added an eslint rule for checking mocha describe blocks for async functions
  - Run fix to remove current accidental usages
- Use metadata to skip range tests

##### Is there new documentation needed for these changes?

No.

#### What is the motivation for this change?

- Async functions in context/describe blocks are incorrect usage of the test framework. We suspect this lead to a problem with mocha exiting silently on latest sharded clusters, that is no longer happening after this change.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
