### PR TITLE
feat(NODE-6094) RFC: Allow the Mongo-AWS creds provider to handle assuming an AWS IAM role.

### DIFF
--- a/src/client-side-encryption/auto_encrypter.ts
+++ b/src/client-side-encryption/auto_encrypter.ts
@@ -502,7 +502,8 @@ export class AutoEncrypter {
    * the original ones.
    */
   async askForKMSCredentials(): Promise<KMSProviders> {
-    return await refreshKMSCredentials(this._kmsProviders);
+    const creds = this._client.options.credentials?.mechanismProperties || {};
+    return await refreshKMSCredentials(this._kmsProviders, creds);
   }
 
   /**

--- a/src/client-side-encryption/client_encryption.ts
+++ b/src/client-side-encryption/client_encryption.ts
@@ -654,7 +654,8 @@ export class ClientEncryption {
    * the original ones.
    */
   async askForKMSCredentials(): Promise<KMSProviders> {
-    return await refreshKMSCredentials(this._kmsProviders);
+    const authProps = this._client.options.credentials?.mechanismProperties || {};
+    return await refreshKMSCredentials(this._kmsProviders, authProps);
   }
 
   static get libmongocryptVersion() {

--- a/src/client-side-encryption/providers/aws.ts
+++ b/src/client-side-encryption/providers/aws.ts
@@ -1,10 +1,14 @@
 import { AWSSDKCredentialProvider } from '../../cmap/auth/aws_temporary_credentials';
+import { type AuthMechanismProperties } from '../../cmap/auth/mongo_credentials';
 import { type KMSProviders } from '.';
 
 /**
  * @internal
  */
-export async function loadAWSCredentials(kmsProviders: KMSProviders): Promise<KMSProviders> {
+export async function loadAWSCredentials(
+  kmsProviders: KMSProviders,
+  props: AuthMechanismProperties
+): Promise<KMSProviders> {
   const credentialProvider = new AWSSDKCredentialProvider();
 
   // We shouldn't ever receive a response from the AWS SDK that doesn't have a `SecretAccessKey`
@@ -14,7 +18,7 @@ export async function loadAWSCredentials(kmsProviders: KMSProviders): Promise<KM
     SecretAccessKey = '',
     AccessKeyId = '',
     Token
-  } = await credentialProvider.getCredentials();
+  } = await credentialProvider.getCredentials(props);
   const aws: NonNullable<KMSProviders['aws']> = {
     secretAccessKey: SecretAccessKey,
     accessKeyId: AccessKeyId

--- a/src/client-side-encryption/providers/index.ts
+++ b/src/client-side-encryption/providers/index.ts
@@ -1,3 +1,4 @@
+import { type AuthMechanismProperties } from '../../cmap/auth/mongo_credentials';
 import { loadAWSCredentials } from './aws';
 import { loadAzureCredentials } from './azure';
 import { loadGCPCredentials } from './gcp';
@@ -150,11 +151,14 @@ export function isEmptyCredentials(
  *
  * @internal
  */
-export async function refreshKMSCredentials(kmsProviders: KMSProviders): Promise<KMSProviders> {
+export async function refreshKMSCredentials(
+  kmsProviders: KMSProviders,
+  props: AuthMechanismProperties
+): Promise<KMSProviders> {
   let finalKMSProviders = kmsProviders;
 
   if (isEmptyCredentials('aws', kmsProviders)) {
-    finalKMSProviders = await loadAWSCredentials(finalKMSProviders);
+    finalKMSProviders = await loadAWSCredentials(finalKMSProviders, props);
   }
 
   if (isEmptyCredentials('gcp', kmsProviders)) {

--- a/src/cmap/auth/aws_temporary_credentials.ts
+++ b/src/cmap/auth/aws_temporary_credentials.ts
@@ -1,6 +1,7 @@
 import { type AWSCredentials, getAwsCredentialProvider } from '../../deps';
 import { MongoAWSError } from '../../error';
 import { request } from '../../utils';
+import { type AuthMechanismProperties } from './mongo_credentials';
 
 const AWS_RELATIVE_URI = 'http://169.254.170.2';
 const AWS_EC2_URI = 'http://169.254.169.254';
@@ -27,7 +28,7 @@ export interface AWSTempCredentials {
  * Fetches temporary AWS credentials.
  */
 export abstract class AWSTemporaryCredentialProvider {
-  abstract getCredentials(): Promise<AWSTempCredentials>;
+  abstract getCredentials(props: AuthMechanismProperties): Promise<AWSTempCredentials>;
   private static _awsSDK: ReturnType<typeof getAwsCredentialProvider>;
   protected static get awsSDK() {
     AWSTemporaryCredentialProvider._awsSDK ??= getAwsCredentialProvider();
@@ -104,7 +105,7 @@ export class AWSSDKCredentialProvider extends AWSTemporaryCredentialProvider {
     return this._provider;
   }
 
-  override async getCredentials(): Promise<AWSTempCredentials> {
+  override async getCredentials(props: AuthMechanismProperties): Promise<AWSTempCredentials> {
     /*
      * Creates a credential provider that will attempt to find credentials from the
      * following sources (listed in order of precedence):
@@ -135,7 +136,7 @@ export class AWSSDKCredentialProvider extends AWSTemporaryCredentialProvider {
  * section of the Auth spec.
  */
 export class LegacyAWSTemporaryCredentialProvider extends AWSTemporaryCredentialProvider {
-  override async getCredentials(): Promise<AWSTempCredentials> {
+  override async getCredentials(_props: AuthMechanismProperties): Promise<AWSTempCredentials> {
     // If the environment variable AWS_CONTAINER_CREDENTIALS_RELATIVE_URI
     // is set then drivers MUST assume that it was set by an AWS ECS agent
     if (process.env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI) {

--- a/src/cmap/auth/mongo_credentials.ts
+++ b/src/cmap/auth/mongo_credentials.ts
@@ -66,6 +66,8 @@ export interface AuthMechanismProperties extends Document {
   ALLOWED_HOSTS?: string[];
   /** @experimental */
   TOKEN_AUDIENCE?: string;
+
+  AWS_ROLE_ARN?: string;
 }
 
 /** @public */

--- a/src/cmap/auth/mongodb_aws.ts
+++ b/src/cmap/auth/mongodb_aws.ts
@@ -176,7 +176,9 @@ async function makeTempCredentials(
       }
     });
   }
-  const temporaryCredentials = await awsCredentialFetcher.getCredentials();
+  const temporaryCredentials = await awsCredentialFetcher.getCredentials(
+    credentials.mechanismProperties
+  );
 
   return makeMongoCredentialsFromAWSTemp(temporaryCredentials);
 }

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -1,4 +1,8 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore -- optional interface, will gracefully degrade to `any` if `foo` isn't installed
+import type { FromTemporaryCredentialsOptions } from '@aws-sdk/credential-providers';
+
 import { type Stream } from './cmap/connect';
 import { MongoMissingDependencyError } from './error';
 import type { Callback } from './utils';
@@ -94,6 +98,10 @@ type CredentialProvider = {
     options: { clientConfig: { region: string } }
   ): () => Promise<AWSCredentials>;
   fromNodeProviderChain(this: void): () => Promise<AWSCredentials>;
+  fromTemporaryCredentials(
+    this: void,
+    options: FromTemporaryCredentialsOptions
+  ): () => Promise<AWSCredentials>;
 };
 
 export function getAwsCredentialProvider():

--- a/test/unit/client-side-encryption/auto_encrypter.test.ts
+++ b/test/unit/client-side-encryption/auto_encrypter.test.ts
@@ -9,7 +9,7 @@ import { MongocryptdManager } from '../../../src/client-side-encryption/mongocry
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { StateMachine } from '../../../src/client-side-encryption/state_machine';
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports
-import { MongoClient } from '../../../src/mongo_client';
+import { MongoClient, type MongoOptions } from '../../../src/mongo_client';
 import { BSON, type DataKey } from '../../mongodb';
 import * as requirements from './requirements.helper';
 
@@ -37,7 +37,11 @@ const MOCK_MONGOCRYPTD_RESPONSE = readExtendedJsonToBuffer(
 const MOCK_KEYDOCUMENT_RESPONSE = readExtendedJsonToBuffer(`${__dirname}/data/key-document.json`);
 const MOCK_KMS_DECRYPT_REPLY = readHttpResponse(`${__dirname}/data/kms-decrypt-reply.txt`);
 
-class MockClient {}
+class MockClient {
+  get options(): Partial<MongoOptions> {
+    return {};
+  }
+}
 
 const originalAccessKeyId = process.env.AWS_ACCESS_KEY_ID;
 const originalSecretAccessKey = process.env.AWS_SECRET_ACCESS_KEY;

--- a/test/unit/client-side-encryption/providers/credentialsProvider.test.ts
+++ b/test/unit/client-side-encryption/providers/credentialsProvider.test.ts
@@ -87,7 +87,7 @@ describe('#refreshKMSCredentials', function () {
         });
 
         it('refreshes the aws credentials', async function () {
-          const providers = await refreshKMSCredentials(kmsProviders);
+          const providers = await refreshKMSCredentials(kmsProviders, {});
           expect(providers).to.deep.equal({
             aws: {
               accessKeyId: accessKey,
@@ -116,7 +116,7 @@ describe('#refreshKMSCredentials', function () {
           });
 
           it('refreshes only the aws credentials', async function () {
-            const providers = await refreshKMSCredentials(kmsProviders);
+            const providers = await refreshKMSCredentials(kmsProviders, {});
             expect(providers).to.deep.equal({
               local: {
                 key: Buffer.alloc(96)


### PR DESCRIPTION
### Description


#### What is changing?
The MONGODB-AWS credential provider will now check if you pass a var AWS_ROLE_ARN as part of your auth mechanism properties. If you do, it will assume that role for you using the AWS SDK's credential provider, which will handle session expiry and re-authentication.

##### Is there new documentation needed for these changes?
Yes.

#### What is the motivation for this change?

In our org, we're using the mongo creds provider with an assumed role. We are assuming the role ourselves and passing the resulting key, secret, and session token to the mongo connector. This works fine...

... until the STS session expires.

At this point we need to implement full expiry and reconnection logic ourselves. This sucks - it's finicky, and the code to handle it already exists in both this repository and in the aws-sdk, probably more reliably than we'll ever manage.
It's also annoying because it has to exist outside of the connection pool, and must kill the whole pool. This is the sort of thing a pool should manage for you.

Because of this, we'd really like if the Mongo connector could handle assuming a role for the user. That way we don't need to do all this invalidation + reconnection stuff ourselves, and it lives inside the pool where it belongs. As a selling point to you guys, it actually lives in the aws sdks, not mongo. There is no reconnection logic added as part of this PR as none is needed with this approach.

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

I haven't set up automated tests with this approach yet, I'd ask for a go/no-go before going to that effort :)

Thanks for your consideration!

### Code notes

Most of the changes are just to pass through the authmechanismproperties to where they are needed. This is the first commit.

You'll see the second commit, actually doing the role assumption, is quite small.

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
