### PR TITLE
refactor(NODE-5916): enforce return-await

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,7 +11,8 @@
     "prettier",
     "unused-imports",
     "tsdoc",
-    "mocha"
+    "mocha",
+    "github"
   ],
   "extends": [
     "eslint:recommended",
@@ -212,7 +213,7 @@
       }
     },
     {
-      // Settings for typescript test files
+      // Settings for typescript src files
       "files": [
         "src/**/*.ts"
       ],
@@ -239,6 +240,7 @@
           "error",
           "always"
         ],
+        "github/no-then": "error",
         "no-restricted-imports": [
           "error",
           {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -237,7 +237,7 @@
         "no-return-await": "off",
         "@typescript-eslint/return-await": [
           "error",
-          "in-try-catch"
+          "always"
         ],
         "no-restricted-imports": [
           "error",

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "chalk": "^4.1.2",
         "eslint": "^8.56.0",
         "eslint-config-prettier": "^8.10.0",
+        "eslint-plugin-github": "^4.10.2",
         "eslint-plugin-import": "^2.29.1",
         "eslint-plugin-mocha": "^10.4.1",
         "eslint-plugin-prettier": "^4.2.1",
@@ -1204,6 +1205,18 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.24.1",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.1.tgz",
+      "integrity": "sha512-+BIznRzyqBf+2wCTxcKE3wDjfGeCoVE61KSHGpkzqrLi8qxqFwBeUFyId2cxkTmm55fzDGnm0+yCxaxygrLUnQ==",
+      "dev": true,
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.23.9",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.23.9.tgz",
@@ -1339,6 +1352,12 @@
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
+    },
+    "node_modules/@github/browserslist-config": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@github/browserslist-config/-/browserslist-config-1.0.0.tgz",
+      "integrity": "sha512-gIhjdJp/c2beaIWWIlsXdqXVRUz3r2BxBCpfz/F3JXHvSAQ1paMYjLH+maEATtENg+k5eLV7gA+9yPp762ieuw==",
+      "dev": true
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.13",
@@ -2147,6 +2166,18 @@
       "dev": true,
       "dependencies": {
         "@octokit/openapi-types": "^20.0.0"
+      }
+    },
+    "node_modules/@pkgr/core": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.1.tgz",
+      "integrity": "sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
       }
     },
     "node_modules/@rushstack/node-core-library": {
@@ -2970,9 +3001,9 @@
       }
     },
     "node_modules/@types/json-schema": {
-      "version": "7.0.11",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
-      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
     },
     "node_modules/@types/json5": {
@@ -3495,14 +3526,26 @@
         "sprintf-js": "~1.0.2"
       }
     },
-    "node_modules/array-buffer-byte-length": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz",
-      "integrity": "sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==",
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "is-array-buffer": "^3.0.1"
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz",
+      "integrity": "sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.5",
+        "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3598,17 +3641,18 @@
       }
     },
     "node_modules/arraybuffer.prototype.slice": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.2.tgz",
-      "integrity": "sha512-yMBKppFur/fbHu9/6USUe03bZ4knMYiwFBcyiaXB8Go0qNehwX6inYPzK9U0NeQvGxKthcmHcaR8P5MStSRBAw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.3.tgz",
+      "integrity": "sha512-bMxMKAjg13EBSVscxTaYA4mRc5t1UAXa2kXiGTNfZ079HIWXEkKmkgFrh/nJqamaLSrXO5H4WFFkPEaLJWbs3A==",
       "dev": true,
       "dependencies": {
-        "array-buffer-byte-length": "^1.0.0",
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1",
-        "get-intrinsic": "^1.2.1",
-        "is-array-buffer": "^3.0.2",
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.5",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.22.3",
+        "es-errors": "^1.2.1",
+        "get-intrinsic": "^1.2.3",
+        "is-array-buffer": "^3.0.4",
         "is-shared-array-buffer": "^1.0.2"
       },
       "engines": {
@@ -3636,16 +3680,43 @@
         "node": "*"
       }
     },
+    "node_modules/ast-types-flow": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
+      "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
+      "dev": true
+    },
     "node_modules/available-typed-arrays": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
-      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
       "dev": true,
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
       "engines": {
         "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.7.0.tgz",
+      "integrity": "sha512-M0JtH+hlOL5pLQwHOLNYZaXuhqmvS8oExsqB1SBYgA4Dk7u/xx+YdGHXaK5pyUfed5mYXdlYiphWq3G8cRi5JQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.2.1.tgz",
+      "integrity": "sha512-jsyHu61e6N4Vbz/v18DHwWYKK0bSWLqn47eeDSKPB7m8tqMHF9YJ+mhIk2lVteyZrY8tnSj/jHOv4YiTCuCJgg==",
+      "dev": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
       }
     },
     "node_modules/balanced-match": {
@@ -3882,13 +3953,19 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
+      "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
       "dev": true,
       "dependencies": {
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2"
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4183,6 +4260,63 @@
         "node": ">= 8"
       }
     },
+    "node_modules/damerau-levenshtein": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
+      "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
+      "dev": true
+    },
+    "node_modules/data-view-buffer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.1.tgz",
+      "integrity": "sha512-0lht7OugA5x3iJLOWFhWK/5ehONdprk0ISXqVFn/NFrDu+cuc8iADFrGQz5BnRK7LLU3JmkbXSxaqX+/mXYtUA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.6",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-length": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.1.tgz",
+      "integrity": "sha512-4J7wRJD3ABAzr8wP+OcIcqq2dlUKp4DVflx++hs5h5ZKydWMI6/D/fAot+yh6g2tHh8fLFTvNOaVN357NvSrOQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-offset": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.0.tgz",
+      "integrity": "sha512-t/Ygsytq+R995EJ5PZlD4Cu56sWa8InXySaViRzw9apusqsOO2bQP+SbYzAhR0pFKoB+43lYy8rWban9JSuXnA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.6",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -4291,12 +4425,30 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/define-properties": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
-      "integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
       "dev": true,
       "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "dependencies": {
+        "define-data-property": "^1.0.1",
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
       },
@@ -4321,6 +4473,15 @@
       "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
       "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
       "dev": true
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/destroy": {
       "version": "1.2.0",
@@ -4429,50 +4590,57 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.22.1.tgz",
-      "integrity": "sha512-ioRRcXMO6OFyRpyzV3kE1IIBd4WG5/kltnzdxSCqoP8CMGs/Li+M1uF5o7lOkZVFjDs+NLesthnF66Pg/0q0Lw==",
+      "version": "1.23.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.2.tgz",
+      "integrity": "sha512-60s3Xv2T2p1ICykc7c+DNDPLDMm9t4QxCOUU0K9JxiLjM3C1zB9YVdN7tjxrFd4+AkZ8CdX1ovUga4P2+1e+/w==",
       "dev": true,
       "dependencies": {
-        "array-buffer-byte-length": "^1.0.0",
-        "arraybuffer.prototype.slice": "^1.0.1",
-        "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.2",
-        "es-set-tostringtag": "^2.0.1",
+        "array-buffer-byte-length": "^1.0.1",
+        "arraybuffer.prototype.slice": "^1.0.3",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.7",
+        "data-view-buffer": "^1.0.1",
+        "data-view-byte-length": "^1.0.1",
+        "data-view-byte-offset": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "es-set-tostringtag": "^2.0.3",
         "es-to-primitive": "^1.2.1",
-        "function.prototype.name": "^1.1.5",
-        "get-intrinsic": "^1.2.1",
-        "get-symbol-description": "^1.0.0",
+        "function.prototype.name": "^1.1.6",
+        "get-intrinsic": "^1.2.4",
+        "get-symbol-description": "^1.0.2",
         "globalthis": "^1.0.3",
         "gopd": "^1.0.1",
-        "has": "^1.0.3",
-        "has-property-descriptors": "^1.0.0",
-        "has-proto": "^1.0.1",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.0.3",
         "has-symbols": "^1.0.3",
-        "internal-slot": "^1.0.5",
-        "is-array-buffer": "^3.0.2",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.0.7",
+        "is-array-buffer": "^3.0.4",
         "is-callable": "^1.2.7",
-        "is-negative-zero": "^2.0.2",
+        "is-data-view": "^1.0.1",
+        "is-negative-zero": "^2.0.3",
         "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.2",
+        "is-shared-array-buffer": "^1.0.3",
         "is-string": "^1.0.7",
-        "is-typed-array": "^1.1.10",
+        "is-typed-array": "^1.1.13",
         "is-weakref": "^1.0.2",
-        "object-inspect": "^1.12.3",
+        "object-inspect": "^1.13.1",
         "object-keys": "^1.1.1",
-        "object.assign": "^4.1.4",
-        "regexp.prototype.flags": "^1.5.0",
-        "safe-array-concat": "^1.0.0",
-        "safe-regex-test": "^1.0.0",
-        "string.prototype.trim": "^1.2.7",
-        "string.prototype.trimend": "^1.0.6",
-        "string.prototype.trimstart": "^1.0.6",
-        "typed-array-buffer": "^1.0.0",
-        "typed-array-byte-length": "^1.0.0",
-        "typed-array-byte-offset": "^1.0.0",
-        "typed-array-length": "^1.0.4",
+        "object.assign": "^4.1.5",
+        "regexp.prototype.flags": "^1.5.2",
+        "safe-array-concat": "^1.1.2",
+        "safe-regex-test": "^1.0.3",
+        "string.prototype.trim": "^1.2.9",
+        "string.prototype.trimend": "^1.0.8",
+        "string.prototype.trimstart": "^1.0.7",
+        "typed-array-buffer": "^1.0.2",
+        "typed-array-byte-length": "^1.0.1",
+        "typed-array-byte-offset": "^1.0.2",
+        "typed-array-length": "^1.0.5",
         "unbox-primitive": "^1.0.2",
-        "which-typed-array": "^1.1.10"
+        "which-typed-array": "^1.1.15"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4481,15 +4649,73 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/es-set-tostringtag": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz",
-      "integrity": "sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==",
+    "node_modules/es-define-property": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
+      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
       "dev": true,
       "dependencies": {
-        "get-intrinsic": "^1.1.3",
-        "has": "^1.0.3",
-        "has-tostringtag": "^1.0.0"
+        "get-intrinsic": "^1.2.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-iterator-helpers": {
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.0.18.tgz",
+      "integrity": "sha512-scxAJaewsahbqTYrGKJihhViaM6DDZDDoucfvzNbK0pOren1g/daDQ3IAhzn+1G14rBG7w+i5N+qul60++zlKA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.0",
+        "es-errors": "^1.3.0",
+        "es-set-tostringtag": "^2.0.3",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "globalthis": "^1.0.3",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.0.3",
+        "has-symbols": "^1.0.3",
+        "internal-slot": "^1.0.7",
+        "iterator.prototype": "^1.1.2",
+        "safe-array-concat": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
+      "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz",
+      "integrity": "sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.2.4",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4689,6 +4915,372 @@
         "ms": "^2.1.1"
       }
     },
+    "node_modules/eslint-plugin-escompat": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-escompat/-/eslint-plugin-escompat-3.4.0.tgz",
+      "integrity": "sha512-ufTPv8cwCxTNoLnTZBFTQ5SxU2w7E7wiMIS7PSxsgP1eAxFjtSaoZ80LRn64hI8iYziE6kJG6gX/ZCJVxh48Bg==",
+      "dev": true,
+      "dependencies": {
+        "browserslist": "^4.21.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=5.14.1"
+      }
+    },
+    "node_modules/eslint-plugin-eslint-comments": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-3.2.0.tgz",
+      "integrity": "sha512-0jkOl0hfojIHHmEHgmNdqv4fmh7300NdpA9FFpF7zaoLvB/QeXOGNLIo86oAveJFrfB1p05kC8hpEMHM8DwWVQ==",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5",
+        "ignore": "^5.0.5"
+      },
+      "engines": {
+        "node": ">=6.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=4.19.1"
+      }
+    },
+    "node_modules/eslint-plugin-eslint-comments/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/eslint-plugin-filenames": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-filenames/-/eslint-plugin-filenames-1.3.2.tgz",
+      "integrity": "sha512-tqxJTiEM5a0JmRCUYQmxw23vtTxrb2+a3Q2mMOPhFxvt7ZQQJmdiuMby9B/vUAuVMghyP7oET+nIf6EO6CBd/w==",
+      "dev": true,
+      "dependencies": {
+        "lodash.camelcase": "4.3.0",
+        "lodash.kebabcase": "4.1.1",
+        "lodash.snakecase": "4.1.1",
+        "lodash.upperfirst": "4.3.1"
+      },
+      "peerDependencies": {
+        "eslint": "*"
+      }
+    },
+    "node_modules/eslint-plugin-github": {
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-github/-/eslint-plugin-github-4.10.2.tgz",
+      "integrity": "sha512-F1F5aAFgi1Y5hYoTFzGQACBkw5W1hu2Fu5FSTrMlXqrojJnKl1S2pWO/rprlowRQpt+hzHhqSpsfnodJEVd5QA==",
+      "dev": true,
+      "dependencies": {
+        "@github/browserslist-config": "^1.0.0",
+        "@typescript-eslint/eslint-plugin": "^7.0.1",
+        "@typescript-eslint/parser": "^7.0.1",
+        "aria-query": "^5.3.0",
+        "eslint-config-prettier": ">=8.0.0",
+        "eslint-plugin-escompat": "^3.3.3",
+        "eslint-plugin-eslint-comments": "^3.2.0",
+        "eslint-plugin-filenames": "^1.3.2",
+        "eslint-plugin-i18n-text": "^1.0.1",
+        "eslint-plugin-import": "^2.25.2",
+        "eslint-plugin-jsx-a11y": "^6.7.1",
+        "eslint-plugin-no-only-tests": "^3.0.0",
+        "eslint-plugin-prettier": "^5.0.0",
+        "eslint-rule-documentation": ">=1.0.0",
+        "jsx-ast-utils": "^3.3.2",
+        "prettier": "^3.0.0",
+        "svg-element-attributes": "^1.3.1"
+      },
+      "bin": {
+        "eslint-ignore-errors": "bin/eslint-ignore-errors.js"
+      },
+      "peerDependencies": {
+        "eslint": "^8.0.1"
+      }
+    },
+    "node_modules/eslint-plugin-github/node_modules/@types/eslint": {
+      "version": "8.56.6",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.6.tgz",
+      "integrity": "sha512-ymwc+qb1XkjT/gfoQwxIeHZ6ixH23A+tCT2ADSA/DPVKzAjwYkTXBMCQ/f6fe4wEa85Lhp26VPeUxI7wMhAi7A==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
+    "node_modules/eslint-plugin-github/node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.4.0.tgz",
+      "integrity": "sha512-yHMQ/oFaM7HZdVrVm/M2WHaNPgyuJH4WelkSVEWSSsir34kxW2kDJCxlXRhhGWEsMN0WAW/vLpKfKVcm8k+MPw==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.5.1",
+        "@typescript-eslint/scope-manager": "7.4.0",
+        "@typescript-eslint/type-utils": "7.4.0",
+        "@typescript-eslint/utils": "7.4.0",
+        "@typescript-eslint/visitor-keys": "7.4.0",
+        "debug": "^4.3.4",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.4",
+        "natural-compare": "^1.4.0",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^7.0.0",
+        "eslint": "^8.56.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-github/node_modules/@typescript-eslint/parser": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.4.0.tgz",
+      "integrity": "sha512-ZvKHxHLusweEUVwrGRXXUVzFgnWhigo4JurEj0dGF1tbcGh6buL+ejDdjxOQxv6ytcY1uhun1p2sm8iWStlgLQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "7.4.0",
+        "@typescript-eslint/types": "7.4.0",
+        "@typescript-eslint/typescript-estree": "7.4.0",
+        "@typescript-eslint/visitor-keys": "7.4.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.56.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-github/node_modules/@typescript-eslint/scope-manager": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.4.0.tgz",
+      "integrity": "sha512-68VqENG5HK27ypafqLVs8qO+RkNc7TezCduYrx8YJpXq2QGZ30vmNZGJJJC48+MVn4G2dCV8m5ZTVnzRexTVtw==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "7.4.0",
+        "@typescript-eslint/visitor-keys": "7.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-github/node_modules/@typescript-eslint/type-utils": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.4.0.tgz",
+      "integrity": "sha512-247ETeHgr9WTRMqHbbQdzwzhuyaJ8dPTuyuUEMANqzMRB1rj/9qFIuIXK7l0FX9i9FXbHeBQl/4uz6mYuCE7Aw==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "7.4.0",
+        "@typescript-eslint/utils": "7.4.0",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.56.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-github/node_modules/@typescript-eslint/types": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.4.0.tgz",
+      "integrity": "sha512-mjQopsbffzJskos5B4HmbsadSJQWaRK0UxqQ7GuNA9Ga4bEKeiO6b2DnB6cM6bpc8lemaPseh0H9B/wyg+J7rw==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-github/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.4.0.tgz",
+      "integrity": "sha512-A99j5AYoME/UBQ1ucEbbMEmGkN7SE0BvZFreSnTd1luq7yulcHdyGamZKizU7canpGDWGJ+Q6ZA9SyQobipePg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "7.4.0",
+        "@typescript-eslint/visitor-keys": "7.4.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "9.0.3",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-github/node_modules/@typescript-eslint/utils": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.4.0.tgz",
+      "integrity": "sha512-NQt9QLM4Tt8qrlBVY9lkMYzfYtNz8/6qwZg8pI3cMGlPnj6mOpRxxAm7BMJN9K0AiY+1BwJ5lVC650YJqYOuNg==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@types/json-schema": "^7.0.12",
+        "@types/semver": "^7.5.0",
+        "@typescript-eslint/scope-manager": "7.4.0",
+        "@typescript-eslint/types": "7.4.0",
+        "@typescript-eslint/typescript-estree": "7.4.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.56.0"
+      }
+    },
+    "node_modules/eslint-plugin-github/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.4.0.tgz",
+      "integrity": "sha512-0zkC7YM0iX5Y41homUUeW1CHtZR01K3ybjM1l6QczoMuay0XKtrb93kv95AxUGwdjGr64nNqnOCwmEl616N8CA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "7.4.0",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-github/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-github/node_modules/eslint-plugin-prettier": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.1.3.tgz",
+      "integrity": "sha512-C9GCVAs4Eq7ZC/XFQHITLiHJxQngdtraXaM+LoUFoFp/lHNl2Zn8f3WQbe9HvTBBQ9YnKFB0/2Ajdqwo5D1EAw==",
+      "dev": true,
+      "dependencies": {
+        "prettier-linter-helpers": "^1.0.0",
+        "synckit": "^0.8.6"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-plugin-prettier"
+      },
+      "peerDependencies": {
+        "@types/eslint": ">=8.0.0",
+        "eslint": ">=8.0.0",
+        "eslint-config-prettier": "*",
+        "prettier": ">=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/eslint": {
+          "optional": true
+        },
+        "eslint-config-prettier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-github/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/eslint-plugin-github/node_modules/prettier": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
+      "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/eslint-plugin-i18n-text": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-i18n-text/-/eslint-plugin-i18n-text-1.0.1.tgz",
+      "integrity": "sha512-3G3UetST6rdqhqW9SfcfzNYMpQXS7wNkJvp6dsXnjzGiku6Iu5hl3B0kmk6lIcFPwYjhQIY+tXVRtK9TlGT7RA==",
+      "dev": true,
+      "peerDependencies": {
+        "eslint": ">=5.0.0"
+      }
+    },
     "node_modules/eslint-plugin-import": {
       "version": "2.29.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.29.1.tgz",
@@ -4750,6 +5342,42 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/eslint-plugin-jsx-a11y": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.8.0.tgz",
+      "integrity": "sha512-Hdh937BS3KdwwbBaKd5+PLCOmYY6U4f2h9Z2ktwtNKvIdIEu137rjYbcb9ApSbVJfWxANNuiKTD/9tOKjK9qOA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.23.2",
+        "aria-query": "^5.3.0",
+        "array-includes": "^3.1.7",
+        "array.prototype.flatmap": "^1.3.2",
+        "ast-types-flow": "^0.0.8",
+        "axe-core": "=4.7.0",
+        "axobject-query": "^3.2.1",
+        "damerau-levenshtein": "^1.0.8",
+        "emoji-regex": "^9.2.2",
+        "es-iterator-helpers": "^1.0.15",
+        "hasown": "^2.0.0",
+        "jsx-ast-utils": "^3.3.5",
+        "language-tags": "^1.0.9",
+        "minimatch": "^3.1.2",
+        "object.entries": "^1.1.7",
+        "object.fromentries": "^2.0.7"
+      },
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
+    },
     "node_modules/eslint-plugin-mocha": {
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-10.4.1.tgz",
@@ -4765,6 +5393,15 @@
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-no-only-tests": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-3.1.0.tgz",
+      "integrity": "sha512-Lf4YW/bL6Un1R6A76pRZyE1dl1vr31G/ev8UzIc/geCgFWyrKil8hVjYqWVKGB/UIGmb6Slzs9T0wNezdSVegw==",
+      "dev": true,
+      "engines": {
+        "node": ">=5.0.0"
       }
     },
     "node_modules/eslint-plugin-prettier": {
@@ -4842,6 +5479,15 @@
       "resolved": "https://registry.npmjs.org/eslint-rule-docs/-/eslint-rule-docs-1.1.235.tgz",
       "integrity": "sha512-+TQ+x4JdTnDoFEXXb3fDvfGOwnyNV7duH8fXWTPD1ieaBmB8omj7Gw/pMBBu4uI2uJCCU8APDaQJzWuXnTsH4A==",
       "dev": true
+    },
+    "node_modules/eslint-rule-documentation": {
+      "version": "1.0.23",
+      "resolved": "https://registry.npmjs.org/eslint-rule-documentation/-/eslint-rule-documentation-1.0.23.tgz",
+      "integrity": "sha512-pWReu3fkohwyvztx/oQWWgld2iad25TfUdi6wvhhaDPIQjHU/pyvlKgXFw1kX31SQK2Nq9MH+vRDWB0ZLy8fYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
     },
     "node_modules/eslint-scope": {
       "version": "5.1.1",
@@ -5408,15 +6054,15 @@
       }
     },
     "node_modules/function.prototype.name": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
