### PR TITLE
refactor(NODE-6057): implement CursorResponse for lazy document parsing

### DIFF
--- a/src/client-side-encryption/auto_encrypter.ts
+++ b/src/client-side-encryption/auto_encrypter.ts
@@ -10,7 +10,7 @@ import { MongoDBResponse, type MongoDBResponseConstructor } from '../cmap/wire_p
 import { getMongoDBClientEncryption } from '../deps';
 import { MongoRuntimeError } from '../error';
 import { MongoClient, type MongoClientOptions } from '../mongo_client';
-import { MongoDBCollectionNamespace } from '../utils';
+import { isUint8Array, MongoDBCollectionNamespace } from '../utils';
 import * as cryptoCallbacks from './crypto_callbacks';
 import { MongoCryptInvalidArgumentError } from './errors';
 import { MongocryptdManager } from './mongocryptd_manager';
@@ -480,7 +480,7 @@ export class AutoEncrypter {
   ): Promise<Document> {
     const buffer = MongoDBResponse.is(response)
       ? response.toBytes()
-      : Buffer.isBuffer(response)
+      : isUint8Array(response)
       ? response
       : serialize(response, options);
 

--- a/src/client-side-encryption/state_machine.ts
+++ b/src/client-side-encryption/state_machine.ts
@@ -153,13 +153,29 @@ export class StateMachine {
   ) {}
 
   /**
-   * Executes the state machine according to the specification
+   * Executes the state machine according to the specification.
+   * Will construct the result using `responseType`.
+   */
+  async execute<R extends MongoDBResponseConstructor>(
+    executor: StateMachineExecutable,
+    context: MongoCryptContext,
+    responseType?: R
+  ): Promise<InstanceType<R>>;
+
+  /**
+   * Executes the state machine according to the specification.
+   * Will return a document from the default BSON deserializer.
    */
   async execute<T extends Document>(
     executor: StateMachineExecutable,
+    context: MongoCryptContext
+  ): Promise<T>;
+
+  async execute<T extends Document, R extends MongoDBResponseConstructor>(
+    executor: StateMachineExecutable,
     context: MongoCryptContext,
-    responseType?: MongoDBResponseConstructor
-  ): Promise<T> {
+    responseType?: R
+  ): Promise<T | InstanceType<R>> {
     const keyVaultNamespace = executor._keyVaultNamespace;
     const keyVaultClient = executor._keyVaultClient;
     const metaDataClient = executor._metaDataClient;

--- a/src/cmap/connection.ts
+++ b/src/cmap/connection.ts
@@ -748,7 +748,7 @@ export class CryptoConnection extends Connection {
     ns: MongoDBNamespace,
     cmd: Document,
     options?: CommandOptions,
-    responseType?: T | undefined
+    _responseType?: T | undefined
   ): Promise<Document> {
     const { autoEncrypter } = this;
     if (!autoEncrypter) {
@@ -762,7 +762,7 @@ export class CryptoConnection extends Connection {
     const serverWireVersion = maxWireVersion(this);
     if (serverWireVersion === 0) {
       // This means the initial handshake hasn't happened yet
-      return await super.command<T>(ns, cmd, options, responseType);
+      return await super.command<T>(ns, cmd, options, undefined);
     }
 
     if (serverWireVersion < 8) {
@@ -796,7 +796,7 @@ export class CryptoConnection extends Connection {
       }
     }
 
-    const response = await super.command<T>(ns, encrypted, options, responseType);
+    const response = await super.command<T>(ns, encrypted, options, undefined);
 
     return await autoEncrypter.decrypt(response, options);
   }

--- a/src/cmap/wire_protocol/on_demand/document.ts
+++ b/src/cmap/wire_protocol/on_demand/document.ts
@@ -198,6 +198,13 @@ export class OnDemandDocument {
   }
 
   /**
+   * Returns the number of elements in this BSON document
+   */
+  public size() {
+    return this.elements.length;
+  }
+
+  /**
    * Checks for the existence of an element by name.
    *
    * @remarks
@@ -303,12 +310,18 @@ export class OnDemandDocument {
     });
   }
 
+  /** Returns this document's bytes only */
+  toBytes() {
+    const size = getInt32LE(this.bson, this.offset);
+    return this.bson.subarray(this.offset, this.offset + size);
+  }
+
   /**
    * Iterates through the elements of a document reviving them using the `as` BSONType.
    *
    * @param as - The type to revive all elements as
    */
-  public *valuesAs<const T extends keyof JSTypeOf>(as: T): Generator<JSTypeOf[T]> {
+  public *valuesAs<const T extends keyof JSTypeOf>(as: T): Generator<JSTypeOf[T], void, void> {
     if (!this.isArray) {
       throw new BSONError('Unexpected conversion of non-array value to array');
     }

--- a/src/cmap/wire_protocol/on_demand/document.ts
+++ b/src/cmap/wire_protocol/on_demand/document.ts
@@ -58,7 +58,7 @@ export class OnDemandDocument {
   private readonly indexFound: Record<number, boolean> = Object.create(null);
 
   /** All bson elements in this document */
-  private readonly elements: BSONElement[];
+  private readonly elements: ReadonlyArray<BSONElement>;
 
   constructor(
     /** BSON bytes, this document begins at offset */
@@ -97,12 +97,28 @@ export class OnDemandDocument {
    * @param name - a basic latin string name of a BSON element
    * @returns
    */
-  private getElement(name: string): CachedBSONElement | null {
+  private getElement(name: string | number): CachedBSONElement | null {
     const cachedElement = this.cache[name];
     if (cachedElement === false) return null;
 
     if (cachedElement != null) {
       return cachedElement;
+    }
+
+    if (typeof name === 'number') {
+      if (this.isArray) {
+        if (name < this.elements.length) {
+          const element = this.elements[name];
+          const cachedElement = { element, value: undefined };
+          this.cache[name] = cachedElement;
+          this.indexFound[name] = true;
+          return cachedElement;
+        } else {
+          return null;
+        }
+      } else {
+        return null;
+      }
     }
 
     for (let index = 0; index < this.elements.length; index++) {
@@ -229,16 +245,20 @@ export class OnDemandDocument {
    * @param required - whether or not the element is expected to exist, if true this function will throw if it is not present
    */
   public get<const T extends keyof JSTypeOf>(
-    name: string,
+    name: string | number,
     as: T,
     required?: false | undefined
   ): JSTypeOf[T] | null;
 
   /** `required` will make `get` throw if name does not exist or is null/undefined */
-  public get<const T extends keyof JSTypeOf>(name: string, as: T, required: true): JSTypeOf[T];
+  public get<const T extends keyof JSTypeOf>(
+    name: string | number,
+    as: T,
+    required: true
+  ): JSTypeOf[T];
 
   public get<const T extends keyof JSTypeOf>(
-    name: string,
+    name: string | number,
     as: T,
     required?: boolean
   ): JSTypeOf[T] | null {
@@ -314,23 +334,5 @@ export class OnDemandDocument {
   toBytes() {
     const size = getInt32LE(this.bson, this.offset);
     return this.bson.subarray(this.offset, this.offset + size);
-  }
-
-  /**
-   * Iterates through the elements of a document reviving them using the `as` BSONType.
-   *
-   * @param as - The type to revive all elements as
-   */
-  public *valuesAs<const T extends keyof JSTypeOf>(as: T): Generator<JSTypeOf[T], void, void> {
-    if (!this.isArray) {
-      throw new BSONError('Unexpected conversion of non-array value to array');
-    }
-    let counter = 0;
-    for (const element of this.elements) {
-      const value = this.toJSValue<T>(element, as);
-      this.cache[counter] = { element, value };
-      yield value;
-      counter += 1;
-    }
   }
 }

--- a/src/cmap/wire_protocol/responses.ts
+++ b/src/cmap/wire_protocol/responses.ts
@@ -121,11 +121,9 @@ function throwUnsupportedError() {
 }
 
 export class CursorResponse extends MongoDBResponse {
-  id: Long | null = null;
-  ns: MongoDBNamespace | null = null;
-
-  documents: any | null = null;
-  bufferForUnshift: any[] = [];
+  public id: Long | null = null;
+  public ns: MongoDBNamespace | null = null;
+  public documents: any | null = null;
 
   private batch: OnDemandDocument | null = null;
   private values: Generator<OnDemandDocument, void, void> | null = null;
@@ -161,20 +159,13 @@ export class CursorResponse extends MongoDBResponse {
       shift: {
         value: (options?: BSONSerializeOptions) => {
           this.iterated += 1;
-          if (this.bufferForUnshift.length) return this.bufferForUnshift.pop();
           const r = this.values?.next();
           if (!r || r.done) return null;
-          if (options.raw) {
+          if (options?.raw) {
             return r.value.toBytes();
           } else {
             return r.value.toObject(options);
           }
-        }
-      },
-      unshift: {
-        value: (v: any) => {
-          this.iterated -= 1;
-          this.bufferForUnshift.push(v);
         }
       },
       clear: {

--- a/src/cmap/wire_protocol/responses.ts
+++ b/src/cmap/wire_protocol/responses.ts
@@ -129,10 +129,10 @@ export class CursorResponse extends MongoDBResponse {
   public id: Long | null = null;
   public ns: MongoDBNamespace | null = null;
   public documents: any | null = null;
+  public batchSize = 0;
 
   private batch: OnDemandDocument | null = null;
   private values: Generator<OnDemandDocument, void, void> | null = null;
-  private batchSize = 0;
   private iterated = 0;
 
   constructor(b: Uint8Array, o?: number, a?: boolean) {
@@ -184,7 +184,7 @@ export class CursorResponse extends MongoDBResponse {
     });
   }
 
-  static isCursorResponse(value: unknown): value is CursorResponse {
+  static override is(value: unknown): value is CursorResponse {
     return value instanceof CursorResponse;
   }
 }

--- a/src/cmap/wire_protocol/responses.ts
+++ b/src/cmap/wire_protocol/responses.ts
@@ -17,6 +17,10 @@ export type MongoDBResponseConstructor = {
 
 /** @internal */
 export class MongoDBResponse extends OnDemandDocument {
+  static is(value: unknown): value is MongoDBResponse {
+    return value instanceof MongoDBResponse;
+  }
+
   // {ok:1}
   static empty = new MongoDBResponse(new Uint8Array([13, 0, 0, 0, 16, 111, 107, 0, 1, 0, 0, 0, 0]));
 
@@ -154,18 +158,18 @@ export class CursorResponse extends MongoDBResponse {
     this.documents = Object.defineProperties(Object.create(null), {
       length: {
         get: () => {
-          return this.batchSize - this.iterated;
+          return Math.max(this.batchSize - this.iterated, 0);
         }
       },
       shift: {
         value: (options?: BSONSerializeOptions) => {
           this.iterated += 1;
-          const r = this.values?.next();
-          if (!r || r.done) return null;
+          const result = this.values?.next();
+          if (!result || result.done) return null;
           if (options?.raw) {
-            return r.value.toBytes();
+            return result.value.toBytes();
           } else {
-            return r.value.toObject(options);
+            return result.value.toObject(options);
           }
         }
       },

--- a/src/cmap/wire_protocol/responses.ts
+++ b/src/cmap/wire_protocol/responses.ts
@@ -190,7 +190,7 @@ export class CursorResponse extends MongoDBResponse {
   }
 
   public id: Long;
-  public ns: MongoDBNamespace;
+  public ns: MongoDBNamespace | null = null;
   public batchSize = 0;
 
   private batch: OnDemandDocument;
@@ -204,8 +204,8 @@ export class CursorResponse extends MongoDBResponse {
     const id = cursor.get('id', BSONType.long, true);
     this.id = new Long(Number(id & 0xffff_ffffn), Number((id >> 32n) & 0xffff_ffffn));
 
-    const namespace = cursor.get('ns', BSONType.string) ?? '';
-    if (namespace) this.ns = ns(namespace);
+    const namespace = cursor.get('ns', BSONType.string);
+    if (namespace != null) this.ns = ns(namespace);
 
     if (cursor.has('firstBatch')) this.batch = cursor.get('firstBatch', BSONType.array, true);
     else if (cursor.has('nextBatch')) this.batch = cursor.get('nextBatch', BSONType.array, true);

--- a/src/cmap/wire_protocol/responses.ts
+++ b/src/cmap/wire_protocol/responses.ts
@@ -120,6 +120,7 @@ function throwUnsupportedError() {
   throw new Error('Unsupported method');
 }
 
+/** @internal */
 export class CursorResponse extends MongoDBResponse {
   public id: Long | null = null;
   public ns: MongoDBNamespace | null = null;

--- a/src/cmap/wire_protocol/responses.ts
+++ b/src/cmap/wire_protocol/responses.ts
@@ -122,6 +122,15 @@ export class MongoDBResponse extends OnDemandDocument {
 
 /** @internal */
 export class CursorResponse extends MongoDBResponse {
+  /**
+   * This is a BSON document containing the following:
+   * ```
+   * { ok: 1, cursor: { id: 0n, nextBatch: new Array(0) } }
+   * ```
+   * This is used when the client side findCursor is closed by tracking the number returned and limit
+   * to avoid an extra round trip. It provides a cursor response that the server _would_ return _if_
+   * that round trip were to be made.
+   */
   static emptyGetMore = new CursorResponse(
     Buffer.from(
       'NgAAABBvawABAAAAA2N1cnNvcgAhAAAAEmlkAAAAAAAAAAAABG5leHRCYXRjaAAFAAAAAAAA',

--- a/src/cmap/wire_protocol/responses.ts
+++ b/src/cmap/wire_protocol/responses.ts
@@ -126,6 +126,17 @@ function throwUnsupportedError() {
 
 /** @internal */
 export class CursorResponse extends MongoDBResponse {
+  static emptyGetMore = new CursorResponse(
+    Buffer.from(
+      'NgAAABBvawABAAAAA2N1cnNvcgAhAAAAEmlkAAAAAAAAAAAABG5leHRCYXRjaAAFAAAAAAAA',
+      'base64'
+    )
+  );
+
+  static override is(value: unknown): value is CursorResponse {
+    return value instanceof CursorResponse;
+  }
+
   public id: Long | null = null;
   public ns: MongoDBNamespace | null = null;
   public documents: any | null = null;
@@ -182,9 +193,5 @@ export class CursorResponse extends MongoDBResponse {
       pushMany: { value: throwUnsupportedError },
       push: { value: throwUnsupportedError }
     });
-  }
-
-  static override is(value: unknown): value is CursorResponse {
-    return value instanceof CursorResponse;
   }
 }

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -961,7 +961,7 @@ class ReadableCursorStream extends Readable {
 
   private _readNext() {
     // eslint-disable-next-line github/no-then
-    next(this._cursor, { blocking: true, transform: true }).then(
+    next(this._cursor, { blocking: true, transform: true, hasNext: false }).then(
       result => {
         if (result == null) {
           this.push(null);

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -961,7 +961,7 @@ class ReadableCursorStream extends Readable {
 
   private _readNext() {
     // eslint-disable-next-line github/no-then
-    next(this._cursor, { blocking: true, transform: true, shift: false }).then(
+    this._cursor.next().then(
       result => {
         if (result == null) {
           this.push(null);

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -660,7 +660,7 @@ export abstract class AbstractCursor<
       if (CursorResponse.is(response)) {
         this[kId] = response.id;
         if (response.ns) this[kNamespace] = response.ns;
-        this[kDocuments] = response.documents;
+        this[kDocuments] = response;
       } else if (response.cursor) {
         // TODO(NODE-2674): Preserve int64 sent from MongoDB
         this[kId] =
@@ -800,7 +800,7 @@ async function next<T>(
       const response = await cursor.getMore(batchSize);
       if (CursorResponse.is(response)) {
         cursor[kId] = response.id;
-        cursor[kDocuments] = response.documents;
+        cursor[kDocuments] = response;
       } else if (response) {
         const cursorId =
           typeof response.cursor.id === 'number'

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -961,7 +961,7 @@ class ReadableCursorStream extends Readable {
 
   private _readNext() {
     // eslint-disable-next-line github/no-then
-    this._cursor.next().then(
+    next(this._cursor, { blocking: true, transform: true, shift: true }).then(
       result => {
         if (result == null) {
           this.push(null);

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -657,7 +657,7 @@ export abstract class AbstractCursor<
       const state = await this._initialize(this[kSession]);
       const response = state.response;
       this[kServer] = state.server;
-      if (CursorResponse.isCursorResponse(response)) {
+      if (CursorResponse.is(response)) {
         this[kId] = response.id;
         if (response.ns) this[kNamespace] = response.ns;
         this[kDocuments] = response.documents;
@@ -798,7 +798,7 @@ async function next<T>(
 
     try {
       const response = await cursor.getMore(batchSize);
-      if (CursorResponse.isCursorResponse(response)) {
+      if (CursorResponse.is(response)) {
         cursor[kId] = response.id;
         cursor[kDocuments] = response.documents;
       } else if (response) {

--- a/src/cursor/find_cursor.ts
+++ b/src/cursor/find_cursor.ts
@@ -111,10 +111,10 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
       }
     }
 
-    const response = await super.getMore(batchSize);
+    const response = await super.getMore(batchSize, true);
     // TODO: wrap this in some logic to prevent it from happening if we don't need this support
     if (response) {
-      this[kNumReturned] = this[kNumReturned] + response.cursor.nextBatch.length;
+      this[kNumReturned] = this[kNumReturned] + response.batchLength;
     }
 
     return response;

--- a/src/cursor/find_cursor.ts
+++ b/src/cursor/find_cursor.ts
@@ -1,4 +1,4 @@
-import { type Document, Long } from '../bson';
+import { type Document } from '../bson';
 import { CursorResponse } from '../cmap/wire_protocol/responses';
 import { MongoInvalidArgumentError, MongoTailableCursorError } from '../error';
 import { type ExplainVerbosityLike } from '../explain';

--- a/src/cursor/find_cursor.ts
+++ b/src/cursor/find_cursor.ts
@@ -110,7 +110,7 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
           // instead, if we determine there are no more documents to request from the server, we preemptively
           // close the cursor
         }
-        return { cursor: { id: Long.ZERO, nextBatch: [] } };
+        return CursorResponse.emptyGetMore;
       }
     }
 

--- a/src/cursor/find_cursor.ts
+++ b/src/cursor/find_cursor.ts
@@ -76,8 +76,6 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
       session
     });
 
-    findOperation.encryptionEnabled = !!this.client.autoEncrypter;
-
     const response = await executeOperation(this.client, findOperation);
 
     // the response is not a cursor when `explain` is enabled

--- a/src/cursor/run_command_cursor.ts
+++ b/src/cursor/run_command_cursor.ts
@@ -125,7 +125,8 @@ export class RunCommandCursor extends AbstractCursor {
     const getMoreOperation = new GetMoreOperation(this.namespace, this.id!, this.server!, {
       ...this.cursorOptions,
       session: this.session,
-      ...this.getMoreOptions
+      ...this.getMoreOptions,
+      useCursorResponse: false
     });
 
     return await executeOperation(this.client, getMoreOperation);

--- a/src/index.ts
+++ b/src/index.ts
@@ -290,7 +290,11 @@ export type { ConnectionPoolMetrics } from './cmap/metrics';
 export type { StreamDescription, StreamDescriptionOptions } from './cmap/stream_description';
 export type { CompressorName } from './cmap/wire_protocol/compression';
 export type { JSTypeOf, OnDemandDocument } from './cmap/wire_protocol/on_demand/document';
-export type { MongoDBResponse, MongoDBResponseConstructor } from './cmap/wire_protocol/responses';
+export type {
+  CursorResponse,
+  MongoDBResponse,
+  MongoDBResponseConstructor
+} from './cmap/wire_protocol/responses';
 export type { CollectionOptions, CollectionPrivate, ModifyResult } from './collection';
 export type {
   COMMAND_FAILED,

--- a/src/operations/execute_operation.ts
+++ b/src/operations/execute_operation.ts
@@ -1,4 +1,5 @@
 import type { Document } from '../bson';
+import { type CursorResponse } from '../cmap/wire_protocol/responses';
 import {
   isRetryableReadError,
   isRetryableWriteError,
@@ -44,7 +45,7 @@ export interface ExecutionResult {
   /** The session used for this operation, may be implicitly created */
   session?: ClientSession;
   /** The raw server response for the operation */
-  response: Document;
+  response: Document | CursorResponse;
 }
 
 /**

--- a/src/operations/find.ts
+++ b/src/operations/find.ts
@@ -78,13 +78,10 @@ export class FindOperation extends CommandOperation<Document> {
   override options: FindOptions & { writeConcern?: never };
   filter: Document;
 
-  constructor(
-    collection: Collection | undefined,
-    ns: MongoDBNamespace,
-    filter: Document = {},
-    options: FindOptions = {}
-  ) {
-    super(collection, options);
+  public encryptionEnabled = false;
+
+  constructor(ns: MongoDBNamespace, filter: Document = {}, options: FindOptions = {}) {
+    super(undefined, options);
 
     this.options = { ...options };
     delete this.options.writeConcern;
@@ -121,7 +118,7 @@ export class FindOperation extends CommandOperation<Document> {
         documentsReturnedIn: 'firstBatch',
         session
       },
-      this.explain ? undefined : CursorResponse
+      this.explain || this.encryptionEnabled ? undefined : CursorResponse
     );
   }
 }

--- a/src/operations/find.ts
+++ b/src/operations/find.ts
@@ -77,8 +77,6 @@ export class FindOperation extends CommandOperation<Document> {
   override options: FindOptions & { writeConcern?: never };
   filter: Document;
 
-  public encryptionEnabled = false;
-
   constructor(ns: MongoDBNamespace, filter: Document = {}, options: FindOptions = {}) {
     super(undefined, options);
 
@@ -117,7 +115,7 @@ export class FindOperation extends CommandOperation<Document> {
         documentsReturnedIn: 'firstBatch',
         session
       },
-      this.explain || this.encryptionEnabled ? undefined : CursorResponse
+      this.explain ? undefined : CursorResponse
     );
   }
 }

--- a/src/operations/find.ts
+++ b/src/operations/find.ts
@@ -1,6 +1,5 @@
 import type { Document } from '../bson';
 import { CursorResponse } from '../cmap/wire_protocol/responses';
-import type { Collection } from '../collection';
 import { MongoInvalidArgumentError } from '../error';
 import { ReadConcern } from '../read_concern';
 import type { Server } from '../sdam/server';

--- a/src/operations/find.ts
+++ b/src/operations/find.ts
@@ -1,4 +1,5 @@
 import type { Document } from '../bson';
+import { CursorResponse } from '../cmap/wire_protocol/responses';
 import type { Collection } from '../collection';
 import { MongoInvalidArgumentError } from '../error';
 import { ReadConcern } from '../read_concern';
@@ -111,12 +112,17 @@ export class FindOperation extends CommandOperation<Document> {
       findCommand = decorateWithExplain(findCommand, this.explain);
     }
 
-    return await server.command(this.ns, findCommand, {
-      ...this.options,
-      ...this.bsonOptions,
-      documentsReturnedIn: 'firstBatch',
-      session
-    });
+    return await server.command(
+      this.ns,
+      findCommand,
+      {
+        ...this.options,
+        ...this.bsonOptions,
+        documentsReturnedIn: 'firstBatch',
+        session
+      },
+      this.explain ? undefined : CursorResponse
+    );
   }
 }
 

--- a/src/operations/get_more.ts
+++ b/src/operations/get_more.ts
@@ -1,4 +1,5 @@
 import type { Document, Long } from '../bson';
+import { CursorResponse } from '../cmap/wire_protocol/responses';
 import { MongoRuntimeError } from '../error';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
@@ -19,6 +20,8 @@ export interface GetMoreOptions extends OperationOptions {
   maxTimeMS?: number;
   /** TODO(NODE-4413): Address bug with maxAwaitTimeMS not being passed in from the cursor correctly */
   maxAwaitTimeMS?: number;
+
+  useCursorResponse: boolean;
 }
 
 /**
@@ -96,7 +99,12 @@ export class GetMoreOperation extends AbstractOperation {
       ...this.options
     };
 
-    return await server.command(this.ns, getMoreCmd, commandOptions);
+    return await server.command(
+      this.ns,
+      getMoreCmd,
+      commandOptions,
+      this.options.useCursorResponse ? CursorResponse : undefined
+    );
   }
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -65,6 +65,19 @@ export const ByteUtils = {
 };
 
 /**
+ * Returns true if value is a Uint8Array or a Buffer
+ * @param value - any value that may be a Uint8Array
+ */
+export function isUint8Array(value: unknown): value is Uint8Array {
+  return (
+    value != null &&
+    typeof value === 'object' &&
+    Symbol.toStringTag in value &&
+    value[Symbol.toStringTag] === 'Uint8Array'
+  );
+}
+
+/**
  * Determines if a connection's address matches a user provided list
  * of domain wildcards.
  */

--- a/test/integration/client-side-encryption/driver.test.ts
+++ b/test/integration/client-side-encryption/driver.test.ts
@@ -298,107 +298,110 @@ describe('Client Side Encryption Functional', function () {
     });
   });
 
-  describe('when @@mdb.decorateDecryptionResult is set on autoEncrypter', () => {
-    let client: MongoClient;
-    let encryptedClient: MongoClient;
+  describe(
+    'when @@mdb.decorateDecryptionResult is set on autoEncrypter',
+    { requires: { mongodb: '>=7.0' } },
+    () => {
+      let client: MongoClient;
+      let encryptedClient: MongoClient;
 
-    beforeEach(async function () {
-      client = this.configuration.newClient();
+      beforeEach(async function () {
+        client = this.configuration.newClient();
 
-      const encryptSchema = (keyId: unknown, bsonType: string) => ({
-        encrypt: {
-          bsonType,
-          algorithm: 'AEAD_AES_256_CBC_HMAC_SHA_512-Random',
-          keyId: [keyId]
-        }
-      });
+        const encryptSchema = (keyId: unknown, bsonType: string) => ({
+          encrypt: {
+            bsonType,
+            algorithm: 'AEAD_AES_256_CBC_HMAC_SHA_512-Random',
+            keyId: [keyId]
+          }
+        });
 
-      const kmsProviders = this.configuration.kmsProviders(crypto.randomBytes(96));
+        const kmsProviders = this.configuration.kmsProviders(crypto.randomBytes(96));
 
-      await client.connect();
+        await client.connect();
 
-      const encryption = new ClientEncryption(client, {
-        keyVaultNamespace,
-        kmsProviders,
-        extraOptions: getEncryptExtraOptions()
-      });
+        const encryption = new ClientEncryption(client, {
+          keyVaultNamespace,
+          kmsProviders,
+          extraOptions: getEncryptExtraOptions()
+        });
 
-      const dataDb = client.db(dataDbName);
-      const keyVaultDb = client.db(keyVaultDbName);
+        const dataDb = client.db(dataDbName);
+        const keyVaultDb = client.db(keyVaultDbName);
 
-      await dataDb.dropCollection(dataCollName).catch(() => null);
-      await keyVaultDb.dropCollection(keyVaultCollName).catch(() => null);
-      await keyVaultDb.createCollection(keyVaultCollName);
-      const dataKey = await encryption.createDataKey('local');
+        await dataDb.dropCollection(dataCollName).catch(() => null);
+        await keyVaultDb.dropCollection(keyVaultCollName).catch(() => null);
+        await keyVaultDb.createCollection(keyVaultCollName);
+        const dataKey = await encryption.createDataKey('local');
 
-      const $jsonSchema = {
-        bsonType: 'object',
-        properties: {
-          a: encryptSchema(dataKey, 'int'),
-          b: encryptSchema(dataKey, 'string'),
-          c: {
-            bsonType: 'object',
-            properties: {
-              d: {
-                encrypt: {
-                  keyId: [dataKey],
-                  algorithm: 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic',
-                  bsonType: 'string'
+        const $jsonSchema = {
+          bsonType: 'object',
+          properties: {
+            a: encryptSchema(dataKey, 'int'),
+            b: encryptSchema(dataKey, 'string'),
+            c: {
+              bsonType: 'object',
+              properties: {
+                d: {
+                  encrypt: {
+                    keyId: [dataKey],
+                    algorithm: 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic',
+                    bsonType: 'string'
+                  }
                 }
               }
             }
           }
-        }
-      };
+        };
 
-      await dataDb.createCollection(dataCollName, {
-        validator: { $jsonSchema }
+        await dataDb.createCollection(dataCollName, {
+          validator: { $jsonSchema }
+        });
+
+        encryptedClient = this.configuration.newClient(
+          {},
+          {
+            autoEncryption: {
+              keyVaultNamespace,
+              kmsProviders,
+              extraOptions: getEncryptExtraOptions()
+            }
+          }
+        );
+
+        encryptedClient.autoEncrypter[Symbol.for('@@mdb.decorateDecryptionResult')] = true;
+        await encryptedClient.connect();
       });
 
-      encryptedClient = this.configuration.newClient(
-        {},
-        {
-          autoEncryption: {
-            keyVaultNamespace,
-            kmsProviders,
-            extraOptions: getEncryptExtraOptions()
-          }
-        }
-      );
+      afterEach(async function () {
+        await encryptedClient?.close();
+        await client?.close();
+      });
 
-      encryptedClient.autoEncrypter[Symbol.for('@@mdb.decorateDecryptionResult')] = true;
-      await encryptedClient.connect();
-    });
+      it('adds decrypted keys to result at @@mdb.decryptedKeys', async function () {
+        const coll = encryptedClient.db(dataDbName).collection(dataCollName);
 
-    afterEach(function () {
-      return Promise.resolve()
-        .then(() => encryptedClient?.close())
-        .then(() => client?.close());
-    });
+        const data = {
+          _id: new BSON.ObjectId(),
+          a: 1,
+          b: 'abc',
+          c: { d: 'def' }
+        };
 
-    it('adds decrypted keys to result at @@mdb.decryptedKeys', async function () {
-      const coll = encryptedClient.db(dataDbName).collection(dataCollName);
+        const result = await coll.insertOne(data);
+        const decrypted = await coll.findOne({ _id: result.insertedId });
 
-      const data = {
-        _id: new BSON.ObjectId(),
-        a: 1,
-        b: 'abc',
-        c: { d: 'def' }
-      };
+        expect(decrypted).to.deep.equal(data);
+        expect(decrypted)
+          .to.have.property(Symbol.for('@@mdb.decryptedKeys'))
+          .that.deep.equals(['a', 'b']);
 
-      const result = await coll.insertOne(data);
-      const decrypted = await coll.findOne({ _id: result.insertedId });
-
-      expect(decrypted).to.deep.equal(data);
-      expect(decrypted)
-        .to.have.property(Symbol.for('@@mdb.decryptedKeys'))
-        .that.deep.equals(['a', 'b']);
-
-      // Nested
-      expect(decrypted).to.have.property('c');
-      expect(decrypted.c)
-        .to.have.property(Symbol.for('@@mdb.decryptedKeys'))
-        .that.deep.equals(['d']);
-    });
-  });
+        // Nested
+        expect(decrypted).to.have.property('c');
+        expect(decrypted.c)
+          .to.have.property(Symbol.for('@@mdb.decryptedKeys'))
+          .that.deep.equals(['d']);
+      });
+    }
+  );
 });

--- a/test/integration/client-side-encryption/driver.test.ts
+++ b/test/integration/client-side-encryption/driver.test.ts
@@ -300,7 +300,7 @@ describe('Client Side Encryption Functional', function () {
 
   describe(
     'when @@mdb.decorateDecryptionResult is set on autoEncrypter',
-    { requires: { mongodb: '>=7.0' } },
+    { requires: { clientSideEncryption: true, mongodb: '>=4.4' } },
     () => {
       let client: MongoClient;
       let encryptedClient: MongoClient;

--- a/test/integration/crud/abstract_operation.test.ts
+++ b/test/integration/crud/abstract_operation.test.ts
@@ -102,7 +102,7 @@ describe('abstract operation', function () {
         correctCommandName: 'count'
       },
       {
-        subclassCreator: () => new mongodb.FindOperation(undefined, collection.fullNamespace),
+        subclassCreator: () => new mongodb.FindOperation(collection.fullNamespace),
         subclassType: mongodb.FindOperation,
         correctCommandName: 'find'
       },

--- a/test/integration/crud/abstract_operation.test.ts
+++ b/test/integration/crud/abstract_operation.test.ts
@@ -102,7 +102,7 @@ describe('abstract operation', function () {
         correctCommandName: 'count'
       },
       {
-        subclassCreator: () => new mongodb.FindOperation(collection, collection.fullNamespace),
+        subclassCreator: () => new mongodb.FindOperation(undefined, collection.fullNamespace),
         subclassType: mongodb.FindOperation,
         correctCommandName: 'find'
       },

--- a/test/unit/assorted/collations.test.js
+++ b/test/unit/assorted/collations.test.js
@@ -55,7 +55,7 @@ describe('Collation', function () {
         request.reply(primary[0]);
       } else if (doc.aggregate) {
         commandResult = doc;
-        request.reply({ ok: 1, cursor: { id: 0, firstBatch: [], ns: 'collation_test' } });
+        request.reply({ ok: 1, cursor: { id: 0n, firstBatch: [], ns: 'collation_test' } });
       } else if (doc.endSessions) {
         request.reply({ ok: 1 });
       }
@@ -183,7 +183,7 @@ describe('Collation', function () {
         request.reply(primary[0]);
       } else if (doc.find) {
         commandResult = doc;
-        request.reply({ ok: 1, cursor: { id: 0, firstBatch: [] } });
+        request.reply({ ok: 1, cursor: { id: 0n, firstBatch: [] } });
       } else if (doc.endSessions) {
         request.reply({ ok: 1 });
       }
@@ -215,7 +215,7 @@ describe('Collation', function () {
         request.reply(primary[0]);
       } else if (doc.find) {
         commandResult = doc;
-        request.reply({ ok: 1, cursor: { id: 0, firstBatch: [] } });
+        request.reply({ ok: 1, cursor: { id: 0n, firstBatch: [] } });
       } else if (doc.endSessions) {
         request.reply({ ok: 1 });
       }
@@ -249,7 +249,7 @@ describe('Collation', function () {
         request.reply(primary[0]);
       } else if (doc.find) {
         commandResult = doc;
-        request.reply({ ok: 1, cursor: { id: 0, firstBatch: [] } });
+        request.reply({ ok: 1, cursor: { id: 0n, firstBatch: [] } });
       } else if (doc.endSessions) {
         request.reply({ ok: 1 });
       }

--- a/test/unit/assorted/sessions_collection.test.js
+++ b/test/unit/assorted/sessions_collection.test.js
@@ -27,7 +27,7 @@ describe('Sessions - unit/sessions', function () {
           request.reply({ ok: 1, operationTime: insertOperationTime });
         } else if (doc.find) {
           findCommand = doc;
-          request.reply({ ok: 1, cursor: { id: 0, firstBatch: [] } });
+          request.reply({ ok: 1, cursor: { id: 0n, firstBatch: [] } });
         } else if (doc.endSessions) {
           request.reply({ ok: 1 });
         }

--- a/test/unit/cmap/wire_protocol/responses.test.ts
+++ b/test/unit/cmap/wire_protocol/responses.test.ts
@@ -1,7 +1,15 @@
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 
-import { BSON, MongoDBResponse, OnDemandDocument } from '../../../mongodb';
+import {
+  BSON,
+  BSONError,
+  CursorResponse,
+  Int32,
+  MongoDBResponse,
+  MongoUnexpectedServerResponseError,
+  OnDemandDocument
+} from '../../../mongodb';
 
 describe('class MongoDBResponse', () => {
   it('is a subclass of OnDemandDocument', () => {
@@ -75,4 +83,91 @@ describe('class MongoDBResponse', () => {
       });
     });
   });
+});
+
+describe('class CursorResponse', () => {
+  describe('constructor()', () => {
+    it('throws if input does not contain cursor embedded document', () => {
+      expect(() => new CursorResponse(BSON.serialize({ ok: 1 }))).to.throw(BSONError);
+    });
+
+    it('throws if input does not contain cursor.id int64', () => {
+      expect(() => new CursorResponse(BSON.serialize({ ok: 1, cursor: {} }))).to.throw(BSONError);
+    });
+
+    it('sets namespace to null if input does not contain cursor.ns', () => {
+      expect(new CursorResponse(BSON.serialize({ ok: 1, cursor: { id: 0n, firstBatch: [] } })).ns)
+        .to.be.null;
+    });
+
+    it('throws if input does not contain firstBatch nor nextBatch', () => {
+      expect(
+        () => new CursorResponse(BSON.serialize({ ok: 1, cursor: { id: 0n, batch: [] } }))
+      ).to.throw(MongoUnexpectedServerResponseError);
+    });
+
+    it('reports a length equal to the batch', () => {
+      expect(
+        new CursorResponse(BSON.serialize({ ok: 1, cursor: { id: 0n, nextBatch: [1, 2, 3] } }))
+      ).to.have.lengthOf(3);
+    });
+  });
+
+  describe('shift()', () => {
+    let response;
+
+    beforeEach(async function () {
+      response = new CursorResponse(
+        BSON.serialize({
+          ok: 1,
+          cursor: { id: 0n, nextBatch: [{ _id: 1 }, { _id: 2 }, { _id: 3 }] }
+        })
+      );
+    });
+
+    it('returns a document from the batch', () => {
+      expect(response.shift()).to.deep.equal({ _id: 1 });
+      expect(response.shift()).to.deep.equal({ _id: 2 });
+      expect(response.shift()).to.deep.equal({ _id: 3 });
+      expect(response.shift()).to.deep.equal(null);
+    });
+
+    it('passes BSON options to deserialization', () => {
+      expect(response.shift({ promoteValues: false })).to.deep.equal({ _id: new Int32(1) });
+      expect(response.shift({ promoteValues: true })).to.deep.equal({ _id: 2 });
+      expect(response.shift({ promoteValues: false })).to.deep.equal({ _id: new Int32(3) });
+      expect(response.shift()).to.deep.equal(null);
+    });
+  });
+
+  describe('clear()', () => {
+    let response;
+
+    beforeEach(async function () {
+      response = new CursorResponse(
+        BSON.serialize({
+          ok: 1,
+          cursor: { id: 0n, nextBatch: [{ _id: 1 }, { _id: 2 }, { _id: 3 }] }
+        })
+      );
+    });
+
+    it('makes length equal to 0', () => {
+      expect(response.clear()).to.be.undefined;
+      expect(response).to.have.lengthOf(0);
+    });
+
+    it('makes shift return null', () => {
+      expect(response.clear()).to.be.undefined;
+      expect(response.shift()).to.be.null;
+    });
+  });
+
+  describe('pushMany()', () =>
+    it('throws unsupported error', () =>
+      expect(CursorResponse.prototype.pushMany).to.throw(/Unsupported/i)));
+
+  describe('push()', () =>
+    it('throws unsupported error', () =>
+      expect(CursorResponse.prototype.push).to.throw(/Unsupported/i)));
 });

--- a/test/unit/operations/find.test.ts
+++ b/test/unit/operations/find.test.ts
@@ -18,7 +18,7 @@ describe('FindOperation', function () {
   });
 
   describe('#constructor', function () {
-    const operation = new FindOperation(undefined, namespace, filter, options);
+    const operation = new FindOperation(namespace, filter, options);
 
     it('sets the namespace', function () {
       expect(operation.ns).to.deep.equal(namespace);
@@ -40,7 +40,7 @@ describe('FindOperation', function () {
       const server = new Server(topology, new ServerDescription('a:1'), {} as any);
 
       it('should build basic find command with filter', async () => {
-        const findOperation = new FindOperation(undefined, namespace, filter);
+        const findOperation = new FindOperation(namespace, filter);
         const stub = sinon.stub(server, 'command').resolves({});
         await findOperation.execute(server, undefined);
         expect(stub).to.have.been.calledOnceWith(namespace, {
@@ -53,7 +53,7 @@ describe('FindOperation', function () {
         const options = {
           oplogReplay: true
         };
-        const findOperation = new FindOperation(undefined, namespace, {}, options);
+        const findOperation = new FindOperation(namespace, {}, options);
         const stub = sinon.stub(server, 'command').resolves({});
         await findOperation.execute(server, undefined);
         expect(stub).to.have.been.calledOnceWith(

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -7,6 +7,7 @@ import {
   HostAddress,
   hostMatchesWildcards,
   isHello,
+  isUint8Array,
   LEGACY_HELLO_COMMAND,
   List,
   matchesParentDomain,
@@ -980,5 +981,30 @@ describe('driver utils', function () {
         expect(matchesParentDomain(exampleHostNamesWithDot, exampleSrvName)).to.be.true;
       });
     });
+  });
+
+  describe('isUint8Array()', () => {
+    describe('when given a UintArray', () =>
+      it('returns true', () => expect(isUint8Array(Uint8Array.from([1]))).to.be.true));
+
+    describe('when given a Buffer', () =>
+      it('returns true', () => expect(isUint8Array(Buffer.from([1]))).to.be.true));
+
+    describe('when given a value that does not have `Uint8Array` at Symbol.toStringTag', () => {
+      it('returns false', () => {
+        const weirdArray = Uint8Array.from([1]);
+        Object.defineProperty(weirdArray, Symbol.toStringTag, { value: 'blah' });
+        expect(isUint8Array(weirdArray)).to.be.false;
+      });
+    });
+
+    describe('when given null', () =>
+      it('returns false', () => expect(isUint8Array(null)).to.be.false));
+
+    describe('when given a non object', () =>
+      it('returns false', () => expect(isUint8Array('')).to.be.false));
+
+    describe('when given an object that does not respond to Symbol.toStringTag', () =>
+      it('returns false', () => expect(isUint8Array(Object.create(null))).to.be.false));
   });
 });


### PR DESCRIPTION
### Description

#### What is changing?

- Implement a `CursorResponse` subclass of MongoDBResponse
  - Implements logic to abstract List vs CursorResponse handling
- Make FindCursors use CursorResponse

##### Is there new documentation needed for these changes?

TBD. Is this something we want to apply to all cursors? Should we progressively migrate to this?

#### What is the motivation for this change?

An attempt at increasing performance. A sucessful decoupling of driver BSON and user BSON settings.

Only for FindCursor, BSON documents from the current batch are now parsed on each iteration. 

One clear improvement is that any cursor that is closed before exhaustion will take significantly less run time.

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
