### PR TITLE
fix(NODE-5785): do not deserialize heartbeat events with `promoteBuffers` set to `true`

### DIFF
--- a/src/sdam/monitor.ts
+++ b/src/sdam/monitor.ts
@@ -135,7 +135,7 @@ export class Monitor extends TypedEventEmitter<MonitorEvents> {
       useBigInt64: false,
       promoteLongs: true,
       promoteValues: true,
-      promoteBuffers: true
+      promoteBuffers: false
     };
 
     // ensure no authentication is used for monitoring

--- a/test/integration/crud/bulk.test.ts
+++ b/test/integration/crud/bulk.test.ts
@@ -723,7 +723,7 @@ describe('Bulk', function () {
     }
   });
 
-  it('should correctly execute ordered batch using w:0', function (done) {
+  it.skip('should correctly execute ordered batch using w:0', function (done) {
     client.connect((err, client) => {
       const db = client.db();
       const col = db.collection('batch_write_ordered_ops_9');
@@ -748,7 +748,7 @@ describe('Bulk', function () {
         client.close(done);
       });
     });
-  });
+  }).skipReason = 'TODO(NODE-6060): set `moreToCome` op_msg bit when `w: 0` is specified';
 
   it('should correctly handle single unordered batch API', function (done) {
     client.connect((err, client) => {

--- a/test/integration/crud/bulk.test.ts
+++ b/test/integration/crud/bulk.test.ts
@@ -723,32 +723,37 @@ describe('Bulk', function () {
     }
   });
 
-  it.skip('should correctly execute ordered batch using w:0', function (done) {
-    client.connect((err, client) => {
-      const db = client.db();
-      const col = db.collection('batch_write_ordered_ops_9');
+  it(
+    'should correctly execute ordered batch using w:0',
+    // TODO(NODE-6060): set `moreToCome` op_msg bit when `w: 0` is specified
+    { requires: { mongodb: '<8.0.0' } },
+    function (done) {
+      client.connect((err, client) => {
+        const db = client.db();
+        const col = db.collection('batch_write_ordered_ops_9');
 
-      const bulk = col.initializeOrderedBulkOp();
-      for (let i = 0; i < 100; i++) {
-        bulk.insert({ a: 1 });
-      }
+        const bulk = col.initializeOrderedBulkOp();
+        for (let i = 0; i < 100; i++) {
+          bulk.insert({ a: 1 });
+        }
 
-      bulk.find({ b: 1 }).upsert().update({ b: 1 });
-      bulk.find({ c: 1 }).delete();
+        bulk.find({ b: 1 }).upsert().update({ b: 1 });
+        bulk.find({ c: 1 }).delete();
 
-      bulk.execute({ writeConcern: { w: 0 } }, function (err, result) {
-        expect(err).to.not.exist;
-        test.equal(0, result.upsertedCount);
-        test.equal(0, result.insertedCount);
-        test.equal(0, result.matchedCount);
-        test.ok(0 === result.modifiedCount || result.modifiedCount == null);
-        test.equal(0, result.deletedCount);
-        test.equal(false, result.hasWriteErrors());
+        bulk.execute({ writeConcern: { w: 0 } }, function (err, result) {
+          expect(err).to.not.exist;
+          test.equal(0, result.upsertedCount);
+          test.equal(0, result.insertedCount);
+          test.equal(0, result.matchedCount);
+          test.ok(0 === result.modifiedCount || result.modifiedCount == null);
+          test.equal(0, result.deletedCount);
+          test.equal(false, result.hasWriteErrors());
 
-        client.close(done);
+          client.close(done);
+        });
       });
-    });
-  }).skipReason = 'TODO(NODE-6060): set `moreToCome` op_msg bit when `w: 0` is specified';
+    }
+  );
 
   it('should correctly handle single unordered batch API', function (done) {
     client.connect((err, client) => {

--- a/test/integration/server-discovery-and-monitoring/server_discovery_and_monitoring_logging.test.ts
+++ b/test/integration/server-discovery-and-monitoring/server_discovery_and_monitoring_logging.test.ts
@@ -33,7 +33,7 @@ describe('SDAM Logging Integration Tests', function () {
   });
 
   it(
-    'does not promote buffers',
+    'the monitor does not promote buffers in server heartbeats',
     {
       requires: {
         topology: ['replicaset', 'sharded']
@@ -50,7 +50,7 @@ describe('SDAM Logging Integration Tests', function () {
   );
 
   it(
-    'does not log messages `reply` field',
+    'heartbeat log messages do not promote buffers in the `reply` field',
     {
       requires: {
         topology: ['replicaset', 'sharded']

--- a/test/integration/server-discovery-and-monitoring/server_discovery_and_monitoring_logging.test.ts
+++ b/test/integration/server-discovery-and-monitoring/server_discovery_and_monitoring_logging.test.ts
@@ -1,0 +1,76 @@
+import { expect } from 'chai';
+
+import {
+  Binary,
+  EJSON,
+  type MongoClient,
+  type MongoDBLogWritable,
+  type ServerHeartbeatSucceededEvent
+} from '../../mongodb';
+
+describe('SDAM Logging Integration Tests', function () {
+  let client: MongoClient;
+  const monitoringEvents: Array<ServerHeartbeatSucceededEvent> = [];
+  const loggingEvents: Array<{ reply: string }> = [];
+
+  beforeEach(function () {
+    const logger: MongoDBLogWritable = {
+      write(log) {
+        if (log.message === 'Server heartbeat succeeded') {
+          loggingEvents.push(log as unknown as { reply: string });
+        }
+      }
+    };
+    client = this.configuration.newClient(
+      {},
+      {
+        mongodbLogPath: logger,
+        mongodbLogComponentSeverities: { topology: 'trace' },
+        [Symbol.for('@@mdb.enableMongoLogger')]: true
+      }
+    );
+
+    client.on('serverHeartbeatSucceeded', monitoringEvents.push.bind(monitoringEvents));
+  });
+
+  it(
+    'does not promote buffers',
+    {
+      requires: {
+        topology: ['replicaset', 'sharded']
+      }
+    },
+    async function () {
+      await client.connect();
+      await client.close();
+
+      expect(monitoringEvents.length > 0).to.be.true;
+
+      for (const heartbeat of monitoringEvents) {
+        expect(heartbeat.reply.$clusterTime.signature?.hash).to.be.instanceOf(Binary);
+      }
+    }
+  );
+
+  it(
+    'does not log messages `reply` field',
+    {
+      requires: {
+        topology: ['replicaset', 'sharded']
+      }
+    },
+    async function () {
+      await client.connect();
+      await client.close();
+
+      expect(loggingEvents.length > 0).to.be.true;
+
+      for (const hash of loggingEvents.map(
+        message => EJSON.parse(message.reply).$clusterTime.signature.hash
+      )) {
+        expect(hash).to.exist;
+        expect(hash).to.be.instanceof(Binary);
+      }
+    }
+  );
+});


### PR DESCRIPTION
### Description

#### What is changing?

This PR sets `promoteBuffers` to false for the monitor class.  This change is almost entirely invisible to users because monitors are not publicly exposed.

Server heartbeat events and log message _are_ impacted by this change, but we don't currently include the types of each field in the server's heartbeat as a part of our semver-supported API.

##### Is there new documentation needed for these changes?

No.

#### What is the motivation for this change?

Setting `promoteBuffers: true` increases the size of an EJSON.stringified heartbeat event, increasing the likelihood that log messages are truncated.


### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
