### PR TITLE
refactor(NODE-6201): cursor to use fetchBatch when current batch is empty

### DIFF
--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -533,7 +533,7 @@ export abstract class AbstractCursor<
     const oldTransform = this[kTransform] as (doc: TSchema) => TSchema; // TODO(NODE-3283): Improve transform typing
     if (oldTransform) {
       this[kTransform] = doc => {
-        return transform(oldTransform(doc));
+        return this.makeSafeTransform(transform)(oldTransform(doc));
       };
     } else {
       this[kTransform] = this.makeSafeTransform(transform);

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -786,7 +786,7 @@ export abstract class AbstractCursor<
     } catch (error) {
       squashError(error);
     } finally {
-      if (!session.hasEnded && session?.owner === this) {
+      if (session?.owner === this) {
         await session.endSession({ error });
       }
       if (!session?.inTransaction()) {

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -720,7 +720,9 @@ export abstract class AbstractCursor<
 
     if (this[kId] == null) {
       await this.cursorInit();
-      return;
+      // If the cursor died or returned documents, return
+      if (this[kDocuments].length !== 0 || this.isDead) return;
+      // Otherwise, run a getMore
     }
 
     // otherwise need to call getMore
@@ -868,6 +870,11 @@ class ReadableCursorStream extends Readable {
   }
 
   private _readNext() {
+    if (this._cursor[kId] === Long.ZERO) {
+      this.push(null);
+      return;
+    }
+
     // eslint-disable-next-line github/no-then
     this._cursor.next().then(
       result => {

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -732,7 +732,12 @@ export abstract class AbstractCursor<
 
     try {
       const response = await this.getMore(batchSize);
-      if (response) {
+      // CursorResponse is disabled in this PR
+      // however the special `emptyGetMore` can be returned from find cursors
+      if (CursorResponse.is(response)) {
+        this[kId] = response.id;
+        this[kDocuments] = response;
+      } else if (response?.cursor) {
         const cursorId = getCursorId(response);
         this[kDocuments].pushMany(response.cursor.nextBatch);
         this[kId] = cursorId;

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -3,12 +3,10 @@ import { Readable, Transform } from 'stream';
 import { type BSONSerializeOptions, type Document, Long, pluckBSONSerializeOptions } from '../bson';
 import { CursorResponse } from '../cmap/wire_protocol/responses';
 import {
-  type AnyError,
   MongoAPIError,
   MongoCursorExhaustedError,
   MongoCursorInUseError,
   MongoInvalidArgumentError,
-  MongoNetworkError,
   MongoRuntimeError,
   MongoTailableCursorError
 } from '../error';
@@ -307,7 +305,11 @@ export abstract class AbstractCursor<
 
     try {
       while (true) {
-        if (this.closed) {
+        if (this.killed) {
+          return;
+        }
+
+        if (this.closed && this[kDocuments].length === 0) {
           return;
         }
 

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -133,13 +133,13 @@ export abstract class AbstractCursor<
   CursorEvents extends AbstractCursorEvents = AbstractCursorEvents
 > extends TypedEventEmitter<CursorEvents> {
   /** @internal */
-  [kId]: Long | null;
+  private [kId]: Long | null;
   /** @internal */
-  [kSession]: ClientSession;
+  private [kSession]: ClientSession;
   /** @internal */
-  [kServer]?: Server;
+  private [kServer]?: Server;
   /** @internal */
-  [kNamespace]: MongoDBNamespace;
+  private [kNamespace]: MongoDBNamespace;
   /** @internal */
   [kDocuments]: {
     length: number;
@@ -149,23 +149,23 @@ export abstract class AbstractCursor<
     push(item: TSchema): void;
   };
   /** @internal */
-  [kClient]: MongoClient;
+  private [kClient]: MongoClient;
   /** @internal */
-  [kTransform]?: (doc: TSchema) => any;
+  private [kTransform]?: (doc: TSchema) => any;
   /** @internal */
-  [kInitialized]: boolean;
+  private [kInitialized]: boolean;
   /** @internal */
-  [kClosed]: boolean;
+  private [kClosed]: boolean;
   /** @internal */
-  [kKilled]: boolean;
+  private [kKilled]: boolean;
   /** @internal */
-  [kOptions]: InternalAbstractCursorOptions;
+  private [kOptions]: InternalAbstractCursorOptions;
 
   /** @event */
   static readonly CLOSE = 'close' as const;
 
   /** @internal */
-  constructor(
+  protected constructor(
     client: MongoClient,
     namespace: MongoDBNamespace,
     options: AbstractCursorOptions = {}
@@ -706,7 +706,7 @@ export abstract class AbstractCursor<
     return;
   }
 
-  /** Attempt to obtain more documents */
+  /** @internal Attempt to obtain more documents */
   private async fetchBatch(): Promise<void> {
     if (this.closed) {
       return;
@@ -759,6 +759,7 @@ export abstract class AbstractCursor<
     }
   }
 
+  /** @internal */
   private async cleanup(error?: Error) {
     this[kClosed] = true;
     const session = this[kSession];
@@ -791,7 +792,9 @@ export abstract class AbstractCursor<
     }
   }
 
+  /** @internal */
   private hasEmittedClose = false;
+  /** @internal */
   private emitClose() {
     try {
       if (!this.hasEmittedClose && (this[kDocuments].length === 0 || this[kClosed])) {
@@ -803,6 +806,7 @@ export abstract class AbstractCursor<
     }
   }
 
+  /** @internal */
   private makeSafeTransform<TSchema>(transform: (doc: TSchema) => any): (doc: TSchema) => any {
     return doc => {
       try {
@@ -823,6 +827,7 @@ export abstract class AbstractCursor<
     };
   }
 
+  /** @internal */
   protected throwIfInitialized() {
     if (this[kInitialized]) throw new MongoCursorInUseError();
   }

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -803,7 +803,7 @@ export abstract class AbstractCursor<
   private emitClose() {
     try {
       if (!this.hasEmittedClose && (this[kDocuments].length === 0 || this[kClosed])) {
-        // @ts-expect-error: not sure..
+        // @ts-expect-error: CursorEvents is generic so Parameters<CursorEvents["close"]> may not be assignable to `[]`. Not sure how to require extenders do not add parameters.
         this.emit('close');
       }
     } finally {

--- a/src/cursor/aggregation_cursor.ts
+++ b/src/cursor/aggregation_cursor.ts
@@ -8,7 +8,7 @@ import type { Sort } from '../sort';
 import type { MongoDBNamespace } from '../utils';
 import { mergeOptions } from '../utils';
 import type { AbstractCursorOptions } from './abstract_cursor';
-import { AbstractCursor, assertUninitialized } from './abstract_cursor';
+import { AbstractCursor } from './abstract_cursor';
 
 /** @public */
 export interface AggregationCursorOptions extends AbstractCursorOptions, AggregateOptions {}
@@ -101,7 +101,7 @@ export class AggregationCursor<TSchema = any> extends AbstractCursor<TSchema> {
   addStage(stage: Document): this;
   addStage<T = Document>(stage: Document): AggregationCursor<T>;
   addStage<T = Document>(stage: Document): AggregationCursor<T> {
-    assertUninitialized(this);
+    this.throwIfInitialized();
     this[kPipeline].push(stage);
     return this as unknown as AggregationCursor<T>;
   }

--- a/src/cursor/find_cursor.ts
+++ b/src/cursor/find_cursor.ts
@@ -11,7 +11,7 @@ import type { Hint } from '../operations/operation';
 import type { ClientSession } from '../sessions';
 import { formatSort, type Sort, type SortDirection } from '../sort';
 import { emitWarningOnce, mergeOptions, type MongoDBNamespace, squashError } from '../utils';
-import { AbstractCursor, assertUninitialized } from './abstract_cursor';
+import { AbstractCursor } from './abstract_cursor';
 
 /** @internal */
 const kFilter = Symbol('filter');
@@ -163,7 +163,7 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
 
   /** Set the cursor query */
   filter(filter: Document): this {
-    assertUninitialized(this);
+    this.throwIfInitialized();
     this[kFilter] = filter;
     return this;
   }
@@ -174,7 +174,7 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
    * @param hint - If specified, then the query system will only consider plans using the hinted index.
    */
   hint(hint: Hint): this {
-    assertUninitialized(this);
+    this.throwIfInitialized();
     this[kBuiltOptions].hint = hint;
     return this;
   }
@@ -185,7 +185,7 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
    * @param min - Specify a $min value to specify the inclusive lower bound for a specific index in order to constrain the results of find(). The $min specifies the lower bound for all keys of a specific index in order.
    */
   min(min: Document): this {
-    assertUninitialized(this);
+    this.throwIfInitialized();
     this[kBuiltOptions].min = min;
     return this;
   }
@@ -196,7 +196,7 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
    * @param max - Specify a $max value to specify the exclusive upper bound for a specific index in order to constrain the results of find(). The $max specifies the upper bound for all keys of a specific index in order.
    */
   max(max: Document): this {
-    assertUninitialized(this);
+    this.throwIfInitialized();
     this[kBuiltOptions].max = max;
     return this;
   }
@@ -209,7 +209,7 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
    * @param value - the returnKey value.
    */
   returnKey(value: boolean): this {
-    assertUninitialized(this);
+    this.throwIfInitialized();
     this[kBuiltOptions].returnKey = value;
     return this;
   }
@@ -220,7 +220,7 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
    * @param value - The $showDiskLoc option has now been deprecated and replaced with the showRecordId field. $showDiskLoc will still be accepted for OP_QUERY stye find.
    */
   showRecordId(value: boolean): this {
-    assertUninitialized(this);
+    this.throwIfInitialized();
     this[kBuiltOptions].showRecordId = value;
     return this;
   }
@@ -232,7 +232,7 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
    * @param value - The modifier value.
    */
   addQueryModifier(name: string, value: string | boolean | number | Document): this {
-    assertUninitialized(this);
+    this.throwIfInitialized();
     if (name[0] !== '$') {
       throw new MongoInvalidArgumentError(`${name} is not a valid query modifier`);
     }
@@ -295,7 +295,7 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
    * @param value - The comment attached to this query.
    */
   comment(value: string): this {
-    assertUninitialized(this);
+    this.throwIfInitialized();
     this[kBuiltOptions].comment = value;
     return this;
   }
@@ -306,7 +306,7 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
    * @param value - Number of milliseconds to wait before aborting the tailed query.
    */
   maxAwaitTimeMS(value: number): this {
-    assertUninitialized(this);
+    this.throwIfInitialized();
     if (typeof value !== 'number') {
       throw new MongoInvalidArgumentError('Argument for maxAwaitTimeMS must be a number');
     }
@@ -321,7 +321,7 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
    * @param value - Number of milliseconds to wait before aborting the query.
    */
   override maxTimeMS(value: number): this {
-    assertUninitialized(this);
+    this.throwIfInitialized();
     if (typeof value !== 'number') {
       throw new MongoInvalidArgumentError('Argument for maxTimeMS must be a number');
     }
@@ -371,7 +371,7 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
    * ```
    */
   project<T extends Document = Document>(value: Document): FindCursor<T> {
-    assertUninitialized(this);
+    this.throwIfInitialized();
     this[kBuiltOptions].projection = value;
     return this as unknown as FindCursor<T>;
   }
@@ -383,7 +383,7 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
    * @param direction - The direction of the sorting (1 or -1).
    */
   sort(sort: Sort | string, direction?: SortDirection): this {
-    assertUninitialized(this);
+    this.throwIfInitialized();
     if (this[kBuiltOptions].tailable) {
       throw new MongoTailableCursorError('Tailable cursor does not support sorting');
     }
@@ -399,7 +399,7 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
    * {@link https://www.mongodb.com/docs/manual/reference/command/find/#find-cmd-allowdiskuse | find command allowDiskUse documentation}
    */
   allowDiskUse(allow = true): this {
-    assertUninitialized(this);
+    this.throwIfInitialized();
 
     if (!this[kBuiltOptions].sort) {
       throw new MongoInvalidArgumentError('Option "allowDiskUse" requires a sort specification');
@@ -421,7 +421,7 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
    * @param value - The cursor collation options (MongoDB 3.4 or higher) settings for update operation (see 3.4 documentation for available fields).
    */
   collation(value: CollationOptions): this {
-    assertUninitialized(this);
+    this.throwIfInitialized();
     this[kBuiltOptions].collation = value;
     return this;
   }
@@ -432,7 +432,7 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
    * @param value - The limit for the cursor query.
    */
   limit(value: number): this {
-    assertUninitialized(this);
+    this.throwIfInitialized();
     if (this[kBuiltOptions].tailable) {
       throw new MongoTailableCursorError('Tailable cursor does not support limit');
     }
@@ -451,7 +451,7 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
    * @param value - The skip for the cursor query.
    */
   skip(value: number): this {
-    assertUninitialized(this);
+    this.throwIfInitialized();
     if (this[kBuiltOptions].tailable) {
       throw new MongoTailableCursorError('Tailable cursor does not support skip');
     }

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -533,7 +533,11 @@ export function maybeClearPinnedConnection(
     const servers = Array.from(topology.s.servers.values());
     const loadBalancer = servers[0];
 
-    if (options?.error == null || options?.force) {
+    if (
+      options?.error == null ||
+      options?.error?.name === 'MongoExpiredSessionError' ||
+      options?.force
+    ) {
       loadBalancer.pool.checkIn(conn);
       session[kPinnedConnection] = undefined;
       conn.emit(

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -533,11 +533,7 @@ export function maybeClearPinnedConnection(
     const servers = Array.from(topology.s.servers.values());
     const loadBalancer = servers[0];
 
-    if (
-      options?.error == null ||
-      options?.error?.name === 'MongoExpiredSessionError' ||
-      options?.force
-    ) {
+    if (options?.error == null || options?.force) {
       loadBalancer.pool.checkIn(conn);
       session[kPinnedConnection] = undefined;
       conn.emit(

--- a/test/integration/change-streams/change_stream.test.ts
+++ b/test/integration/change-streams/change_stream.test.ts
@@ -33,9 +33,9 @@ import {
 import { delay, filterForCommands } from '../shared';
 
 const initIteratorMode = async (cs: ChangeStream) => {
-  const kInit = getSymbolFrom(AbstractCursor.prototype, 'kInit');
   const initEvent = once(cs.cursor, 'init');
-  await cs.cursor[kInit]();
+  //@ts-expect-error: private method
+  await cs.cursor.cursorInit();
   await initEvent;
   return;
 };

--- a/test/integration/change-streams/change_stream.test.ts
+++ b/test/integration/change-streams/change_stream.test.ts
@@ -7,7 +7,6 @@ import { PassThrough } from 'stream';
 import { setTimeout } from 'timers';
 
 import {
-  AbstractCursor,
   type ChangeStream,
   type ChangeStreamOptions,
   type Collection,

--- a/test/integration/change-streams/change_streams.prose.test.ts
+++ b/test/integration/change-streams/change_streams.prose.test.ts
@@ -4,7 +4,6 @@ import * as sinon from 'sinon';
 import { setTimeout } from 'timers';
 
 import {
-  AbstractCursor,
   type ChangeStream,
   type CommandFailedEvent,
   type CommandStartedEvent,
@@ -18,7 +17,6 @@ import {
   Timestamp
 } from '../../mongodb';
 import * as mock from '../../tools/mongodb-mock/index';
-import { getSymbolFrom } from '../../tools/utils';
 import { setupDatabase } from '../shared';
 
 /**

--- a/test/integration/change-streams/change_streams.prose.test.ts
+++ b/test/integration/change-streams/change_streams.prose.test.ts
@@ -72,9 +72,9 @@ function triggerResumableError(
 }
 
 const initIteratorMode = async (cs: ChangeStream) => {
-  const kInit = getSymbolFrom(AbstractCursor.prototype, 'kInit');
   const initEvent = once(cs.cursor, 'init');
-  await cs.cursor[kInit]();
+  //@ts-expect-error: private method
+  await cs.cursor.cursorInit();
   await initEvent;
   return;
 };

--- a/test/integration/crud/misc_cursors.test.js
+++ b/test/integration/crud/misc_cursors.test.js
@@ -1870,7 +1870,7 @@ describe('Cursor', function () {
     const rejectedEarlyBecauseClientClosed = cursor.next().catch(error => error);
 
     await client.close();
-    expect(cursor).to.have.property('killed', true);
+    expect(cursor).to.have.property('closed', true);
 
     const error = await rejectedEarlyBecauseClientClosed;
     expect(error).to.be.instanceOf(MongoExpiredSessionError);

--- a/test/integration/node-specific/cursor_async_iterator.test.js
+++ b/test/integration/node-specific/cursor_async_iterator.test.js
@@ -72,6 +72,17 @@ describe('Cursor Async Iterator Tests', function () {
       }
     });
 
+    it('should not iterate if closed immediately', async function () {
+      const cursor = collection.find();
+      await cursor.close();
+
+      let count = 0;
+      for await (const _ of cursor) count++;
+
+      expect(count).to.equal(0);
+      expect(cursor.closed).to.be.true;
+    });
+
     it('should properly stop when cursor is closed', async function () {
       const cursor = collection.find();
 

--- a/test/integration/node-specific/cursor_async_iterator.test.js
+++ b/test/integration/node-specific/cursor_async_iterator.test.js
@@ -77,6 +77,7 @@ describe('Cursor Async Iterator Tests', function () {
       await cursor.close();
 
       let count = 0;
+      // eslint-disable-next-line no-unused-vars
       for await (const _ of cursor) count++;
 
       expect(count).to.equal(0);

--- a/test/tools/unified-spec-runner/operations.ts
+++ b/test/tools/unified-spec-runner/operations.ts
@@ -6,6 +6,7 @@ import { AssertionError, expect } from 'chai';
 
 import {
   AbstractCursor,
+  type ChangeStream,
   Collection,
   CommandStartedEvent,
   Db,
@@ -240,9 +241,9 @@ operations.set('createChangeStream', async ({ entities, operation }) => {
   }
 
   const { pipeline, ...args } = operation.arguments!;
-  const changeStream = watchable.watch(pipeline, args);
-  const kInit = getSymbolFrom(AbstractCursor.prototype, 'kInit');
-  await changeStream.cursor[kInit]();
+  const changeStream: ChangeStream = watchable.watch(pipeline, args);
+  //@ts-expect-error: private method
+  await changeStream.cursor.cursorInit();
   return changeStream;
 });
 


### PR DESCRIPTION
### Description

#### What is changing?

- Move `next` into cursor and rename to fetchBatch
- Remove transform and blocking flags
- tryNext/next now call fetchBatch as appropriate to get the same behavior the flags provided
- move cleanupCursor logic to cleanup()

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

The `next` floating function owned too many details of the implementation of each cursor API, tryNext and next now do a small amount more lifting and we have a fetchBatch method that is focused on obtaining the next batch either with the init command or with a getMore.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