-      "integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
+      "integrity": "sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.0",
-        "functions-have-names": "^1.2.2"
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1",
+        "functions-have-names": "^1.2.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5490,15 +6136,19 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
-      "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
+      "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
       "dev": true,
       "dependencies": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
         "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3"
+        "has-symbols": "^1.0.3",
+        "hasown": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5514,13 +6164,14 @@
       }
     },
     "node_modules/get-symbol-description": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
-      "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.2.tgz",
+      "integrity": "sha512-g0QYk1dZBxGwk+Ngc+ltRH2IBp2f7zBkBMBJZCDerh6EhlhSR6+9irMCuT/09zD6qkarHUSn529sK/yL4S27mg==",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.1"
+        "call-bind": "^1.0.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5681,21 +6332,21 @@
       }
     },
     "node_modules/has-property-descriptors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
-      "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
       "dev": true,
       "dependencies": {
-        "get-intrinsic": "^1.1.1"
+        "es-define-property": "^1.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
-      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
+      "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
       "dev": true,
       "engines": {
         "node": ">= 0.4"
@@ -5717,12 +6368,12 @@
       }
     },
     "node_modules/has-tostringtag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
-      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
       "dev": true,
       "dependencies": {
-        "has-symbols": "^1.0.2"
+        "has-symbols": "^1.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5757,9 +6408,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
-      "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
       "dev": true,
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -5955,13 +6606,13 @@
       "dev": true
     },
     "node_modules/internal-slot": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
-      "integrity": "sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.7.tgz",
+      "integrity": "sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==",
       "dev": true,
       "dependencies": {
-        "get-intrinsic": "^1.2.0",
-        "has": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.0",
         "side-channel": "^1.0.4"
       },
       "engines": {
@@ -6006,14 +6657,16 @@
       }
     },
     "node_modules/is-array-buffer": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
-      "integrity": "sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.4.tgz",
+      "integrity": "sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.2.0",
-        "is-typed-array": "^1.1.10"
+        "get-intrinsic": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6024,6 +6677,21 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true
+    },
+    "node_modules/is-async-function": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.0.0.tgz",
+      "integrity": "sha512-Y1JXKrfykRJGdlDwdKlLpLyMIiWqWvuSd17TvZk68PLAOGOoF4Xyav1z0Xhoi+gCYjZVeC5SI+hYFOfvXmGRCA==",
+      "dev": true,
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-bigint": {
       "version": "1.0.4",
@@ -6089,6 +6757,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-data-view": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.1.tgz",
+      "integrity": "sha512-AHkaJrsUVW6wq6JS8y3JnM/GJF/9cf+k20+iDzlSaJrinEo5+7vRiteOSwBhHRiAyQATN1AmY4hwzxJKPmYf+w==",
+      "dev": true,
+      "dependencies": {
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-date-object": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
@@ -6113,6 +6796,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-finalizationregistry": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.0.2.tgz",
+      "integrity": "sha512-0by5vtUJs8iFQb5TYUHHPudOR+qXYIMKtiUzvLIZITZUjknFmziyBJuLhVRc+Ds0dREFlskDNJKYIdIzu/9pfw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -6120,6 +6815,21 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
+      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+      "dev": true,
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-glob": {
@@ -6134,10 +6844,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-negative-zero": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
-      "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
       "dev": true,
       "engines": {
         "node": ">= 0.4"
@@ -6204,13 +6926,28 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-shared-array-buffer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
-      "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nA2hv5XIhLR3uVzDDfCIknerhx8XUKnstuOERPNNIinXG7v9u+ohXF67vxm4TPTEPU6lm61ZkwP3c9PCB97rhg==",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.2"
+        "call-bind": "^1.0.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6259,16 +6996,12 @@
       }
     },
     "node_modules/is-typed-array": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
-      "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.13.tgz",
+      "integrity": "sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==",
       "dev": true,
       "dependencies": {
-        "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.2",
-        "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
-        "has-tostringtag": "^1.0.0"
+        "which-typed-array": "^1.1.14"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6295,6 +7028,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-weakref": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
@@ -6302,6 +7047,22 @@
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.3.tgz",
+      "integrity": "sha512-LvIm3/KWzS9oRFHugab7d+M/GcBXuXX5xZkzPmN+NxihdQlZUQ4dWuSV1xR/sq6upL1TJEDrfBgRepHFdBtSNQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "get-intrinsic": "^1.2.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6431,6 +7192,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/iterator.prototype": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.2.tgz",
+      "integrity": "sha512-DR33HMMr8EzwuRL8Y9D3u2BMj8+RqSE850jfGu59kS7tbmPLzGkZmVSfyCFSDxuZiEY6Rzt3T2NA/qU+NwVj1w==",
+      "dev": true,
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "get-intrinsic": "^1.2.1",
+        "has-symbols": "^1.0.3",
+        "reflect.getprototypeof": "^1.0.4",
+        "set-function-name": "^2.0.1"
+      }
+    },
     "node_modules/jest-diff": {
       "version": "29.5.0",
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.5.0.tgz",
@@ -6551,6 +7325,21 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jsx-ast-utils": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
+      "integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
+      "dev": true,
+      "dependencies": {
+        "array-includes": "^3.1.6",
+        "array.prototype.flat": "^1.3.1",
+        "object.assign": "^4.1.4",
+        "object.values": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/just-extend": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
@@ -6564,6 +7353,24 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/language-subtag-registry": {
+      "version": "0.3.22",
+      "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.22.tgz",
+      "integrity": "sha512-tN0MCzyWnoz/4nHS6uxdlFWoUZT7ABptwKPQ52Ea7URk6vll88bWBVhodtnlfEuCcKWNGoc+uGbw1cwa9IKh/w==",
+      "dev": true
+    },
+    "node_modules/language-tags": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.9.tgz",
+      "integrity": "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==",
+      "dev": true,
+      "dependencies": {
+        "language-subtag-registry": "^0.3.20"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/levn": {
@@ -6606,6 +7413,12 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "dev": true
+    },
     "node_modules/lodash.flattendeep": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
@@ -6624,10 +7437,28 @@
       "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
       "dev": true
     },
+    "node_modules/lodash.kebabcase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
+      "integrity": "sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==",
+      "dev": true
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
+    },
+    "node_modules/lodash.snakecase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
+      "dev": true
+    },
+    "node_modules/lodash.upperfirst": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz",
+      "integrity": "sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==",
       "dev": true
     },
     "node_modules/log-symbols": {
@@ -7440,9 +8271,9 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.12.3",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
-      "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
+      "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7458,13 +8289,13 @@
       }
     },
     "node_modules/object.assign": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
-      "integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
+      "integrity": "sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
+        "call-bind": "^1.0.5",
+        "define-properties": "^1.2.1",
         "has-symbols": "^1.0.3",
         "object-keys": "^1.1.1"
       },
@@ -7473,6 +8304,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.entries": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.8.tgz",
+      "integrity": "sha512-cmopxi8VwRIAw/fkijJohSfpef5PdN0pMQJN6VC/ZKvn0LIknWD8KtgY6KlQdEc4tIjcQ3HxSMmnvtzIscdaYQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/object.fromentries": {
@@ -7809,6 +8654,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
+      "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/prebuild-install": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
@@ -8092,15 +8946,43 @@
         "node": ">=8"
       }
     },
-    "node_modules/regexp.prototype.flags": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.0.tgz",
-      "integrity": "sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==",
+    "node_modules/reflect.getprototypeof": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.6.tgz",
+      "integrity": "sha512-fmfw4XgoDke3kdI6h4xcUz1dG8uaiv5q9gcEwLS4Pnth2kxT+GZ7YehS1JTMGBQmtV7Y4GFGbs2re2NqhdozUg==",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "functions-have-names": "^1.2.3"
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.1",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.4",
+        "globalthis": "^1.0.3",
+        "which-builtin-type": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+      "dev": true
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz",
+      "integrity": "sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.6",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "set-function-name": "^2.0.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8211,13 +9093,13 @@
       }
     },
     "node_modules/safe-array-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.0.1.tgz",
-      "integrity": "sha512-6XbUAseYE2KtOuGueyeobCySj9L4+66Tn6KQMOPQJrAJEowYKW/YR/MGJZl7FdydUdaFu4LYyDZjxf4/Nmo23Q==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.2.tgz",
+      "integrity": "sha512-vj6RsCsWBCf19jIeHEfkRMw8DPiBb+DMXklQ/1SGDHOMlHdPUkZXFQ2YdplS23zESTijAcurb1aSgJA3AgMu1Q==",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.2.1",
+        "call-bind": "^1.0.7",
+        "get-intrinsic": "^1.2.4",
         "has-symbols": "^1.0.3",
         "isarray": "^2.0.5"
       },
@@ -8249,14 +9131,17 @@
       ]
     },
     "node_modules/safe-regex-test": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
-      "integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.3.tgz",
+      "integrity": "sha512-CdASjNJPvRa7roO6Ra/gLYBTzYzzPyyBXxIMdGW3USQLyjWEls2RgW5UBTXaQVp+OrpeCK3bLem8smtmheoRuw==",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.3",
+        "call-bind": "^1.0.6",
+        "es-errors": "^1.3.0",
         "is-regex": "^1.1.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -8375,6 +9260,38 @@
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "dev": true
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dev": true,
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -8700,14 +9617,15 @@
       }
     },
     "node_modules/string.prototype.trim": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.7.tgz",
