### PR TITLE
chore: enforce consistent block spacing in mocha tests

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,7 +18,6 @@
     "plugin:@typescript-eslint/eslint-recommended",
     "plugin:@typescript-eslint/recommended",
     "plugin:prettier/recommended"
-    // "plugin:mocha/recommended"
   ],
   "env": {
     "node": true,
@@ -27,21 +26,6 @@
   },
   "reportUnusedDisableDirectives": true,
   "rules": {
-    "no-restricted-properties": [
-      "error",
-      {
-        "object": "describe",
-        "property": "only"
-      },
-      {
-        "object": "it",
-        "property": "only"
-      },
-      {
-        "object": "context",
-        "property": "only"
-      }
-    ],
     "no-restricted-globals": [
       "error",
       {
@@ -115,6 +99,8 @@
       }
     ],
     "mocha/no-async-describe": "error",
+    "mocha/no-exclusive-tests": "error",
+    "mocha/consistent-spacing-between-blocks": "error",
     "no-restricted-syntax": [
       "error",
       {

--- a/test/action/dependency.test.ts
+++ b/test/action/dependency.test.ts
@@ -132,6 +132,7 @@ describe('package.json', function () {
 
   describe('mongodb imports', () => {
     let imports: string[];
+
     beforeEach(async function () {
       for (const key of Object.keys(require.cache)) delete require.cache[key];
       require('../../src');

--- a/test/integration/change-streams/change_streams.prose.test.ts
+++ b/test/integration/change-streams/change_streams.prose.test.ts
@@ -111,6 +111,7 @@ describe('Change Stream prose tests', function () {
       await client.close();
     }
   });
+
   afterEach(async () => await mock.cleanup());
 
   // TODO(NODE-3884): Add tests 1-4, 6-8. (#5 is removed from spec)
@@ -590,6 +591,7 @@ describe('Change Stream prose tests', function () {
             expect(tokens[0]).to.deep.equal(successes[1].nextBatch[0]._id);
           });
       });
+
       it('must return resumeAfter from the initial aggregate if the option was specified', function () {
         const manager = new MockServerManager(this.configuration, {
           aggregate: (function* () {
@@ -629,6 +631,7 @@ describe('Change Stream prose tests', function () {
             expect(token).to.deep.equal(resumeAfter);
           });
       });
+
       it('must be empty if resumeAfter options was not specified', function () {
         const manager = new MockServerManager(this.configuration, {
           aggregate: (function* () {
@@ -762,6 +765,7 @@ describe('Change Stream prose tests', function () {
             expect(token).to.deep.equal(startAfter).and.to.not.deep.equal(resumeAfter);
           });
       });
+
       it('must return resumeAfter from the initial aggregate if the option was specified', function () {
         const manager = new MockServerManager(this.configuration, {
           aggregate: (function* () {
@@ -797,6 +801,7 @@ describe('Change Stream prose tests', function () {
             expect(token).to.deep.equal(resumeAfter);
           });
       });
+
       it('must be empty if neither the startAfter nor resumeAfter options were specified', function () {
         const manager = new MockServerManager(this.configuration, {
           aggregate: (function* () {

--- a/test/integration/client-side-encryption/client_side_encryption.prose.12.deadlock.test.ts
+++ b/test/integration/client-side-encryption/client_side_encryption.prose.12.deadlock.test.ts
@@ -105,6 +105,7 @@ const metadata = {
 };
 describe('Connection Pool Deadlock Prevention', function () {
   installNodeDNSWorkaroundHooks();
+
   beforeEach(async function () {
     const url: string = this.configuration.url();
 
@@ -153,6 +154,7 @@ describe('Connection Pool Deadlock Prevention', function () {
   });
 
   const CASE1 = { maxPoolSize: 1, bypassAutoEncryption: false, useKeyVaultClient: false };
+
   it(
     'Case 1',
     metadata,
@@ -177,6 +179,7 @@ describe('Connection Pool Deadlock Prevention', function () {
   );
 
   const CASE2 = { maxPoolSize: 1, bypassAutoEncryption: false, useKeyVaultClient: true };
+
   it(
     'Case 2',
     metadata,
@@ -204,6 +207,7 @@ describe('Connection Pool Deadlock Prevention', function () {
   );
 
   const CASE3 = { maxPoolSize: 1, bypassAutoEncryption: true, useKeyVaultClient: false };
+
   it(
     'Case 3',
     metadata,
@@ -222,6 +226,7 @@ describe('Connection Pool Deadlock Prevention', function () {
   );
 
   const CASE4 = { maxPoolSize: 1, bypassAutoEncryption: true, useKeyVaultClient: true };
+
   it(
     'Case 4',
     metadata,
@@ -243,6 +248,7 @@ describe('Connection Pool Deadlock Prevention', function () {
   );
 
   const CASE5 = { maxPoolSize: 0, bypassAutoEncryption: false, useKeyVaultClient: false };
+
   it(
     'Case 5',
     metadata,
@@ -270,6 +276,7 @@ describe('Connection Pool Deadlock Prevention', function () {
   );
 
   const CASE6 = { maxPoolSize: 0, bypassAutoEncryption: false, useKeyVaultClient: true };
+
   it(
     'Case 6',
     metadata,
@@ -297,6 +304,7 @@ describe('Connection Pool Deadlock Prevention', function () {
   );
 
   const CASE7 = { maxPoolSize: 0, bypassAutoEncryption: true, useKeyVaultClient: false };
+
   it(
     'Case 7',
     metadata,
@@ -315,6 +323,7 @@ describe('Connection Pool Deadlock Prevention', function () {
   );
 
   const CASE8 = { maxPoolSize: 0, bypassAutoEncryption: true, useKeyVaultClient: true };
+
   it(
     'Case 8',
     metadata,

--- a/test/integration/client-side-encryption/client_side_encryption.prose.test.js
+++ b/test/integration/client-side-encryption/client_side_encryption.prose.test.js
@@ -565,6 +565,7 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
     const limitsDoc = loadLimits('limits-doc.json');
 
     let hasRunFirstTimeSetup = false;
+
     beforeEach(async function () {
       if (hasRunFirstTimeSetup) {
         // Even though we have to use a beforeEach here
@@ -1274,6 +1275,7 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
     describe('via loading shared library', function () {
       let clientEncrypted;
       let client;
+
       beforeEach(function () {
         const { cryptSharedLibPath } = getEncryptExtraOptions();
         if (!cryptSharedLibPath) {

--- a/test/integration/client-side-encryption/client_side_encryption.spec.test.ts
+++ b/test/integration/client-side-encryption/client_side_encryption.spec.test.ts
@@ -69,7 +69,9 @@ describe('Client Side Encryption (Legacy)', function () {
   );
 
   installNodeDNSWorkaroundHooks();
+
   after(() => testContext.teardown());
+
   before(function () {
     return testContext.setup(this.configuration);
   });

--- a/test/integration/collection-management/collection.test.ts
+++ b/test/integration/collection-management/collection.test.ts
@@ -6,6 +6,7 @@ import { setupDatabase } from '../shared';
 
 describe('Collection', function () {
   let configuration;
+
   before(function () {
     configuration = this.configuration;
     return setupDatabase(configuration, ['listCollectionsDb', 'listCollectionsDb2', 'test_db']);
@@ -14,6 +15,7 @@ describe('Collection', function () {
   describe('standard collection tests', function () {
     let client: MongoClient;
     let db: Db;
+
     beforeEach(function () {
       client = configuration.newClient(configuration.writeConcernMax(), {
         maxPoolSize: 1

--- a/test/integration/collection-management/view.test.ts
+++ b/test/integration/collection-management/view.test.ts
@@ -5,6 +5,7 @@ import { type CollectionInfo, type Db, type MongoClient } from '../../mongodb';
 describe('Views', function () {
   let client: MongoClient;
   let db: Db;
+
   beforeEach(async function () {
     const configuration = this.configuration;
     client = this.configuration.newClient();

--- a/test/integration/command-logging-and-monitoring/command_monitoring.test.ts
+++ b/test/integration/command-logging-and-monitoring/command_monitoring.test.ts
@@ -607,6 +607,7 @@ describe('Command Monitoring', function () {
 
   describe('Internal state references', function () {
     let client;
+
     beforeEach(function () {
       client = this.configuration.newClient(
         { writeConcern: { w: 1 } },

--- a/test/integration/connection-monitoring-and-pooling/connection_pool.test.ts
+++ b/test/integration/connection-monitoring-and-pooling/connection_pool.test.ts
@@ -7,6 +7,7 @@ import { type ConnectionPoolCreatedEvent, type Db, type MongoClient } from '../.
 describe('Connection Pool', function () {
   let client: MongoClient;
   let db: Db;
+
   afterEach(async function () {
     if (client) {
       if (db) {
@@ -15,6 +16,7 @@ describe('Connection Pool', function () {
       await client.close();
     }
   });
+
   describe('Events', function () {
     describe('ConnectionPoolCreatedEvent', function () {
       context('when no connection pool options are passed in', function () {

--- a/test/integration/crud/aggregation.test.ts
+++ b/test/integration/crud/aggregation.test.ts
@@ -5,6 +5,7 @@ import { filterForCommands } from '../shared';
 
 describe('Aggregation', function () {
   let client;
+
   beforeEach(async function () {
     client = this.configuration.newClient();
   });

--- a/test/integration/crud/bulk.test.ts
+++ b/test/integration/crud/bulk.test.ts
@@ -33,6 +33,7 @@ describe('Bulk', function () {
       .createCollection('test')
       .catch(() => null); // make ns exist
   });
+
   afterEach(async function () {
     const cleanup = this.configuration.newClient();
     await cleanup

--- a/test/integration/crud/crud.prose.test.ts
+++ b/test/integration/crud/crud.prose.test.ts
@@ -77,6 +77,7 @@ describe('CRUD Prose Spec Tests', () => {
      */
 
     let collection;
+
     beforeEach(async () => {
       try {
         await client.db().collection('wc_details').drop();

--- a/test/integration/crud/find.test.js
+++ b/test/integration/crud/find.test.js
@@ -7,6 +7,7 @@ const { Code, ObjectId, Long, Binary, ReturnDocument } = require('../../mongodb'
 
 describe('Find', function () {
   let client;
+
   beforeEach(async function () {
     client = this.configuration.newClient();
   });

--- a/test/integration/crud/find_cursor_methods.test.js
+++ b/test/integration/crud/find_cursor_methods.test.js
@@ -19,6 +19,7 @@ describe('Find Cursor', function () {
   beforeEach(async function () {
     client = this.configuration.newClient({ monitorCommands: true });
   });
+
   afterEach(async function () {
     await client.close();
   });
@@ -43,6 +44,7 @@ describe('Find Cursor', function () {
 
   describe('#readBufferedDocuments', function () {
     let cursor;
+
     beforeEach(async () => {
       const coll = client.db().collection('abstract_cursor');
       cursor = coll.find({}, { batchSize: 5 });

--- a/test/integration/crud/insert.test.js
+++ b/test/integration/crud/insert.test.js
@@ -63,6 +63,7 @@ const ISODate = function (string) {
 
 describe('crud - insert', function () {
   let client;
+
   beforeEach(async function () {
     client = this.configuration.newClient();
   });

--- a/test/integration/crud/misc_cursors.test.js
+++ b/test/integration/crud/misc_cursors.test.js
@@ -25,9 +25,11 @@ describe('Cursor', function () {
   });
 
   let client;
+
   beforeEach(async function () {
     client = this.configuration.newClient({ maxPoolSize: 1, monitorCommands: true });
   });
+
   afterEach(async function () {
     await client.close();
   });

--- a/test/integration/crud/remove.test.js
+++ b/test/integration/crud/remove.test.js
@@ -3,6 +3,7 @@ const { expect } = require('chai');
 
 describe('Remove', function () {
   let client;
+
   beforeEach(async function () {
     client = this.configuration.newClient();
   });

--- a/test/integration/crud/server_errors.test.js
+++ b/test/integration/crud/server_errors.test.js
@@ -14,10 +14,12 @@ describe('Errors', function () {
   });
 
   let client;
+
   beforeEach(function () {
     client = this.configuration.newClient(this.configuration.writeConcernMax(), { maxPoolSize: 1 });
     return client.connect();
   });
+
   afterEach(function () {
     return client.close();
   });

--- a/test/integration/gridfs/gridfs_stream.test.js
+++ b/test/integration/gridfs/gridfs_stream.test.js
@@ -11,6 +11,7 @@ const { GridFSBucket, ObjectId, MongoAPIError } = require('../../mongodb');
 describe('GridFS Stream', function () {
   let client;
   let db;
+
   beforeEach(async function () {
     client = this.configuration.newClient();
     db = client.db('gridfs_stream_tests');

--- a/test/integration/index_management.test.ts
+++ b/test/integration/index_management.test.ts
@@ -101,6 +101,7 @@ describe('Indexes', function () {
 
   describe('Collection.indexes()', function () {
     beforeEach(() => collection.createIndex({ age: 1 }));
+
     afterEach(() => collection.dropIndexes());
 
     context('when `full` is not provided', () => {
@@ -130,6 +131,7 @@ describe('Indexes', function () {
 
   describe('Collection.indexInformation()', function () {
     beforeEach(() => collection.createIndex({ age: 1 }));
+
     afterEach(() => collection.dropIndexes());
 
     context('when `full` is not provided', () => {
@@ -162,6 +164,7 @@ describe('Indexes', function () {
 
   describe('Collection.createIndex()', function () {
     const started: CommandStartedEvent[] = [];
+
     beforeEach(() => {
       started.length = 0;
       client.on('commandStarted', filterForCommands('createIndexes', started));
@@ -188,6 +191,7 @@ describe('Indexes', function () {
 
   describe('Collection.createIndexes()', function () {
     const started: CommandStartedEvent[] = [];
+
     beforeEach(() => {
       started.length = 0;
       client.on('commandStarted', filterForCommands('createIndexes', started));
@@ -238,6 +242,7 @@ describe('Indexes', function () {
 
   describe('Collection.indexExists()', function () {
     beforeEach(() => collection.createIndex({ age: 1 }));
+
     afterEach(() => collection.dropIndexes());
 
     context('when provided a string index name', () => {

--- a/test/integration/max-staleness/max_staleness.test.js
+++ b/test/integration/max-staleness/max_staleness.test.js
@@ -9,6 +9,7 @@ const test = {};
 // TODO (NODE-3799): convert these to run against a real server
 describe('Max Staleness', function () {
   afterEach(() => mock.cleanup());
+
   beforeEach(() => {
     return mock.createServer().then(server => {
       test.server = server;

--- a/test/integration/node-specific/abstract_cursor.test.ts
+++ b/test/integration/node-specific/abstract_cursor.test.ts
@@ -17,6 +17,7 @@ describe('class AbstractCursor', function () {
     let client: MongoClient;
     let collection: Collection;
     const docs = [{ count: 0 }, { count: 10 }];
+
     beforeEach(async function () {
       client = this.configuration.newClient();
 
@@ -49,6 +50,7 @@ describe('class AbstractCursor', function () {
     let client: MongoClient;
     let collection: Collection;
     const transformSpy = sinon.spy(doc => ({ ...doc, name: doc.name.toUpperCase() }));
+
     beforeEach(async function () {
       client = this.configuration.newClient();
 
@@ -137,6 +139,7 @@ describe('class AbstractCursor', function () {
     const falseyValues = [0, 0n, NaN, '', false, undefined];
 
     let collection: Collection;
+
     beforeEach(async function () {
       client = this.configuration.newClient();
 
@@ -245,6 +248,7 @@ describe('class AbstractCursor', function () {
     let client: MongoClient;
     let collection: Collection;
     const docs = [{ count: 0 }];
+
     beforeEach(async function () {
       client = this.configuration.newClient();
 

--- a/test/integration/node-specific/auto_connect.test.ts
+++ b/test/integration/node-specific/auto_connect.test.ts
@@ -210,6 +210,7 @@ describe('When executing an operation for the first time', () => {
     let changeCausingCollection: Collection;
     let collection: Collection;
     let cs: ChangeStream;
+
     beforeEach(async function () {
       if (this.configuration.topologyType === TopologyType.Single) {
         return;

--- a/test/integration/node-specific/auto_encrypter.test.ts
+++ b/test/integration/node-specific/auto_encrypter.test.ts
@@ -48,15 +48,18 @@ const MOCK_KMS_DECRYPT_REPLY = readHttpResponse(dataPath(`kms-decrypt-reply.txt`
 describe('crypt_shared library', function () {
   let client: MongoClient;
   let autoEncrypter: AutoEncrypter | undefined;
+
   beforeEach(async function () {
     client = this.configuration.newClient();
     await client.connect();
   });
+
   afterEach(async () => {
     await autoEncrypter?.teardown(true);
     await client?.close();
   });
   const sandbox = sinon.createSandbox();
+
   beforeEach(() => {
     sandbox.restore();
     sandbox.stub(StateMachine.prototype, 'kmsRequest').callsFake(request => {
@@ -95,6 +98,7 @@ describe('crypt_shared library', function () {
   afterEach(() => {
     sandbox.restore();
   });
+
   describe('autoSpawn', function () {
     it(
       'should autoSpawn a mongocryptd on init by default',

--- a/test/integration/node-specific/bson-options/ignore_undefined.test.js
+++ b/test/integration/node-specific/bson-options/ignore_undefined.test.js
@@ -9,6 +9,7 @@ describe('Ignore Undefined', function () {
   });
 
   let client;
+
   beforeEach(async function () {
     client = this.configuration.newClient();
   });

--- a/test/integration/node-specific/bson-options/raw.test.ts
+++ b/test/integration/node-specific/bson-options/raw.test.ts
@@ -47,6 +47,7 @@ describe('raw bson support', () => {
     describe('returns shared buffer', () => {
       let client: MongoClient;
       let collection: Collection<{ _id: number; myData: string }>;
+
       beforeEach(async function () {
         client = this.configuration.newClient();
         collection = client.db('test_raw').collection('test_raw');

--- a/test/integration/node-specific/bson-options/use_bigint_64.test.ts
+++ b/test/integration/node-specific/bson-options/use_bigint_64.test.ts
@@ -94,6 +94,7 @@ describe('useBigInt64 option', function () {
 
   describe('when set to true at collection level', function () {
     let res: WithId<BSON.Document> | null;
+
     beforeEach(async function () {
       client = await this.configuration.newClient().connect();
       db = client.db(this.configuration.db);
@@ -112,6 +113,7 @@ describe('useBigInt64 option', function () {
 
   describe('when set to false at collection level', function () {
     let res: WithId<BSON.Document> | null;
+
     beforeEach(async function () {
       client = await this.configuration.newClient().connect();
       db = client.db(this.configuration.db);

--- a/test/integration/node-specific/bson-options/utf8_validation.test.ts
+++ b/test/integration/node-specific/bson-options/utf8_validation.test.ts
@@ -27,6 +27,7 @@ describe('class OpMsgResponse', () => {
   });
 
   let client;
+
   afterEach(async () => {
     if (client) await client.close();
   });

--- a/test/integration/node-specific/client_encryption.test.ts
+++ b/test/integration/node-specific/client_encryption.test.ts
@@ -45,6 +45,7 @@ describe('ClientEncryption integration tests', function () {
     const sandbox = sinon.createSandbox();
 
     after(() => sandbox.restore());
+
     before(() => {
       // stubbed out for AWS unit testing below
       const MOCK_KMS_ENCRYPT_REPLY = readHttpResponse(

--- a/test/integration/node-specific/cursor_stream.test.js
+++ b/test/integration/node-specific/cursor_stream.test.js
@@ -5,6 +5,7 @@ const { setTimeout, setImmediate } = require('timers');
 
 describe('Cursor Streams', function () {
   let client;
+
   beforeEach(async function () {
     client = this.configuration.newClient();
   });

--- a/test/integration/node-specific/examples/versioned_api.js
+++ b/test/integration/node-specific/examples/versioned_api.js
@@ -5,6 +5,7 @@ describe('examples.versionedApi:', function () {
   let uri;
   // eslint-disable-next-line no-unused-vars
   let client;
+
   before(function () {
     uri = this.configuration.url();
   });

--- a/test/integration/node-specific/feature_flags.test.ts
+++ b/test/integration/node-specific/feature_flags.test.ts
@@ -126,6 +126,7 @@ describe('Feature Flags', () => {
     before(() => {
       cachedEnv = process.env;
     });
+
     after(() => {
       process.env = cachedEnv;
     });

--- a/test/integration/node-specific/mongo_client.test.ts
+++ b/test/integration/node-specific/mongo_client.test.ts
@@ -21,6 +21,7 @@ import { setupDatabase } from '../shared';
 
 describe('class MongoClient', function () {
   let client: MongoClient;
+
   before(function () {
     return setupDatabase(this.configuration);
   });

--- a/test/integration/node-specific/operation_examples.test.ts
+++ b/test/integration/node-specific/operation_examples.test.ts
@@ -14,6 +14,7 @@ import { setupDatabase } from '../shared';
 
 describe('Operations', function () {
   let client: MongoClient;
+
   beforeEach(async function () {
     client = this.configuration.newClient();
   });

--- a/test/integration/objectid.test.ts
+++ b/test/integration/objectid.test.ts
@@ -9,6 +9,7 @@ describe('ObjectId', function () {
   let collection: Collection<{ name: string }>;
   let commandStartedEvents;
   let commandSucceededEvents;
+
   beforeEach(async function () {
     client = this.configuration.newClient({ monitorCommands: true });
     await client

--- a/test/integration/read-write-concern/read_write_concern.spec.test.js
+++ b/test/integration/read-write-concern/read_write_concern.spec.test.js
@@ -9,6 +9,7 @@ describe('Read Write Concern spec tests', function () {
     const testSuites = loadSpecTests('read-write-concern/operation');
 
     after(() => testContext.teardown());
+
     before(function () {
       return testContext.setup(this.configuration);
     });

--- a/test/integration/read-write-concern/write_concern.test.ts
+++ b/test/integration/read-write-concern/write_concern.test.ts
@@ -37,6 +37,7 @@ describe('Write Concern', function () {
 
   describe('mock server write concern test', () => {
     let server;
+
     before(() => {
       return mock.createServer().then(s => {
         server = s;

--- a/test/integration/retryable-reads/retryable_reads.spec.prose.test.ts
+++ b/test/integration/retryable-reads/retryable_reads.spec.prose.test.ts
@@ -25,6 +25,7 @@ describe('Retryable Reads Spec Prose', () => {
     let cmapEvents: Array<{ name: string; event: Record<string, any> }>;
     let commandStartedEvents: Array<Record<string, any>>;
     let testCollection: Collection;
+
     beforeEach(async function () {
       // 1. Create a client with maxPoolSize=1 and retryReads=true.
       client = this.configuration.newClient(

--- a/test/integration/retryable-reads/retryable_reads.spec.test.ts
+++ b/test/integration/retryable-reads/retryable_reads.spec.test.ts
@@ -9,6 +9,7 @@ describe('Retryable Reads (legacy)', function () {
   const testSuites = loadSpecTests(path.join('retryable-reads', 'legacy'));
 
   after(() => testContext.teardown());
+
   before(function () {
     return testContext.setup(this.configuration);
   });

--- a/test/integration/retryable-writes/retryable_writes.spec.prose.test.ts
+++ b/test/integration/retryable-writes/retryable_writes.spec.prose.test.ts
@@ -90,6 +90,7 @@ describe('Retryable Writes Spec Prose', () => {
     let cmapEvents: Array<{ name: string; event: Record<string, any> }>;
     let commandStartedEvents: Array<Record<string, any>>;
     let testCollection: Collection;
+
     beforeEach(async function () {
       // i. Create a client with maxPoolSize=1 and retryWrites=true.
       client = this.configuration.newClient(

--- a/test/integration/run-command/run_command.test.ts
+++ b/test/integration/run-command/run_command.test.ts
@@ -13,6 +13,7 @@ describe('RunCommand API', () => {
   let client: MongoClient;
   let db: Db;
   let commandsStarted: CommandStartedEvent[];
+
   beforeEach(async function () {
     const options = {
       serverApi: { version: '1', strict: true, deprecationErrors: false },

--- a/test/integration/sessions/sessions.prose.test.ts
+++ b/test/integration/sessions/sessions.prose.test.ts
@@ -15,6 +15,7 @@ describe('Sessions Prose Tests', () => {
   describe('5. Session argument is for the right client', () => {
     let client1: MongoClient;
     let client2: MongoClient;
+
     beforeEach(async function () {
       client1 = this.configuration.newClient();
       client2 = this.configuration.newClient();
@@ -67,6 +68,7 @@ describe('Sessions Prose Tests', () => {
   describe('14. Implicit sessions only allocate their server session after a successful connection checkout', () => {
     let client: MongoClient;
     let testCollection: Collection<{ _id: number; a?: number }>;
+
     beforeEach(async function () {
       const configuration = this.configuration;
       client = await configuration.newClient({ maxPoolSize: 1, monitorCommands: true }).connect();
@@ -127,6 +129,7 @@ describe('Sessions Prose Tests', () => {
     const mongocryptdTestPort = '27022';
     let client: MongoClient;
     let childProcess: ChildProcess;
+
     before(() => {
       childProcess = spawn('mongocryptd', ['--port', mongocryptdTestPort, '--ipv6'], {
         stdio: 'ignore',

--- a/test/integration/sessions/sessions.test.ts
+++ b/test/integration/sessions/sessions.test.ts
@@ -46,6 +46,7 @@ const test: {
 
 describe('Sessions Spec', function () {
   let client: MongoClient;
+
   beforeEach(async function () {
     client = this.configuration.newClient({ monitorCommands: true });
   });

--- a/test/integration/transactions/transactions.test.ts
+++ b/test/integration/transactions/transactions.test.ts
@@ -264,6 +264,7 @@ describe('Transactions', function () {
 
   describe('TransientTransactionError', function () {
     let client: MongoClient;
+
     beforeEach(async function () {
       client = this.configuration.newClient();
     });

--- a/test/integration/uri-options/uri.test.js
+++ b/test/integration/uri-options/uri.test.js
@@ -6,6 +6,7 @@ const { Topology } = require('../../mongodb');
 
 describe('URI', function () {
   let client;
+
   beforeEach(async function () {
     client = this.configuration.newClient();
   });

--- a/test/tools/spec-runner/index.js
+++ b/test/tools/spec-runner/index.js
@@ -206,7 +206,9 @@ function generateTopologyTests(testSuites, testContext, filter) {
 
     describe(testSuite.name, function () {
       beforeEach(beforeEachFilter);
+
       beforeEach(() => prepareDatabaseForSuite(testSuite, testContext));
+
       afterEach(() => testContext.cleanupAfterSuite());
       for (const spec of testSuite.tests) {
         const mochaTest = it(spec.description, async function () {

--- a/test/unit/assorted/client.test.js
+++ b/test/unit/assorted/client.test.js
@@ -13,6 +13,7 @@ describe('Client (unit)', function () {
     await client.close();
     await mock.cleanup();
   });
+
   beforeEach(() => {
     return mock.createServer().then(_server => (server = _server));
   });

--- a/test/unit/assorted/collations.test.js
+++ b/test/unit/assorted/collations.test.js
@@ -8,6 +8,7 @@ const { MongoClient } = require('../../mongodb');
 const testContext = {};
 describe('Collation', function () {
   afterEach(() => mock.cleanup());
+
   beforeEach(() => {
     return mock.createServer().then(mockServer => (testContext.server = mockServer));
   });

--- a/test/unit/assorted/max_staleness.spec.test.js
+++ b/test/unit/assorted/max_staleness.spec.test.js
@@ -33,6 +33,7 @@ function collectStalenessTests(specDir) {
 
 describe('Max Staleness (spec)', function () {
   let serverConnect;
+
   before(() => {
     serverConnect = sinon.stub(Server.prototype, 'connect').callsFake(function () {
       this.s.state = 'connected';

--- a/test/unit/assorted/polling_srv_records_for_mongos_discovery.prose.test.ts
+++ b/test/unit/assorted/polling_srv_records_for_mongos_discovery.prose.test.ts
@@ -59,6 +59,7 @@ describe('Polling Srv Records for Mongos Discovery', () => {
 
     if (test.skipReason) this.skip();
   });
+
   describe('SRV polling prose cases 1-5', () => {
     const SRV_HOST = 'darmok.tanagra.com';
     const context: Record<string, any> = {};

--- a/test/unit/assorted/server_discovery_and_monitoring.spec.test.ts
+++ b/test/unit/assorted/server_discovery_and_monitoring.spec.test.ts
@@ -185,6 +185,7 @@ function assertMonitoringOutcome(outcome: any): asserts outcome is MonitoringOut
 
 describe('Server Discovery and Monitoring (spec)', function () {
   let serverConnect: sinon.SinonStub;
+
   before(() => {
     serverConnect = sinon.stub(Server.prototype, 'connect').callsFake(function () {
       this.s.state = 'connected';

--- a/test/unit/assorted/sessions_client.test.js
+++ b/test/unit/assorted/sessions_client.test.js
@@ -10,6 +10,7 @@ const test = {};
 describe('Sessions - client/unit', function () {
   describe('Client', function () {
     afterEach(() => mock.cleanup());
+
     beforeEach(() => {
       return mock.createServer().then(server => {
         test.server = server;

--- a/test/unit/assorted/sessions_collection.test.js
+++ b/test/unit/assorted/sessions_collection.test.js
@@ -9,6 +9,7 @@ const test = {};
 describe('Sessions - unit/sessions', function () {
   describe('Collection', function () {
     afterEach(() => mock.cleanup());
+
     beforeEach(() => {
       return mock.createServer().then(server => {
         test.server = server;

--- a/test/unit/assorted/uri_options.spec.test.ts
+++ b/test/unit/assorted/uri_options.spec.test.ts
@@ -38,6 +38,7 @@ describe('URI option spec tests', function () {
         writeFileSync('ca.pem', 'ca.pem');
         writeFileSync('cert.pem', 'cert.pem');
       });
+
       after(() => {
         unlinkSync('ca.pem');
         unlinkSync('cert.pem');

--- a/test/unit/assorted/wire_version.test.js
+++ b/test/unit/assorted/wire_version.test.js
@@ -31,6 +31,7 @@ describe('Wire Protocol Version', () => {
   beforeEach(async () => {
     server = await mock.createServer();
   });
+
   afterEach(async () => {
     await client.close();
     await mock.cleanup();

--- a/test/unit/client-side-encryption/auto_encrypter.test.ts
+++ b/test/unit/client-side-encryption/auto_encrypter.test.ts
@@ -46,6 +46,7 @@ describe('AutoEncrypter', function () {
   this.timeout(12000);
   let ENABLE_LOG_TEST = false;
   const sandbox = sinon.createSandbox();
+
   beforeEach(() => {
     sandbox.restore();
     sandbox.stub(StateMachine.prototype, 'kmsRequest').callsFake(request => {

--- a/test/unit/cmap/connection.test.ts
+++ b/test/unit/cmap/connection.test.ts
@@ -23,7 +23,9 @@ const connectionOptionsDefaults = {
 
 describe('new Connection()', function () {
   let server;
+
   after(() => mock.cleanup());
+
   before(() => mock.createServer().then(s => (server = s)));
 
   it('supports fire-and-forget messages', async function () {

--- a/test/unit/cmap/connection_pool.test.js
+++ b/test/unit/cmap/connection_pool.test.js
@@ -29,7 +29,9 @@ describe('Connection Pool', function () {
       }
     }
   };
+
   after(() => mock.cleanup());
+
   before(() =>
     mock.createServer().then(s => {
       mockMongod = s;
@@ -133,6 +135,7 @@ describe('Connection Pool', function () {
 
   describe('minPoolSize population', function () {
     let clock, timerSandbox;
+
     beforeEach(() => {
       timerSandbox = createTimerSandbox();
       clock = sinon.useFakeTimers();

--- a/test/unit/collection.test.ts
+++ b/test/unit/collection.test.ts
@@ -5,9 +5,11 @@ import { cleanup, createServer, HELLO } from '../tools/mongodb-mock';
 
 describe('Collection', function () {
   let server = null;
+
   beforeEach(async () => {
     server = await createServer();
   });
+
   afterEach(async () => {
     await cleanup();
   });

--- a/test/unit/cursor/abstract_cursor.test.ts
+++ b/test/unit/cursor/abstract_cursor.test.ts
@@ -26,6 +26,7 @@ class ConcreteCursor extends AbstractCursor {
 
 describe('class AbstractCursor', () => {
   let client: MongoClient;
+
   beforeEach(async function () {
     client = new MongoClient('mongodb://iLoveJavascript');
   });

--- a/test/unit/cursor/run_command_cursor.test.ts
+++ b/test/unit/cursor/run_command_cursor.test.ts
@@ -4,6 +4,7 @@ import { MongoAPIError, MongoClient } from '../../mongodb';
 
 describe('class RunCommandCursor', () => {
   let client: MongoClient;
+
   beforeEach(async function () {
     client = new MongoClient('mongodb://iLoveJavascript');
   });

--- a/test/unit/error.test.ts
+++ b/test/unit/error.test.ts
@@ -335,7 +335,9 @@ describe('MongoErrors', () => {
     };
 
     before(() => (test = new ReplSetFixture()));
+
     afterEach(() => cleanup());
+
     beforeEach(() => test.setup());
 
     function makeAndConnectReplSet(cb) {
@@ -590,6 +592,7 @@ describe('MongoErrors', () => {
         expect(isResumableError(new MongoNetworkTimeoutError('ah!'), 8)).to.be.true;
         expect(isResumableError(new MongoNetworkTimeoutError('ah!'), 9)).to.be.true;
       });
+
       it('for labelless MongoError with CursorNotFound code regardless of wire version', () => {
         const mongoError = new MongoError('ah!');
         mongoError.code = MONGODB_ERROR_CODES.CursorNotFound;

--- a/test/unit/mongo_client.test.js
+++ b/test/unit/mongo_client.test.js
@@ -752,12 +752,14 @@ describe('MongoClient', function () {
         expect(db).to.have.property('databaseName', 'myDb');
         expect(client).to.have.nested.property('options.credentials.source', 'myDb');
       });
+
       it('should set the database name to the uri pathname and respect the authSource option', () => {
         const client = new MongoClient('mongodb://u:p@host/myDb?authSource=myAuthDb');
         const db = client.db();
         expect(db).to.have.property('databaseName', 'myDb');
         expect(client).to.have.nested.property('options.credentials.source', 'myAuthDb');
       });
+
       it('should set the database name to the uri pathname and respect the authSource option in options object', () => {
         const client = new MongoClient('mongodb://u:p@host/myDb', { authSource: 'myAuthDb' });
         const db = client.db();
@@ -773,6 +775,7 @@ describe('MongoClient', function () {
         expect(db).to.have.property('databaseName', 'myDb');
         expect(client).to.have.nested.property('options.credentials.source', 'myDb');
       });
+
       it('should set the database name to dbName and respect the authSource option', () => {
         const client = new MongoClient('mongodb://u:p@host?authSource=myAuthDb', {
           dbName: 'myDb'
@@ -781,6 +784,7 @@ describe('MongoClient', function () {
         expect(db).to.have.property('databaseName', 'myDb');
         expect(client).to.have.nested.property('options.credentials.source', 'myAuthDb');
       });
+
       it('should set the database name to dbName and respect the authSource option in options object', () => {
         const client = new MongoClient('mongodb://u:p@host', {
           dbName: 'myDb',
@@ -830,6 +834,7 @@ describe('MongoClient', function () {
 
   describe('logging client options', function () {
     const loggerFeatureFlag = Symbol.for('@@mdb.enableMongoLogger');
+
     describe('mongodbLogPath', function () {
       context('when mongodbLogPath is in options', function () {
         let stderrStub;
@@ -942,6 +947,7 @@ describe('MongoClient', function () {
         });
       });
     });
+
     describe('mongodbLogComponentSeverities', function () {
       const components = Object.values(MongoLoggableComponent);
       const env_component_names = [
@@ -1105,6 +1111,7 @@ describe('MongoClient', function () {
         });
       });
     });
+
     describe('mongodbLogMaxDocumentLength', function () {
       context('when mongodbLogMaxDocumentLength is in options', function () {
         context('when env option for MONGODB_LOG_MAX_DOCUMENT_LENGTH is not provided', function () {

--- a/test/unit/mongo_logger.test.ts
+++ b/test/unit/mongo_logger.test.ts
@@ -50,6 +50,7 @@ describe('meta tests for BufferingStream', function () {
     const stream = new BufferingStream();
     expect(stream.buffer).to.have.lengthOf(0);
   });
+
   it('pushes messages to the buffer when written to', function () {
     const stream = new BufferingStream();
     stream.write('message');
@@ -1251,6 +1252,7 @@ describe('class MongoLogger', function () {
   describe('stringifyWithMaxLen', function () {
     const largeDoc = {};
     const smallDoc = { test: 'Hello' };
+
     before(function () {
       for (let i = 0; i < DEFAULT_MAX_DOCUMENT_LENGTH; i++) {
         largeDoc[`test${i}`] = `Hello_${i}`;
@@ -1407,6 +1409,7 @@ describe('class MongoLogger', function () {
         });
       });
     });
+
     describe('async stream failure handling', function () {
       context('when stream is not stderr', function () {
         let stderrStub;

--- a/test/unit/operations/get_more.test.ts
+++ b/test/unit/operations/get_more.test.ts
@@ -22,6 +22,7 @@ describe('GetMoreOperation', function () {
     maxAwaitTimeMS: 500,
     readPreference: ReadPreference.primary
   };
+
   afterEach(function () {
     sinon.restore();
   });

--- a/test/unit/read_preference.test.ts
+++ b/test/unit/read_preference.test.ts
@@ -6,6 +6,7 @@ describe('class ReadPreference', function () {
   const maxStalenessSeconds = 1234;
   const { PRIMARY, PRIMARY_PREFERRED, SECONDARY, SECONDARY_PREFERRED, NEAREST } = ReadPreference;
   const TAGS = [{ loc: 'dc' }];
+
   describe('::constructor', function () {
     it('should accept (mode)', function () {
       expect(new ReadPreference(PRIMARY)).to.be.an.instanceOf(ReadPreference);

--- a/test/unit/sdam/monitor.test.ts
+++ b/test/unit/sdam/monitor.test.ts
@@ -66,6 +66,7 @@ describe('monitoring', function () {
   });
 
   after(() => mock.cleanup());
+
   beforeEach(function () {
     return mock.createServer().then(server => (mockServer = server));
   });

--- a/test/unit/sdam/server.test.ts
+++ b/test/unit/sdam/server.test.ts
@@ -57,6 +57,7 @@ const unhandledErrors = [
 describe('Server', () => {
   describe('#handleError', () => {
     let server: Server, connection: Connection | undefined;
+
     beforeEach(() => {
       server = new Server(
         topologyWithPlaceholderClient([], {}),

--- a/test/unit/sdam/topology.test.ts
+++ b/test/unit/sdam/topology.test.ts
@@ -41,9 +41,11 @@ describe('Topology (unit)', function () {
 
   describe('client metadata', function () {
     let mockServer;
+
     before(async () => {
       mockServer = await mock.createServer();
     });
+
     after(() => mock.cleanup());
 
     it('should correctly pass appname', function () {
@@ -86,7 +88,9 @@ describe('Topology (unit)', function () {
 
   describe('black holes', function () {
     let mockServer;
+
     beforeEach(async () => (mockServer = await mock.createServer()));
+
     afterEach(() => mock.cleanup());
 
     it('should time out operations against servers that have been blackholed', function (done) {
@@ -122,10 +126,12 @@ describe('Topology (unit)', function () {
   describe('error handling', function () {
     let mockServer;
     let secondMockServer;
+
     beforeEach(async () => {
       mockServer = await mock.createServer();
       secondMockServer = await mock.createServer();
     });
+
     afterEach(async () => {
       await mock.cleanup();
       sinon.restore();
@@ -463,6 +469,7 @@ describe('Topology (unit)', function () {
     describe('waitQueue', function () {
       let selectServer;
       let topology;
+
       afterEach(() => {
         selectServer.restore();
         topology.close();

--- a/test/unit/sessions.test.js
+++ b/test/unit/sessions.test.js
@@ -21,6 +21,7 @@ describe('Sessions - unit', function () {
   let client;
   let serverSessionPool;
   let session;
+
   beforeEach(async function () {
     client = new MongoClient('mongodb://iLoveJavascript');
     serverSessionPool = client.s.sessionPool;
@@ -275,6 +276,7 @@ describe('Sessions - unit', function () {
 
     describe('get serverSession()', () => {
       let serverSessionSymbol;
+
       before(() => {
         serverSessionSymbol = getSymbolFrom(
           new ClientSession({}, serverSessionPool, {}),
@@ -436,6 +438,7 @@ describe('Sessions - unit', function () {
   describe('class ServerSessionPool', function () {
     let client;
     let server;
+
     beforeEach(async () => {
       server = await mock.createServer();
       server.setMessageHandler(request => {

--- a/test/unit/tools/mongodb-legacy.test.ts
+++ b/test/unit/tools/mongodb-legacy.test.ts
@@ -41,6 +41,7 @@ describe('mongodb-legacy', () => {
       expect(ctor.prototype).to.have.property(Symbol.for('@@mdb.callbacks.toLegacy'));
     });
   }
+
   it('test suite imports a LegacyMongoClient as MongoClient', () => {
     // Just confirming that the mongodb-legacy import is correctly overriding the local copy
     // of MongoClient from "src". See test/mongodb.ts for more.

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -495,6 +495,7 @@ describe('driver utils', function () {
         expect(list.shift()).to.be.null;
       });
     });
+
     describe('pop()', () => {
       let list: List<number>;
 
@@ -644,6 +645,7 @@ describe('driver utils', function () {
       expect(output).to.not.deep.equal(input);
       expect(output).to.have.lengthOf(input.length);
     });
+
     it('should give a random shuffling of the entire input when limit is explicitly set to 0', () => {
       const input = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'];
       const output = shuffle(input, 0);
@@ -769,6 +771,7 @@ describe('driver utils', function () {
       });
 
       const socketPath = '/tmp/mongodb-27017.sock';
+
       it('should handle decoded unix socket path', () => {
         const ha = new HostAddress(socketPath);
         expect(ha).to.have.property('socketPath', socketPath);


### PR DESCRIPTION
### Description

#### What is changing?

This PR enables a lint rule that enforces consistent spacing between blocks in mocha test files.  

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
