### PR TITLE
test(NODE-6096): fix gcp kms tests

### DIFF
--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -1371,14 +1371,8 @@ task_groups:
         params:
           working_dir: "src"
           binary: bash
-          add_expansions_to_env: true
-          env:
-            testgcpkms_key_file: ${gcpkms_key_file}
-            GCPKMS_SERVICEACCOUNT: ${gcpkms_service_account}
-            GCPKMS_DRIVERS_TOOLS: ${DRIVERS_TOOLS}
-            GCPKMS_MACHINETYPE: "e2-standard-4"
           args:
-            - .evergreen/setup-gcp-instance.sh
+            - ${DRIVERS_TOOLS}/.evergreen/csfle/gcpkms/setup.sh
       - command: expansions.update
         # Load the GCPKMS_GCLOUD, GCPKMS_INSTANCE, GCPKMS_REGION, and GCPKMS_ZONE expansions.
         params:
@@ -1395,7 +1389,7 @@ task_groups:
             GCPKMS_ZONE: ${GCPKMS_ZONE}
             GCPKMS_INSTANCENAME: ${GCPKMS_INSTANCENAME}
           args:
-            - ${DRIVERS_TOOLS}/.evergreen/csfle/gcpkms/delete-instance.sh
+            - ${DRIVERS_TOOLS}/.evergreen/csfle/gcpkms/teardown.sh
     tasks:
       - test-gcpkms-task
 

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -3803,14 +3803,8 @@ task_groups:
         params:
           working_dir: src
           binary: bash
-          add_expansions_to_env: true
-          env:
-            testgcpkms_key_file: ${gcpkms_key_file}
-            GCPKMS_SERVICEACCOUNT: ${gcpkms_service_account}
-            GCPKMS_DRIVERS_TOOLS: ${DRIVERS_TOOLS}
-            GCPKMS_MACHINETYPE: e2-standard-4
           args:
-            - .evergreen/setup-gcp-instance.sh
+            - ${DRIVERS_TOOLS}/.evergreen/csfle/gcpkms/setup.sh
       - command: expansions.update
         params:
           file: src/testgcpkms-expansions.yml
@@ -3825,7 +3819,7 @@ task_groups:
             GCPKMS_ZONE: ${GCPKMS_ZONE}
             GCPKMS_INSTANCENAME: ${GCPKMS_INSTANCENAME}
           args:
-            - ${DRIVERS_TOOLS}/.evergreen/csfle/gcpkms/delete-instance.sh
+            - ${DRIVERS_TOOLS}/.evergreen/csfle/gcpkms/teardown.sh
     tasks:
       - test-gcpkms-task
   - name: test_azurekms_task_group

--- a/.evergreen/setup-gcp-instance.sh
+++ b/.evergreen/setup-gcp-instance.sh
@@ -1,9 +1,0 @@
-#! /usr/bin/env bash
-
-set -o errexit
-if [ -z ${testgcpkms_key_file+omitted} ]; then echo "testgcpkms_key_file is unset" && exit 1; fi
-
-echo "${testgcpkms_key_file}" > ./testgcpkms_key_file.json
-export GCPKMS_KEYFILE=./testgcpkms_key_file.json
-
-"$GCPKMS_DRIVERS_TOOLS/.evergreen/csfle/gcpkms/create-and-setup-instance.sh"

--- a/.evergreen/setup-gcp-testing.sh
+++ b/.evergreen/setup-gcp-testing.sh
@@ -1,5 +1,7 @@
 #! /usr/bin/env bash
 
+source "${DRIVERS_TOOLS}/.evergreen/csfle/gcpkms/secrets-export.sh"
+
 # Assert required environment variables are present without printing them
 if [ -z ${GCPKMS_GCLOUD+omitted} ]; then echo "GCPKMS_GCLOUD is unset" && exit 1; fi
 if [ -z ${GCPKMS_PROJECT+omitted} ]; then echo "GCPKMS_PROJECT is unset" && exit 1; fi


### PR DESCRIPTION
### Description

Fixes the GCP KMS test suite.

#### What is changing?

Updates the evergreen config to use the new setup and teardown scripts and pull env variables from the secrets manager.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-6096

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
