### PR TITLE
fix(NODE-5530): make topology descriptions JSON stringifiable 

### DIFF
--- a/src/sdam/topology_description.ts
+++ b/src/sdam/topology_description.ts
@@ -343,6 +343,12 @@ export class TopologyDescription {
     return this.servers.has(address);
   }
 
+  /**
+   * Returns a JSON-serializable representation of the TopologyDescription.  This is primarily
+   * intended for use with JSON.stringify().
+   *
+   * This method will not throw.
+   */
   toJSON() {
     return EJSON.serialize(this);
   }

--- a/src/sdam/topology_description.ts
+++ b/src/sdam/topology_description.ts
@@ -1,4 +1,4 @@
-import type { ObjectId } from '../bson';
+import { EJSON, type ObjectId } from '../bson';
 import * as WIRE_CONSTANTS from '../cmap/wire_protocol/constants';
 import { type MongoError, MongoRuntimeError } from '../error';
 import { compareObjectId, shuffle } from '../utils';
@@ -341,6 +341,10 @@ export class TopologyDescription {
    */
   hasServer(address: string): boolean {
     return this.servers.has(address);
+  }
+
+  toJSON() {
+    return EJSON.serialize(this);
   }
 }
 

--- a/test/integration/node-specific/errors.test.ts
+++ b/test/integration/node-specific/errors.test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 
-import { MongoClient, MongoServerSelectionError } from '../../mongodb';
+import { MongoClient, MongoServerSelectionError, ReadPreference } from '../../mongodb';
 
 describe('Error (Integration)', function () {
   it('NODE-5296: handles aggregate errors from dns lookup', async function () {
@@ -9,5 +9,32 @@ describe('Error (Integration)', function () {
     }).catch(e => e);
     expect(error).to.be.instanceOf(MongoServerSelectionError);
     expect(error.message).not.to.be.empty;
+  });
+
+  context('when a server selection error is stringified', function () {
+    it('the error"s topology description correctly displays the `servers`', async function () {
+      const client: MongoClient = this.configuration.newClient({ serverSelectionTimeoutMS: 1000 });
+      try {
+        await client.connect();
+
+        const error = await client
+          .db('foo')
+          .collection('bar')
+          .find(
+            {},
+            {
+              // Use meaningless read preference tags to ensure that the server selection fails
+              readPreference: new ReadPreference('secondary', [{ ny: 'ny' }])
+            }
+          )
+          .toArray()
+          .catch(e => JSON.parse(JSON.stringify(e)));
+
+        const servers = error.reason.servers;
+        expect(Object.keys(servers).length > 0).to.be.true;
+      } finally {
+        await client.close();
+      }
+    });
   });
 });

--- a/test/integration/node-specific/errors.test.ts
+++ b/test/integration/node-specific/errors.test.ts
@@ -12,29 +12,35 @@ describe('Error (Integration)', function () {
   });
 
   context('when a server selection error is stringified', function () {
-    it('the error"s topology description correctly displays the `servers`', async function () {
-      const client: MongoClient = this.configuration.newClient({ serverSelectionTimeoutMS: 1000 });
-      try {
-        await client.connect();
+    it(
+      'the error"s topology description correctly displays the `servers`',
+      { requires: { topology: 'replicaset' } },
+      async function () {
+        const client: MongoClient = this.configuration.newClient({
+          serverSelectionTimeoutMS: 1000
+        });
+        try {
+          await client.connect();
 
-        const error = await client
-          .db('foo')
-          .collection('bar')
-          .find(
-            {},
-            {
-              // Use meaningless read preference tags to ensure that the server selection fails
-              readPreference: new ReadPreference('secondary', [{ ny: 'ny' }])
-            }
-          )
-          .toArray()
-          .catch(e => JSON.parse(JSON.stringify(e)));
+          const error = await client
+            .db('foo')
+            .collection('bar')
+            .find(
+              {},
+              {
+                // Use meaningless read preference tags to ensure that the server selection fails
+                readPreference: new ReadPreference('secondary', [{ ny: 'ny' }])
+              }
+            )
+            .toArray()
+            .catch(e => JSON.parse(JSON.stringify(e)));
 
-        const servers = error.reason.servers;
-        expect(Object.keys(servers).length > 0).to.be.true;
-      } finally {
-        await client.close();
+          const servers = error.reason.servers;
+          expect(Object.keys(servers).length > 0).to.be.true;
+        } finally {
+          await client.close();
+        }
       }
-    });
+    );
   });
 });

