### PR TITLE
refactor(NODE-6146): put cursor response back under a flag

### DIFF
--- a/src/cursor/find_cursor.ts
+++ b/src/cursor/find_cursor.ts
@@ -114,7 +114,7 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
       }
     }
 
-    const response = await super.getMore(batchSize, this.client.autoEncrypter ? false : true);
+    const response = await super.getMore(batchSize, false);
     // TODO: wrap this in some logic to prevent it from happening if we don't need this support
     if (CursorResponse.is(response)) {
       this[kNumReturned] = this[kNumReturned] + response.batchSize;

--- a/src/cursor/find_cursor.ts
+++ b/src/cursor/find_cursor.ts
@@ -82,7 +82,8 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
     if (CursorResponse.is(response)) {
       this[kNumReturned] = response.batchSize;
     } else {
-      this[kNumReturned] = this[kNumReturned] + (response?.cursor.firstBatch.length ?? 0);
+      // Can be an explain response, hence the ?. on everything
+      this[kNumReturned] = this[kNumReturned] + (response?.cursor?.firstBatch?.length ?? 0);
     }
 
     // TODO: NODE-2882
@@ -121,7 +122,7 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
     if (CursorResponse.is(response)) {
       this[kNumReturned] = this[kNumReturned] + response.batchSize;
     } else {
-      this[kNumReturned] = this[kNumReturned] + (response?.cursor.nextBatch.length ?? 0);
+      this[kNumReturned] = this[kNumReturned] + (response?.cursor?.nextBatch?.length ?? 0);
     }
 
     return response;

--- a/src/cursor/find_cursor.ts
+++ b/src/cursor/find_cursor.ts
@@ -81,6 +81,8 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
     // the response is not a cursor when `explain` is enabled
     if (CursorResponse.is(response)) {
       this[kNumReturned] = response.batchSize;
+    } else {
+      this[kNumReturned] = this[kNumReturned] + (response?.cursor.firstBatch.length ?? 0);
     }
 
     // TODO: NODE-2882
@@ -118,6 +120,8 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
     // TODO: wrap this in some logic to prevent it from happening if we don't need this support
     if (CursorResponse.is(response)) {
       this[kNumReturned] = this[kNumReturned] + response.batchSize;
+    } else {
+      this[kNumReturned] = this[kNumReturned] + (response?.cursor.nextBatch.length ?? 0);
     }
 
     return response;

--- a/src/operations/find.ts
+++ b/src/operations/find.ts
@@ -1,5 +1,4 @@
 import type { Document } from '../bson';
-import { CursorResponse } from '../cmap/wire_protocol/responses';
 import { MongoInvalidArgumentError } from '../error';
 import { ReadConcern } from '../read_concern';
 import type { Server } from '../sdam/server';
@@ -115,7 +114,7 @@ export class FindOperation extends CommandOperation<Document> {
         documentsReturnedIn: 'firstBatch',
         session
       },
-      this.explain ? undefined : CursorResponse
+      undefined
     );
   }
 }


### PR DESCRIPTION
### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

Undo CursorResponse temporarily to improve performance.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
