### PR TITLE
fix(NODE-6066): signature can be optional at runtime

### DIFF
--- a/src/sdam/common.ts
+++ b/src/sdam/common.ts
@@ -55,10 +55,16 @@ export function drainTimerQueue(queue: TimerQueue): void {
   queue.clear();
 }
 
-/** @public */
+/**
+ * @public
+ * Gossiped in component for the cluster time tracking the state of user databases
+ * across the cluster. It may optionally include a signature identifying the process that
+ * generated such a value.
+ */
 export interface ClusterTime {
   clusterTime: Timestamp;
-  signature: {
+  /** Used to validate the identity of a request or response's ClusterTime. */
+  signature?: {
     hash: Binary;
     keyId: Long;
   };

--- a/test/types/sessions.test-d.ts
+++ b/test/types/sessions.test-d.ts
@@ -1,6 +1,6 @@
-import { expectError, expectType } from 'tsd';
+import { expectAssignable, expectDocCommentIncludes, expectError, expectType } from 'tsd';
 
-import type { ClientSession } from '../mongodb';
+import type { Binary, ClientSession, ClusterTime, Long, Timestamp } from '../mongodb';
 import { MongoClient, ReadConcern, ReadConcernLevel } from '../mongodb';
 
 // test mapped cursor types
@@ -25,3 +25,9 @@ const unknownFn: () => Promise<unknown> = async () => 2;
 expectType<unknown>(await client.withSession(unknownFn));
 // Not a promise returning function
 expectError(await client.withSession(() => null));
+
+declare const ct: ClusterTime;
+expectType<Timestamp>(ct.clusterTime);
+expectAssignable<ClusterTime['signature']>(undefined);
+expectType<Binary>(ct.signature?.hash);
+expectType<Long>(ct.signature?.keyId);

--- a/test/types/sessions.test-d.ts
+++ b/test/types/sessions.test-d.ts
@@ -1,4 +1,4 @@
-import { expectAssignable, expectDocCommentIncludes, expectError, expectType } from 'tsd';
+import { expectAssignable, expectError, expectType } from 'tsd';
 
 import type { Binary, ClientSession, ClusterTime, Long, Timestamp } from '../mongodb';
 import { MongoClient, ReadConcern, ReadConcernLevel } from '../mongodb';
@@ -29,5 +29,5 @@ expectError(await client.withSession(() => null));
 declare const ct: ClusterTime;
 expectType<Timestamp>(ct.clusterTime);
 expectAssignable<ClusterTime['signature']>(undefined);
-expectType<Binary>(ct.signature?.hash);
-expectType<Long>(ct.signature?.keyId);
+expectType<Binary | undefined>(ct.signature?.hash);
+expectType<Long | undefined>(ct.signature?.keyId);


### PR DESCRIPTION
### Description

#### What is changing?

- Correct typescript for signature property on ClusterTime interface

##### Is there new documentation needed for these changes?

No.. well yes, these are docs changes!

#### What is the motivation for this change?

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### `ClusterTime` interface `signature` optionality

The `ClusterTime` interface incorrectly reported the `signature` field as required, [the server may omit it](https://github.com/10gen/mongo/blob/a6ede4e300909230b3ec9cc47ea71a9abedde65b/src/mongo/db/vector_clock.idl#L47-L58), so the typescript has been updated to reflect reality. 

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