-      "integrity": "sha512-p6TmeT1T3411M8Cgg9wBTMRtY2q9+PNy9EV1i2lIXUN/btt763oIfxwN3RR8VU6wHX8j/1CFy0L+YuThm6bgOg==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.9.tgz",
+      "integrity": "sha512-klHuCNxiMZ8MlsOihJhJEBJAiMVqU3Z2nEXWfWnIqjN0gEFS9J9+IxKozWWtQGcgoa1WUZzLjKPTr4ZHNFTFxw==",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4"
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.0",
+        "es-object-atoms": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8717,28 +9635,31 @@
       }
     },
     "node_modules/string.prototype.trimend": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
-      "integrity": "sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.8.tgz",
+      "integrity": "sha512-p73uL5VCHCO2BZZ6krwwQE3kCzM7NKmis8S//xEC6fQonchbum4eP6kR4DLEjQFO3Wnj3Fuo8NM0kOSjVdHjZQ==",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4"
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/string.prototype.trimstart": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz",
-      "integrity": "sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4"
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -8830,6 +9751,32 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/svg-element-attributes": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/svg-element-attributes/-/svg-element-attributes-1.3.1.tgz",
+      "integrity": "sha512-Bh05dSOnJBf3miNMqpsormfNtfidA/GxQVakhtn0T4DECWKeXQRQUceYjJ+OxYiiLdGe4Jo9iFV8wICFapFeIA==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/synckit": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.8.tgz",
+      "integrity": "sha512-HwOKAP7Wc5aRGYdKH+dw0PRRpbO841v2DENBtjnR5HFWoiNByAl7vrx3p0G/rCyYXQsrxqtX48TImFtPcIHSpQ==",
+      "dev": true,
+      "dependencies": {
+        "@pkgr/core": "^0.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
       }
     },
     "node_modules/tar-fs": {
@@ -8928,6 +9875,18 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
+      "integrity": "sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.2.0"
       }
     },
     "node_modules/ts-node": {
@@ -9307,29 +10266,30 @@
       }
     },
     "node_modules/typed-array-buffer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.0.tgz",
-      "integrity": "sha512-Y8KTSIglk9OZEr8zywiIHG/kmQ7KWyjseXs1CbSo8vC42w7hg2HgYTxSWwP0+is7bWDc1H+Fo026CpHFwm8tkw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.2.tgz",
+      "integrity": "sha512-gEymJYKZtKXzzBzM4jqa9w6Q1Jjm7x2d+sh19AdsD4wqnMPDYyvwpsIc2Q/835kHuo3BEQ7CjelGhfTsoBb2MQ==",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.2.1",
-        "is-typed-array": "^1.1.10"
+        "call-bind": "^1.0.7",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.13"
       },
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/typed-array-byte-length": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.0.tgz",
-      "integrity": "sha512-Or/+kvLxNpeQ9DtSydonMxCx+9ZXOswtwJn17SNLvhptaXYDJvkFFP5zbfU/uLmvnBJlI4yrnXRxpdWH/M5tNA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.1.tgz",
+      "integrity": "sha512-3iMJ9q0ao7WE9tWcaYKIptkNBuOIcZCCT0d4MRvuuH88fEoEH62IuQe0OtraD3ebQEoTRk8XCBoknUNc1Y67pw==",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.2",
+        "call-bind": "^1.0.7",
         "for-each": "^0.3.3",
-        "has-proto": "^1.0.1",
-        "is-typed-array": "^1.1.10"
+        "gopd": "^1.0.1",
+        "has-proto": "^1.0.3",
+        "is-typed-array": "^1.1.13"
       },
       "engines": {
         "node": ">= 0.4"
@@ -9339,16 +10299,17 @@
       }
     },
     "node_modules/typed-array-byte-offset": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.0.tgz",
-      "integrity": "sha512-RD97prjEt9EL8YgAgpOkf3O4IF9lhJFr9g0htQkm0rchFp/Vx7LW5Q8fSXXub7BXAODyUQohRMyOc3faCPd0hg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.2.tgz",
+      "integrity": "sha512-Ous0vodHa56FviZucS2E63zkgtgrACj7omjwd/8lTEMEPFFyjfixMZ1ZXenpgCFBBt4EC1J2XsyVS2gkG0eTFA==",
       "dev": true,
       "dependencies": {
-        "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.2",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.7",
         "for-each": "^0.3.3",
-        "has-proto": "^1.0.1",
-        "is-typed-array": "^1.1.10"
+        "gopd": "^1.0.1",
+        "has-proto": "^1.0.3",
+        "is-typed-array": "^1.1.13"
       },
       "engines": {
         "node": ">= 0.4"
@@ -9358,14 +10319,20 @@
       }
     },
     "node_modules/typed-array-length": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.4.tgz",
-      "integrity": "sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.6.tgz",
+      "integrity": "sha512-/OxDN6OtAk5KBpGb28T+HZc2M+ADtvRxXrKKbUwtsLgdoxgX13hyy7ek6bFRl5+aBs2yZzB0c4CnQfAtVypW/g==",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.2",
+        "call-bind": "^1.0.7",
         "for-each": "^0.3.3",
