### PR TITLE
fix(NODE-6029): update types for collection listing indexes

### DIFF
--- a/src/collection.ts
+++ b/src/collection.ts
@@ -701,13 +701,21 @@ export class Collection<TSchema extends Document = Document> {
    *
    * @param options - Optional settings for the command
    */
-  async indexInformation<TFull extends boolean = false>(
-    options?: IndexInformationOptions<TFull>
-  ): Promise<IndexesInformation<TFull>> {
-    return (await this.indexes({
+  indexInformation(
+    options: IndexInformationOptions & { full: true }
+  ): Promise<IndexDescriptionInfo[]>;
+  indexInformation(
+    options: IndexInformationOptions & { full?: false }
+  ): Promise<IndexDescriptionCompact>;
+  indexInformation(
+    options: IndexInformationOptions & { full: boolean }
+  ): Promise<IndexDescriptionCompact | IndexDescriptionInfo[]>;
+  indexInformation(): Promise<IndexDescriptionCompact>;
+  async indexInformation(options?: IndexInformationOptions) {
+    return await this.indexes({
       ...options,
       full: options?.full ?? false
-    })) as IndexesInformation<TFull>;
+    });
   }
 
   /**
@@ -811,20 +819,24 @@ export class Collection<TSchema extends Document = Document> {
    *
    * @param options - Optional settings for the command
    */
-  async indexes<TFull extends boolean = true>(
-    options?: IndexInformationOptions<TFull>
-  ): Promise<IndexesInformation<TFull>> {
+  indexes(options: IndexInformationOptions & { full?: true }): Promise<IndexDescriptionInfo[]>;
+  indexes(options: IndexInformationOptions & { full: false }): Promise<IndexDescriptionCompact>;
+  indexes(
+    options: IndexInformationOptions & { full: boolean }
+  ): Promise<IndexDescriptionCompact | IndexDescriptionInfo[]>;
+  indexes(): Promise<IndexDescriptionInfo[]>;
+  async indexes(options?: IndexInformationOptions) {
     const indexes: IndexDescriptionInfo[] = await this.listIndexes(options).toArray();
     const full = options?.full ?? true;
     if (full) {
-      return indexes as IndexesInformation<TFull>;
+      return indexes;
     }
 
     const object: IndexDescriptionCompact = Object.fromEntries(
       indexes.map(({ name, key }) => [name, Object.entries(key)])
     );
 
-    return object as IndexesInformation<TFull>;
+    return object;
   }
 
   /**

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -701,7 +701,7 @@ export class Collection<TSchema extends Document = Document> {
     options: IndexInformationOptions & { full?: false }
   ): Promise<IndexDescriptionCompact>;
   indexInformation(
-    options: IndexInformationOptions & { full: boolean }
+    options: IndexInformationOptions
   ): Promise<IndexDescriptionCompact | IndexDescriptionInfo[]>;
   indexInformation(): Promise<IndexDescriptionCompact>;
   async indexInformation(
@@ -817,9 +817,9 @@ export class Collection<TSchema extends Document = Document> {
   indexes(options: IndexInformationOptions & { full?: true }): Promise<IndexDescriptionInfo[]>;
   indexes(options: IndexInformationOptions & { full: false }): Promise<IndexDescriptionCompact>;
   indexes(
-    options: IndexInformationOptions & { full: boolean }
+    options: IndexInformationOptions
   ): Promise<IndexDescriptionCompact | IndexDescriptionInfo[]>;
-  indexes(): Promise<IndexDescriptionInfo[]>;
+  indexes(options?: ListIndexesOptions): Promise<IndexDescriptionInfo[]>;
   async indexes(
     options?: IndexInformationOptions
   ): Promise<IndexDescriptionCompact | IndexDescriptionInfo[]> {

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -704,7 +704,9 @@ export class Collection<TSchema extends Document = Document> {
     options: IndexInformationOptions & { full: boolean }
   ): Promise<IndexDescriptionCompact | IndexDescriptionInfo[]>;
   indexInformation(): Promise<IndexDescriptionCompact>;
-  async indexInformation(options?: IndexInformationOptions) {
+  async indexInformation(
+    options?: IndexInformationOptions
+  ): Promise<IndexDescriptionCompact | IndexDescriptionInfo[]> {
     return await this.indexes({
       ...options,
       full: options?.full ?? false
@@ -818,7 +820,9 @@ export class Collection<TSchema extends Document = Document> {
     options: IndexInformationOptions & { full: boolean }
   ): Promise<IndexDescriptionCompact | IndexDescriptionInfo[]>;
   indexes(): Promise<IndexDescriptionInfo[]>;
-  async indexes(options?: IndexInformationOptions) {
+  async indexes(
+    options?: IndexInformationOptions
+  ): Promise<IndexDescriptionCompact | IndexDescriptionInfo[]> {
     const indexes: IndexDescriptionInfo[] = await this.listIndexes(options).toArray();
     const full = options?.full ?? true;
     if (full) {

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -122,13 +122,6 @@ export interface CollectionPrivate {
   writeConcern?: WriteConcern;
 }
 
-/** @public */
-export type IndexesInformation<TFull extends boolean = boolean> = TFull extends true
-  ? IndexDescriptionInfo[]
-  : TFull extends false
-  ? IndexDescriptionCompact
-  : IndexDescriptionInfo[] | IndexDescriptionCompact;
-
 /**
  * The **Collection** class is an internal class that embodies a MongoDB collection
  * allowing for insert/find/update/delete and other command operation on that MongoDB collection.

--- a/src/db.ts
+++ b/src/db.ts
@@ -497,7 +497,10 @@ export class Db {
     options: IndexInformationOptions & { full: boolean }
   ): Promise<IndexDescriptionCompact | IndexDescriptionInfo[]>;
   indexInformation(name: string): Promise<IndexDescriptionCompact>;
-  async indexInformation(name: string, options?: IndexInformationOptions) {
+  async indexInformation(
+    name: string,
+    options?: IndexInformationOptions
+  ): Promise<IndexDescriptionCompact | IndexDescriptionInfo[]> {
     return await this.collection(name).indexInformation(
       resolveOptions(this, options as IndexInformationOptions & { full: boolean })
     );

--- a/src/db.ts
+++ b/src/db.ts
@@ -482,7 +482,10 @@ export class Db {
    * @param name - The name of the collection.
    * @param options - Optional settings for the command
    */
-  async indexInformation(name: string, options?: IndexInformationOptions): Promise<Document> {
+  async indexInformation<TFull extends boolean = false>(
+    name: string,
+    options?: IndexInformationOptions<TFull>
+  ) {
     return await this.collection(name).indexInformation(resolveOptions(this, options));
   }
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -494,16 +494,14 @@ export class Db {
   ): Promise<IndexDescriptionCompact>;
   indexInformation(
     name: string,
-    options: IndexInformationOptions & { full: boolean }
+    options: IndexInformationOptions
   ): Promise<IndexDescriptionCompact | IndexDescriptionInfo[]>;
   indexInformation(name: string): Promise<IndexDescriptionCompact>;
   async indexInformation(
     name: string,
     options?: IndexInformationOptions
   ): Promise<IndexDescriptionCompact | IndexDescriptionInfo[]> {
-    return await this.collection(name).indexInformation(
-      resolveOptions(this, options as IndexInformationOptions & { full: boolean })
-    );
+    return await this.collection(name).indexInformation(resolveOptions(this, options));
   }
 
   /**

--- a/src/db.ts
+++ b/src/db.ts
@@ -25,6 +25,8 @@ import { executeOperation } from './operations/execute_operation';
 import {
   CreateIndexesOperation,
   type CreateIndexesOptions,
+  type IndexDescriptionCompact,
+  type IndexDescriptionInfo,
   type IndexInformationOptions,
   type IndexSpecification
 } from './operations/indexes';
@@ -482,11 +484,23 @@ export class Db {
    * @param name - The name of the collection.
    * @param options - Optional settings for the command
    */
-  async indexInformation<TFull extends boolean = false>(
+  indexInformation(
     name: string,
-    options?: IndexInformationOptions<TFull>
-  ) {
-    return await this.collection(name).indexInformation(resolveOptions(this, options));
+    options: IndexInformationOptions & { full: true }
+  ): Promise<IndexDescriptionInfo[]>;
+  indexInformation(
+    name: string,
+    options: IndexInformationOptions & { full?: false }
+  ): Promise<IndexDescriptionCompact>;
+  indexInformation(
+    name: string,
+    options: IndexInformationOptions & { full: boolean }
+  ): Promise<IndexDescriptionCompact | IndexDescriptionInfo[]>;
+  indexInformation(name: string): Promise<IndexDescriptionCompact>;
+  async indexInformation(name: string, options?: IndexInformationOptions) {
+    return await this.collection(name).indexInformation(
+      resolveOptions(this, options as IndexInformationOptions & { full: boolean })
+    );
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -291,12 +291,7 @@ export type { StreamDescription, StreamDescriptionOptions } from './cmap/stream_
 export type { CompressorName } from './cmap/wire_protocol/compression';
 export type { JSTypeOf, OnDemandDocument } from './cmap/wire_protocol/on_demand/document';
 export type { MongoDBResponse, MongoDBResponseConstructor } from './cmap/wire_protocol/responses';
-export type {
-  CollectionOptions,
-  CollectionPrivate,
-  IndexesInformation,
-  ModifyResult
-} from './collection';
+export type { CollectionOptions, CollectionPrivate, ModifyResult } from './collection';
 export type {
   COMMAND_FAILED,
   COMMAND_STARTED,

--- a/src/index.ts
+++ b/src/index.ts
@@ -291,7 +291,12 @@ export type { StreamDescription, StreamDescriptionOptions } from './cmap/stream_
 export type { CompressorName } from './cmap/wire_protocol/compression';
 export type { JSTypeOf, OnDemandDocument } from './cmap/wire_protocol/on_demand/document';
 export type { MongoDBResponse, MongoDBResponseConstructor } from './cmap/wire_protocol/responses';
-export type { CollectionOptions, CollectionPrivate, ModifyResult } from './collection';
+export type {
+  CollectionOptions,
+  CollectionPrivate,
+  IndexesInformation,
+  ModifyResult
+} from './collection';
 export type {
   COMMAND_FAILED,
   COMMAND_STARTED,
@@ -471,6 +476,8 @@ export type {
   CreateIndexesOptions,
   DropIndexesOptions,
   IndexDescription,
+  IndexDescriptionCompact,
+  IndexDescriptionInfo,
   IndexDirection,
   IndexSpecification,
   ListIndexesOptions

--- a/src/operations/indexes.ts
+++ b/src/operations/indexes.ts
@@ -72,7 +72,7 @@ export type IndexSpecification = OneOrMore<
 >;
 
 /** @public */
-export interface IndexInformationOptions<TFull extends boolean> extends ListIndexesOptions {
+export interface IndexInformationOptions extends ListIndexesOptions {
   /**
    * When `true`, an array of index descriptions is returned.
    * When `false`, the driver returns an object that with keys corresponding to index names with values
@@ -91,7 +91,7 @@ export interface IndexInformationOptions<TFull extends boolean> extends ListInde
    * }
    * ```
    */
-  full?: TFull;
+  full?: boolean;
 }
 
 /** @public */
@@ -221,7 +221,7 @@ function resolveIndexDescription(
 export type IndexDescriptionInfo = Omit<IndexDescription, 'key' | 'version'> & {
   key: { [key: string]: IndexDirection };
   v?: IndexDescription['version'];
-};
+} & Document;
 
 /** @public */
 export type IndexDescriptionCompact = Record<string, [name: string, direction: IndexDirection][]>;

--- a/src/operations/indexes.ts
+++ b/src/operations/indexes.ts
@@ -72,7 +72,7 @@ export type IndexSpecification = OneOrMore<
 >;
 
 /** @public */
-export interface IndexInformationOptions extends ListIndexesOptions {
+export interface IndexInformationOptions<TFull extends boolean> extends ListIndexesOptions {
   /**
    * When `true`, an array of index descriptions is returned.
    * When `false`, the driver returns an object that with keys corresponding to index names with values
@@ -91,7 +91,7 @@ export interface IndexInformationOptions extends ListIndexesOptions {
    * }
    * ```
    */
-  full?: boolean;
+  full?: TFull;
 }
 
 /** @public */
@@ -213,6 +213,18 @@ function resolveIndexDescription(
     validProvidedOptions.map(([name, value]) => (name === 'version' ? ['v', value] : [name, value]))
   );
 }
+
+/**
+ * @public
+ * The index information returned by the listIndexes command. https://www.mongodb.com/docs/manual/reference/command/listIndexes/#mongodb-dbcommand-dbcmd.listIndexes
+ */
+export type IndexDescriptionInfo = Omit<IndexDescription, 'key' | 'version'> & {
+  key: { [key: string]: IndexDirection };
+  v?: IndexDescription['version'];
+};
+
+/** @public */
+export type IndexDescriptionCompact = Record<string, [name: string, direction: IndexDirection][]>;
 
 /**
  * @internal

--- a/test/types/indexes_test-d.ts
+++ b/test/types/indexes_test-d.ts
@@ -1,16 +1,69 @@
-import { expectType } from 'tsd';
+import { expectAssignable, expectType } from 'tsd';
 
-import { type Document, MongoClient } from '../../src';
+import { MongoClient } from '../../src';
+import { type IndexDescriptionCompact, type IndexDescriptionInfo } from '../mongodb';
 
 const client = new MongoClient('');
 const db = client.db('test');
 const collection = db.collection('test.find');
 
-// Promise variant testing
-expectType<Promise<Document[]>>(collection.indexes());
-expectType<Promise<Document[]>>(collection.indexes({}));
+const exampleFullIndexes: IndexDescriptionInfo[] = [
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  { v: 2, key: { listingName: 'hashed' }, name: 'listingName_hashed' },
+  {
+    v: 2,
+    key: { 'auctionDetails.listingId': 1 },
+    name: 'auctionDetails_listingId_1',
+    unique: true
+  }
+];
+const exampleCompactIndexes: IndexDescriptionCompact = {
+  _id_: [['_id', 1]],
+  listingName_hashed: [['listingName', 'hashed']],
+  auctionDetails_listingId_1: [['auctionDetails.listingId', 1]]
+};
+
+const ambiguousFullness = Math.random() > 0.5;
+
+// test Collection.prototype.indexes
+
+const defaultIndexes = await collection.indexes();
+const emptyOptionsIndexes = await collection.indexes({});
+const fullIndexes = await collection.indexes({ full: true });
+const notFullIndexes = await collection.indexes({ full: false });
+const ambiguousIndexes = await collection.indexes({ full: ambiguousFullness });
+
+expectAssignable<typeof fullIndexes>(exampleFullIndexes);
+expectAssignable<typeof ambiguousIndexes>(exampleFullIndexes);
+expectAssignable<typeof ambiguousIndexes>(exampleCompactIndexes);
+expectAssignable<typeof notFullIndexes>(exampleCompactIndexes);
+
+expectType<IndexDescriptionInfo[]>(defaultIndexes);
+expectType<IndexDescriptionInfo[]>(emptyOptionsIndexes);
+expectType<IndexDescriptionInfo[]>(fullIndexes);
+expectType<IndexDescriptionCompact>(notFullIndexes);
+expectType<IndexDescriptionInfo[] | IndexDescriptionCompact>(ambiguousIndexes);
+
+// test Collection.prototype.indexInformation
+
+const defaultIndexInfo = await collection.indexInformation();
+const emptyOptionsIndexInfo = await collection.indexInformation({});
+const fullIndexInfo = await collection.indexInformation({ full: true });
+const notFullIndexInfo = await collection.indexInformation({ full: false });
+const ambiguousIndexInfo = await collection.indexInformation({ full: ambiguousFullness });
+
+expectAssignable<typeof fullIndexInfo>(exampleFullIndexes);
+expectAssignable<typeof ambiguousIndexInfo>(exampleFullIndexes);
+expectAssignable<typeof ambiguousIndexInfo>(exampleCompactIndexes);
+expectAssignable<typeof notFullIndexInfo>(exampleCompactIndexes);
+
+expectType<IndexDescriptionCompact>(defaultIndexInfo);
+expectType<IndexDescriptionCompact>(emptyOptionsIndexInfo);
+expectType<IndexDescriptionInfo[]>(fullIndexInfo);
+expectType<IndexDescriptionCompact>(notFullIndexInfo);
+expectType<IndexDescriptionInfo[] | IndexDescriptionCompact>(ambiguousIndexInfo);
 
 // Explicit check for iterable result
 for (const index of await collection.indexes()) {
-  expectType<Document>(index);
+  expectType<IndexDescriptionInfo>(index);
 }

--- a/test/types/indexes_test-d.ts
+++ b/test/types/indexes_test-d.ts
@@ -67,3 +67,21 @@ expectType<IndexDescriptionInfo[] | IndexDescriptionCompact>(ambiguousIndexInfo)
 for (const index of await collection.indexes()) {
   expectType<IndexDescriptionInfo>(index);
 }
+
+const dbDefaultIndexInfo = await db.indexInformation('some-collection');
+const dbEmptyOptionsIndexInfo = await db.indexInformation('some-collection', {});
+const dbFullIndexInfo = await db.indexInformation('some-collection', { full: true });
+const dbNotFullIndexInfo = await db.indexInformation('some-collection', { full: false });
+const dbAmbiguousIndexInfo = await db.indexInformation('some-collection', {
+  full: ambiguousFullness
+});
+
+expectAssignable<typeof dbFullIndexInfo>(exampleFullIndexes);
+expectAssignable<typeof dbAmbiguousIndexInfo>(exampleFullIndexes);
+expectAssignable<typeof dbAmbiguousIndexInfo>(exampleCompactIndexes);
+
+expectType<IndexDescriptionCompact>(dbDefaultIndexInfo);
+expectType<IndexDescriptionCompact>(dbEmptyOptionsIndexInfo);
+expectType<IndexDescriptionInfo[]>(dbFullIndexInfo);
+expectType<IndexDescriptionCompact>(dbNotFullIndexInfo);
+expectType<IndexDescriptionInfo[] | IndexDescriptionCompact>(dbAmbiguousIndexInfo);

--- a/test/types/indexes_test-d.ts
+++ b/test/types/indexes_test-d.ts
@@ -68,6 +68,8 @@ for (const index of await collection.indexes()) {
   expectType<IndexDescriptionInfo>(index);
 }
 
+// test Db.prototype.indexInformation
+
 const dbDefaultIndexInfo = await db.indexInformation('some-collection');
 const dbEmptyOptionsIndexInfo = await db.indexInformation('some-collection', {});
 const dbFullIndexInfo = await db.indexInformation('some-collection', { full: true });

--- a/test/types/indexes_test-d.ts
+++ b/test/types/indexes_test-d.ts
@@ -1,6 +1,6 @@
 import { expectAssignable, expectType } from 'tsd';
 
-import { MongoClient } from '../../src';
+import { type IndexInformationOptions, MongoClient } from '../../src';
 import { type IndexDescriptionCompact, type IndexDescriptionInfo } from '../mongodb';
 
 const client = new MongoClient('');
@@ -87,3 +87,13 @@ expectType<IndexDescriptionCompact>(dbEmptyOptionsIndexInfo);
 expectType<IndexDescriptionInfo[]>(dbFullIndexInfo);
 expectType<IndexDescriptionCompact>(dbNotFullIndexInfo);
 expectType<IndexDescriptionInfo[] | IndexDescriptionCompact>(dbAmbiguousIndexInfo);
+
+// test indexInformation with non-literal options
+const options: IndexInformationOptions = {};
+const indexInfo = await db.collection('some-collection').indexInformation(options);
+const indexes = await db.collection('some-collection').indexes(options);
+const indexDbInfo = await db.indexInformation('some-collection', options);
+
+expectType<IndexDescriptionCompact | IndexDescriptionInfo[]>(indexInfo);
+expectType<IndexDescriptionCompact | IndexDescriptionInfo[]>(indexes);
+expectType<IndexDescriptionCompact | IndexDescriptionInfo[]>(indexDbInfo);


### PR DESCRIPTION
### Description

#### What is changing?

Update the return type of `Collection.prototype.indexes` and `Collection.prototype.indexInformation` to an array of indexes with full properties when the `full` option is true and to a Record of \<index name\> - \<keys and direction\> when the full option is false.

##### Is there new documentation needed for these changes?

No.

#### What is the motivation for this change?

The old types were incorrect in regards to the `full` option and were very wide. This will avoid making some type mistakes when using these methods.

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Index information helpers have accurate Typescript return types

`Collection.indexInformation()`, `Collection.indexes()` and `Db.indexInformation()` are helpers that return index information for a given collection or database.  These helpers take an option, `full`, that configures whether the return value contains full index descriptions or a compact summary:

```typescript
collection.indexes({ full: true });   // returns an array of index descriptions
collection.indexes({ full: false });  // returns an object, mapping index names to index keys
```

However, the Typescript return type of these helpers was always `Document`.  Thanks to @prenaissance, these helpers now have accurate type information!  The helpers return a new type,  `IndexDescriptionCompact | IndexDescriptionInfo[]`, which accurately reflects the return type of these helpers.  The helpers also support type narrowing by providing a boolean literal as an option to the API:

```typescript
collection.indexes();   // returns `IndexDescriptionCompact | IndexDescriptionInfo[]`
collection.indexes({ full: false });  // returns an `IndexDescriptionCompact`
collection.indexes({ full: true });  // returns an `IndexDescriptionInfo[]`

collection.indexInfo();   // returns `IndexDescriptionCompact | IndexDescriptionInfo[]`
collection.indexInfo({ full: false });  // returns an `IndexDescriptionCompact`
collection.indexInfo({ full: true });  // returns an `IndexDescriptionInfo[]`

db.indexInfo();   // returns `IndexDescriptionCompact | IndexDescriptionInfo[]`
db.indexInfo({ full: false });  // returns an `IndexDescriptionCompact`
db.indexInfo({ full: true });  // returns an `IndexDescriptionInfo[]`
```

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
