### PR TITLE
test(NODE-5610): unskip uri invalid port (zero) with hostname/IP literal tests on Node 20+

### DIFF
--- a/test/unit/connection_string.spec.test.ts
+++ b/test/unit/connection_string.spec.test.ts
@@ -1,5 +1,3 @@
-import { satisfies } from 'semver';
-
 import { loadSpecTests } from '../spec';
 import { executeUriValidationTest } from '../tools/uri_spec_runner';
 
@@ -10,22 +8,6 @@ const skipTests = [
 
 describe('Connection String spec tests', function () {
   const suites = loadSpecTests('connection-string');
-
-  beforeEach(function () {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const test = this.currentTest!;
-
-    const skippedTests = [
-      'Invalid port (zero) with IP literal',
-      'Invalid port (zero) with hostname'
-    ];
-    test.skipReason =
-      satisfies(process.version, '>=20.0.0') && skippedTests.includes(test.title)
-        ? 'TODO(NODE-5666): fix failing unit tests on Node20+'
-        : undefined;
-
-    if (test.skipReason) this.skip();
-  });
 
   for (const suite of suites) {
     describe(suite.name, function () {


### PR DESCRIPTION
### Description
Unskip following tests [invalid port (zero) with hostname](https://github.com/mongodb/specifications/blob/b88f80027812f6833252ab5990a099d4d8d6b5f9/source/connection-string/tests/invalid-uris.yml) and [invalid port (zero) with IP literal.](https://github.com/mongodb/specifications/blob/b88f80027812f6833252ab5990a099d4d8d6b5f9/source/connection-string/tests/invalid-uris.yml) on Node 20+

#### What is changing?
Unskipping 2 uri tests that failed on Node 18.17 and some Node 20 back in September 2023, the issue has gone away now.

##### Is there new documentation needed for these changes?
No.

#### What is the motivation for this change?
Issue has gone away.

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->


### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
