### PR TITLE
perf(NODE-6127): move error construction into setTimeout callback

### DIFF
--- a/src/timeout.ts
+++ b/src/timeout.ts
@@ -33,7 +33,6 @@ export class Timeout extends Promise<never> {
     return 'MongoDBTimeout';
   }
 
-  private timeoutError: TimeoutError;
   private id?: NodeJS.Timeout;
 
   public readonly start: number;
@@ -55,9 +54,6 @@ export class Timeout extends Promise<never> {
       executor(noop, promiseReject);
     });
 
-    // NOTE: Construct timeout error at point of Timeout instantiation to preserve stack traces
-    this.timeoutError = new TimeoutError(`Expired after ${duration}ms`);
-
     this.duration = duration;
     this.start = Math.trunc(performance.now());
 
@@ -65,7 +61,7 @@ export class Timeout extends Promise<never> {
       this.id = setTimeout(() => {
         this.ended = Math.trunc(performance.now());
         this.timedOut = true;
-        reject(this.timeoutError);
+        reject(new TimeoutError(`Expired after ${duration}ms`));
       }, this.duration);
       // Ensure we do not keep the Node.js event loop running
       if (typeof this.id.unref === 'function') {


### PR DESCRIPTION
### Description

#### What is changing?
- Make TimeoutError construction lazy

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
