### PR TITLE
fix(NODE-5925): driver throws error when non-read operation in a transaction has a ReadPreferenceMode other than 'primary'

### DIFF
--- a/src/operations/execute_operation.ts
+++ b/src/operations/execute_operation.ts
@@ -122,7 +122,7 @@ export async function executeOperation<
   if (
     inTransaction &&
     !readPreference.equals(ReadPreference.primary) &&
-    operation.hasAspect(Aspect.READ_OPERATION)
+    (operation.hasAspect(Aspect.READ_OPERATION) || operation.commandName === 'runCommand')
   ) {
     throw new MongoTransactionError(
       `Read preference in a transaction must be primary, not: ${readPreference.mode}`

--- a/src/operations/execute_operation.ts
+++ b/src/operations/execute_operation.ts
@@ -119,7 +119,11 @@ export async function executeOperation<
   const readPreference = operation.readPreference ?? ReadPreference.primary;
   const inTransaction = !!session?.inTransaction();
 
-  if (inTransaction && !readPreference.equals(ReadPreference.primary)) {
+  if (
+    inTransaction &&
+    !readPreference.equals(ReadPreference.primary) &&
+    operation.hasAspect(Aspect.READ_OPERATION)
+  ) {
     throw new MongoTransactionError(
       `Read preference in a transaction must be primary, not: ${readPreference.mode}`
     );

--- a/src/operations/execute_operation.ts
+++ b/src/operations/execute_operation.ts
@@ -119,10 +119,13 @@ export async function executeOperation<
   const readPreference = operation.readPreference ?? ReadPreference.primary;
   const inTransaction = !!session?.inTransaction();
 
+  const hasReadAspect = operation.hasAspect(Aspect.READ_OPERATION);
+  const hasWriteAspect = operation.hasAspect(Aspect.WRITE_OPERATION);
+
   if (
     inTransaction &&
     !readPreference.equals(ReadPreference.primary) &&
-    (operation.hasAspect(Aspect.READ_OPERATION) || operation.commandName === 'runCommand')
+    (hasReadAspect || operation.commandName === 'runCommand')
   ) {
     throw new MongoTransactionError(
       `Read preference in a transaction must be primary, not: ${readPreference.mode}`
@@ -181,8 +184,6 @@ export async function executeOperation<
     supportsRetryableWrites(server) &&
     operation.canRetryWrite;
 
-  const hasReadAspect = operation.hasAspect(Aspect.READ_OPERATION);
-  const hasWriteAspect = operation.hasAspect(Aspect.WRITE_OPERATION);
   const willRetry = (hasReadAspect && willRetryRead) || (hasWriteAspect && willRetryWrite);
 
   if (hasWriteAspect && willRetryWrite) {

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -41,7 +41,6 @@ import {
   ByteUtils,
   calculateDurationInMs,
   type Callback,
-  commandIsReadOperation,
   commandSupportsReadConcern,
   isPromiseLike,
   List,
@@ -1038,16 +1037,6 @@ export function applySession(
       session.transaction.options.readConcern || session?.clientOptions?.readConcern;
     if (readConcern) {
       command.readConcern = readConcern;
-    }
-
-    if (
-      commandIsReadOperation(command) &&
-      ((typeof session.transaction.options.readPreference === 'string' &&
-        session.transaction.options.readPreference !== 'primary') ||
-        (typeof session.transaction.options.readPreference === 'object' &&
-          session.transaction.options.readPreference.mode !== 'primary'))
-    ) {
-      throw new MongoTransactionError('read preference in a transaction must be primary');
     }
 
     if (session.supports.causalConsistency && session.operationTime) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1077,22 +1077,6 @@ export function commandSupportsReadConcern(command: Document): boolean {
   return false;
 }
 
-export function commandIsReadOperation(command: Document): boolean {
-  if (
-    command.find ||
-    command.count ||
-    command.aggregate ||
-    command.distinct ||
-    command.dbStats ||
-    command.listDatabases ||
-    command.listCollections ||
-    command.getMore
-  ) {
-    return true;
-  }
-  return false;
-}
-
 /**
  * Compare objectIds. `null` is always less
  * - `+1 = oid1 is greater than oid2`

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1077,6 +1077,20 @@ export function commandSupportsReadConcern(command: Document): boolean {
   return false;
 }
 
+export function commandIsReadOperation(command: Document): boolean {
+  if (
+    command.find ||
+    command.findOne ||
+    command.ensureIndex ||
+    command.count ||
+    command.aggregate ||
+    command.distinct
+  ) {
+    return true;
+  }
+  return false;
+}
+
 /**
  * Compare objectIds. `null` is always less
  * - `+1 = oid1 is greater than oid2`

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1080,11 +1080,13 @@ export function commandSupportsReadConcern(command: Document): boolean {
 export function commandIsReadOperation(command: Document): boolean {
   if (
     command.find ||
-    command.findOne ||
-    command.ensureIndex ||
     command.count ||
     command.aggregate ||
-    command.distinct
+    command.distinct ||
+    command.dbStats ||
+    command.listDatabases ||
+    command.listCollections ||
+    command.getMore
   ) {
     return true;
   }

--- a/test/integration/transactions/transactions.spec.test.ts
+++ b/test/integration/transactions/transactions.spec.test.ts
@@ -4,8 +4,6 @@ import { loadSpecTests } from '../../spec';
 import { runUnifiedSuite } from '../../tools/unified-spec-runner/runner';
 
 const SKIPPED_TESTS = [
-  // TODO(NODE-5925) - secondary read preference not allowed in transactions.
-  'readPreference inherited from defaultTransactionOptions',
   // TODO(NODE-5924) - Fix modification of readConcern object post message send.
   'readConcern local in defaultTransactionOptions',
   'defaultTransactionOptions override client options',
@@ -17,7 +15,7 @@ const SKIPPED_TESTS = [
 describe('Transactions Spec Unified Tests', function () {
   runUnifiedSuite(loadSpecTests(path.join('transactions', 'unified')), test => {
     return SKIPPED_TESTS.includes(test.description)
-      ? 'TODO(NODE-5924/NODE-5925): Skipping failing transaction tests'
+      ? 'TODO(NODE-5924): Skipping failing transaction tests'
       : false;
   });
 });

--- a/test/tools/unified-spec-runner/entities.ts
+++ b/test/tools/unified-spec-runner/entities.ts
@@ -620,9 +620,8 @@ export class EntitiesMap<E = Entity> extends Map<string, E> {
               WriteConcern.fromOptions(defaultOptions);
           }
           if (defaultOptions.readPreference) {
-            options.defaultTransactionOptions.readPreference = ReadPreference.fromOptions(
-              defaultOptions.readPreference
-            );
+            options.defaultTransactionOptions.readPreference =
+              ReadPreference.fromOptions(defaultOptions);
           }
           if (typeof defaultOptions.maxCommitTimeMS === 'number') {
             options.defaultTransactionOptions.maxCommitTimeMS = defaultOptions.maxCommitTimeMS;


### PR DESCRIPTION
### Description
Within a transaction, readPreferences != 'primary' are not supported, and our error logic must support that to comply with spec. An error should only be thrown in these circumstances when a read operation is being executed. 

#### What is changing?
In a transaction, when a user provides a readPreference != 'primary' and then tries to perform a command that involves a read, the Node Driver will now throw a 

##### Is there new documentation needed for these changes?
Yes, update [Transactions Node.js Manual](https://www.mongodb.com/docs/drivers/node/current/fundamentals/transactions/) to reflect desired readPreference inputs.

#### What is the motivation for this change?
See Release Highlights

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Don't throw error when non-read operation in a transaction has a `ReadPreferenceMode` other than `'primary'`
The following error will now only be thrown  when a user provides a `ReadPreferenceMode` other than `primary` and then tries to perform a command that involves a read:
```javascript
new MongoTransactionError('Read preference in a transaction must be primary');
```
Prior to this change, the Node Driver would incorrectly throw this error even when the operation does not perform a read. 
Note: a `RunCommandOperation` is treated as a read operation for this error.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