--- a/test/integration/server-discovery-and-monitoring/topology_description.test.ts
+++ b/test/integration/server-discovery-and-monitoring/topology_description.test.ts
@@ -14,7 +14,22 @@ describe('TopologyDescription (integration tests)', function () {
     await client.close();
   });
 
+  beforeEach(async function () {
+    client = this.configuration.newClient();
+    await client.connect();
+  });
+
   context('options', function () {
+    let client: MongoClient;
+
+    afterEach(async function () {
+      await client.close();
+    });
+
+    beforeEach(async function () {
+      client = this.configuration.newClient();
+    });
+
     context('localThresholdMS', function () {
       it('should default to 15ms', async function () {
         const options: MongoClientOptions = {};
@@ -35,15 +50,6 @@ describe('TopologyDescription (integration tests)', function () {
   });
 
   context('topology types', function () {
-    let client: MongoClient;
-    beforeEach(async function () {
-      client = this.configuration.newClient();
-    });
-
-    afterEach(async function () {
-      await client.close();
-    });
-
     const topologyTypesMap = new Map<TopologyTypeRequirement, TopologyType>([
       ['single', TopologyType.Single],
       ['replicaset', TopologyType.ReplicaSetWithPrimary],
@@ -64,5 +70,24 @@ describe('TopologyDescription (integration tests)', function () {
         }
       );
     }
+  });
+
+  describe('json stringification', function () {
+    it('can be stringified without error', function () {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-non-null-asserted-optional-chain
+      const description = client.topology?.description!;
+      expect(description).to.exist;
+
+      expect(() => JSON.stringify(description)).not.to.throw;
+    });
+
+    it('properly stringifies the server description map', function () {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-non-null-asserted-optional-chain
+      const description = client.topology?.description!;
+      expect(description).to.exist;
+
+      const { servers } = JSON.parse(JSON.stringify(description));
+      expect(Object.keys(servers).length > 0).to.be.true;
+    });
   });
 });

--- a/test/integration/server-discovery-and-monitoring/topology_description.test.ts
+++ b/test/integration/server-discovery-and-monitoring/topology_description.test.ts
@@ -87,7 +87,7 @@ describe('TopologyDescription (integration tests)', function () {
       expect(description).to.exist;
 
       const { servers } = JSON.parse(JSON.stringify(description));
-      expect(Object.keys(servers).length > 0).to.be.true;
+      expect(Object.keys(servers).length > 0, '`servers` stringified with no servers.').to.be.true;
     });
   });
 });


### PR DESCRIPTION
### Description

#### What is changing?

This is basically entirely invisible to users.  However, the TopologyDescription is a field on `MongoServerSelectionError`s, so if a user is calling JSON.stringify on their errors, they will now see the `servers` field in the output instead of an empty object.

##### Is there new documentation needed for these changes?

No.

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### TopologyDescription now properly stringifies itself to JSON

The `TopologyDescription` class is exposed by the driver in server selection errors and topology monitoring events to provide insight into the driver's current representation of the server's topology and to aid in debugging.  However, the TopologyDescription uses `Map`s internally, which get serialized to `{}` when JSON stringified.  We recommend using Node's `util.inspect()` helper to print topology descriptions because `inspect` properly handles all JS types and all types we use in the driver.  However, if JSON must be used, the `TopologyDescription` now provides a custom `toJSON()` hook:

```typescript
client.on('topologyDescriptionChanged', ({ newDescription }) => {
   // recommended!
	console.log('topology description changed', inspect(newDescription, { depth: Infinity, colors: true }))

    // now properly prints the entire topology description
	console.log('topology description changed', JSON.stringify(newDescription))
});
```

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
