### PR TITLE
feat(NODE-5919): support new `type` option in create search index helpers

### DIFF
--- a/src/operations/search_indexes/create.ts
+++ b/src/operations/search_indexes/create.ts
@@ -8,12 +8,15 @@ import { AbstractOperation } from '../operation';
 /**
  * @public
  */
-export interface SearchIndexDescription {
+export interface SearchIndexDescription extends Document {
   /** The name of the index. */
   name?: string;
 
   /** The index definition. */
   definition: Document;
+
+  /** The type of the index.  Currently `search` or `vectorSearch` are supported. */
+  type?: string;
 }
 
 /** @internal */

--- a/test/manual/search-index-management.prose.test.ts
+++ b/test/manual/search-index-management.prose.test.ts
@@ -340,5 +340,167 @@ describe('Index Management Prose Tests', function () {
           .to.deep.equal({ dynamic: false });
       }
     );
+
+    it(
+      'Case 7: Driver can successfully handle search index types when creating indexes',
+      metadata,
+      async function () {
+        // 01. Create a collection with the "create" command using a randomly generated name (referred to as `coll0`).
+        const coll0 = collection;
+        {
+          // 02. Create a new search index on `coll0` with the `createSearchIndex` helper. Use the following definition:
+          //     ```typescript
+          //       {
+          //         name: 'test-search-index-case7-implicit',
+          //         definition: {
+          //           mappings: { dynamic: false }
+          //         }
+          //       }
+          //     ```
+          const indexName = await coll0.createSearchIndex({
+            name: 'test-search-index-case7-implicit',
+            definition: {
+              mappings: { dynamic: false }
+            }
+          });
+          // 03. Assert that the command returns the name of the index: `"test-search-index-case7-implicit"`.
+          expect(indexName).to.equal('test-search-index-case7-implicit');
+          // 04. Run `coll0.listSearchIndexes('test-search-index-case7-implicit')` repeatedly every 5 seconds until the following
+          //     condition is satisfied and store the value in a variable `index1`:
+
+          //     - An index with the `name` of `test-search-index-case7-implicit` is present and the index has a field `queryable`
+          //       with a value of `true`.
+
+          const [index1] = await waitForIndexes({
+            predicate: indexes => indexes.every(index => index.queryable),
+            indexNames: 'test-search-index-case7-implicit',
+            collection: coll0
+          });
+
+          // 05. Assert that `index1` has a property `type` whose value is `search`.
+          expect(index1).to.have.property('type', 'search');
+        }
+        {
+          // 06. Create a new search index on `coll0` with the `createSearchIndex` helper. Use the following definition:
+          //     ```typescript
+          //       {
+          //         name: 'test-search-index-case7-explicit',
+          //         type: 'search',
+          //         definition: {
+          //           mappings: { dynamic: false }
+          //         }
+          //       }
+          //     ```
+          const indexName = await coll0.createSearchIndex({
+            name: 'test-search-index-case7-explicit',
+            type: 'search',
+            definition: {
+              mappings: { dynamic: false }
+            }
+          });
+          // 07. Assert that the command returns the name of the index: `"test-search-index-case7-explicit"`.
+          expect(indexName).to.equal('test-search-index-case7-explicit');
+          // 08. Run `coll0.listSearchIndexes('test-search-index-case7-explicit')` repeatedly every 5 seconds until the following
+          //     condition is satisfied and store the value in a variable `index2`:
+
+          //     - An index with the `name` of `test-search-index-case7-explicit` is present and the index has a field `queryable`
+          //       with a value of `true`.
+
+          const [index2] = await waitForIndexes({
+            predicate: indexes => indexes.every(index => index.queryable),
+            indexNames: 'test-search-index-case7-explicit',
+            collection: coll0
+          });
+          // 09. Assert that `index2` has a property `type` whose value is `search`.
+          expect(index2).to.have.property('type', 'search');
+        }
+        {
+          // 10. Create a new vector search index on `coll0` with the `createSearchIndex` helper. Use the following definition:
+          // ```typescript
+          //   {
+          //     name: 'test-search-index-case7-vector',
+          //     type: 'vectorSearch',
+          //     definition: {
+          //       "fields": [
+          //          {
+          //              "type": "vector",
+          //              "path": "plot_embedding",
+          //              "numDimensions": 1536,
+          //              "similarity": "euclidean",
+          //          },
+          //       ]
+          //     }
+          //   }
+          // ```
+
+          const indexName = await coll0.createSearchIndex({
+            name: 'test-search-index-case7-vector',
+            type: 'vectorSearch',
+            definition: {
+              fields: [
+                {
+                  type: 'vector',
+                  path: 'plot_embedding',
+                  numDimensions: 1536,
+                  similarity: 'euclidean'
+                }
+              ]
+            }
+          });
+          // 11. Assert that the command returns the name of the index: `"test-search-index-case7-vector"`.
+          expect(indexName).to.equal('test-search-index-case7-vector');
+          // 12. Run `coll0.listSearchIndexes('test-search-index-case7-vector')` repeatedly every 5 seconds until the following
+          //     condition is satisfied and store the value in a variable `index3`:
+          //     - An index with the `name` of `test-search-index-case7-vector` is present and the index has a field `queryable` with
+          //       a value of `true`.
+          const [index3] = await waitForIndexes({
+            predicate: indexes => indexes.every(index => index.queryable),
+            indexNames: 'test-search-index-case7-vector',
+            collection: coll0
+          });
+
+          // 13. Assert that `index3` has a property `type` whose value is `vectorSearch`.
+          expect(index3).to.have.property('type', 'vectorSearch');
+        }
+      }
+    );
+
+    it('Case 8: Driver requires explicit type to create a vector search index', async function () {
+      // 1. Create a collection with the "create" command using a randomly generated name (referred to as `coll0`).
+      const coll0 = collection;
+
+      // 2. Create a new vector search index on `coll0` with the `createSearchIndex` helper. Use the following definition:
+      //    {
+      //      name: 'test-search-index-case8-error',
+      //      definition: {
+      //        fields: [
+      //           {
+      //               type: 'vector',
+      //               path: 'plot_embedding',
+      //               numDimensions: 1536,
+      //               similarity: 'euclidean',
+      //           },
+      //        ]
+      //      }
+      //    }
+      const definition = {
+        name: 'test-search-index-case8-error',
+        definition: {
+          fields: [
+            {
+              type: 'vector',
+              path: 'plot_embedding',
+              numDimensions: 1536,
+              similarity: 'euclidean'
+            }
+          ]
+        }
+      };
+      const error = await coll0.createSearchIndex(definition).catch(e => e);
+
+      // 3. Assert that the command throws an exception containing the string "Attribute mappings missing" due to the `mappings`
+      //  field missing.
+      expect(error).to.match(/Attribute mappings missing/i);
+    });
   });
 });

