### PR TITLE
test(NODE-5898): small fixes and unskips of test TODOs

### DIFF
--- a/test/integration/client-side-encryption/client_side_encryption.prose.test.js
+++ b/test/integration/client-side-encryption/client_side_encryption.prose.test.js
@@ -1174,7 +1174,6 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
 
         expect(insertError).to.be.instanceOf(MongoServerSelectionError);
 
-        // TODO(NODE-5296): check error.message once AggregateErrors are handled correctly
         expect(insertError, 'Error must contain ECONNREFUSED').to.satisfy(
           error =>
             /ECONNREFUSED/.test(error.message) ||
@@ -1260,7 +1259,6 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
         client = new MongoClient('mongodb://localhost:27021/db?serverSelectionTimeoutMS=1000');
         const error = await client.connect().catch(e => e);
 
-        // TODO(NODE-5296): check error.message once AggregateErrors are handled correctly
         expect(error, 'Error MUST be a MongoServerSelectionError error').to.be.instanceOf(
           MongoServerSelectionError
         );

--- a/test/integration/client-side-encryption/client_side_encryption.spec.test.ts
+++ b/test/integration/client-side-encryption/client_side_encryption.spec.test.ts
@@ -47,9 +47,8 @@ const skippedAuthTests = [
   'Insert a document with auto encryption using KMIP KMS provider'
 ];
 
-// TODO(NODE-4006): Investigate csfle test "operation fails with maxWireVersion < 8"
-// TODO(NODE-4324): Int32 and Long not allowed as batchSize option to cursor.
-const skippedNoAuthTests = ['getMore with encryption', 'operation fails with maxWireVersion < 8'];
+// TODO(NODE-6048): Int32 and Long not allowed as batchSize option to cursor.
+const skippedNoAuthTests = ['getMore with encryption'];
 
 const SKIPPED_TESTS = new Set([
   ...(isAuthEnabled ? skippedAuthTests.concat(skippedNoAuthTests) : skippedNoAuthTests),

--- a/test/integration/command-logging-and-monitoring/command_logging_and_monitoring.spec.test.ts
+++ b/test/integration/command-logging-and-monitoring/command_logging_and_monitoring.spec.test.ts
@@ -5,22 +5,7 @@ import { runUnifiedSuite } from '../../tools/unified-spec-runner/runner';
 
 describe('Command Logging and Monitoring Spec', function () {
   describe('Command Monitoring Spec (unified)', () => {
-    runUnifiedSuite(
-      loadSpecTests(path.join('command-logging-and-monitoring', 'monitoring')),
-      ({ description }) => {
-        // This is skipped because our command monitoring happens at the connection
-        // level and is using the server reply for the single insert that the bulk
-        // performed since it was only one document in the test. The test expectation
-        // is that we are using the bulk write result which was returned to the user
-        // as the reply in the command succeeded event instead of our raw reply from
-        // the server. There's nothing we can change here.
-        return description.includes(
-          'A successful unordered bulk write with an unacknowledged write concern'
-        )
-          ? `Test not applicable to Node.`
-          : false;
-      }
-    );
+    runUnifiedSuite(loadSpecTests(path.join('command-logging-and-monitoring', 'monitoring')));
   });
 
   describe('Command Logging Spec', () => {

--- a/test/integration/command-logging-and-monitoring/command_logging_and_monitoring.spec.test.ts
+++ b/test/integration/command-logging-and-monitoring/command_logging_and_monitoring.spec.test.ts
@@ -3,22 +3,23 @@ import * as path from 'path';
 import { loadSpecTests } from '../../spec';
 import { runUnifiedSuite } from '../../tools/unified-spec-runner/runner';
 
-// This is skipped because our command monitoring happens at the connection
-// level and is using the server reply for the single insert that the bulk
-// performed since it was only one document in the test. The test expectation
-// is that we are using the bulk write result which was returned to the user
-// as the reply in the command succeeded event instead of our raw reply from
-// the server. There's nothing we can change here.
-const SKIP = ['A successful unordered bulk write with an unacknowledged write concern'];
-
 describe('Command Logging and Monitoring Spec', function () {
   describe('Command Monitoring Spec (unified)', () => {
     runUnifiedSuite(
       loadSpecTests(path.join('command-logging-and-monitoring', 'monitoring')),
-      ({ description }) =>
-        SKIP.includes(description)
-          ? `TODO(NODE-4261): support skip reasons in unified tests`
-          : false
+      ({ description }) => {
+        // This is skipped because our command monitoring happens at the connection
+        // level and is using the server reply for the single insert that the bulk
+        // performed since it was only one document in the test. The test expectation
+        // is that we are using the bulk write result which was returned to the user
+        // as the reply in the command succeeded event instead of our raw reply from
+        // the server. There's nothing we can change here.
+        return description.includes(
+          'A successful unordered bulk write with an unacknowledged write concern'
+        )
+          ? `Test not applicable to Node.`
+          : false;
+      }
     );
   });
 

--- a/test/integration/command-logging-and-monitoring/command_logging_and_monitoring.spec.test.ts
+++ b/test/integration/command-logging-and-monitoring/command_logging_and_monitoring.spec.test.ts
@@ -5,7 +5,22 @@ import { runUnifiedSuite } from '../../tools/unified-spec-runner/runner';
 
 describe('Command Logging and Monitoring Spec', function () {
   describe('Command Monitoring Spec (unified)', () => {
-    runUnifiedSuite(loadSpecTests(path.join('command-logging-and-monitoring', 'monitoring')));
+    runUnifiedSuite(
+      loadSpecTests(path.join('command-logging-and-monitoring', 'monitoring')),
+      ({ description }) => {
+        // This is skipped because our command monitoring happens at the connection
+        // level and is using the server reply for the single insert that the bulk
+        // performed since it was only one document in the test. The test expectation
+        // is that we are using the bulk write result which was returned to the user
+        // as the reply in the command succeeded event instead of our raw reply from
+        // the server. There's nothing we can change here.
+        return description.includes(
+          'A successful unordered bulk write with an unacknowledged write concern'
+        )
+          ? `Test not applicable to Node.`
+          : false;
+      }
+    );
   });
 
   describe('Command Logging Spec', () => {

--- a/test/integration/command-logging-and-monitoring/command_monitoring.test.ts
+++ b/test/integration/command-logging-and-monitoring/command_monitoring.test.ts
@@ -98,8 +98,7 @@ describe('Command Monitoring', function () {
     }
   });
 
-  // NODE-3308
-  it.skip('should correctly receive the APM events for a listIndexes command', {
+  it('should correctly receive the APM events for a listIndexes command', {
     metadata: { requires: { topology: ['replicaset'], mongodb: '>=3.0.0' } },
 
     test: function () {

--- a/test/integration/crud/aggregation.test.ts
+++ b/test/integration/crud/aggregation.test.ts
@@ -332,7 +332,7 @@ describe('Aggregation', function () {
         });
       });
     }
-  ).skipReason = 'TODO(NODE-5617): aggregate explain tests failing on latest servers';
+  );
 
   it('should correctly return a cursor with batchSize 1 and call next', function (done) {
     const client = this.configuration.newClient({ w: 1 }, { maxPoolSize: 1 }),

--- a/test/integration/crud/explain.test.ts
+++ b/test/integration/crud/explain.test.ts
@@ -76,17 +76,6 @@ describe('CRUD API explain option', function () {
     collection = db.collection('test');
     await collection.insertOne({ a: 1 });
     commandStartedPromise = once(client, 'commandStarted');
-
-    const test = this.currentTest;
-    if (
-      test?.fullTitle().includes('aggregate') &&
-      gte(this.configuration.version, '7.1.0') &&
-      this.currentTest
-    ) {
-      this.currentTest.skipReason =
-        'TODO(NODE-5617): aggregate explain tests failing on latest servers';
-      this.skip();
-    }
   });
 
   afterEach(async function () {

--- a/test/integration/crud/explain.test.ts
+++ b/test/integration/crud/explain.test.ts
@@ -1,6 +1,5 @@
 import { expect } from 'chai';
 import { once } from 'events';
-import { gte } from 'semver';
 
 import {
   type Collection,

--- a/test/integration/load-balancers/load_balancers.spec.test.ts
+++ b/test/integration/load-balancers/load_balancers.spec.test.ts
@@ -8,7 +8,6 @@ const filter = ({ description }) => {
     // Verified they use the same connection but the Node implementation executes
     // a getMore before the killCursors even though the stream is immediately
     // closed.
-    // TODO(NODE-3970): implement and reference a node specific integration test for this
     return 'TODO(NODE-3970): implement and reference a node specific integration test for this';
   }
 

--- a/test/integration/node-specific/client_encryption.test.ts
+++ b/test/integration/node-specific/client_encryption.test.ts
@@ -264,63 +264,6 @@ describe('ClientEncryption integration tests', function () {
       expect(rewrapManyDataKeyResult.bulkWriteResult).to.equal(undefined);
     });
 
-    it.skip(
-      'should explicitly encrypt and decrypt with a re-wrapped local key (explicit session/transaction)',
-      metadata,
-      function () {
-        const encryption = new ClientEncryption(client, {
-          keyVaultNamespace: 'client.encryption',
-          kmsProviders: { local: { key: 'A'.repeat(128) } }
-        });
-        let encrypted;
-        let rewrapManyDataKeyResult;
-
-        return encryption
-          .createDataKey('local')
-          .then(dataKey => {
-            const encryptOptions = {
-              keyId: dataKey,
-              algorithm: 'Indexed',
-              contentionFactor: 0
-            };
-
-            return encryption.encrypt('hello', encryptOptions);
-          })
-          .then(_encrypted => {
-            encrypted = _encrypted;
-          })
-          .then(() => {
-            // withSession does not forward the callback's return value, hence
-            // the slightly awkward 'rewrapManyDataKeyResult' passing here
-            return client.withSession(session => {
-              return session.withTransaction(() => {
-                expect(session.transaction.isStarting).to.equal(true);
-                expect(session.transaction.isActive).to.equal(true);
-                rewrapManyDataKeyResult = encryption.rewrapManyDataKey(
-                  {},
-                  { provider: 'local', session }
-                );
-                return rewrapManyDataKeyResult.then(() => {
-                  // Verify that the 'session' argument was actually used
-                  expect(session.transaction.isStarting).to.equal(false);
-                  expect(session.transaction.isActive).to.equal(true);
-                });
-              });
-            });
-          })
-          .then(() => {
-            return rewrapManyDataKeyResult;
-          })
-          .then(rewrapManyDataKeyResult => {
-            expect(rewrapManyDataKeyResult.bulkWriteResult.result.nModified).to.equal(1);
-            return encryption.decrypt(encrypted);
-          })
-          .then(decrypted => {
-            expect(decrypted).to.equal('hello');
-          });
-      }
-    ).skipReason = 'TODO(DRIVERS-2389): add explicit session support to key management API';
-
     // TODO(NODE-3371): resolve KMS JSON response does not include string 'Plaintext'. HTTP status=200 error
     it.skip(
       'should explicitly encrypt and decrypt with the "aws" KMS provider',

--- a/test/integration/node-specific/crypto_callbacks.test.ts
+++ b/test/integration/node-specific/crypto_callbacks.test.ts
@@ -54,14 +54,11 @@ describe('cryptoCallbacks', function () {
     await client?.close();
   });
 
-  // TODO(NODE-3370): fix key formatting error "asn1_check_tlen:wrong tag"
-  it.skip('should support support crypto callback for signing RSA-SHA256', function () {
+  it('should support support crypto callback for signing RSA-SHA256', function () {
     const input = Buffer.from('data to sign');
     const pemFileData =
-      '-----BEGIN PRIVATE KEY-----\n' +
-      'MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQC4JOyv5z05cL18ztpknRC7CFY2gYol4DAKerdVUoDJxCTmFMf39dVUEqD0WDiw/qcRtSO1/FRut08PlSPmvbyKetsLoxlpS8lukSzEFpFK7+L+R4miFOl6HvECyg7lbC1H/WGAhIz9yZRlXhRo9qmO/fB6PV9IeYtU+1xYuXicjCDPp36uuxBAnCz7JfvxJ3mdVc0vpSkbSb141nWuKNYR1mgyvvL6KzxO6mYsCo4hRAdhuizD9C4jDHk0V2gDCFBk0h8SLEdzStX8L0jG90/Og4y7J1b/cPo/kbYokkYisxe8cPlsvGBf+rZex7XPxc1yWaP080qeABJb+S88O//LAgMBAAECggEBAKVxP1m3FzHBUe2NZ3fYCc0Qa2zjK7xl1KPFp2u4CU+9sy0oZJUqQHUdm5CMprqWwIHPTftWboFenmCwrSXFOFzujljBO7Z3yc1WD3NJl1ZNepLcsRJ3WWFH5V+NLJ8Bdxlj1DMEZCwr7PC5+vpnCuYWzvT0qOPTl9RNVaW9VVjHouJ9Fg+s2DrShXDegFabl1iZEDdI4xScHoYBob06A5lw0WOCTayzw0Naf37lM8Y4psRAmI46XLiF/Vbuorna4hcChxDePlNLEfMipICcuxTcei1RBSlBa2t1tcnvoTy6cuYDqqImRYjp1KnMKlKQBnQ1NjS2TsRGm+F0FbreVCECgYEA4IDJlm8q/hVyNcPe4OzIcL1rsdYN3bNm2Y2O/YtRPIkQ446ItyxD06d9VuXsQpFp9jNACAPfCMSyHpPApqlxdc8z/xATlgHkcGezEOd1r4E7NdTpGg8y6Rj9b8kVlED6v4grbRhKcU6moyKUQT3+1B6ENZTOKyxuyDEgTwZHtFECgYEA0fqdv9h9s77d6eWmIioP7FSymq93pC4umxf6TVicpjpMErdD2ZfJGulN37dq8FOsOFnSmFYJdICj/PbJm6p1i8O21lsFCltEqVoVabJ7/0alPfdG2U76OeBqI8ZubL4BMnWXAB/VVEYbyWCNpQSDTjHQYs54qa2I0dJB7OgJt1sCgYEArctFQ02/7H5Rscl1yo3DBXO94SeiCFSPdC8f2Kt3MfOxvVdkAtkjkMACSbkoUsgbTVqTYSEOEc2jTgR3iQ13JgpHaFbbsq64V0QP3TAxbLIQUjYGVgQaF1UfLOBv8hrzgj45z/ST/G80lOl595+0nCUbmBcgG1AEWrmdF0/3RmECgYAKvIzKXXB3+19vcT2ga5Qq2l3TiPtOGsppRb2XrNs9qKdxIYvHmXo/9QP1V3SRW0XoD7ez8FpFabp42cmPOxUNk3FK3paQZABLxH5pzCWI9PzIAVfPDrm+sdnbgG7vAnwfL2IMMJSA3aDYGCbF9EgefG+STcpfqq7fQ6f5TBgLFwKBgCd7gn1xYL696SaKVSm7VngpXlczHVEpz3kStWR5gfzriPBxXgMVcWmcbajRser7ARpCEfbxM1UJyv6oAYZWVSNErNzNVb4POqLYcCNySuC6xKhs9FrEQnyKjyk8wI4VnrEMGrQ8e+qYSwYk9Gh6dKGoRMAPYVXQAO0fIsHF/T0a\n' +
-      '-----END PRIVATE KEY-----';
-    const key = Buffer.from(pemFileData);
+      'MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQC4JOyv5z05cL18ztpknRC7CFY2gYol4DAKerdVUoDJxCTmFMf39dVUEqD0WDiw/qcRtSO1/FRut08PlSPmvbyKetsLoxlpS8lukSzEFpFK7+L+R4miFOl6HvECyg7lbC1H/WGAhIz9yZRlXhRo9qmO/fB6PV9IeYtU+1xYuXicjCDPp36uuxBAnCz7JfvxJ3mdVc0vpSkbSb141nWuKNYR1mgyvvL6KzxO6mYsCo4hRAdhuizD9C4jDHk0V2gDCFBk0h8SLEdzStX8L0jG90/Og4y7J1b/cPo/kbYokkYisxe8cPlsvGBf+rZex7XPxc1yWaP080qeABJb+S88O//LAgMBAAECggEBAKVxP1m3FzHBUe2NZ3fYCc0Qa2zjK7xl1KPFp2u4CU+9sy0oZJUqQHUdm5CMprqWwIHPTftWboFenmCwrSXFOFzujljBO7Z3yc1WD3NJl1ZNepLcsRJ3WWFH5V+NLJ8Bdxlj1DMEZCwr7PC5+vpnCuYWzvT0qOPTl9RNVaW9VVjHouJ9Fg+s2DrShXDegFabl1iZEDdI4xScHoYBob06A5lw0WOCTayzw0Naf37lM8Y4psRAmI46XLiF/Vbuorna4hcChxDePlNLEfMipICcuxTcei1RBSlBa2t1tcnvoTy6cuYDqqImRYjp1KnMKlKQBnQ1NjS2TsRGm+F0FbreVCECgYEA4IDJlm8q/hVyNcPe4OzIcL1rsdYN3bNm2Y2O/YtRPIkQ446ItyxD06d9VuXsQpFp9jNACAPfCMSyHpPApqlxdc8z/xATlgHkcGezEOd1r4E7NdTpGg8y6Rj9b8kVlED6v4grbRhKcU6moyKUQT3+1B6ENZTOKyxuyDEgTwZHtFECgYEA0fqdv9h9s77d6eWmIioP7FSymq93pC4umxf6TVicpjpMErdD2ZfJGulN37dq8FOsOFnSmFYJdICj/PbJm6p1i8O21lsFCltEqVoVabJ7/0alPfdG2U76OeBqI8ZubL4BMnWXAB/VVEYbyWCNpQSDTjHQYs54qa2I0dJB7OgJt1sCgYEArctFQ02/7H5Rscl1yo3DBXO94SeiCFSPdC8f2Kt3MfOxvVdkAtkjkMACSbkoUsgbTVqTYSEOEc2jTgR3iQ13JgpHaFbbsq64V0QP3TAxbLIQUjYGVgQaF1UfLOBv8hrzgj45z/ST/G80lOl595+0nCUbmBcgG1AEWrmdF0/3RmECgYAKvIzKXXB3+19vcT2ga5Qq2l3TiPtOGsppRb2XrNs9qKdxIYvHmXo/9QP1V3SRW0XoD7ez8FpFabp42cmPOxUNk3FK3paQZABLxH5pzCWI9PzIAVfPDrm+sdnbgG7vAnwfL2IMMJSA3aDYGCbF9EgefG+STcpfqq7fQ6f5TBgLFwKBgCd7gn1xYL696SaKVSm7VngpXlczHVEpz3kStWR5gfzriPBxXgMVcWmcbajRser7ARpCEfbxM1UJyv6oAYZWVSNErNzNVb4POqLYcCNySuC6xKhs9FrEQnyKjyk8wI4VnrEMGrQ8e+qYSwYk9Gh6dKGoRMAPYVXQAO0fIsHF/T0a\n';
+    const key = Buffer.from(pemFileData, 'base64');
     const output = Buffer.alloc(256);
     const expectedOutput = Buffer.from(
       'VocBRhpMmQ2XCzVehWSqheQLnU889gf3dhU4AnVnQTJjsKx/CM23qKDPkZDd2A/BnQsp99SN7ksIX5Raj0TPwyN5OCN/YrNFNGoOFlTsGhgP/hyE8X3Duiq6sNO0SMvRYNPFFGlJFsp1Fw3Z94eYMg4/Wpw5s4+Jo5Zm/qY7aTJIqDKDQ3CNHLeJgcMUOc9sz01/GzoUYKDVODHSxrYEk5ireFJFz9vP8P7Ha+VDUZuQIQdXer9NBbGFtYmWprY3nn4D3Dw93Sn0V0dIqYeIo91oKyslvMebmUM95S2PyIJdEpPb2DJDxjvX/0LLwSWlSXRWy9gapWoBkb4ynqZBsg==',
@@ -75,7 +72,7 @@ describe('cryptoCallbacks', function () {
     }
 
     expect(output).to.deep.equal(expectedOutput);
-  }).skipReason = 'TODO(NODE-3370): fix key formatting error "asn1_check_tlen:wrong tag"';
+  });
 
   it('should invoke crypto callbacks when doing encryption', async function () {
     function assertCertainHooksCalled(expectedSet?) {

--- a/test/integration/unified-test-format/unified_test_format.spec.test.ts
+++ b/test/integration/unified-test-format/unified_test_format.spec.test.ts
@@ -3,12 +3,6 @@ import { runUnifiedSuite } from '../../tools/unified-spec-runner/runner';
 import { type TestFilter } from '../../tools/unified-spec-runner/schema';
 
 const filter: TestFilter = ({ description }) => {
-  if (description === 'unpin after transient error within a transaction and commit') {
-    // OLD COMMENT: commitTransaction retry seems to be swallowed by mongos in this case
-    // TODO(NODE-3943):
-    return `TODO(NODE-3943): commitTransaction retry seems to be swallowed by mongos in this case`;
-  }
-
   if (description === 'Client side error in command starting transaction') {
     // TODO(NODE-2034): Will be implemented as part of NODE-2034
     return 'TODO(NODE-2034): Specify effect of client-side errors on in-progress transactions';
@@ -17,10 +11,6 @@ const filter: TestFilter = ({ description }) => {
   if (description === 'Dirty explicit session is discarded') {
     // TODO(NODE-3951): investigate why this is failing while the legacy version is passing
     return 'TODO(NODE-3951): investigate why this is failing while the legacy version is passing';
-  }
-
-  if (description === 'A successful find event with a getmore and the server kills the cursor') {
-    return 'TODO(NODE-3308): failures due unnecessary getMore and killCursors calls in 5.0';
   }
 
   if (

--- a/test/integration/unified-test-format/unified_test_format.spec.test.ts
+++ b/test/integration/unified-test-format/unified_test_format.spec.test.ts
@@ -34,7 +34,7 @@ const filter: TestFilter = ({ description }) => {
       'remain pinned after non-transient Interrupted error on insertOne'
     ].includes(description)
   ) {
-    return 'TODO(DRIVERS-2816): fix migration conflict in transaction tests';
+    return 'TODO(NODE-5962): fix migration conflict in transaction tests';
   }
 
   if (

--- a/test/tools/unified-spec-runner/runner.ts
+++ b/test/tools/unified-spec-runner/runner.ts
@@ -178,7 +178,6 @@ async function runUnifiedTest(
     if (topologyType === TopologyType.Sharded || topologyType === TopologyType.LoadBalanced) {
       for (const [, collection] of entities.mapOf('collection')) {
         try {
-          // TODO(NODE-4238): create / cleanup entities for each test suite
           await utilClient.db(ns(collection.namespace).db).command({
             distinct: collection.collectionName,
             key: '_id'

--- a/test/types/client-side-encryption.test-d.ts
+++ b/test/types/client-side-encryption.test-d.ts
@@ -1,65 +1,85 @@
-// TODO(NODE-5422): add TS support for FLE in the driver and unskip type tests
+import { expectAssignable, expectError, expectType } from 'tsd';
 
-// import { expectAssignable, expectError, expectType, expectNotType, expectNotAssignable } from 'tsd';
-// import { RangeOptions, AWSEncryptionKeyOptions, AzureEncryptionKeyOptions, ClientEncryption, GCPEncryptionKeyOptions, ClientEncryptionEncryptOptions, KMSProviders } from '../..';
+import type {
+  AWSEncryptionKeyOptions,
+  AzureEncryptionKeyOptions,
+  ClientEncryption,
+  ClientEncryptionEncryptOptions,
+  GCPEncryptionKeyOptions,
+  KMSProviders,
+  RangeOptions
+} from '../..';
 
-// type RequiredCreateEncryptedCollectionSettings = Parameters<
-//   ClientEncryption['createEncryptedCollection']
-// >[2];
+type RequiredCreateEncryptedCollectionSettings = Parameters<
+  ClientEncryption['createEncryptedCollection']
+>[2];
 
-// expectError<RequiredCreateEncryptedCollectionSettings>({});
-// expectError<RequiredCreateEncryptedCollectionSettings>({
-//   provider: 'blah!',
-//   createCollectionOptions: { encryptedFields: {} }
-// });
-// expectError<RequiredCreateEncryptedCollectionSettings>({
-//   provider: 'aws',
-//   createCollectionOptions: {}
-// });
-// expectError<RequiredCreateEncryptedCollectionSettings>({
-//   provider: 'aws',
-//   createCollectionOptions: { encryptedFields: null }
-// });
+expectError<RequiredCreateEncryptedCollectionSettings>({});
+expectError<RequiredCreateEncryptedCollectionSettings>({
+  provider: 'blah!',
+  createCollectionOptions: { encryptedFields: {} }
+});
+expectError<RequiredCreateEncryptedCollectionSettings>({
+  provider: 'aws',
+  createCollectionOptions: {}
+});
+expectError<RequiredCreateEncryptedCollectionSettings>({
+  provider: 'aws',
+  createCollectionOptions: { encryptedFields: null }
+});
 
-// expectAssignable<RequiredCreateEncryptedCollectionSettings>({
-//   provider: 'aws',
-//   createCollectionOptions: { encryptedFields: {} }
-// });
-// expectAssignable<RequiredCreateEncryptedCollectionSettings>({
-//   provider: 'aws',
-//   createCollectionOptions: { encryptedFields: {} },
-//   masterKey: { } as AWSEncryptionKeyOptions | AzureEncryptionKeyOptions | GCPEncryptionKeyOptions
-// });
+expectAssignable<RequiredCreateEncryptedCollectionSettings>({
+  provider: 'aws',
+  createCollectionOptions: { encryptedFields: {} }
+});
+expectAssignable<RequiredCreateEncryptedCollectionSettings>({
+  provider: 'aws',
+  createCollectionOptions: { encryptedFields: {} },
+  masterKey: {} as AWSEncryptionKeyOptions | AzureEncryptionKeyOptions | GCPEncryptionKeyOptions
+});
 
-// {
-//   // NODE-5041 - incorrect spelling of rangeOpts in typescript definitions
-//   const options = {} as ClientEncryptionEncryptOptions;
-//   expectType<RangeOptions | undefined>(options.rangeOptions)
-// }
+{
+  // NODE-5041 - incorrect spelling of rangeOpts in typescript definitions
+  const options = {} as ClientEncryptionEncryptOptions;
+  expectType<RangeOptions | undefined>(options.rangeOptions);
+}
 
-// {
-//   // KMSProviders
-//   // aws
-//   expectAssignable<KMSProviders['aws']>({ accessKeyId: '', secretAccessKey: '' });
-//   expectAssignable<KMSProviders['aws']>({ accessKeyId: '', secretAccessKey: '', sessionToken: undefined });
-//   expectAssignable<KMSProviders['aws']>({ accessKeyId: '', secretAccessKey: '', sessionToken: '' });
-//   // automatic
-//   expectAssignable<KMSProviders['aws']>({});
+{
+  // KMSProviders
+  // aws
+  expectAssignable<KMSProviders['aws']>({ accessKeyId: '', secretAccessKey: '' });
+  expectAssignable<KMSProviders['aws']>({
+    accessKeyId: '',
+    secretAccessKey: '',
+    sessionToken: undefined
+  });
+  expectAssignable<KMSProviders['aws']>({ accessKeyId: '', secretAccessKey: '', sessionToken: '' });
+  // automatic
+  expectAssignable<KMSProviders['aws']>({});
 
-//   // azure
-//   expectAssignable<KMSProviders['azure']>({ tenantId: 'a', clientId: 'a', clientSecret: 'a' });
-//   expectAssignable<KMSProviders['azure']>({ tenantId: 'a', clientId: 'a', clientSecret: 'a' });
-//   expectAssignable<KMSProviders['azure']>({ tenantId: 'a', clientId: 'a', clientSecret: 'a', identityPlatformEndpoint: undefined });
-//   expectAssignable<KMSProviders['azure']>({ tenantId: 'a', clientId: 'a', clientSecret: 'a', identityPlatformEndpoint: '' });
-//   expectAssignable<KMSProviders['azure']>({ accessToken: 'a' });
-//   expectAssignable<KMSProviders['azure']>({});
+  // azure
+  expectAssignable<KMSProviders['azure']>({ tenantId: 'a', clientId: 'a', clientSecret: 'a' });
+  expectAssignable<KMSProviders['azure']>({ tenantId: 'a', clientId: 'a', clientSecret: 'a' });
+  expectAssignable<KMSProviders['azure']>({
+    tenantId: 'a',
+    clientId: 'a',
+    clientSecret: 'a',
+    identityPlatformEndpoint: undefined
+  });
+  expectAssignable<KMSProviders['azure']>({
+    tenantId: 'a',
+    clientId: 'a',
+    clientSecret: 'a',
+    identityPlatformEndpoint: ''
+  });
+  expectAssignable<KMSProviders['azure']>({ accessToken: 'a' });
+  expectAssignable<KMSProviders['azure']>({});
 
-//   // gcp
-//   expectAssignable<KMSProviders['gcp']>({ email: 'a', privateKey: 'a' });
-//   expectAssignable<KMSProviders['gcp']>({ email: 'a', privateKey: 'a', endpoint: undefined });
-//   expectAssignable<KMSProviders['gcp']>({ email: 'a', privateKey: 'a', endpoint: 'a' });
-//   expectAssignable<KMSProviders['gcp']>({ accessToken: 'a' });
-//   // automatic
-//   expectAssignable<KMSProviders['gcp']>({});
-
-// }
+  // gcp
+  expectAssignable<KMSProviders['gcp']>({ email: 'a', privateKey: 'a' });
+  expectAssignable<KMSProviders['gcp']>({ email: 'a', privateKey: 'a', endpoint: undefined });
+  expectAssignable<KMSProviders['gcp']>({ email: 'a', privateKey: 'a', endpoint: 'a' });
+  expectAssignable<KMSProviders['gcp']>({ accessToken: 'a' });
+  // automatic
+  expectAssignable<KMSProviders['gcp']>({});
+}

--- a/test/unit/connection_string.test.ts
+++ b/test/unit/connection_string.test.ts
@@ -143,7 +143,6 @@ describe('Connection String', function () {
       });
     });
 
-    // TODO(NODE-4172): align uri behavior with object options behavior
     context('when set in the uri', () => {
       it('should parse a string value', () => {
         const options = parseOptions('mongodb://localhost?ca=hello', {});


### PR DESCRIPTION
### Description

#### What is changing?

While auditing the existing skipped tests, I found a couple of quick fixes.  This PR unskips some tests that not longer fail, removes some unnecessary skip reason assignment, and removes some unnecessary TODO comments.

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?



### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
