### PR TITLE
fix(NODE-6051): only provide expected allowed keys to libmongocrypt after fetching aws kms credentials

### DIFF
--- a/src/client-side-encryption/providers/aws.ts
+++ b/src/client-side-encryption/providers/aws.ts
@@ -1,6 +1,5 @@
-import { getAwsCredentialProvider } from '../../deps';
-import { type KMSProviders } from '.';
 import { AWSSDKCredentialProvider } from '../../cmap/auth/aws_temporary_credentials';
+import { type KMSProviders } from '.';
 
 /**
  * @internal

--- a/src/client-side-encryption/providers/aws.ts
+++ b/src/client-side-encryption/providers/aws.ts
@@ -1,20 +1,28 @@
 import { getAwsCredentialProvider } from '../../deps';
 import { type KMSProviders } from '.';
+import { AWSSDKCredentialProvider } from '../../cmap/auth/aws_temporary_credentials';
 
 /**
  * @internal
  */
 export async function loadAWSCredentials(kmsProviders: KMSProviders): Promise<KMSProviders> {
-  const credentialProvider = getAwsCredentialProvider();
+  const credentialProvider = new AWSSDKCredentialProvider();
 
-  if ('kModuleError' in credentialProvider) {
-    return kmsProviders;
-  }
+  // We shouldn't ever receive a response from the AWS SDK that doesn't have a `SecretAccessKey`
+  // or `AccessKeyId`.  However, TS says these fields are optional.  We provide empty strings
+  // and let libmongocrypt error if we're unable to fetch the required keys.
+  const {
+    SecretAccessKey = '',
+    AccessKeyId = '',
+    Token
+  } = await credentialProvider.getCredentials();
+  const aws: NonNullable<KMSProviders['aws']> = {
+    secretAccessKey: SecretAccessKey,
+    accessKeyId: AccessKeyId
+  };
+  // the AWS session token is only required for temporary credentials so only attach it to the
+  // result if it's present in the response from the aws sdk
+  Token != null && (aws.sessionToken = Token);
 
-  const { fromNodeProviderChain } = credentialProvider;
-  const provider = fromNodeProviderChain();
-  // The state machine is the only place calling this so it will
-  // catch if there is a rejection here.
-  const aws = await provider();
   return { ...kmsProviders, aws };
 }

--- a/test/integration/auth/mongodb_aws.test.ts
+++ b/test/integration/auth/mongodb_aws.test.ts
@@ -5,30 +5,26 @@ import * as http from 'http';
 import { performance } from 'perf_hooks';
 import * as sinon from 'sinon';
 
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
+import { KMSCredentialProvider, refreshKMSCredentials } from '../../../src/client-side-encryption/providers';
 import {
   AWSTemporaryCredentialProvider,
   MongoAWSError,
   type MongoClient,
   MongoDBAWS,
   MongoMissingCredentialsError,
-  MongoServerError
+  MongoServerError,
+  setDifference
 } from '../../mongodb';
 