-        "is-typed-array": "^1.1.9"
+        "gopd": "^1.0.1",
+        "has-proto": "^1.0.3",
+        "is-typed-array": "^1.1.13",
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -9643,6 +10610,50 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/which-builtin-type": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.1.3.tgz",
+      "integrity": "sha512-YmjsSMDBYsM1CaFiayOVT06+KJeXf0o5M/CAd4o1lTadFAtacTUM49zoYxr/oroopFDfhvN6iEcBxUyc3gvKmw==",
+      "dev": true,
+      "dependencies": {
+        "function.prototype.name": "^1.1.5",
+        "has-tostringtag": "^1.0.0",
+        "is-async-function": "^2.0.0",
+        "is-date-object": "^1.0.5",
+        "is-finalizationregistry": "^1.0.2",
+        "is-generator-function": "^1.0.10",
+        "is-regex": "^1.1.4",
+        "is-weakref": "^1.0.2",
+        "isarray": "^2.0.5",
+        "which-boxed-primitive": "^1.0.2",
+        "which-collection": "^1.0.1",
+        "which-typed-array": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "dev": true,
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/which-module": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
@@ -9650,16 +10661,16 @@
       "dev": true
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.11.tgz",
-      "integrity": "sha512-qe9UWWpkeG5yzZ0tNYxDmd7vo58HDBc39mZ0xWWpolAGADdFOzkfamWLDxkOWcvHQKVmdTyQdLD4NOfjLWTKew==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.15.tgz",
+      "integrity": "sha512-oV0jmFtUky6CXfkqehVvBP/LSWJ2sy4vWMioiENyJLePrBO/yKyV9OyJySfAKosh+RYkIl5zJCNZ8/4JncrpdA==",
       "dev": true,
       "dependencies": {
-        "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.2",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.7",
         "for-each": "^0.3.3",
         "gopd": "^1.0.1",
-        "has-tostringtag": "^1.0.0"
+        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "chalk": "^4.1.2",
     "eslint": "^8.56.0",
     "eslint-config-prettier": "^8.10.0",
+    "eslint-plugin-github": "^4.10.2",
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-mocha": "^10.4.1",
     "eslint-plugin-prettier": "^4.2.1",

--- a/src/admin.ts
+++ b/src/admin.ts
@@ -73,7 +73,7 @@ export class Admin {
    * @param options - Optional settings for the command
    */
   async command(command: Document, options?: RunCommandOptions): Promise<Document> {
-    return executeOperation(
+    return await executeOperation(
       this.s.db.client,
       new RunAdminCommandOperation(command, {
         ...resolveBSONOptions(options),
@@ -89,7 +89,7 @@ export class Admin {
    * @param options - Optional settings for the command
    */
   async buildInfo(options?: CommandOperationOptions): Promise<Document> {
-    return this.command({ buildinfo: 1 }, options);
+    return await this.command({ buildinfo: 1 }, options);
   }
 
   /**
@@ -98,7 +98,7 @@ export class Admin {
    * @param options - Optional settings for the command
    */
   async serverInfo(options?: CommandOperationOptions): Promise<Document> {
-    return this.command({ buildinfo: 1 }, options);
+    return await this.command({ buildinfo: 1 }, options);
   }
 
   /**
@@ -107,7 +107,7 @@ export class Admin {
    * @param options - Optional settings for the command
    */
   async serverStatus(options?: CommandOperationOptions): Promise<Document> {
-    return this.command({ serverStatus: 1 }, options);
+    return await this.command({ serverStatus: 1 }, options);
   }
 
   /**
@@ -116,7 +116,7 @@ export class Admin {
    * @param options - Optional settings for the command
    */
   async ping(options?: CommandOperationOptions): Promise<Document> {
-    return this.command({ ping: 1 }, options);
+    return await this.command({ ping: 1 }, options);
   }
 
   /**
@@ -126,7 +126,7 @@ export class Admin {
    * @param options - Optional settings for the command
    */
   async removeUser(username: string, options?: RemoveUserOptions): Promise<boolean> {
-    return executeOperation(
+    return await executeOperation(
       this.s.db.client,
       new RemoveUserOperation(this.s.db, username, { dbName: 'admin', ...options })
     );
@@ -142,7 +142,7 @@ export class Admin {
     collectionName: string,
     options: ValidateCollectionOptions = {}
   ): Promise<Document> {
-    return executeOperation(
+    return await executeOperation(
       this.s.db.client,
       new ValidateCollectionOperation(this, collectionName, options)
     );
@@ -154,7 +154,7 @@ export class Admin {
    * @param options - Optional settings for the command
    */
   async listDatabases(options?: ListDatabasesOptions): Promise<ListDatabasesResult> {
-    return executeOperation(this.s.db.client, new ListDatabasesOperation(this.s.db, options));
+    return await executeOperation(this.s.db.client, new ListDatabasesOperation(this.s.db, options));
   }
 
   /**
@@ -163,6 +163,6 @@ export class Admin {
    * @param options - Optional settings for the command
    */
   async replSetGetStatus(options?: CommandOperationOptions): Promise<Document> {
-    return this.command({ replSetGetStatus: 1 }, options);
+    return await this.command({ replSetGetStatus: 1 }, options);
   }
 }

--- a/src/bulk/common.ts
+++ b/src/bulk/common.ts
@@ -1224,7 +1224,7 @@ export abstract class BulkOperationBase {
     const finalOptions = { ...this.s.options, ...options };
     const operation = new BulkWriteShimOperation(this, finalOptions);
 
-    return executeOperation(this.s.collection.client, operation);
+    return await executeOperation(this.s.collection.client, operation);
   }
 
   /**

--- a/src/bulk/common.ts
+++ b/src/bulk/common.ts
@@ -1,5 +1,3 @@
-import { promisify } from 'util';
-
 import { type BSONSerializeOptions, type Document, resolveBSONOptions } from '../bson';
 import type { Collection } from '../collection';
 import {
@@ -23,7 +21,6 @@ import type { ClientSession } from '../sessions';
 import { maybeAddIdToDocuments } from '../utils';
 import {
   applyRetryableWrites,
-  type Callback,
   getTopology,
   hasAtomicOperators,
   type MongoDBNamespace,
@@ -500,126 +497,103 @@ export function mergeBatchResults(
   }
 }
 
-function executeCommands(
+async function executeCommands(
   bulkOperation: BulkOperationBase,
-  options: BulkWriteOptions,
-  callback: Callback<BulkWriteResult>
-) {
-  if (bulkOperation.s.batches.length === 0) {
-    return callback(
-      undefined,
-      new BulkWriteResult(bulkOperation.s.bulkResult, bulkOperation.isOrdered)
-    );
-  }
+  options: BulkWriteOptions
+): Promise<BulkWriteResult> {
+  for (const batch of bulkOperation.s.batches) {
+    const finalOptions = resolveOptions(bulkOperation, {
+      ...options,
+      ordered: bulkOperation.isOrdered
+    });
 
-  const batch = bulkOperation.s.batches.shift() as Batch;
+    if (finalOptions.bypassDocumentValidation !== true) {
+      delete finalOptions.bypassDocumentValidation;
+    }
 
-  function resultHandler(err?: AnyError, result?: Document) {
-    // Error is a driver related error not a bulk op error, return early
-    if (err && 'message' in err && !(err instanceof MongoWriteConcernError)) {
-      return callback(
-        new MongoBulkWriteError(
+    // Is the bypassDocumentValidation options specific
+    if (bulkOperation.s.bypassDocumentValidation === true) {
+      finalOptions.bypassDocumentValidation = true;
+    }
+
+    // Is the checkKeys option disabled
+    if (bulkOperation.s.checkKeys === false) {
+      finalOptions.checkKeys = false;
+    }
+
+    if (finalOptions.retryWrites) {
+      if (isUpdateBatch(batch)) {
+        finalOptions.retryWrites =
+          finalOptions.retryWrites && !batch.operations.some(op => op.multi);
+      }
+
+      if (isDeleteBatch(batch)) {
+        finalOptions.retryWrites =
+          finalOptions.retryWrites && !batch.operations.some(op => op.limit === 0);
+      }
+    }
+
+    try {
+      const operation = isInsertBatch(batch)
+        ? new InsertOperation(bulkOperation.s.namespace, batch.operations, finalOptions)
+        : isUpdateBatch(batch)
+        ? new UpdateOperation(bulkOperation.s.namespace, batch.operations, finalOptions)
+        : isDeleteBatch(batch)
+        ? new DeleteOperation(bulkOperation.s.namespace, batch.operations, finalOptions)
+        : null;
+
+      if (operation != null) {
+        const result = await executeOperation(bulkOperation.s.collection.client, operation);
+        // Merge the results together
+        mergeBatchResults(batch, bulkOperation.s.bulkResult, undefined, result);
+
+        const writeResult = new BulkWriteResult(
+          bulkOperation.s.bulkResult,
+          bulkOperation.isOrdered
+        );
+
+        bulkOperation.handleWriteError(writeResult);
+
+        // Execute the next command in line
+        await executeCommands(bulkOperation, options);
+      }
+    } catch (err) {
+      if (!(err instanceof MongoWriteConcernError)) {
+        // Error is a driver related error not a bulk op error
+        throw new MongoBulkWriteError(
           err,
           new BulkWriteResult(bulkOperation.s.bulkResult, bulkOperation.isOrdered)
-        )
-      );
-    }
+        );
+      }
 
-    if (err instanceof MongoWriteConcernError) {
-      return handleMongoWriteConcernError(
-        batch,
-        bulkOperation.s.bulkResult,
-        bulkOperation.isOrdered,
-        err,
-        callback
-      );
-    }
-
-    // Merge the results together
-    mergeBatchResults(batch, bulkOperation.s.bulkResult, err, result);
-    const writeResult = new BulkWriteResult(bulkOperation.s.bulkResult, bulkOperation.isOrdered);
-    if (bulkOperation.handleWriteError(callback, writeResult)) return;
-
-    // Execute the next command in line
-    executeCommands(bulkOperation, options, callback);
-  }
-
-  const finalOptions = resolveOptions(bulkOperation, {
-    ...options,
-    ordered: bulkOperation.isOrdered
-  });
-
-  if (finalOptions.bypassDocumentValidation !== true) {
-    delete finalOptions.bypassDocumentValidation;
-  }
-
-  // Set an operationIf if provided
-  if (bulkOperation.operationId) {
-    resultHandler.operationId = bulkOperation.operationId;
-  }
-
-  // Is the bypassDocumentValidation options specific
-  if (bulkOperation.s.bypassDocumentValidation === true) {
-    finalOptions.bypassDocumentValidation = true;
-  }
-
-  // Is the checkKeys option disabled
-  if (bulkOperation.s.checkKeys === false) {
-    finalOptions.checkKeys = false;
-  }
-
-  if (finalOptions.retryWrites) {
-    if (isUpdateBatch(batch)) {
-      finalOptions.retryWrites = finalOptions.retryWrites && !batch.operations.some(op => op.multi);
-    }
-
-    if (isDeleteBatch(batch)) {
-      finalOptions.retryWrites =
-        finalOptions.retryWrites && !batch.operations.some(op => op.limit === 0);
+      if (err instanceof MongoWriteConcernError) {
+        handleMongoWriteConcernError(
+          batch,
+          bulkOperation.s.bulkResult,
+          bulkOperation.isOrdered,
+          err
+        );
+      }
     }
   }
 
-  try {
-    const operation = isInsertBatch(batch)
-      ? new InsertOperation(bulkOperation.s.namespace, batch.operations, finalOptions)
-      : isUpdateBatch(batch)
-      ? new UpdateOperation(bulkOperation.s.namespace, batch.operations, finalOptions)
-      : isDeleteBatch(batch)
-      ? new DeleteOperation(bulkOperation.s.namespace, batch.operations, finalOptions)
-      : null;
-
-    if (operation != null) {
-      executeOperation(bulkOperation.s.collection.client, operation).then(
-        result => resultHandler(undefined, result),
-        error => resultHandler(error)
-      );
-    }
-  } catch (err) {
-    // Force top level error
-    err.ok = 0;
-    // Merge top level error and return
-    mergeBatchResults(batch, bulkOperation.s.bulkResult, err, undefined);
-    callback();
-  }
+  return new BulkWriteResult(bulkOperation.s.bulkResult, bulkOperation.isOrdered);
 }
 
 function handleMongoWriteConcernError(
   batch: Batch,
   bulkResult: BulkResult,
   isOrdered: boolean,
-  err: MongoWriteConcernError,
-  callback: Callback<BulkWriteResult>
-) {
+  err: MongoWriteConcernError
+): never {
   mergeBatchResults(batch, bulkResult, undefined, err.result);
 
-  callback(
-    new MongoBulkWriteError(
-      {
-        message: err.result?.writeConcernError.errmsg,
-        code: err.result?.writeConcernError.result
-      },
-      new BulkWriteResult(bulkResult, isOrdered)
-    )
+  throw new MongoBulkWriteError(
+    {
+      message: err.result?.writeConcernError.errmsg,
+      code: err.result?.writeConcernError.result
+    },
+    new BulkWriteResult(bulkResult, isOrdered)
   );
 }
 
@@ -875,8 +849,6 @@ export interface BulkWriteOptions extends CommandOperationOptions {
   let?: Document;
 }
 
-const executeCommandsAsync = promisify(executeCommands);
-
 /**
  * TODO(NODE-4063)
  * BulkWrites merge complexity is implemented in executeCommands
@@ -903,7 +875,7 @@ export class BulkWriteShimOperation extends AbstractOperation {
       // an explicit session would be
       this.options.session = session;
     }
-    return executeCommandsAsync(this.bulkOperation, this.options);
+    return executeCommands(this.bulkOperation, this.options);
   }
 }
 
@@ -1231,33 +1203,26 @@ export abstract class BulkOperationBase {
    * Handles the write error before executing commands
    * @internal
    */
-  handleWriteError(callback: Callback<BulkWriteResult>, writeResult: BulkWriteResult): boolean {
+  handleWriteError(writeResult: BulkWriteResult): void {
     if (this.s.bulkResult.writeErrors.length > 0) {
       const msg = this.s.bulkResult.writeErrors[0].errmsg
         ? this.s.bulkResult.writeErrors[0].errmsg
         : 'write operation failed';
 
-      callback(
-        new MongoBulkWriteError(
-          {
-            message: msg,
-            code: this.s.bulkResult.writeErrors[0].code,
-            writeErrors: this.s.bulkResult.writeErrors
-          },
-          writeResult
-        )
+      throw new MongoBulkWriteError(
+        {
+          message: msg,
+          code: this.s.bulkResult.writeErrors[0].code,
+          writeErrors: this.s.bulkResult.writeErrors
+        },
+        writeResult
       );
-
-      return true;
     }
 
     const writeConcernError = writeResult.getWriteConcernError();
     if (writeConcernError) {
-      callback(new MongoBulkWriteError(writeConcernError, writeResult));
-      return true;
+      throw new MongoBulkWriteError(writeConcernError, writeResult);
     }
-
-    return false;
   }
 
   abstract addToOperationsList(

--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -19,7 +19,7 @@ import type { AggregateOptions } from './operations/aggregate';
 import type { CollationOptions, OperationParent } from './operations/command';
 import type { ReadPreference } from './read_preference';
 import type { ServerSessionId } from './sessions';
-import { filterOptions, getTopology, type MongoDBNamespace } from './utils';
+import { filterOptions, getTopology, type MongoDBNamespace, squashError } from './utils';
 
 /** @internal */
 const kCursorStream = Symbol('cursorStream');
@@ -867,7 +867,8 @@ export class ChangeStream<
   private _closeEmitterModeWithError(error: AnyError): void {
     this.emit(ChangeStream.ERROR, error);
 
-    this.close().catch(() => null);
+    // eslint-disable-next-line github/no-then
+    this.close().then(undefined, squashError);
   }
 
   /** @internal */
@@ -931,13 +932,15 @@ export class ChangeStream<
 
     if (isResumableError(changeStreamError, this.cursor.maxWireVersion)) {
       this._endStream();
-      this.cursor.close().catch(() => null);
+      // eslint-disable-next-line github/no-then
+      this.cursor.close().then(undefined, squashError);
 
       const topology = getTopology(this.parent);
       topology
         .selectServer(this.cursor.readPreference, {
           operationName: 'reconnect topology in change stream'
         })
+        // eslint-disable-next-line github/no-then
         .then(
           () => {
             this.cursor = this._createChangeStreamCursor(this.cursor.resumeOptions);
@@ -965,7 +968,11 @@ export class ChangeStream<
       throw changeStreamError;
     }
 
-    await this.cursor.close().catch(() => null);
+    try {
+      await this.cursor.close();
+    } catch {
+      // ignore errors from close
+    }
     const topology = getTopology(this.parent);
     try {
       await topology.selectServer(this.cursor.readPreference, {

--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -676,8 +676,8 @@ export class ChangeStream<
         } catch (error) {
           try {
             await this.close();
-          } catch {
-            // We are not concerned with errors from close()
+          } catch (error) {
+            squashError(error);
           }
           throw error;
         }
@@ -703,8 +703,8 @@ export class ChangeStream<
         } catch (error) {
           try {
             await this.close();
-          } catch {
-            // We are not concerned with errors from close()
+          } catch (error) {
+            squashError(error);
           }
           throw error;
         }
@@ -731,8 +731,8 @@ export class ChangeStream<
         } catch (error) {
           try {
             await this.close();
-          } catch {
-            // We are not concerned with errors from close()
+          } catch (error) {
+            squashError(error);
           }
           throw error;
         }
@@ -754,8 +754,8 @@ export class ChangeStream<
     } finally {
       try {
         await this.close();
-      } catch {
-        // we're not concerned with errors from close()
+      } catch (error) {
+        squashError(error);
       }
     }
   }
@@ -962,16 +962,16 @@ export class ChangeStream<
     if (!isResumableError(changeStreamError, this.cursor.maxWireVersion)) {
       try {
         await this.close();
-      } catch {
-        // ignore errors from close
+      } catch (error) {
+        squashError(error);
       }
       throw changeStreamError;
     }
 
     try {
       await this.cursor.close();
-    } catch {
-      // ignore errors from close
+    } catch (error) {
+      squashError(error);
     }
     const topology = getTopology(this.parent);
     try {

--- a/src/client-side-encryption/auto_encrypter.ts
+++ b/src/client-side-encryption/auto_encrypter.ts
@@ -467,7 +467,7 @@ export class AutoEncrypter {
       proxyOptions: this._proxyOptions,
       tlsOptions: this._tlsOptions
     });
-    return stateMachine.execute<Document>(this, context);
+    return await stateMachine.execute<Document>(this, context);
   }
 
   /**
@@ -502,7 +502,7 @@ export class AutoEncrypter {
    * the original ones.
    */
   async askForKMSCredentials(): Promise<KMSProviders> {
-    return refreshKMSCredentials(this._kmsProviders);
+    return await refreshKMSCredentials(this._kmsProviders);
   }
 
   /**

--- a/src/client-side-encryption/client_encryption.ts
+++ b/src/client-side-encryption/client_encryption.ts
@@ -315,7 +315,7 @@ export class ClientEncryption {
       this._keyVaultNamespace
     );
 
-    return this._keyVaultClient
+    return await this._keyVaultClient
       .db(dbName)
       .collection<DataKey>(collectionName)
       .deleteOne({ _id }, { writeConcern: { w: 'majority' } });
@@ -364,7 +364,7 @@ export class ClientEncryption {
       this._keyVaultNamespace
     );
 
-    return this._keyVaultClient
+    return await this._keyVaultClient
       .db(dbName)
       .collection<DataKey>(collectionName)
       .findOne({ _id }, { readConcern: { level: 'majority' } });
@@ -391,7 +391,7 @@ export class ClientEncryption {
       this._keyVaultNamespace
     );
 
-    return this._keyVaultClient
+    return await this._keyVaultClient
       .db(dbName)
       .collection<DataKey>(collectionName)
       .findOne({ keyAltNames: keyAltName }, { readConcern: { level: 'majority' } });
@@ -589,7 +589,7 @@ export class ClientEncryption {
    * ```
    */
   async encrypt(value: unknown, options: ClientEncryptionEncryptOptions): Promise<Binary> {
-    return this._encrypt(value, false, options);
+    return await this._encrypt(value, false, options);
   }
 
   /**
@@ -614,7 +614,7 @@ export class ClientEncryption {
     expression: Document,
     options: ClientEncryptionEncryptOptions
   ): Promise<Binary> {
-    return this._encrypt(expression, true, options);
+    return await this._encrypt(expression, true, options);
   }
 
   /**
@@ -654,7 +654,7 @@ export class ClientEncryption {
    * the original ones.
    */
   async askForKMSCredentials(): Promise<KMSProviders> {
-    return refreshKMSCredentials(this._kmsProviders);
+    return await refreshKMSCredentials(this._kmsProviders);
   }
 
   static get libmongocryptVersion() {

--- a/src/client-side-encryption/providers/azure.ts
+++ b/src/client-side-encryption/providers/azure.ts
@@ -148,13 +148,15 @@ export async function fetchAzureKMSToken(
   options: AzureKMSRequestOptions = {}
 ): Promise<AzureTokenCacheEntry> {
   const { headers, url } = prepareRequest(options);
-  const response = await get(url, { headers }).catch(error => {
+  try {
+    const response = await get(url, { headers });
+    return await parseResponse(response);
+  } catch (error) {
     if (error instanceof MongoCryptKMSRequestNetworkTimeoutError) {
       throw new MongoCryptAzureKMSRequestError(`[Azure KMS] ${error.message}`);
     }
     throw error;
-  });
-  return await parseResponse(response);
+  }
 }
 
 /**

--- a/src/client-side-encryption/providers/azure.ts
+++ b/src/client-side-encryption/providers/azure.ts
@@ -154,7 +154,7 @@ export async function fetchAzureKMSToken(
     }
     throw error;
   });
-  return parseResponse(response);
+  return await parseResponse(response);
 }
 
 /**

--- a/src/cmap/auth/aws_temporary_credentials.ts
+++ b/src/cmap/auth/aws_temporary_credentials.ts
@@ -139,7 +139,9 @@ export class LegacyAWSTemporaryCredentialProvider extends AWSTemporaryCredential
     // If the environment variable AWS_CONTAINER_CREDENTIALS_RELATIVE_URI
     // is set then drivers MUST assume that it was set by an AWS ECS agent
     if (process.env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI) {
-      return request(`${AWS_RELATIVE_URI}${process.env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI}`);
+      return await request(
+        `${AWS_RELATIVE_URI}${process.env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI}`
+      );
     }
 
     // Otherwise assume we are on an EC2 instance

--- a/src/cmap/auth/gssapi.ts
+++ b/src/cmap/auth/gssapi.ts
@@ -30,10 +30,10 @@ async function externalCommand(
   connection: Connection,
   command: ReturnType<typeof saslStart> | ReturnType<typeof saslContinue>
 ): Promise<{ payload: string; conversationId: any }> {
-  return connection.command(ns('$external.$cmd'), command, undefined) as Promise<{
+  return await (connection.command(ns('$external.$cmd'), command, undefined) as Promise<{
     payload: string;
     conversationId: any;
-  }>;
+  }>);
 }
 
 let krb: typeof Kerberos;
@@ -104,7 +104,7 @@ async function makeKerberosClient(authContext: AuthContext): Promise<KerberosCli
     spn = `${spn}@${mechanismProperties.SERVICE_REALM}`;
   }
 
-  return initializeClient(spn, initOptions);
+  return await initializeClient(spn, initOptions);
 }
 
 function saslStart(payload: string) {
@@ -138,14 +138,14 @@ async function negotiate(
       throw error;
     }
     // Adjust number of retries and call step again
-    return negotiate(client, retries - 1, payload);
+    return await negotiate(client, retries - 1, payload);
   }
 }
 
 async function finalize(client: KerberosClient, user: string, payload: string): Promise<string> {
   // GSS Client Unwrap
   const response = await client.unwrap(payload);
-  return client.wrap(response || '', { user });
+  return await client.wrap(response || '', { user });
 }
 
 export async function performGSSAPICanonicalizeHostName(
@@ -174,12 +174,12 @@ export async function performGSSAPICanonicalizeHostName(
       // This can error as ptr records may not exist for all ips. In this case
       // fallback to a cname lookup as dns.lookup() does not return the
       // cname.
-      return resolveCname(host);
+      return await resolveCname(host);
     }
   } else {
     // The case for forward is just to resolve the cname as dns.lookup()
     // will not return it.
-    return resolveCname(host);
+    return await resolveCname(host);
   }
 }
 

--- a/src/cmap/auth/mongodb_oidc/aws_service_workflow.ts
+++ b/src/cmap/auth/mongodb_oidc/aws_service_workflow.ts
@@ -24,6 +24,6 @@ export class AwsServiceWorkflow extends ServiceWorkflow {
     if (!tokenFile) {
       throw new MongoAWSError(TOKEN_MISSING_ERROR);
     }
-    return fs.promises.readFile(tokenFile, 'utf8');
+    return await fs.promises.readFile(tokenFile, 'utf8');
   }
 }

--- a/src/cmap/auth/mongodb_oidc/callback_lock_cache.ts
+++ b/src/cmap/auth/mongodb_oidc/callback_lock_cache.ts
@@ -88,7 +88,7 @@ function withLock(callback: OIDCRequestFunction | OIDCRefreshFunction) {
   return async (info: IdPServerInfo, context: OIDCCallbackContext): Promise<IdPServerResponse> => {
     await lock;
     lock = lock.then(() => callback(info, context));
-    return lock;
+    return await lock;
   };
 }
 

--- a/src/cmap/auth/mongodb_oidc/callback_lock_cache.ts
+++ b/src/cmap/auth/mongodb_oidc/callback_lock_cache.ts
@@ -87,6 +87,7 @@ function withLock(callback: OIDCRequestFunction | OIDCRefreshFunction) {
   let lock: Promise<any> = Promise.resolve();
   return async (info: IdPServerInfo, context: OIDCCallbackContext): Promise<IdPServerResponse> => {
     await lock;
+    // eslint-disable-next-line github/no-then
     lock = lock.then(() => callback(info, context));
     return await lock;
   };

--- a/src/cmap/auth/mongodb_oidc/service_workflow.ts
+++ b/src/cmap/auth/mongodb_oidc/service_workflow.ts
@@ -18,7 +18,7 @@ export abstract class ServiceWorkflow implements Workflow {
   async execute(connection: Connection, credentials: MongoCredentials): Promise<Document> {
     const token = await this.getToken(credentials);
     const command = commandDocument(token);
-    return connection.command(ns(credentials.source), command, undefined);
+    return await connection.command(ns(credentials.source), command, undefined);
   }
 
   /**

--- a/src/cmap/auth/scram.ts
+++ b/src/cmap/auth/scram.ts
@@ -51,13 +51,13 @@ class ScramSHA extends AuthProvider {
   override async auth(authContext: AuthContext) {
     const { reauthenticating, response } = authContext;
     if (response?.speculativeAuthenticate && !reauthenticating) {
-      return continueScramConversation(
+      return await continueScramConversation(
         this.cryptoMethod,
         response.speculativeAuthenticate,
         authContext
       );
     }
-    return executeScram(this.cryptoMethod, authContext);
+    return await executeScram(this.cryptoMethod, authContext);
   }
 }
 

--- a/src/cmap/connect.ts
+++ b/src/cmap/connect.ts
@@ -226,13 +226,13 @@ export async function prepareHandshakeDocument(
           `No AuthProvider for ${AuthMechanism.MONGODB_SCRAM_SHA256} defined.`
         );
       }
-      return provider.prepare(handshakeDoc, authContext);
+      return await provider.prepare(handshakeDoc, authContext);
     }
     const provider = authContext.options.authProviders.getOrCreateProvider(credentials.mechanism);
     if (!provider) {
       throw new MongoInvalidArgumentError(`No AuthProvider for ${credentials.mechanism} defined.`);
     }
-    return provider.prepare(handshakeDoc, authContext);
+    return await provider.prepare(handshakeDoc, authContext);
   }
   return handshakeDoc;
 }
@@ -325,7 +325,7 @@ export async function makeSocket(options: MakeConnectionOptions): Promise<Stream
 
   if (options.proxyHost != null) {
     // Currently, only Socks5 is supported.
-    return makeSocks5Connection({
+    return await makeSocks5Connection({
       ...options,
       connectTimeoutMS // Should always be present for Socks5
     });

--- a/src/cmap/connection.ts
+++ b/src/cmap/connection.ts
@@ -607,7 +607,7 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
     const buffer = Buffer.concat(await finalCommand.toBin());
 
     if (this.socket.write(buffer)) return;
-    return once(this.socket, 'drain');
+    return await once(this.socket, 'drain');
   }
 
   /**
@@ -698,7 +698,7 @@ export class CryptoConnection extends Connection {
     const serverWireVersion = maxWireVersion(this);
     if (serverWireVersion === 0) {
       // This means the initial handshake hasn't happened yet
-      return super.command(ns, cmd, options);
+      return await super.command(ns, cmd, options);
     }
 
     if (serverWireVersion < 8) {
@@ -734,6 +734,6 @@ export class CryptoConnection extends Connection {
 
     const response = await super.command(ns, encrypted, options);
 
-    return autoEncrypter.decrypt(response, options);
+    return await autoEncrypter.decrypt(response, options);
   }
 }

--- a/src/cmap/connection.ts
+++ b/src/cmap/connection.ts
@@ -38,6 +38,7 @@ import {
   type MongoDBNamespace,
   now,
   once,
+  squashError,
   uuidV4
 } from '../utils';
 import type { WriteConcern } from '../write_concern';
@@ -324,7 +325,8 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
 
     this.socket.destroy();
     this.error = error;
-    this.dataEvents?.throw(error).then(undefined, () => null); // squash unhandled rejection
+    // eslint-disable-next-line github/no-then
+    this.dataEvents?.throw(error).then(undefined, squashError);
     this.closed = true;
     this.emit(Connection.CLOSE);
   }
@@ -579,7 +581,8 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
       }
       throw new MongoUnexpectedServerResponseError('Server ended moreToCome unexpectedly');
     };
-    exhaustLoop().catch(replyListener);
+    // eslint-disable-next-line github/no-then
+    exhaustLoop().then(undefined, replyListener);
   }
 
   private throwIfAborted() {

--- a/src/cmap/connection_pool.ts
+++ b/src/cmap/connection_pool.ts
@@ -394,7 +394,7 @@ export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
     this[kWaitQueue].push(waitQueueMember);
     process.nextTick(() => this.processWaitQueue());
 
-    return promise;
+    return await promise;
   }
 
   /**

--- a/src/cmap/connection_pool.ts
+++ b/src/cmap/connection_pool.ts
@@ -614,7 +614,7 @@ export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
     return true;
   }
 
-  private async createConnection(): Promise<Connection> {
+  private createConnection(callback: Callback<Connection>) {
     const connectOptions: ConnectionOptions = {
       ...this.options,
       id: this[kConnectionCounter].next().value,
@@ -631,60 +631,66 @@ export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
       new ConnectionCreatedEvent(this, { id: connectOptions.id })
     );
 
-    try {
-      const connection = await connect(connectOptions);
-      // The pool might have closed since we started trying to create a connection
-      if (this[kPoolState] !== PoolState.ready) {
-        this[kPending]--;
-        connection.destroy();
-        const error = this.closed ? new PoolClosedError(this) : new PoolClearedError(this);
-        throw error;
-      }
+    // eslint-disable-next-line github/no-then
+    connect(connectOptions).then(
+      connection => {
+        // The pool might have closed since we started trying to create a connection
+        if (this[kPoolState] !== PoolState.ready) {
+          this[kPending]--;
+          connection.destroy();
+          callback(this.closed ? new PoolClosedError(this) : new PoolClearedError(this));
+          return;
+        }
 
-      // forward all events from the connection to the pool
-      for (const event of [...APM_EVENTS, Connection.CLUSTER_TIME_RECEIVED]) {
-        connection.on(event, (e: any) => this.emit(event, e));
-      }
+        // forward all events from the connection to the pool
+        for (const event of [...APM_EVENTS, Connection.CLUSTER_TIME_RECEIVED]) {
+          connection.on(event, (e: any) => this.emit(event, e));
+        }
 
-      if (this.loadBalanced) {
-        connection.on(Connection.PINNED, pinType => this[kMetrics].markPinned(pinType));
-        connection.on(Connection.UNPINNED, pinType => this[kMetrics].markUnpinned(pinType));
+        if (this.loadBalanced) {
+          connection.on(Connection.PINNED, pinType => this[kMetrics].markPinned(pinType));
+          connection.on(Connection.UNPINNED, pinType => this[kMetrics].markUnpinned(pinType));
 
-        const serviceId = connection.serviceId;
-        if (serviceId) {
-          let generation;
-          const sid = serviceId.toHexString();
-          if ((generation = this.serviceGenerations.get(sid))) {
-            connection.generation = generation;
-          } else {
-            this.serviceGenerations.set(sid, 0);
-            connection.generation = 0;
+          const serviceId = connection.serviceId;
+          if (serviceId) {
+            let generation;
+            const sid = serviceId.toHexString();
+            if ((generation = this.serviceGenerations.get(sid))) {
+              connection.generation = generation;
+            } else {
+              this.serviceGenerations.set(sid, 0);
+              connection.generation = 0;
+            }
           }
         }
-      }
 
-      connection.markAvailable();
-      this.emitAndLog(ConnectionPool.CONNECTION_READY, new ConnectionReadyEvent(this, connection));
+        connection.markAvailable();
+        this.emitAndLog(
+          ConnectionPool.CONNECTION_READY,
+          new ConnectionReadyEvent(this, connection)
+        );
 
-      this[kPending]--;
-      return connection;
-    } catch (error) {
-      this[kPending]--;
-      this.emitAndLog(
-        ConnectionPool.CONNECTION_CLOSED,
-        new ConnectionClosedEvent(
-          this,
-          { id: connectOptions.id, serviceId: undefined },
-          'error',
-          // TODO(NODE-5192): Remove this cast
-          error as MongoError
-        )
-      );
-      if (error instanceof MongoNetworkError || error instanceof MongoServerError) {
-        error.connectionGeneration = connectOptions.generation;
+        this[kPending]--;
+        callback(undefined, connection);
+      },
+      error => {
+        this[kPending]--;
+        this.emitAndLog(
+          ConnectionPool.CONNECTION_CLOSED,
+          new ConnectionClosedEvent(
+            this,
+            { id: connectOptions.id, serviceId: undefined },
+            'error',
+            // TODO(NODE-5192): Remove this cast
+            error as MongoError
+          )
+        );
+        if (error instanceof MongoNetworkError || error instanceof MongoServerError) {
+          error.connectionGeneration = connectOptions.generation;
+        }
+        callback(error ?? new MongoRuntimeError('Connection creation failed without error'));
       }
-      throw new MongoRuntimeError('Connection creation failed without error');
-    }
+    );
   }
 
   private ensureMinPoolSize() {
@@ -702,26 +708,22 @@ export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
       // NOTE: ensureMinPoolSize should not try to get all the pending
       // connection permits because that potentially delays the availability of
       // the connection to a checkout request
-      this.createConnection()
-        // eslint-disable-next-line github/no-then
-        .then(
-          connection => {
-            this[kConnections].push(connection);
-            process.nextTick(() => this.processWaitQueue());
-          },
-          error => {
-            this[kServer].handleError(error);
-          }
-        )
-        .finally(() => {
-          if (this[kPoolState] === PoolState.ready) {
-            clearTimeout(this[kMinPoolSizeTimer]);
-            this[kMinPoolSizeTimer] = setTimeout(
-              () => this.ensureMinPoolSize(),
-              this.options.minPoolSizeCheckFrequencyMS
-            );
-          }
-        });
+      this.createConnection((err, connection) => {
+        if (err) {
+          this[kServer].handleError(err);
+        }
+        if (!err && connection) {
+          this[kConnections].push(connection);
+          process.nextTick(() => this.processWaitQueue());
+        }
+        if (this[kPoolState] === PoolState.ready) {
+          clearTimeout(this[kMinPoolSizeTimer]);
+          this[kMinPoolSizeTimer] = setTimeout(
+            () => this.ensureMinPoolSize(),
+            this.options.minPoolSizeCheckFrequencyMS
+          );
+        }
+      });
     } else {
       clearTimeout(this[kMinPoolSizeTimer]);
       this[kMinPoolSizeTimer] = setTimeout(
@@ -794,34 +796,32 @@ export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
       if (!waitQueueMember || waitQueueMember[kCancelled]) {
         continue;
       }
-
-      this.createConnection()
-        // eslint-disable-next-line github/no-then
-        .then(
-          connection => {
-            if (waitQueueMember[kCancelled]) {
-              this[kConnections].push(connection);
-            }
+      this.createConnection((err, connection) => {
+        if (waitQueueMember[kCancelled]) {
+          if (!err && connection) {
+            this[kConnections].push(connection);
+          }
+        } else {
+          if (err) {
+            this.emitAndLog(
+              ConnectionPool.CONNECTION_CHECK_OUT_FAILED,
+              // TODO(NODE-5192): Remove this cast
+              new ConnectionCheckOutFailedEvent(this, 'connectionError', err as MongoError)
+            );
+            waitQueueMember.reject(err);
+          } else if (connection) {
             this[kCheckedOut].add(connection);
             this.emitAndLog(
               ConnectionPool.CONNECTION_CHECKED_OUT,
               new ConnectionCheckedOutEvent(this, connection)
             );
             waitQueueMember.resolve(connection);
-          },
-          error => {
-            this.emitAndLog(
-              ConnectionPool.CONNECTION_CHECK_OUT_FAILED,
-              // TODO(NODE-5192): Remove this cast
-              new ConnectionCheckOutFailedEvent(this, 'connectionError', error)
-            );
-            waitQueueMember.reject(error);
           }
-        )
-        .finally(() => {
+
           waitQueueMember.timeoutController.clear();
-          process.nextTick(() => this.processWaitQueue());
-        });
+        }
+        process.nextTick(() => this.processWaitQueue());
+      });
     }
     this[kProcessingWaitQueue] = false;
   }

--- a/src/cmap/handshake/client_metadata.ts
+++ b/src/cmap/handshake/client_metadata.ts
@@ -1,4 +1,3 @@
-import { promises as fs } from 'fs';
 import * as os from 'os';
 import * as process from 'process';
 

--- a/src/cmap/handshake/client_metadata.ts
+++ b/src/cmap/handshake/client_metadata.ts
@@ -156,15 +156,18 @@ export function makeClientMetadata(options: MakeClientMetadataOptions): ClientMe
   return metadataDocument.toObject() as ClientMetadata;
 }
 
-let dockerPromise: Promise<boolean>;
+let isDocker: Promise<void> | boolean | undefined;
 /** @internal */
 async function getContainerMetadata() {
   const containerMetadata: Record<string, any> = {};
-  dockerPromise ??= fs.access('/.dockerenv').then(
-    () => true,
-    () => false
-  );
-  const isDocker = await dockerPromise;
+  if (typeof isDocker !== 'boolean') {
+    try {
+      await (isDocker ??= fs.access('/.dockerenv'));
+      isDocker = true;
+    } catch {
+      isDocker = false;
+    }
+  }
 
   const { KUBERNETES_SERVICE_HOST = '' } = process.env;
   const isKubernetes = KUBERNETES_SERVICE_HOST.length > 0 ? true : false;

--- a/src/cmap/wire_protocol/compression.ts
+++ b/src/cmap/wire_protocol/compression.ts
@@ -67,20 +67,20 @@ export async function compress(
   switch (options.agreedCompressor) {
     case 'snappy': {
       Snappy ??= loadSnappy();
-      return Snappy.compress(dataToBeCompressed);
+      return await Snappy.compress(dataToBeCompressed);
     }
     case 'zstd': {
       loadZstd();
       if ('kModuleError' in zstd) {
         throw zstd['kModuleError'];
       }
-      return zstd.compress(dataToBeCompressed, ZSTD_COMPRESSION_LEVEL);
+      return await zstd.compress(dataToBeCompressed, ZSTD_COMPRESSION_LEVEL);
     }
     case 'zlib': {
       if (options.zlibCompressionLevel) {
         zlibOptions.level = options.zlibCompressionLevel;
       }
-      return zlibDeflate(dataToBeCompressed, zlibOptions);
+      return await zlibDeflate(dataToBeCompressed, zlibOptions);
     }
     default: {
       throw new MongoInvalidArgumentError(
@@ -106,17 +106,17 @@ export async function decompress(compressorID: number, compressedData: Buffer): 
   switch (compressorID) {
     case Compressor.snappy: {
       Snappy ??= loadSnappy();
-      return Snappy.uncompress(compressedData, { asBuffer: true });
+      return await Snappy.uncompress(compressedData, { asBuffer: true });
     }
     case Compressor.zstd: {
       loadZstd();
       if ('kModuleError' in zstd) {
         throw zstd['kModuleError'];
       }
-      return zstd.decompress(compressedData);
+      return await zstd.decompress(compressedData);
     }
     case Compressor.zlib: {
-      return zlibInflate(compressedData);
+      return await zlibInflate(compressedData);
     }
     default: {
       return compressedData;

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -263,7 +263,7 @@ export class Collection<TSchema extends Document = Document> {
     doc: OptionalUnlessRequiredId<TSchema>,
     options?: InsertOneOptions
   ): Promise<InsertOneResult<TSchema>> {
-    return executeOperation(
+    return await executeOperation(
       this.client,
       new InsertOneOperation(
         this as TODO_NODE_3286,
@@ -285,7 +285,7 @@ export class Collection<TSchema extends Document = Document> {
     docs: OptionalUnlessRequiredId<TSchema>[],
     options?: BulkWriteOptions
   ): Promise<InsertManyResult<TSchema>> {
-    return executeOperation(
+    return await executeOperation(
       this.client,
       new InsertManyOperation(
         this as TODO_NODE_3286,
@@ -322,7 +322,7 @@ export class Collection<TSchema extends Document = Document> {
       throw new MongoInvalidArgumentError('Argument "operations" must be an array of documents');
     }
 
-    return executeOperation(
+    return await executeOperation(
       this.client,
       new BulkWriteOperation(
         this as TODO_NODE_3286,
@@ -348,7 +348,7 @@ export class Collection<TSchema extends Document = Document> {
     update: UpdateFilter<TSchema> | Document[],
     options?: UpdateOptions
   ): Promise<UpdateResult<TSchema>> {
-    return executeOperation(
+    return await executeOperation(
       this.client,
       new UpdateOneOperation(
         this as TODO_NODE_3286,
@@ -371,7 +371,7 @@ export class Collection<TSchema extends Document = Document> {
     replacement: WithoutId<TSchema>,
     options?: ReplaceOptions
   ): Promise<UpdateResult<TSchema> | Document> {
-    return executeOperation(
+    return await executeOperation(
       this.client,
       new ReplaceOneOperation(
         this as TODO_NODE_3286,
@@ -398,7 +398,7 @@ export class Collection<TSchema extends Document = Document> {
     update: UpdateFilter<TSchema> | Document[],
     options?: UpdateOptions
   ): Promise<UpdateResult<TSchema>> {
-    return executeOperation(
+    return await executeOperation(
       this.client,
       new UpdateManyOperation(
         this as TODO_NODE_3286,
@@ -419,7 +419,7 @@ export class Collection<TSchema extends Document = Document> {
     filter: Filter<TSchema> = {},
     options: DeleteOptions = {}
   ): Promise<DeleteResult> {
-    return executeOperation(
+    return await executeOperation(
       this.client,
       new DeleteOneOperation(this as TODO_NODE_3286, filter, resolveOptions(this, options))
     );
@@ -435,7 +435,7 @@ export class Collection<TSchema extends Document = Document> {
     filter: Filter<TSchema> = {},
     options: DeleteOptions = {}
   ): Promise<DeleteResult> {
-    return executeOperation(
+    return await executeOperation(
       this.client,
       new DeleteManyOperation(this as TODO_NODE_3286, filter, resolveOptions(this, options))
     );
@@ -452,7 +452,7 @@ export class Collection<TSchema extends Document = Document> {
    */
   async rename(newName: string, options?: RenameOptions): Promise<Collection> {
     // Intentionally, we do not inherit options from parent for this operation.
-    return executeOperation(
+    return await executeOperation(
       this.client,
       new RenameOperation(this as TODO_NODE_3286, newName, {
         ...options,
@@ -467,7 +467,7 @@ export class Collection<TSchema extends Document = Document> {
    * @param options - Optional settings for the command
    */
   async drop(options?: DropCollectionOptions): Promise<boolean> {
-    return executeOperation(
+    return await executeOperation(
       this.client,
       new DropCollectionOperation(this.s.db, this.collectionName, options)
     );
@@ -521,7 +521,7 @@ export class Collection<TSchema extends Document = Document> {
    * @param options - Optional settings for the command
    */
   async options(options?: OperationOptions): Promise<Document> {
-    return executeOperation(
+    return await executeOperation(
       this.client,
       new OptionsOperation(this as TODO_NODE_3286, resolveOptions(this, options))
     );
@@ -533,7 +533,7 @@ export class Collection<TSchema extends Document = Document> {
    * @param options - Optional settings for the command
    */
   async isCapped(options?: OperationOptions): Promise<boolean> {
-    return executeOperation(
+    return await executeOperation(
       this.client,
       new IsCappedOperation(this as TODO_NODE_3286, resolveOptions(this, options))
     );
@@ -619,7 +619,7 @@ export class Collection<TSchema extends Document = Document> {
     indexSpecs: IndexDescription[],
     options?: CreateIndexesOptions
   ): Promise<string[]> {
-    return executeOperation(
+    return await executeOperation(
       this.client,
       CreateIndexesOperation.fromIndexDescriptionArray(
         this,
@@ -637,7 +637,7 @@ export class Collection<TSchema extends Document = Document> {
    * @param options - Optional settings for the command
    */
   async dropIndex(indexName: string, options?: DropIndexesOptions): Promise<Document> {
-    return executeOperation(
+    return await executeOperation(
       this.client,
       new DropIndexOperation(this as TODO_NODE_3286, indexName, {
         ...resolveOptions(this, options),
@@ -694,7 +694,7 @@ export class Collection<TSchema extends Document = Document> {
    * @param options - Optional settings for the command
    */
   async indexInformation(options?: IndexInformationOptions): Promise<Document> {
-    return this.indexes({ ...options, full: options?.full ?? false });
+    return await this.indexes({ ...options, full: options?.full ?? false });
   }
 
   /**
@@ -711,7 +711,7 @@ export class Collection<TSchema extends Document = Document> {
    * @param options - Optional settings for the command
    */
   async estimatedDocumentCount(options?: EstimatedDocumentCountOptions): Promise<number> {
-    return executeOperation(
+    return await executeOperation(
       this.client,
       new EstimatedDocumentCountOperation(this as TODO_NODE_3286, resolveOptions(this, options))
     );
@@ -746,7 +746,7 @@ export class Collection<TSchema extends Document = Document> {
     filter: Filter<TSchema> = {},
     options: CountDocumentsOptions = {}
   ): Promise<number> {
-    return executeOperation(
+    return await executeOperation(
       this.client,
       new CountDocumentsOperation(this as TODO_NODE_3286, filter, resolveOptions(this, options))
     );
@@ -782,7 +782,7 @@ export class Collection<TSchema extends Document = Document> {
     filter: Filter<TSchema> = {},
     options: DistinctOptions = {}
   ): Promise<any[]> {
-    return executeOperation(
+    return await executeOperation(
       this.client,
       new DistinctOperation(
         this as TODO_NODE_3286,
@@ -837,7 +837,7 @@ export class Collection<TSchema extends Document = Document> {
     filter: Filter<TSchema>,
     options?: FindOneAndDeleteOptions
   ): Promise<WithId<TSchema> | ModifyResult<TSchema> | null> {
-    return executeOperation(
+    return await executeOperation(
       this.client,
       new FindOneAndDeleteOperation(
         this as TODO_NODE_3286,
@@ -878,7 +878,7 @@ export class Collection<TSchema extends Document = Document> {
     replacement: WithoutId<TSchema>,
     options?: FindOneAndReplaceOptions
   ): Promise<WithId<TSchema> | ModifyResult<TSchema> | null> {
-    return executeOperation(
+    return await executeOperation(
       this.client,
       new FindOneAndReplaceOperation(
         this as TODO_NODE_3286,
@@ -920,7 +920,7 @@ export class Collection<TSchema extends Document = Document> {
     update: UpdateFilter<TSchema>,
     options?: FindOneAndUpdateOptions
   ): Promise<WithId<TSchema> | ModifyResult<TSchema> | null> {
-    return executeOperation(
+    return await executeOperation(
       this.client,
       new FindOneAndUpdateOperation(
         this as TODO_NODE_3286,
@@ -1043,7 +1043,7 @@ export class Collection<TSchema extends Document = Document> {
    * @param options - Optional settings for the command
    */
   async count(filter: Filter<TSchema> = {}, options: CountOptions = {}): Promise<number> {
-    return executeOperation(
+    return await executeOperation(
       this.client,
       new CountOperation(this.fullNamespace, filter, resolveOptions(this, options))
     );
@@ -1105,7 +1105,7 @@ export class Collection<TSchema extends Document = Document> {
    * @returns
    */
   async createSearchIndexes(descriptions: SearchIndexDescription[]): Promise<string[]> {
-    return executeOperation(
+    return await executeOperation(
       this.client,
       new CreateSearchIndexesOperation(this as TODO_NODE_3286, descriptions)
     );
@@ -1119,7 +1119,7 @@ export class Collection<TSchema extends Document = Document> {
    * @remarks Only available when used against a 7.0+ Atlas cluster.
    */
   async dropSearchIndex(name: string): Promise<void> {
-    return executeOperation(
+    return await executeOperation(
       this.client,
       new DropSearchIndexOperation(this as TODO_NODE_3286, name)
     );
@@ -1134,7 +1134,7 @@ export class Collection<TSchema extends Document = Document> {
    * @remarks Only available when used against a 7.0+ Atlas cluster.
    */
   async updateSearchIndex(name: string, definition: Document): Promise<void> {
-    return executeOperation(
+    return await executeOperation(
       this.client,
       new UpdateSearchIndexOperation(this as TODO_NODE_3286, name, definition)
     );

--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -74,7 +74,7 @@ export async function resolveSRVRecord(options: MongoOptions): Promise<HostAddre
   const lookupAddress = options.srvHost;
   const txtResolutionPromise = dns.promises.resolveTxt(lookupAddress);
   // eslint-disable-next-line github/no-then
-  txtResolutionPromise.then(undefined, squashError);
+  txtResolutionPromise.then(undefined, squashError); // rejections will be handled later
 
   // Resolve the SRV record and use the result as the list of hosts to connect to.
   const addresses = await dns.promises.resolveSrv(
@@ -556,7 +556,7 @@ export function parseOptions(
   mongoOptions.extendedMetadata = addContainerMetadata(mongoOptions.metadata).then(
     undefined,
     squashError
-  );
+  ); // rejections will be handled later
 
   return mongoOptions;
 }

--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -40,7 +40,8 @@ import {
   isRecord,
   matchesParentDomain,
   parseInteger,
-  setDifference
+  setDifference,
+  squashError
 } from './utils';
 import { type W, WriteConcern } from './write_concern';
 
@@ -72,9 +73,8 @@ export async function resolveSRVRecord(options: MongoOptions): Promise<HostAddre
   // the SRV record is resolved before starting a second DNS query.
   const lookupAddress = options.srvHost;
   const txtResolutionPromise = dns.promises.resolveTxt(lookupAddress);
-  txtResolutionPromise.catch(() => {
-    /* rejections will be handled later */
-  });
+  // eslint-disable-next-line github/no-then
+  txtResolutionPromise.then(undefined, squashError);
 
   // Resolve the SRV record and use the result as the list of hosts to connect to.
   const addresses = await dns.promises.resolveSrv(
@@ -552,9 +552,11 @@ export function parseOptions(
 
   mongoOptions.metadata = makeClientMetadata(mongoOptions);
 
-  mongoOptions.extendedMetadata = addContainerMetadata(mongoOptions.metadata).catch(() => {
-    /* rejections will be handled later */
-  });
+  // eslint-disable-next-line github/no-then
+  mongoOptions.extendedMetadata = addContainerMetadata(mongoOptions.metadata).then(
+    undefined,
+    squashError
+  );
 
   return mongoOptions;
 }

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -387,7 +387,7 @@ export abstract class AbstractCursor<
       throw new MongoCursorExhaustedError();
     }
 
-    return next(this, { blocking: true, transform: true });
+    return await next(this, { blocking: true, transform: true });
   }
 
   /**
@@ -398,7 +398,7 @@ export abstract class AbstractCursor<
       throw new MongoCursorExhaustedError();
     }
 
-    return next(this, { blocking: false, transform: true });
+    return await next(this, { blocking: false, transform: true });
   }
 
   /**
@@ -629,7 +629,7 @@ export abstract class AbstractCursor<
       batchSize
     });
 
-    return executeOperation(this[kClient], getMoreOperation);
+    return await executeOperation(this[kClient], getMoreOperation);
   }
 
   /**
@@ -802,7 +802,7 @@ async function cleanupCursor(
 
   if (error) {
     if (cursor.loadBalanced && error instanceof MongoNetworkError) {
-      return completeCleanup();
+      return await completeCleanup();
     }
   }
 
@@ -850,7 +850,7 @@ async function cleanupCursor(
   cursor[kKilled] = true;
 
   if (session.hasEnded) {
-    return completeCleanup();
+    return await completeCleanup();
   }
 
   try {

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -311,8 +311,8 @@ export abstract class AbstractCursor<
 
             try {
               await cleanupCursor(this, { needsToEmitClosed: true });
-            } catch {
-              // ignore cleanupCursor errors
+            } catch (error) {
+              squashError(error);
             }
 
             throw new MongoAPIError(message);
@@ -333,8 +333,8 @@ export abstract class AbstractCursor<
       if (!this.closed) {
         try {
           await this.close();
-        } catch {
-          // ignore close errors
+        } catch (error) {
+          squashError(error);
         }
       }
     }
@@ -735,8 +735,9 @@ async function next<T>(
         } catch (error) {
           try {
             await cleanupCursor(cursor, { error, needsToEmitClosed: true });
-          } catch {
+          } catch (error) {
             // `cleanupCursor` should never throw, squash and throw the original error
+            squashError(error);
           }
           throw error;
         }
@@ -773,8 +774,9 @@ async function next<T>(
     } catch (error) {
       try {
         await cleanupCursor(cursor, { error, needsToEmitClosed: true });
-      } catch {
+      } catch (error) {
         // `cleanupCursor` should never throw, squash and throw the original error
+        squashError(error);
       }
       throw error;
     }
@@ -871,8 +873,8 @@ async function cleanupCursor(
       cursor[kClient],
       new KillCursorsOperation(cursorId, cursorNs, server, { session })
     );
-  } catch {
-    // squash kill cursor errors
+  } catch (error) {
+    squashError(error);
   } finally {
     await completeCleanup();
   }

--- a/src/cursor/aggregation_cursor.ts
+++ b/src/cursor/aggregation_cursor.ts
@@ -76,7 +76,7 @@ export class AggregationCursor<TSchema = any> extends AbstractCursor<TSchema> {
 
   /** Execute the explain for the cursor */
   async explain(verbosity?: ExplainVerbosityLike): Promise<Document> {
-    return executeOperation(
+    return await executeOperation(
       this.client,
       new AggregateOperation(this.namespace, this[kPipeline], {
         ...this[kOptions], // NOTE: order matters here, we may need to refine this

--- a/src/cursor/find_cursor.ts
+++ b/src/cursor/find_cursor.ts
@@ -9,7 +9,7 @@ import { FindOperation, type FindOptions } from '../operations/find';
 import type { Hint } from '../operations/operation';
 import type { ClientSession } from '../sessions';
 import { formatSort, type Sort, type SortDirection } from '../sort';
-import { emitWarningOnce, mergeOptions, type MongoDBNamespace } from '../utils';
+import { emitWarningOnce, mergeOptions, type MongoDBNamespace, squashError } from '../utils';
 import { AbstractCursor, assertUninitialized } from './abstract_cursor';
 
 /** @internal */
@@ -96,7 +96,8 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
       if (batchSize <= 0) {
         try {
           await this.close();
-        } catch {
+        } catch (error) {
+          squashError(error);
           // this is an optimization for the special case of a limit for a find command to avoid an
           // extra getMore when the limit has been reached and the limit is a multiple of the batchSize.
           // This is a consequence of the new query engine in 5.0 having no knowledge of the limit as it

--- a/src/cursor/find_cursor.ts
+++ b/src/cursor/find_cursor.ts
@@ -127,7 +127,7 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
     if (typeof options === 'boolean') {
       throw new MongoInvalidArgumentError('Invalid first parameter to count');
     }
-    return executeOperation(
+    return await executeOperation(
       this.client,
       new CountOperation(this.namespace, this[kFilter], {
         ...this[kBuiltOptions], // NOTE: order matters here, we may need to refine this
@@ -139,7 +139,7 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
 
   /** Execute the explain for the cursor */
   async explain(verbosity?: ExplainVerbosityLike): Promise<Document> {
-    return executeOperation(
+    return await executeOperation(
       this.client,
       new FindOperation(undefined, this.namespace, this[kFilter], {
         ...this[kBuiltOptions], // NOTE: order matters here, we may need to refine this

--- a/src/cursor/run_command_cursor.ts
+++ b/src/cursor/run_command_cursor.ts
@@ -128,6 +128,6 @@ export class RunCommandCursor extends AbstractCursor {
       ...this.getMoreOptions
     });
 
-    return executeOperation(this.client, getMoreOperation);
+    return await executeOperation(this.client, getMoreOperation);
   }
 }

--- a/src/db.ts
+++ b/src/db.ts
@@ -230,7 +230,7 @@ export class Db {
     name: string,
     options?: CreateCollectionOptions
   ): Promise<Collection<TSchema>> {
-    return executeOperation(
+    return await executeOperation(
       this.client,
       new CreateCollectionOperation(this, name, resolveOptions(this, options)) as TODO_NODE_3286
     );
@@ -263,7 +263,7 @@ export class Db {
    */
   async command(command: Document, options?: RunCommandOptions): Promise<Document> {
     // Intentionally, we do not inherit options from parent for this operation.
-    return executeOperation(
+    return await executeOperation(
       this.client,
       new RunCommandOperation(this, command, {
         ...resolveBSONOptions(options),
@@ -320,7 +320,10 @@ export class Db {
    * @param options - Optional settings for the command
    */
   async stats(options?: DbStatsOptions): Promise<Document> {
-    return executeOperation(this.client, new DbStatsOperation(this, resolveOptions(this, options)));
+    return await executeOperation(
+      this.client,
+      new DbStatsOperation(this, resolveOptions(this, options))
+    );
   }
 
   /**
@@ -366,7 +369,7 @@ export class Db {
     options?: RenameOptions
   ): Promise<Collection<TSchema>> {
     // Intentionally, we do not inherit options from parent for this operation.
-    return executeOperation(
+    return await executeOperation(
       this.client,
       new RenameOperation(
         this.collection<TSchema>(fromCollection) as TODO_NODE_3286,
@@ -383,7 +386,7 @@ export class Db {
    * @param options - Optional settings for the command
    */
   async dropCollection(name: string, options?: DropCollectionOptions): Promise<boolean> {
-    return executeOperation(
+    return await executeOperation(
       this.client,
       new DropCollectionOperation(this, name, resolveOptions(this, options))
     );
@@ -395,7 +398,7 @@ export class Db {
    * @param options - Optional settings for the command
    */
   async dropDatabase(options?: DropDatabaseOptions): Promise<boolean> {
-    return executeOperation(
+    return await executeOperation(
       this.client,
       new DropDatabaseOperation(this, resolveOptions(this, options))
     );
@@ -407,7 +410,7 @@ export class Db {
    * @param options - Optional settings for the command
    */
   async collections(options?: ListCollectionsOptions): Promise<Collection[]> {
-    return executeOperation(
+    return await executeOperation(
       this.client,
       new CollectionsOperation(this, resolveOptions(this, options))
     );
@@ -439,7 +442,7 @@ export class Db {
    * @param options - Optional settings for the command
    */
   async removeUser(username: string, options?: RemoveUserOptions): Promise<boolean> {
-    return executeOperation(
+    return await executeOperation(
       this.client,
       new RemoveUserOperation(this, username, resolveOptions(this, options))
     );
@@ -455,7 +458,7 @@ export class Db {
     level: ProfilingLevel,
     options?: SetProfilingLevelOptions
   ): Promise<ProfilingLevel> {
-    return executeOperation(
+    return await executeOperation(
       this.client,
       new SetProfilingLevelOperation(this, level, resolveOptions(this, options))
     );
@@ -467,7 +470,7 @@ export class Db {
    * @param options - Optional settings for the command
    */
   async profilingLevel(options?: ProfilingLevelOptions): Promise<string> {
-    return executeOperation(
+    return await executeOperation(
       this.client,
       new ProfilingLevelOperation(this, resolveOptions(this, options))
     );
@@ -480,7 +483,7 @@ export class Db {
    * @param options - Optional settings for the command
    */
   async indexInformation(name: string, options?: IndexInformationOptions): Promise<Document> {
-    return this.collection(name).indexInformation(resolveOptions(this, options));
+    return await this.collection(name).indexInformation(resolveOptions(this, options));
   }
 
   /**

--- a/src/encrypter.ts
+++ b/src/encrypter.ts
@@ -108,13 +108,18 @@ export class Encrypter {
   }
 
   async close(client: MongoClient, force: boolean): Promise<void> {
-    const maybeError: Error | void = await this.autoEncrypter.teardown(!!force).catch(e => e);
+    let error;
+    try {
+      await this.autoEncrypter.teardown(!!force);
+    } catch (autoEncrypterError) {
+      error = autoEncrypterError;
+    }
     const internalClient = this[kInternalClient];
     if (internalClient != null && client !== internalClient) {
       return await internalClient.close(force);
     }
-    if (maybeError) {
-      throw maybeError;
+    if (error != null) {
+      throw error;
     }
   }
 

--- a/src/encrypter.ts
+++ b/src/encrypter.ts
@@ -110,7 +110,7 @@ export class Encrypter {
   async close(client: MongoClient, force: boolean): Promise<void> {
     let error;
     try {
-      await this.autoEncrypter.teardown(!!force);
+      await this.autoEncrypter.teardown(force);
     } catch (autoEncrypterError) {
       error = autoEncrypterError;
     }

--- a/src/encrypter.ts
+++ b/src/encrypter.ts
@@ -111,7 +111,7 @@ export class Encrypter {
     const maybeError: Error | void = await this.autoEncrypter.teardown(!!force).catch(e => e);
     const internalClient = this[kInternalClient];
     if (internalClient != null && client !== internalClient) {
-      return internalClient.close(force);
+      return await internalClient.close(force);
     }
     if (maybeError) {
       throw maybeError;

--- a/src/gridfs/upload.ts
+++ b/src/gridfs/upload.ts
@@ -4,7 +4,7 @@ import type { Document } from '../bson';
 import { ObjectId } from '../bson';
 import type { Collection } from '../collection';
 import { MongoAPIError, MONGODB_ERROR_CODES, MongoError } from '../error';
-import type { Callback } from '../utils';
+import { type Callback, squashError } from '../utils';
 import type { WriteConcernOptions } from '../write_concern';
 import { WriteConcern } from './../write_concern';
 import type { GridFSFile } from './download';
@@ -133,13 +133,11 @@ export class GridFSBucketWriteStream extends Writable {
     if (!this.bucket.s.calledOpenUploadStream) {
       this.bucket.s.calledOpenUploadStream = true;
 
-      checkIndexes(this).then(
-        () => {
-          this.bucket.s.checkedIndexes = true;
-          this.bucket.emit('index');
-        },
-        () => null
-      );
+      // eslint-disable-next-line github/no-then
+      checkIndexes(this).then(() => {
+        this.bucket.s.checkedIndexes = true;
+        this.bucket.emit('index');
+      }, squashError);
     }
   }
 
@@ -272,6 +270,7 @@ function checkDone(stream: GridFSBucketWriteStream, callback: Callback): void {
       return;
     }
 
+    // eslint-disable-next-line github/no-then
     stream.files.insertOne(gridFSFile, { writeConcern: stream.writeConcern }).then(
       () => {
         stream.gridFSFile = gridFSFile;
@@ -395,6 +394,7 @@ function doWrite(
         return;
       }
 
+      // eslint-disable-next-line github/no-then
       stream.chunks.insertOne(doc, { writeConcern: stream.writeConcern }).then(
         () => {
           --stream.state.outstandingRequests;
@@ -435,6 +435,7 @@ function writeRemnant(stream: GridFSBucketWriteStream, callback: Callback): void
     return;
   }
 
+  // eslint-disable-next-line github/no-then
   stream.chunks.insertOne(doc, { writeConcern: stream.writeConcern }).then(
     () => {
       --stream.state.outstandingRequests;

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -49,7 +49,8 @@ import {
   isHostMatch,
   type MongoDBNamespace,
   ns,
-  resolveOptions
+  resolveOptions,
+  squashError
 } from './utils';
 import type { W, WriteConcern, WriteConcernSettings } from './write_concern';
 
@@ -607,8 +608,8 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> {
               { readPreference: ReadPreference.primaryPreferred, noResponse: true }
             )
           );
-        } catch {
-          // endSessions is best effort
+        } catch (error) {
+          squashError(error);
         }
       }
     }
@@ -721,8 +722,8 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> {
     } finally {
       try {
         await session.endSession();
-      } catch {
-        // We are not concerned with errors from endSession()
+      } catch (error) {
+        squashError(error);
       }
     }
   }

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -468,7 +468,7 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> {
    */
   async connect(): Promise<this> {
     if (this.connectionLock) {
-      return this.connectionLock;
+      return await this.connectionLock;
     }
 
     try {
@@ -655,7 +655,7 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> {
    */
   static async connect(url: string, options?: MongoClientOptions): Promise<MongoClient> {
     const client = new this(url, options);
-    return client.connect();
+    return await client.connect();
   }
 
   /**

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -599,13 +599,17 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> {
     if (servers.length !== 0) {
       const endSessions = Array.from(this.s.sessionPool.sessions, ({ id }) => id);
       if (endSessions.length !== 0) {
-        await executeOperation(
-          this,
-          new RunAdminCommandOperation(
-            { endSessions },
-            { readPreference: ReadPreference.primaryPreferred, noResponse: true }
-          )
-        ).catch(() => null); // outcome does not matter;
+        try {
+          await executeOperation(
+            this,
+            new RunAdminCommandOperation(
+              { endSessions },
+              { readPreference: ReadPreference.primaryPreferred, noResponse: true }
+            )
+          );
+        } catch {
+          // endSessions is best effort
+        }
       }
     }
 

--- a/src/mongo_logger.ts
+++ b/src/mongo_logger.ts
@@ -836,7 +836,9 @@ export class MongoLogger {
 
     if (isPromiseLike(this.pendingLog)) {
       this.pendingLog = this.pendingLog
+        // eslint-disable-next-line github/no-then
         .then(() => this.logDestination.write(logMessage))
+        // eslint-disable-next-line github/no-then
         .then(this.clearPendingLog.bind(this), this.logWriteFailureHandler.bind(this));
       return;
     }
@@ -844,6 +846,7 @@ export class MongoLogger {
     try {
       const logResult = this.logDestination.write(logMessage);
       if (isPromiseLike(logResult)) {
+        // eslint-disable-next-line github/no-then
         this.pendingLog = logResult.then(
           this.clearPendingLog.bind(this),
           this.logWriteFailureHandler.bind(this)

--- a/src/operations/aggregate.ts
+++ b/src/operations/aggregate.ts
@@ -134,7 +134,8 @@ export class AggregateOperation<T = Document> extends CommandOperation<T> {
       command.cursor.batchSize = options.batchSize;
     }
 
-    return super.executeCommand(server, session, command) as TODO_NODE_3286;
+    const res: TODO_NODE_3286 = await super.executeCommand(server, session, command);
+    return res;
   }
 }
 

--- a/src/operations/command.ts
+++ b/src/operations/command.ts
@@ -152,6 +152,6 @@ export abstract class CommandOperation<T> extends AbstractOperation<T> {
       cmd = decorateWithExplain(cmd, this.explain);
     }
 
-    return server.command(this.ns, cmd, options);
+    return await server.command(this.ns, cmd, options);
   }
 }

--- a/src/operations/delete.ts
+++ b/src/operations/delete.ts
@@ -95,7 +95,8 @@ export class DeleteOperation extends CommandOperation<DeleteResult> {
       }
     }
 
-    return super.executeCommand(server, session, command) as TODO_NODE_3286;
+    const res: TODO_NODE_3286 = await super.executeCommand(server, session, command);
+    return res;
   }
 }
 
@@ -108,7 +109,7 @@ export class DeleteOneOperation extends DeleteOperation {
     server: Server,
     session: ClientSession | undefined
   ): Promise<DeleteResult> {
-    const res = (await super.execute(server, session)) as TODO_NODE_3286;
+    const res: TODO_NODE_3286 = await super.execute(server, session);
     if (this.explain) return res;
     if (res.code) throw new MongoServerError(res);
     if (res.writeErrors) throw new MongoServerError(res.writeErrors[0]);
@@ -128,7 +129,7 @@ export class DeleteManyOperation extends DeleteOperation {
     server: Server,
     session: ClientSession | undefined
   ): Promise<DeleteResult> {
-    const res = (await super.execute(server, session)) as TODO_NODE_3286;
+    const res: TODO_NODE_3286 = await super.execute(server, session);
     if (this.explain) return res;
     if (res.code) throw new MongoServerError(res);
     if (res.writeErrors) throw new MongoServerError(res.writeErrors[0]);

--- a/src/operations/drop.ts
+++ b/src/operations/drop.ts
@@ -69,7 +69,7 @@ export class DropCollectionOperation extends CommandOperation<boolean> {
       }
     }
 
-    return this.executeWithoutEncryptedFieldsCheck(server, session);
+    return await this.executeWithoutEncryptedFieldsCheck(server, session);
   }
 
   private async executeWithoutEncryptedFieldsCheck(

--- a/src/operations/execute_operation.ts
+++ b/src/operations/execute_operation.ts
@@ -146,7 +146,7 @@ export async function executeOperation<
 
   if (session == null) {
     // No session also means it is not retryable, early exit
-    return operation.execute(server, undefined);
+    return await operation.execute(server, undefined);
   }
 
   if (!operation.hasAspect(Aspect.RETRYABLE)) {

--- a/src/operations/execute_operation.ts
+++ b/src/operations/execute_operation.ts
@@ -26,7 +26,7 @@ import {
 } from '../sdam/server_selection';
 import type { Topology } from '../sdam/topology';
 import type { ClientSession } from '../sessions';
-import { squashError, supportsRetryableWrites } from '../utils';
+import { supportsRetryableWrites } from '../utils';
 import { AbstractOperation, Aspect } from './operation';
 
 const MMAPv1_RETRY_WRITES_ERROR_CODE = MONGODB_ERROR_CODES.IllegalOperation;
@@ -155,8 +155,11 @@ export async function executeOperation<
       return await operation.execute(server, session);
     } finally {
       if (session?.owner != null && session.owner === owner) {
-        // eslint-disable-next-line github/no-then
-        await session.endSession().then(undefined, squashError);
+        try {
+          await session.endSession();
+        } catch {
+          // ignore endSession errors
+        }
       }
     }
   }
@@ -192,8 +195,11 @@ export async function executeOperation<
     throw operationError;
   } finally {
     if (session?.owner != null && session.owner === owner) {
-      // eslint-disable-next-line github/no-then
-      await session.endSession().then(undefined, squashError);
+      try {
+        await session.endSession();
+      } catch {
+        // ignore endSession errors
+      }
     }
   }
 }

--- a/src/operations/execute_operation.ts
+++ b/src/operations/execute_operation.ts
@@ -26,7 +26,7 @@ import {
 } from '../sdam/server_selection';
 import type { Topology } from '../sdam/topology';
 import type { ClientSession } from '../sessions';
-import { supportsRetryableWrites } from '../utils';
+import { squashError, supportsRetryableWrites } from '../utils';
 import { AbstractOperation, Aspect } from './operation';
 
 const MMAPv1_RETRY_WRITES_ERROR_CODE = MONGODB_ERROR_CODES.IllegalOperation;
@@ -157,8 +157,8 @@ export async function executeOperation<
       if (session?.owner != null && session.owner === owner) {
         try {
           await session.endSession();
-        } catch {
-          // ignore endSession errors
+        } catch (error) {
+          squashError(error);
         }
       }
     }
@@ -197,8 +197,8 @@ export async function executeOperation<
     if (session?.owner != null && session.owner === owner) {
       try {
         await session.endSession();
-      } catch {
-        // ignore endSession errors
+      } catch (error) {
+        squashError(error);
       }
     }
   }

--- a/src/operations/execute_operation.ts
+++ b/src/operations/execute_operation.ts
@@ -26,7 +26,7 @@ import {
 } from '../sdam/server_selection';
 import type { Topology } from '../sdam/topology';
 import type { ClientSession } from '../sessions';
-import { supportsRetryableWrites } from '../utils';
+import { squashError, supportsRetryableWrites } from '../utils';
 import { AbstractOperation, Aspect } from './operation';
 
 const MMAPv1_RETRY_WRITES_ERROR_CODE = MONGODB_ERROR_CODES.IllegalOperation;
@@ -155,7 +155,8 @@ export async function executeOperation<
       return await operation.execute(server, session);
     } finally {
       if (session?.owner != null && session.owner === owner) {
-        await session.endSession().catch(() => null);
+        // eslint-disable-next-line github/no-then
+        await session.endSession().then(undefined, squashError);
       }
     }
   }
@@ -191,7 +192,8 @@ export async function executeOperation<
     throw operationError;
   } finally {
     if (session?.owner != null && session.owner === owner) {
-      await session.endSession().catch(() => null);
+      // eslint-disable-next-line github/no-then
+      await session.endSession().then(undefined, squashError);
     }
   }
 }

--- a/src/operations/find.ts
+++ b/src/operations/find.ts
@@ -111,7 +111,7 @@ export class FindOperation extends CommandOperation<Document> {
       findCommand = decorateWithExplain(findCommand, this.explain);
     }
 
-    return server.command(this.ns, findCommand, {
+    return await server.command(this.ns, findCommand, {
       ...this.options,
       ...this.bsonOptions,
       documentsReturnedIn: 'firstBatch',

--- a/src/operations/get_more.ts
+++ b/src/operations/get_more.ts
@@ -96,7 +96,7 @@ export class GetMoreOperation extends AbstractOperation {
       ...this.options
     };
 
-    return server.command(this.ns, getMoreCmd, commandOptions);
+    return await server.command(this.ns, getMoreCmd, commandOptions);
   }
 }
 

--- a/src/operations/indexes.ts
+++ b/src/operations/indexes.ts
@@ -333,7 +333,7 @@ export class DropIndexOperation extends CommandOperation<Document> {
 
   override async execute(server: Server, session: ClientSession | undefined): Promise<Document> {
     const cmd = { dropIndexes: this.collection.collectionName, index: this.indexName };
-    return super.executeCommand(server, session, cmd);
+    return await super.executeCommand(server, session, cmd);
   }
 }
 
@@ -377,7 +377,7 @@ export class ListIndexesOperation extends CommandOperation<Document> {
       command.comment = this.options.comment;
     }
 
-    return super.executeCommand(server, session, command);
+    return await super.executeCommand(server, session, command);
   }
 }
 

--- a/src/operations/insert.ts
+++ b/src/operations/insert.ts
@@ -47,7 +47,7 @@ export class InsertOperation extends CommandOperation<Document> {
       command.comment = options.comment;
     }
 
-    return super.executeCommand(server, session, command);
+    return await super.executeCommand(server, session, command);
   }
 }
 

--- a/src/operations/kill_cursors.ts
+++ b/src/operations/kill_cursors.ts
@@ -2,7 +2,7 @@ import type { Long } from '../bson';
 import { MongoRuntimeError } from '../error';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
-import type { MongoDBNamespace } from '../utils';
+import { type MongoDBNamespace, squashError } from '../utils';
 import { AbstractOperation, Aspect, defineAspects, type OperationOptions } from './operation';
 
 /**
@@ -47,8 +47,9 @@ export class KillCursorsOperation extends AbstractOperation {
     };
     try {
       await server.command(this.ns, killCursorsCommand, { session });
-    } catch {
+    } catch (error) {
       // The driver should never emit errors from killCursors, this is spec-ed behavior
+      squashError(error);
     }
   }
 }

--- a/src/operations/list_collections.ts
+++ b/src/operations/list_collections.ts
@@ -52,7 +52,11 @@ export class ListCollectionsOperation extends CommandOperation<Document> {
   }
 
   override async execute(server: Server, session: ClientSession | undefined): Promise<Document> {
-    return super.executeCommand(server, session, this.generateCommand(maxWireVersion(server)));
+    return await super.executeCommand(
+      server,
+      session,
+      this.generateCommand(maxWireVersion(server))
+    );
   }
 
   /* This is here for the purpose of unit testing the final command that gets sent. */

--- a/src/operations/list_databases.ts
+++ b/src/operations/list_databases.ts
@@ -63,7 +63,8 @@ export class ListDatabasesOperation extends CommandOperation<ListDatabasesResult
       cmd.comment = this.options.comment;
     }
 
-    return super.executeCommand(server, session, cmd) as TODO_NODE_3286;
+    const res: TODO_NODE_3286 = super.executeCommand(server, session, cmd);
+    return res;
   }
 }
 

--- a/src/operations/list_databases.ts
+++ b/src/operations/list_databases.ts
@@ -63,8 +63,7 @@ export class ListDatabasesOperation extends CommandOperation<ListDatabasesResult
       cmd.comment = this.options.comment;
     }
 
-    const res: TODO_NODE_3286 = super.executeCommand(server, session, cmd);
-    return res;
+    return await (super.executeCommand(server, session, cmd) as Promise<TODO_NODE_3286>);
   }
 }
 

--- a/src/operations/run_command.ts
+++ b/src/operations/run_command.ts
@@ -28,11 +28,12 @@ export class RunCommandOperation<T = Document> extends AbstractOperation<T> {
 
   override async execute(server: Server, session: ClientSession | undefined): Promise<T> {
     this.server = server;
-    return server.command(this.ns, this.command, {
+    const res: TODO_NODE_3286 = await server.command(this.ns, this.command, {
       ...this.options,
       readPreference: this.readPreference,
       session
-    }) as TODO_NODE_3286;
+    });
+    return res;
   }
 }
 
@@ -54,10 +55,11 @@ export class RunAdminCommandOperation<T = Document> extends AbstractOperation<T>
 
   override async execute(server: Server, session: ClientSession | undefined): Promise<T> {
     this.server = server;
-    return server.command(this.ns, this.command, {
+    const res: TODO_NODE_3286 = await server.command(this.ns, this.command, {
       ...this.options,
       readPreference: this.readPreference,
       session
-    }) as TODO_NODE_3286;
+    });
+    return res;
   }
 }

--- a/src/operations/stats.ts
+++ b/src/operations/stats.ts
@@ -30,7 +30,7 @@ export class DbStatsOperation extends CommandOperation<Document> {
       command.scale = this.options.scale;
     }
 
-    return super.executeCommand(server, session, command);
+    return await super.executeCommand(server, session, command);
   }
 }
 

--- a/src/operations/update.ts
+++ b/src/operations/update.ts
@@ -122,7 +122,7 @@ export class UpdateOperation extends CommandOperation<Document> {
       }
     }
 
-    return super.executeCommand(server, session, command);
+    return await super.executeCommand(server, session, command);
   }
 }
 

--- a/src/operations/update.ts
+++ b/src/operations/update.ts
@@ -144,8 +144,8 @@ export class UpdateOneOperation extends UpdateOperation {
     server: Server,
     session: ClientSession | undefined
   ): Promise<UpdateResult> {
-    const res = await super.execute(server, session);
-    if (this.explain != null) return res as TODO_NODE_3286;
+    const res: TODO_NODE_3286 = await super.execute(server, session);
+    if (this.explain != null) return res;
     if (res.code) throw new MongoServerError(res);
     if (res.writeErrors) throw new MongoServerError(res.writeErrors[0]);
 
@@ -178,8 +178,8 @@ export class UpdateManyOperation extends UpdateOperation {
     server: Server,
     session: ClientSession | undefined
   ): Promise<UpdateResult> {
-    const res = await super.execute(server, session);
-    if (this.explain != null) return res as TODO_NODE_3286;
+    const res: TODO_NODE_3286 = await super.execute(server, session);
+    if (this.explain != null) return res;
     if (res.code) throw new MongoServerError(res);
     if (res.writeErrors) throw new MongoServerError(res.writeErrors[0]);
 
@@ -231,8 +231,8 @@ export class ReplaceOneOperation extends UpdateOperation {
     server: Server,
     session: ClientSession | undefined
   ): Promise<UpdateResult> {
-    const res = await super.execute(server, session);
-    if (this.explain != null) return res as TODO_NODE_3286;
+    const res: TODO_NODE_3286 = await super.execute(server, session);
+    if (this.explain != null) return res;
     if (res.code) throw new MongoServerError(res);
     if (res.writeErrors) throw new MongoServerError(res.writeErrors[0]);
 

--- a/src/sdam/monitor.ts
+++ b/src/sdam/monitor.ts
@@ -351,6 +351,7 @@ function checkServer(monitor: Monitor, callback: Callback<Document | null>) {
     awaited = false;
     connection
       .command(ns('admin.$cmd'), cmd, options)
+      // eslint-disable-next-line github/no-then
       .then(onHeartbeatSucceeded, onHeartbeatFailed);
 
     return;
@@ -369,6 +370,7 @@ function checkServer(monitor: Monitor, callback: Callback<Document | null>) {
       connection.destroy();
       throw error;
     }
+    // eslint-disable-next-line github/no-then
   })().then(
     connection => {
       if (isInCloseState(monitor)) {
@@ -512,6 +514,7 @@ function measureRoundTripTime(rttPinger: RTTPinger, options: RTTPingerOptions) {
 
   const connection = rttPinger.connection;
   if (connection == null) {
+    // eslint-disable-next-line github/no-then
     connect(options).then(
       connection => {
         measureAndReschedule(connection);
@@ -526,6 +529,7 @@ function measureRoundTripTime(rttPinger: RTTPinger, options: RTTPingerOptions) {
 
   const commandName =
     connection.serverApi?.version || connection.helloOk ? 'hello' : LEGACY_HELLO_COMMAND;
+  // eslint-disable-next-line github/no-then
   connection.command(ns('admin.$cmd'), { [commandName]: 1 }, undefined).then(
     () => measureAndReschedule(),
     () => {

--- a/src/sdam/srv_polling.ts
+++ b/src/sdam/srv_polling.ts
@@ -3,7 +3,7 @@ import { clearTimeout, setTimeout } from 'timers';
 
 import { MongoRuntimeError } from '../error';
 import { TypedEventEmitter } from '../mongo_types';
-import { HostAddress, matchesParentDomain } from '../utils';
+import { HostAddress, matchesParentDomain, squashError } from '../utils';
 
 /**
  * @internal
@@ -95,7 +95,8 @@ export class SrvPoller extends TypedEventEmitter<SrvPollerEvents> {
     }
 
     this._timeout = setTimeout(() => {
-      this._poll().catch(() => null);
+      // eslint-disable-next-line github/no-then
+      this._poll().then(undefined, squashError);
     }, this.intervalMS);
   }
 

--- a/src/sdam/topology.ts
+++ b/src/sdam/topology.ts
@@ -623,7 +623,7 @@ export class Topology extends TypedEventEmitter<TopologyEvents> {
     this[kWaitQueue].push(waitQueueMember);
     processWaitQueue(this);
 
-    return serverPromise;
+    return await serverPromise;
   }
   /**
    * Update the internal TopologyDescription with a ServerDescription

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -1,3 +1,4 @@
+/* eslint-disable github/no-then */
 import { promisify } from 'util';
 
 import { Binary, type Document, Long, type Timestamp } from './bson';

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -45,6 +45,7 @@ import {
   List,
   maxWireVersion,
   now,
+  squashError,
   uuidV4
 } from './utils';
 import { WriteConcern } from './write_concern';
@@ -275,8 +276,9 @@ export class ClientSession extends TypedEventEmitter<ClientSessionEvents> {
         this.hasEnded = true;
         this.emit('ended', this);
       }
-    } catch {
+    } catch (error) {
       // spec indicates that we should ignore all errors for `endSessions`
+      squashError(error);
     } finally {
       maybeClearPinnedConnection(this, { force: true, ...options });
     }

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -415,14 +415,14 @@ export class ClientSession extends TypedEventEmitter<ClientSessionEvents> {
    * Commits the currently active transaction in this session.
    */
   async commitTransaction(): Promise<void> {
-    return endTransactionAsync(this, 'commitTransaction');
+    return await endTransactionAsync(this, 'commitTransaction');
   }
 
   /**
    * Aborts the currently active transaction in this session.
    */
   async abortTransaction(): Promise<void> {
-    return endTransactionAsync(this, 'abortTransaction');
+    return await endTransactionAsync(this, 'abortTransaction');
   }
 
   /**
@@ -464,7 +464,7 @@ export class ClientSession extends TypedEventEmitter<ClientSessionEvents> {
     options?: TransactionOptions
   ): Promise<T> {
     const startTime = now();
-    return attemptTransaction(this, startTime, fn, options);
+    return await attemptTransaction(this, startTime, fn, options);
   }
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1271,7 +1271,7 @@ export function promiseWithResolvers<T>(): {
  * promise.then(undefined, squashError);
  * ```
  */
-export function squashError() {
+export function squashError(_error: unknown) {
   return;
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -178,6 +178,7 @@ export function isPromiseLike<T = unknown>(value?: unknown): value is PromiseLik
     value != null &&
     typeof value === 'object' &&
     'then' in value &&
+    // eslint-disable-next-line github/no-then
     typeof value.then === 'function'
   );
 }
@@ -1257,6 +1258,20 @@ export function promiseWithResolvers<T>(): {
     reject = promiseReject;
   });
   return { promise, resolve, reject } as const;
+}
+
+/**
+ * A noop function intended for use in preventing unhandled rejections.
+ *
+ * @example
+ * ```js
+ * const promise = myAsyncTask();
+ * // eslint-disable-next-line github/no-then
+ * promise.then(undefined, squashError);
+ * ```
+ */
+export function squashError() {
+  return;
 }
 
 export const randomBytes = promisify(crypto.randomBytes);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,7 @@
 import * as crypto from 'crypto';
 import type { SrvRecord } from 'dns';
 import { type EventEmitter } from 'events';
+import { promises as fs } from 'fs';
 import * as http from 'http';
 import { clearTimeout, setTimeout } from 'timers';
 import * as url from 'url';
@@ -1333,4 +1334,13 @@ export function maybeAddIdToDocuments(
     return doc;
   };
   return Array.isArray(docOrDocs) ? docOrDocs.map(transform) : transform(docOrDocs);
+}
+
+export async function fileIsAccessible(fileName: string, mode?: number) {
+  try {
+    await fs.access(fileName, mode);
+    return true;
+  } catch {
+    return false;
+  }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1156,7 +1156,7 @@ export async function request(
   uri: string,
   options: RequestOptions = {}
 ): Promise<string | Record<string, any>> {
-  return new Promise<string | Record<string, any>>((resolve, reject) => {
+  return await new Promise<string | Record<string, any>>((resolve, reject) => {
     const requestOptions = {
       method: 'GET',
       timeout: 10000,


### PR DESCRIPTION
### Description

#### What is changing?

- enforce return-await
- make `.then` discouraged

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

Async stack traces


### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
