### PR TITLE
test(NODE-6077): fix flaky maxConnecting is enforced CMAP test

### DIFF
--- a/test/spec/connection-monitoring-and-pooling/cmap-format/pool-checkout-maxConnecting-is-enforced.json
+++ b/test/spec/connection-monitoring-and-pooling/cmap-format/pool-checkout-maxConnecting-is-enforced.json
@@ -19,7 +19,7 @@
       ],
       "closeConnection": false,
       "blockConnection": true,
-      "blockTimeMS": 750
+      "blockTimeMS": 800
     }
   },
   "poolOptions": {
@@ -53,7 +53,7 @@
     },
     {
       "name": "wait",
-      "ms": 100
+      "ms": 400
     },
     {
       "name": "checkOut",

--- a/test/spec/connection-monitoring-and-pooling/cmap-format/pool-checkout-maxConnecting-is-enforced.yml
+++ b/test/spec/connection-monitoring-and-pooling/cmap-format/pool-checkout-maxConnecting-is-enforced.yml
@@ -13,7 +13,7 @@ failPoint:
     failCommands: ["isMaster","hello"]
     closeConnection: false
     blockConnection: true
-    blockTimeMS: 750
+    blockTimeMS: 800
 poolOptions:
   maxPoolSize: 10
   waitQueueTimeoutMS: 5000
@@ -36,7 +36,7 @@ operations:
     count: 1
   # wait some more time to ensure thread1 has begun establishing a Connection
   - name: wait
-    ms: 100
+    ms: 400
   # start 2 check out requests. Only one thread should
   # start creating a Connection and the other one should be
   # waiting for pendingConnectionCount to be less than maxConnecting,


### PR DESCRIPTION
### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