--- a/test/spec/index-management/createSearchIndex.json
+++ b/test/spec/index-management/createSearchIndex.json
@@ -50,54 +50,8 @@
                 "mappings": {
                   "dynamic": true
                 }
-              }
-            }
-          },
-          "expectError": {
-            "isError": true,
-            "errorContains": "Atlas"
-          }
-        }
-      ],
-      "expectEvents": [
-        {
-          "client": "client0",
-          "events": [
-            {
-              "commandStartedEvent": {
-                "command": {
-                  "createSearchIndexes": "collection0",
-                  "indexes": [
-                    {
-                      "definition": {
-                        "mappings": {
-                          "dynamic": true
-                        }
-                      }
-                    }
-                  ],
-                  "$db": "database0"
-                }
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "description": "name provided for an index definition",
-      "operations": [
-        {
-          "name": "createSearchIndex",
-          "object": "collection0",
-          "arguments": {
-            "model": {
-              "definition": {
-                "mappings": {
-                  "dynamic": true
-                }
               },
-              "name": "test index"
+              "type": "search"
             }
           },
           "expectError": {
@@ -121,7 +75,117 @@
                           "dynamic": true
                         }
                       },
-                      "name": "test index"
+                      "type": "search"
+                    }
+                  ],
+                  "$db": "database0"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "name provided for an index definition",
+      "operations": [
+        {
+          "name": "createSearchIndex",
+          "object": "collection0",
+          "arguments": {
+            "model": {
+              "definition": {
+                "mappings": {
+                  "dynamic": true
+                }
+              },
+              "name": "test index",
+              "type": "search"
+            }
+          },
+          "expectError": {
+            "isError": true,
+            "errorContains": "Atlas"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "createSearchIndexes": "collection0",
+                  "indexes": [
+                    {
+                      "definition": {
+                        "mappings": {
+                          "dynamic": true
+                        }
+                      },
+                      "name": "test index",
+                      "type": "search"
+                    }
+                  ],
+                  "$db": "database0"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "create a vector search index",
+      "operations": [
+        {
+          "name": "createSearchIndex",
+          "object": "collection0",
+          "arguments": {
+            "model": {
+              "definition": {
+                "fields": [
+                  {
+                    "type": "vector",
+                    "path": "plot_embedding",
+                    "numDimensions": 1536,
+                    "similarity": "euclidean"
+                  }
+                ]
+              },
+              "name": "test index",
+              "type": "vectorSearch"
+            }
+          },
+          "expectError": {
+            "isError": true,
+            "errorContains": "Atlas"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "createSearchIndexes": "collection0",
+                  "indexes": [
+                    {
+                      "definition": {
+                        "fields": [
+                          {
+                            "type": "vector",
+                            "path": "plot_embedding",
+                            "numDimensions": 1536,
+                            "similarity": "euclidean"
+                          }
+                        ]
+                      },
+                      "name": "test index",
+                      "type": "vectorSearch"
                     }
                   ],
                   "$db": "database0"

--- a/test/spec/index-management/createSearchIndex.yml
+++ b/test/spec/index-management/createSearchIndex.yml
@@ -26,7 +26,7 @@ tests:
       - name: createSearchIndex
         object: *collection0
         arguments:
-          model: { definition: &definition { mappings: { dynamic: true } } }
+          model: { definition: &definition { mappings: { dynamic: true } } , type: 'search' }
         expectError:
           # This test always errors in a non-Atlas environment.  The test functions as a unit test  by asserting
           # that the driver constructs and sends the correct command.
@@ -39,7 +39,7 @@ tests:
           - commandStartedEvent:
               command:
                 createSearchIndexes: *collection0
-                indexes: [ { definition: *definition } ]
+                indexes: [ { definition: *definition, type: 'search'} ]
                 $db: *database0
 
   - description: "name provided for an index definition"
@@ -47,7 +47,7 @@ tests:
       - name: createSearchIndex
         object: *collection0
         arguments: 
-          model: { definition: &definition { mappings: { dynamic: true } } , name: 'test index' }
+          model: { definition: &definition { mappings: { dynamic: true } } , name: 'test index', type: 'search' }
         expectError:
           # This test always errors in a non-Atlas environment.  The test functions as a unit test  by asserting
           # that the driver constructs and sends the correct command.
@@ -60,5 +60,27 @@ tests:
           - commandStartedEvent:
               command:
                 createSearchIndexes: *collection0
-                indexes: [ { definition: *definition, name: 'test index' } ]
+                indexes: [ { definition: *definition, name: 'test index', type: 'search' } ]
+                $db: *database0
+
+  - description: "create a vector search index"
+    operations:
+      - name: createSearchIndex
+        object: *collection0
+        arguments:
+          model: { definition: &definition { fields: [ {"type": "vector", "path": "plot_embedding", "numDimensions": 1536, "similarity": "euclidean"} ] }
+            , name: 'test index', type: 'vectorSearch' }
+        expectError:
+          # This test always errors in a non-Atlas environment.  The test functions as a unit test  by asserting
+          # that the driver constructs and sends the correct command.
+          # The expected error message was changed in SERVER-83003. Check for the substring "Atlas" shared by both error messages.
+          isError: true
+          errorContains: Atlas
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                createSearchIndexes: *collection0
+                indexes: [ { definition: *definition, name: 'test index', type: 'vectorSearch' } ]
                 $db: *database0

--- a/test/spec/index-management/createSearchIndexes.json
+++ b/test/spec/index-management/createSearchIndexes.json
@@ -83,56 +83,8 @@
                   "mappings": {
                     "dynamic": true
                   }
-                }
-              }
-            ]
-          },
-          "expectError": {
-            "isError": true,
-            "errorContains": "Atlas"
-          }
-        }
-      ],
-      "expectEvents": [
-        {
-          "client": "client0",
-          "events": [
-            {
-              "commandStartedEvent": {
-                "command": {
-                  "createSearchIndexes": "collection0",
-                  "indexes": [
-                    {
-                      "definition": {
-                        "mappings": {
-                          "dynamic": true
-                        }
-                      }
-                    }
-                  ],
-                  "$db": "database0"
-                }
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "description": "name provided for an index definition",
-      "operations": [
-        {
-          "name": "createSearchIndexes",
-          "object": "collection0",
-          "arguments": {
-            "models": [
-              {
-                "definition": {
-                  "mappings": {
-                    "dynamic": true
-                  }
                 },
-                "name": "test index"
+                "type": "search"
               }
             ]
           },
@@ -157,7 +109,121 @@
                           "dynamic": true
                         }
                       },
-                      "name": "test index"
+                      "type": "search"
+                    }
+                  ],
+                  "$db": "database0"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "name provided for an index definition",
+      "operations": [
+        {
+          "name": "createSearchIndexes",
+          "object": "collection0",
+          "arguments": {
+            "models": [
+              {
+                "definition": {
+                  "mappings": {
+                    "dynamic": true
+                  }
+                },
+                "name": "test index",
+                "type": "search"
+              }
+            ]
+          },
+          "expectError": {
+            "isError": true,
+            "errorContains": "Atlas"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "createSearchIndexes": "collection0",
+                  "indexes": [
+                    {
+                      "definition": {
+                        "mappings": {
+                          "dynamic": true
+                        }
+                      },
+                      "name": "test index",
+                      "type": "search"
+                    }
+                  ],
+                  "$db": "database0"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "create a vector search index",
+      "operations": [
+        {
+          "name": "createSearchIndexes",
+          "object": "collection0",
+          "arguments": {
+            "models": [
+              {
+                "definition": {
+                  "fields": [
+                    {
+                      "type": "vector",
+                      "path": "plot_embedding",
+                      "numDimensions": 1536,
+                      "similarity": "euclidean"
+                    }
+                  ]
+                },
+                "name": "test index",
+                "type": "vectorSearch"
+              }
+            ]
+          },
+          "expectError": {
+            "isError": true,
+            "errorContains": "Atlas"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "createSearchIndexes": "collection0",
+                  "indexes": [
+                    {
+                      "definition": {
+                        "fields": [
+                          {
+                            "type": "vector",
+                            "path": "plot_embedding",
+                            "numDimensions": 1536,
+                            "similarity": "euclidean"
+                          }
+                        ]
+                      },
+                      "name": "test index",
+                      "type": "vectorSearch"
                     }
                   ],
                   "$db": "database0"

--- a/test/spec/index-management/createSearchIndexes.yml
+++ b/test/spec/index-management/createSearchIndexes.yml
@@ -48,7 +48,7 @@ tests:
       - name: createSearchIndexes
         object: *collection0
         arguments:
-          models: [ { definition: &definition { mappings: { dynamic: true } } } ]
+          models: [ { definition: &definition { mappings: { dynamic: true } } , type: 'search' } ]
         expectError:
           # This test always errors in a non-Atlas environment.  The test functions as a unit test  by asserting
           # that the driver constructs and sends the correct command.
@@ -61,7 +61,7 @@ tests:
           - commandStartedEvent:
               command:
                 createSearchIndexes: *collection0
-                indexes: [ { definition: *definition } ]
+                indexes: [ { definition: *definition, type: 'search'} ]
                 $db: *database0
 
   - description: "name provided for an index definition"
@@ -69,7 +69,7 @@ tests:
       - name: createSearchIndexes
         object: *collection0
         arguments: 
-          models: [ { definition: &definition { mappings: { dynamic: true } } , name: 'test index' } ]
+          models: [ { definition: &definition { mappings: { dynamic: true } } , name: 'test index' , type: 'search' } ]
         expectError:
           # This test always errors in a non-Atlas environment.  The test functions as a unit test  by asserting
           # that the driver constructs and sends the correct command.
@@ -82,5 +82,27 @@ tests:
           - commandStartedEvent:
               command:
                 createSearchIndexes: *collection0
-                indexes: [ { definition: *definition, name: 'test index' } ]
+                indexes: [ { definition: *definition, name: 'test index', type: 'search' } ]
+                $db: *database0
+
+  - description: "create a vector search index"
+    operations:
+      - name: createSearchIndexes
+        object: *collection0
+        arguments:
+          models: [ { definition: &definition { fields: [ {"type": "vector", "path": "plot_embedding", "numDimensions": 1536, "similarity": "euclidean"} ] },
+                                                name: 'test index' , type: 'vectorSearch' } ]
+        expectError:
+          # This test always errors in a non-Atlas environment.  The test functions as a unit test  by asserting
+          # that the driver constructs and sends the correct command.
+          # The expected error message was changed in SERVER-83003. Check for the substring "Atlas" shared by both error messages.
+          isError: true
+          errorContains: Atlas
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                createSearchIndexes: *collection0
+                indexes: [ { definition: *definition, name: 'test index', type: 'vectorSearch' } ]
                 $db: *database0


### PR DESCRIPTION
### Description

#### What is changing?

Add support for the `type` field in `SearchIndexDescription`.  Also syncs the unified search index tests and adds two new search index prose tests, as added in https://jira.mongodb.org/browse/DRIVERS-2768.

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### `type` supported in `SearchIndexDescription`

It is now possible to specify the type of a search index when creating a search index:

```typescript
const indexName = await collection.createSearchIndex({
  name: 'my-vector-search-index',
  // new! specifies that a `vectorSearch` index is created
  type: 'vectorSearch',
  definition: {
    mappings: { dynamic: false }
  }
});
```
<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