-function awsSdk() {
-  try {
-    return require('@aws-sdk/credential-providers');
-  } catch {
-    return null;
-  }
-}
+const isMongoDBAWSAuthEnvironment = (process.env.MONGODB_URI ?? '').includes('MONGODB_AWS');
 
 describe('MONGODB-AWS', function () {
   let awsSdkPresent;
   let client: MongoClient;
 
   beforeEach(function () {
-    const MONGODB_URI = process.env.MONGODB_URI;
-    if (!MONGODB_URI || MONGODB_URI.indexOf('MONGODB-AWS') === -1) {
+    if (!isMongoDBAWSAuthEnvironment) {
       this.currentTest.skipReason = 'requires MONGODB_URI to contain MONGODB-AWS auth mechanism';
       return this.skip();
     }
@@ -39,7 +35,7 @@ describe('MONGODB-AWS', function () {
       `Always inform the AWS tests if they run with or without the SDK (MONGODB_AWS_SDK=${MONGODB_AWS_SDK})`
     ).to.include(MONGODB_AWS_SDK);
 
-    awsSdkPresent = !!awsSdk();
+    awsSdkPresent = AWSTemporaryCredentialProvider.isAWSSDKInstalled;
     expect(
       awsSdkPresent,
       MONGODB_AWS_SDK === 'true'
@@ -244,8 +240,10 @@ describe('MONGODB-AWS', function () {
 
         const envCheck = () => {
           const { AWS_WEB_IDENTITY_TOKEN_FILE = '' } = process.env;
-          credentialProvider = awsSdk();
-          return AWS_WEB_IDENTITY_TOKEN_FILE.length === 0 || credentialProvider == null;
+          return (
+            AWS_WEB_IDENTITY_TOKEN_FILE.length === 0 ||
+            !AWSTemporaryCredentialProvider.isAWSSDKInstalled
+          );
         };
 
         beforeEach(function () {
@@ -254,6 +252,9 @@ describe('MONGODB-AWS', function () {
             this.skipReason = 'only relevant to AssumeRoleWithWebIdentity with SDK installed';
             return this.skip();
           }
+
+          // @ts-expect-error We intentionally access a protected variable.
+          credentialProvider = AWSTemporaryCredentialProvider.awsSDK;
 
           storedEnv = process.env;
           if (test.env.AWS_STS_REGIONAL_ENDPOINTS === undefined) {
@@ -322,5 +323,51 @@ describe('MONGODB-AWS', function () {
         });
       });
     }
+  });
+});
+
+describe('AWS KMS Credential Fetching', function () {
+  context('when the AWS SDK is not installed', function () {
+    beforeEach(function () {
+      this.currentTest.skipReason = !isMongoDBAWSAuthEnvironment
+        ? 'Test must run in an AWS auth testing environment'
+        : AWSTemporaryCredentialProvider.isAWSSDKInstalled
+        ? 'This test must run in an environment where the AWS SDK is not installed.'
+        : undefined;
+      this.currentTest?.skipReason && this.skip();
+    });
+    it('fetching AWS KMS credentials throws an error', async function () {
+      const error = await new KMSCredentialProvider({ aws: {} }).refreshCredentials().catch(e => e);
+      expect(error).to.be.instanceOf(MongoAWSError);
+    });
+  });
+
+  context('when the AWS SDK is installed', function () {
+    beforeEach(function () {
+      this.currentTest.skipReason = !isMongoDBAWSAuthEnvironment
+        ? 'Test must run in an AWS auth testing environment'
+        : AWSTemporaryCredentialProvider.isAWSSDKInstalled
+        ? 'This test must run in an environment where the AWS SDK is installed.'
+        : undefined;
+      this.currentTest?.skipReason && this.skip();
+    });
+    it('KMS credentials are successfully fetched.', async function () {
+      const { aws } = await refreshKMSCredentials({ aws: {} });
+
+      expect(aws).to.have.property('accessKeyId');
+      expect(aws).to.have.property('secretAccessKey');
+    });
+
+    it('does not return any extra keys for the `aws` credential provider', async function () {
+      const { aws } = await refreshKMSCredentials({ aws: {} });
+
+      const keys = new Set(Object.keys(aws ?? {}));
+      const allowedKeys = ['accessKeyId', 'secretAccessKey', 'sessionToken'];
+
+      expect(
+        setDifference(keys, allowedKeys),
+        'received an unexpected key in the response refreshing KMS credentials'
+      ).to.deep.equal([]);
+    });
   });
 });

--- a/test/integration/auth/mongodb_aws.test.ts
+++ b/test/integration/auth/mongodb_aws.test.ts
@@ -6,7 +6,7 @@ import { performance } from 'perf_hooks';
 import * as sinon from 'sinon';
 
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports
-import { KMSCredentialProvider, refreshKMSCredentials } from '../../../src/client-side-encryption/providers';
+import { refreshKMSCredentials } from '../../../src/client-side-encryption/providers';
 import {
   AWSTemporaryCredentialProvider,
   MongoAWSError,
@@ -17,7 +17,7 @@ import {
   setDifference
 } from '../../mongodb';
 
-const isMongoDBAWSAuthEnvironment = (process.env.MONGODB_URI ?? '').includes('MONGODB_AWS');
+const isMongoDBAWSAuthEnvironment = (process.env.MONGODB_URI ?? '').includes('MONGODB-AWS');
 
 describe('MONGODB-AWS', function () {
   let awsSdkPresent;
@@ -337,7 +337,7 @@ describe('AWS KMS Credential Fetching', function () {
       this.currentTest?.skipReason && this.skip();
     });
     it('fetching AWS KMS credentials throws an error', async function () {
-      const error = await new KMSCredentialProvider({ aws: {} }).refreshCredentials().catch(e => e);
+      const error = await refreshKMSCredentials({ aws: {} }).catch(e => e);
       expect(error).to.be.instanceOf(MongoAWSError);
     });
   });

--- a/test/integration/auth/mongodb_aws.test.ts
+++ b/test/integration/auth/mongodb_aws.test.ts
@@ -365,7 +365,7 @@ describe('AWS KMS Credential Fetching', function () {
       const allowedKeys = ['accessKeyId', 'secretAccessKey', 'sessionToken'];
 
       expect(
-        setDifference(keys, allowedKeys),
+        Array.from(setDifference(keys, allowedKeys)),
         'received an unexpected key in the response refreshing KMS credentials'
       ).to.deep.equal([]);
     });

--- a/test/integration/auth/mongodb_aws.test.ts
+++ b/test/integration/auth/mongodb_aws.test.ts
@@ -346,7 +346,7 @@ describe('AWS KMS Credential Fetching', function () {
     beforeEach(function () {
       this.currentTest.skipReason = !isMongoDBAWSAuthEnvironment
         ? 'Test must run in an AWS auth testing environment'
-        : AWSTemporaryCredentialProvider.isAWSSDKInstalled
+        : !AWSTemporaryCredentialProvider.isAWSSDKInstalled
         ? 'This test must run in an environment where the AWS SDK is installed.'
         : undefined;
       this.currentTest?.skipReason && this.skip();

--- a/test/integration/crud/bulk.test.ts
+++ b/test/integration/crud/bulk.test.ts
@@ -723,7 +723,7 @@ describe('Bulk', function () {
     }
   });
 
-  it('should correctly execute ordered batch using w:0', function (done) {
+  it.skip('should correctly execute ordered batch using w:0', function (done) {
     client.connect((err, client) => {
       const db = client.db();
       const col = db.collection('batch_write_ordered_ops_9');
@@ -748,7 +748,7 @@ describe('Bulk', function () {
         client.close(done);
       });
     });
-  });
+  }).skipReason = 'TODO(NODE-6060): set `moreToCome` op_msg bit when `w: 0` is specified';
 
   it('should correctly handle single unordered batch API', function (done) {
     client.connect((err, client) => {

--- a/test/integration/crud/bulk.test.ts
+++ b/test/integration/crud/bulk.test.ts
@@ -723,32 +723,37 @@ describe('Bulk', function () {
     }
   });
 
-  it.skip('should correctly execute ordered batch using w:0', function (done) {
-    client.connect((err, client) => {
-      const db = client.db();
-      const col = db.collection('batch_write_ordered_ops_9');
+  it(
+    'should correctly execute ordered batch using w:0',
+    // TODO(NODE-6060): set `moreToCome` op_msg bit when `w: 0` is specified
+    { requires: { mongodb: '<8.0.0' } },
+    function (done) {
+      client.connect((err, client) => {
+        const db = client.db();
+        const col = db.collection('batch_write_ordered_ops_9');
 
-      const bulk = col.initializeOrderedBulkOp();
-      for (let i = 0; i < 100; i++) {
-        bulk.insert({ a: 1 });
-      }
+        const bulk = col.initializeOrderedBulkOp();
+        for (let i = 0; i < 100; i++) {
+          bulk.insert({ a: 1 });
+        }
 
-      bulk.find({ b: 1 }).upsert().update({ b: 1 });
-      bulk.find({ c: 1 }).delete();
+        bulk.find({ b: 1 }).upsert().update({ b: 1 });
+        bulk.find({ c: 1 }).delete();
 
-      bulk.execute({ writeConcern: { w: 0 } }, function (err, result) {
-        expect(err).to.not.exist;
-        test.equal(0, result.upsertedCount);
-        test.equal(0, result.insertedCount);
-        test.equal(0, result.matchedCount);
-        test.ok(0 === result.modifiedCount || result.modifiedCount == null);
-        test.equal(0, result.deletedCount);
-        test.equal(false, result.hasWriteErrors());
+        bulk.execute({ writeConcern: { w: 0 } }, function (err, result) {
+          expect(err).to.not.exist;
+          test.equal(0, result.upsertedCount);
+          test.equal(0, result.insertedCount);
+          test.equal(0, result.matchedCount);
+          test.ok(0 === result.modifiedCount || result.modifiedCount == null);
+          test.equal(0, result.deletedCount);
+          test.equal(false, result.hasWriteErrors());
 
-        client.close(done);
+          client.close(done);
+        });
       });
-    });
-  }).skipReason = 'TODO(NODE-6060): set `moreToCome` op_msg bit when `w: 0` is specified';
+    }
+  );
 
   it('should correctly handle single unordered batch API', function (done) {
     client.connect((err, client) => {

--- a/test/unit/assorted/polling_srv_records_for_mongos_discovery.prose.test.ts
+++ b/test/unit/assorted/polling_srv_records_for_mongos_discovery.prose.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import * as dns from 'dns';
 import { once } from 'events';
-import { coerce } from 'semver';
+import { satisfies } from 'semver';
 import * as sinon from 'sinon';
 
 import {
@@ -51,11 +51,9 @@ describe('Polling Srv Records for Mongos Discovery', () => {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const test = this.currentTest!;
 
-    const { major } = coerce(process.version);
-    test.skipReason =
-      major === 18 || major === 20
-        ? 'TODO(NODE-5666): fix failing unit tests on Node18'
-        : undefined;
+    test.skipReason = satisfies(process.version, '>=18.0.0')
+      ? `TODO(NODE-5666): fix failing unit tests on Node18 (Running with Nodejs ${process.version})`
+      : undefined;
 
     if (test.skipReason) this.skip();
   });

--- a/test/unit/client-side-encryption/providers/credentialsProvider.test.ts
+++ b/test/unit/client-side-encryption/providers/credentialsProvider.test.ts
@@ -20,9 +20,9 @@ import {
 } from '../../../../src/client-side-encryption/providers/azure';
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import * as utils from '../../../../src/client-side-encryption/providers/utils';
-import * as requirements from '../requirements.helper';
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { AWSSDKCredentialProvider } from '../../../../src/cmap/auth/aws_temporary_credentials';
-import { MongoAWSError } from '../../../../src/error';
+import * as requirements from '../requirements.helper';
 
 const originalAccessKeyId = process.env.AWS_ACCESS_KEY_ID;
 const originalSecretAccessKey = process.env.AWS_SECRET_ACCESS_KEY;
@@ -153,29 +153,6 @@ describe('#refreshKMSCredentials', function () {
             expect(providers).to.deep.equal(kmsProviders);
           });
         });
-      });
-    });
-
-    context('when the sdk is not installed', function () {
-      const kmsProviders = {
-        local: {
-          key: Buffer.alloc(96)
-        },
-        aws: {}
-      };
-
-      before(function () {
-        if (requirements.credentialProvidersInstalled.aws && this.currentTest) {
-          this.currentTest.skipReason = 'Credentials will be loaded when sdk present';
-          this.currentTest.skip();
-          return;
-        }
-      });
-
-      it('throws a MongoAWSError', async function () {
-        const error = await refreshKMSCredentials(kmsProviders).catch(e => e);
-        const expectedErrorMessage = 'Optional module `@aws-sdk/credential-providers` not found';
-        expect(error).to.be.instanceOf(MongoAWSError).to.match(new RegExp(expectedErrorMessage, 'i'));
       });
     });
 

--- a/test/unit/connection_string.spec.test.ts
+++ b/test/unit/connection_string.spec.test.ts
@@ -1,4 +1,4 @@
-import { coerce } from 'semver';
+import { satisfies } from 'semver';
 
 import { loadSpecTests } from '../spec';
 import { executeUriValidationTest } from '../tools/uri_spec_runner';
@@ -15,13 +15,12 @@ describe('Connection String spec tests', function () {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const test = this.currentTest!;
 
-    const { major } = coerce(process.version);
     const skippedTests = [
       'Invalid port (zero) with IP literal',
       'Invalid port (zero) with hostname'
     ];
     test.skipReason =
-      major === 20 && skippedTests.includes(test.title)
+      satisfies(process.version, '>=20.0.0') && skippedTests.includes(test.title)
         ? 'TODO(NODE-5666): fix failing unit tests on Node18'
         : undefined;
 

--- a/test/unit/connection_string.spec.test.ts
+++ b/test/unit/connection_string.spec.test.ts
@@ -21,7 +21,7 @@ describe('Connection String spec tests', function () {
     ];
     test.skipReason =
       satisfies(process.version, '>=20.0.0') && skippedTests.includes(test.title)
-        ? 'TODO(NODE-5666): fix failing unit tests on Node18'
+        ? 'TODO(NODE-5666): fix failing unit tests on Node20+'
         : undefined;
 
     if (test.skipReason) this.skip();

--- a/test/unit/sdam/monitor.test.ts
+++ b/test/unit/sdam/monitor.test.ts
@@ -1,7 +1,7 @@
 import * as net from 'node:net';
 
 import { expect } from 'chai';
-import { coerce } from 'semver';
+import { satisfies } from 'semver';
 import * as sinon from 'sinon';
 import { setTimeout } from 'timers';
 
@@ -49,7 +49,6 @@ describe('monitoring', function () {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const test = this.currentTest!;
 
-    const { major } = coerce(process.version);
     const failingTests = [
       'should connect and issue an initial server check',
       'should ignore attempts to connect when not already closed',
@@ -58,7 +57,7 @@ describe('monitoring', function () {
       'should upgrade to hello from legacy hello when initial handshake contains helloOk'
     ];
     test.skipReason =
-      (major === 18 || major === 20) && failingTests.includes(test.title)
+      satisfies(process.version, '>=18.0.0') && failingTests.includes(test.title)
         ? 'TODO(NODE-5666): fix failing unit tests on Node18'
         : undefined;
 

--- a/test/unit/sdam/topology.test.ts
+++ b/test/unit/sdam/topology.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { once } from 'events';
 import * as net from 'net';
 import { type AddressInfo } from 'net';
-import { coerce, type SemVer } from 'semver';
+import { satisfies } from 'semver';
 import * as sinon from 'sinon';
 import { clearTimeout } from 'timers';
 
@@ -284,11 +284,9 @@ describe('Topology (unit)', function () {
     it('should encounter a server selection timeout on garbled server responses', function () {
       const test = this.test;
 
-      const { major } = coerce(process.version) as SemVer;
-      test.skipReason =
-        major === 18 || major === 20
-          ? 'TODO(NODE-5666): fix failing unit tests on Node18'
-          : undefined;
+      test.skipReason = satisfies(process.version, '>=18.0.0')
+        ? 'TODO(NODE-5666): fix failing unit tests on Node18'
+        : undefined;
 
       if (test.skipReason) this.skip();
 


### PR DESCRIPTION
### Description

#### What is changing?

- AWS KMS credentials are now fetched using the same logic as AWS authentication (the AWSSDKTemporaryCredentialProvider). 
- Only expected keys (`sessionToken`,`accessKeyId`, `secretAccessKey`) are returned to libmongocrypt after fetching kms credentials

I also fixed some unit test skipping logic on Node18+, which previously only skipped on Node 18 and 20.  Now it skips on Node18+.

This PR includes changes from https://github.com/mongodb/node-mongodb-native/pull/4064 to get a greener CI.

##### Is there new documentation needed for these changes?

Nope.

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### AWS credentials with expirations no longer throw when using on-demand AWS KMS credentials

In addition to letting users provide KMS credentials manually, client-side encryption supports fetching AWS KMS credentials on-demand using the AWS SDK.  However, AWS credential mechanisms that returned access keys with expiration timestamps caused the driver to throw an error.

The driver will no longer throw an error when receiving an expiration token from the AWS SDK.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
