### PR TITLE
fix(NODE-3681): Typescript error in Collection.findOneAndModify UpdateFilter $currentDate

### DIFF
--- a/src/mongo_types.ts
+++ b/src/mongo_types.ts
@@ -219,7 +219,7 @@ export type NotAcceptedFields<TSchema, FieldType> = {
 /** @public */
 export type OnlyFieldsOfType<TSchema, FieldType = any, AssignableType = FieldType> = IsAny<
   TSchema[keyof TSchema],
-  Record<string, FieldType>,
+  AssignableType extends FieldType ? Record<string, FieldType> : Record<string, AssignableType>,
   AcceptedFields<TSchema, FieldType, AssignableType> &
     NotAcceptedFields<TSchema, FieldType> &
     Record<string, AssignableType>
@@ -283,7 +283,7 @@ export type PullAllOperator<TSchema> = ({
 export type UpdateFilter<TSchema> = {
   $currentDate?: OnlyFieldsOfType<
     TSchema,
-    true | Date | Timestamp,
+    Date | Timestamp,
     true | { $type: 'date' | 'timestamp' }
   >;
   $inc?: OnlyFieldsOfType<TSchema, NumericType | undefined>;

--- a/src/mongo_types.ts
+++ b/src/mongo_types.ts
@@ -283,7 +283,7 @@ export type PullAllOperator<TSchema> = ({
 export type UpdateFilter<TSchema> = {
   $currentDate?: OnlyFieldsOfType<
     TSchema,
-    Date | Timestamp | true,
+    true | Date | Timestamp,
     true | { $type: 'date' | 'timestamp' }
   >;
   $inc?: OnlyFieldsOfType<TSchema, NumericType | undefined>;
@@ -588,7 +588,7 @@ export type StrictFilter<TSchema> =
 export type StrictUpdateFilter<TSchema> = {
   $currentDate?: OnlyFieldsOfType<
     TSchema,
-    Date | Timestamp,
+    true | Date | Timestamp,
     true | { $type: 'date' | 'timestamp' }
   >;
   $inc?: OnlyFieldsOfType<TSchema, NumericType | undefined>;

--- a/src/mongo_types.ts
+++ b/src/mongo_types.ts
@@ -588,7 +588,7 @@ export type StrictFilter<TSchema> =
 export type StrictUpdateFilter<TSchema> = {
   $currentDate?: OnlyFieldsOfType<
     TSchema,
-    true | Date | Timestamp,
+    Date | Timestamp,
     true | { $type: 'date' | 'timestamp' }
   >;
   $inc?: OnlyFieldsOfType<TSchema, NumericType | undefined>;

--- a/src/mongo_types.ts
+++ b/src/mongo_types.ts
@@ -283,7 +283,7 @@ export type PullAllOperator<TSchema> = ({
 export type UpdateFilter<TSchema> = {
   $currentDate?: OnlyFieldsOfType<
     TSchema,
-    Date | Timestamp,
+    Date | Timestamp | true,
     true | { $type: 'date' | 'timestamp' }
   >;
   $inc?: OnlyFieldsOfType<TSchema, NumericType | undefined>;

--- a/test/integration/crud/find_and_modify.test.ts
+++ b/test/integration/crud/find_and_modify.test.ts
@@ -330,35 +330,6 @@ describe('Collection (#findOneAnd...)', function () {
         });
       });
     });
-
-    describe('update filter', function () {
-      context('when $currentDate is provided', function () {
-        let client;
-        let db: Db;
-        let collection: Collection;
-
-        beforeEach(async function () {
-          client = this.configuration.newClient({ w: 1 });
-          await client.connect();
-          db = client.db(this.configuration.db);
-          collection = db.collection('test_coll');
-          await collection.insertOne({ a: 'c' });
-        });
-
-        afterEach(async function () {
-          await collection.drop();
-          await client.close();
-        });
-
-        it(`should support fields with value 'true'`, async function () {
-          await collection.findOneAndUpdate(
-            {},
-            { $set: { a: 1 }, $currentDate: { lastModified: true } },
-            { writeConcern: { w: 1 } }
-          );
-        });
-      });
-    });
   });
 
   describe('#findOneAndReplace', function () {

--- a/test/integration/crud/find_and_modify.test.ts
+++ b/test/integration/crud/find_and_modify.test.ts
@@ -1,6 +1,12 @@
 import { expect } from 'chai';
 
-import { type CommandStartedEvent, MongoServerError, ObjectId } from '../../mongodb';
+import {
+  type Collection,
+  type CommandStartedEvent,
+  type Db,
+  MongoServerError,
+  ObjectId
+} from '../../mongodb';
 import { setupDatabase } from '../shared';
 
 describe('Collection (#findOneAnd...)', function () {
@@ -321,6 +327,35 @@ describe('Collection (#findOneAnd...)', function () {
         it('passes through the writeConcern', async function () {
           await collection.findOneAndUpdate({}, { $set: { a: 1 } });
           expect(started[0].command.writeConcern).to.deep.equal({ j: 1 });
+        });
+      });
+    });
+
+    describe('update filter', function () {
+      context('when $currentDate is provided', function () {
+        let client;
+        let db: Db;
+        let collection: Collection;
+
+        beforeEach(async function () {
+          client = this.configuration.newClient({ w: 1 });
+          await client.connect();
+          db = client.db(this.configuration.db);
+          collection = db.collection('test_coll');
+          await collection.insertOne({ a: 'c' });
+        });
+
+        afterEach(async function () {
+          await collection.drop();
+          await client.close();
+        });
+
+        it(`should support fields with value 'true'`, async function () {
+          await collection.findOneAndUpdate(
+            {},
+            { $set: { a: 1 }, $currentDate: { lastModified: true } },
+            { writeConcern: { w: 1 } }
+          );
         });
       });
     });

--- a/test/integration/crud/find_and_modify.test.ts
+++ b/test/integration/crud/find_and_modify.test.ts
@@ -1,12 +1,6 @@
 import { expect } from 'chai';
 
-import {
-  type Collection,
-  type CommandStartedEvent,
-  type Db,
-  MongoServerError,
-  ObjectId
-} from '../../mongodb';
+import { type CommandStartedEvent, MongoServerError, ObjectId } from '../../mongodb';
 import { setupDatabase } from '../shared';
 
 describe('Collection (#findOneAnd...)', function () {

--- a/test/types/community/collection/updateX.test-d.ts
+++ b/test/types/community/collection/updateX.test-d.ts
@@ -60,6 +60,12 @@ expectAssignable<UpdateFilter<Document>>({ $inc: { anyKeyWhatsoever: 2 } });
 // But this no longer asserts anything about what the original keys map to
 expectNotType<UpdateFilter<Document>>({ $inc: { numberField: '2' } });
 
+
+expectAssignable<UpdateFilter<Document>>({ $currentDate: { anyKeyWhatsoever:  { $type: 'timestamp' }} });
+expectAssignable<UpdateFilter<Document>>({ $currentDate: { anyKeyWhatsoever:  { $type: 'date' }} });
+expectAssignable<UpdateFilter<Document>>({ $currentDate: { anyKeyWhatsoever:  true } });
+expectNotType<UpdateFilter<Document>>({ $currentDate: { anyKeyWhatsoever:  'true' } });
+expectNotType<UpdateFilter<Document>>({ $currentDate: { anyKeyWhatsoever: { key2:  true }} });
 // collection.updateX tests
 const client = new MongoClient('');
 const db = client.db('test');

--- a/test/types/community/collection/updateX.test-d.ts
+++ b/test/types/community/collection/updateX.test-d.ts
@@ -60,12 +60,13 @@ expectAssignable<UpdateFilter<Document>>({ $inc: { anyKeyWhatsoever: 2 } });
 // But this no longer asserts anything about what the original keys map to
 expectNotType<UpdateFilter<Document>>({ $inc: { numberField: '2' } });
 
-
-expectAssignable<UpdateFilter<Document>>({ $currentDate: { anyKeyWhatsoever:  { $type: 'timestamp' }} });
-expectAssignable<UpdateFilter<Document>>({ $currentDate: { anyKeyWhatsoever:  { $type: 'date' }} });
-expectAssignable<UpdateFilter<Document>>({ $currentDate: { anyKeyWhatsoever:  true } });
-expectNotType<UpdateFilter<Document>>({ $currentDate: { anyKeyWhatsoever:  'true' } });
-expectNotType<UpdateFilter<Document>>({ $currentDate: { anyKeyWhatsoever: { key2:  true }} });
+expectAssignable<UpdateFilter<Document>>({
+  $currentDate: { anyKeyWhatsoever: { $type: 'timestamp' } }
+});
+expectAssignable<UpdateFilter<Document>>({ $currentDate: { anyKeyWhatsoever: { $type: 'date' } } });
+expectAssignable<UpdateFilter<Document>>({ $currentDate: { anyKeyWhatsoever: true } });
+expectNotType<UpdateFilter<Document>>({ $currentDate: { anyKeyWhatsoever: 'true' } });
+expectNotType<UpdateFilter<Document>>({ $currentDate: { anyKeyWhatsoever: { key2: true } } });
 // collection.updateX tests
 const client = new MongoClient('');
 const db = client.db('test');

--- a/test/types/helper_types.test-d.ts
+++ b/test/types/helper_types.test-d.ts
@@ -68,6 +68,7 @@ expectType<NotAcceptedFields<{ a: number; b: string; c: string }, number>>(notAc
 expectAssignable<OnlyFieldsOfType<{ a: number; b: string }, number>>({ a: 2 });
 expectAssignable<OnlyFieldsOfType<{ a: number; b: string }, string>>({ b: 'hello' });
 expectAssignable<OnlyFieldsOfType<{ a: number; b: string }, string, boolean>>({ b: true });
+expectAssignable<OnlyFieldsOfType<{ a: number; b: string }, string, boolean>>({ b: true });
 
 // test generic schema, essentially we expect nearly no safety here
 expectAssignable<OnlyFieldsOfType<Document, NumericType | undefined>>({ someKey: 2 });

--- a/test/types/helper_types.test-d.ts
+++ b/test/types/helper_types.test-d.ts
@@ -69,6 +69,9 @@ expectAssignable<OnlyFieldsOfType<{ a: number; b: string }, number>>({ a: 2 });
 expectAssignable<OnlyFieldsOfType<{ a: number; b: string }, string>>({ b: 'hello' });
 expectAssignable<OnlyFieldsOfType<{ a: number; b: string }, string, boolean>>({ b: true });
 
+// test the case in which AssignableType does not inherit from FieldType, and AssignableType is provided
+expectAssignable<OnlyFieldsOfType<any, string, boolean>>({ b: false });
+
 // test generic schema, essentially we expect nearly no safety here
 expectAssignable<OnlyFieldsOfType<Document, NumericType | undefined>>({ someKey: 2 });
 // We can still at least enforce the type that the keys map to

--- a/test/types/helper_types.test-d.ts
+++ b/test/types/helper_types.test-d.ts
@@ -68,7 +68,6 @@ expectType<NotAcceptedFields<{ a: number; b: string; c: string }, number>>(notAc
 expectAssignable<OnlyFieldsOfType<{ a: number; b: string }, number>>({ a: 2 });
 expectAssignable<OnlyFieldsOfType<{ a: number; b: string }, string>>({ b: 'hello' });
 expectAssignable<OnlyFieldsOfType<{ a: number; b: string }, string, boolean>>({ b: true });
-expectAssignable<OnlyFieldsOfType<{ a: number; b: string }, string, boolean>>({ b: true });
 
 // test generic schema, essentially we expect nearly no safety here
 expectAssignable<OnlyFieldsOfType<Document, NumericType | undefined>>({ someKey: 2 });


### PR DESCRIPTION
### Description
When a field with boolean value `true`, is passed into `$currentDate`, it will no longer throw an TS error.

#### What is changing?
Example:
```
$currentData: {
   lastModified: true
} // no longer throws a TS error
```

##### Is there new documentation needed for these changes?
No. 

#### What is the motivation for this change?
The motivation is that the Node Driver should not output unnecessary errors to users. 

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### `Collection.findOneAndModify`'s `UpdateFilter.$currentDate` no longer throws on collections with limited schema

Example:
```typescript
const collection = new Collection(); // collection with no schema
collection.update(
    $currentData: {
       lastModified: true
    } // no longer throws a TS error
);
```
<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
