### PR TITLE
fix(NODE-6171): RTT set to zero when serverMonitoringMode=stream

### DIFF
--- a/src/sdam/monitor.ts
+++ b/src/sdam/monitor.ts
@@ -521,10 +521,7 @@ export class RTTPinger {
     this.connection = undefined;
   }
 
-  private measureAndReschedule(start?: number, conn?: Connection) {
-    if (start == null) {
-      start = now();
-    }
+  private measureAndReschedule(start: number, conn?: Connection) {
     if (this.closed) {
       conn?.destroy();
       return;

--- a/src/sdam/monitor.ts
+++ b/src/sdam/monitor.ts
@@ -220,7 +220,7 @@ export class Monitor extends TypedEventEmitter<MonitorEvents> {
   }
 
   get latestRtt(): number | null {
-    return this.rttSampler.last; // FIXME: Check if this is acceptable
+    return this.rttSampler.last;
   }
 
   addRttSample(rtt: number) {

--- a/src/sdam/monitor.ts
+++ b/src/sdam/monitor.ts
@@ -219,8 +219,8 @@ export class Monitor extends TypedEventEmitter<MonitorEvents> {
     return this.rttSampler.min();
   }
 
-  get latestRtt(): number {
-    return this.rttSampler.last ?? 0; // FIXME: Check if this is acceptable
+  get latestRtt(): number | null {
+    return this.rttSampler.last; // FIXME: Check if this is acceptable
   }
 
   addRttSample(rtt: number) {
@@ -304,7 +304,8 @@ function checkServer(monitor: Monitor, callback: Callback<Document | null>) {
     }
 
     // NOTE: here we use the latestRtt as this measurement corresponds with the value
-    // obtained for this successful heartbeat
+    // obtained for this successful heartbeat, if there is no latestRtt, then we calculate the
+    // duration
     const duration =
       isAwaitable && monitor.rttPinger
         ? monitor.rttPinger.latestRtt ?? calculateDurationInMs(start)
@@ -498,7 +499,7 @@ export class RTTPinger {
     this[kCancellationToken] = monitor[kCancellationToken];
     this.closed = false;
     this.monitor = monitor;
-    this.latestRtt = monitor.latestRtt;
+    this.latestRtt = monitor.latestRtt ?? undefined;
 
     const heartbeatFrequencyMS = monitor.options.heartbeatFrequencyMS;
     this[kMonitorId] = setTimeout(() => this.measureRoundTripTime(), heartbeatFrequencyMS);
@@ -565,7 +566,7 @@ export class RTTPinger {
       connection.serverApi?.version || connection.helloOk ? 'hello' : LEGACY_HELLO_COMMAND;
     // eslint-disable-next-line github/no-then
     connection.command(ns('admin.$cmd'), { [commandName]: 1 }, undefined).then(
-      () => this.measureAndReschedule(),
+      () => this.measureAndReschedule(start),
       () => {
         this.connection?.destroy();
         this.connection = undefined;

--- a/test/integration/server-discovery-and-monitoring/server_discover_and_monitoring.test.ts
+++ b/test/integration/server-discovery-and-monitoring/server_discover_and_monitoring.test.ts
@@ -17,10 +17,11 @@ describe('SDAM Unified Tests (Node Driver)', function () {
 describe('Monitoring rtt tests', function () {
   let client: MongoClient;
   let windows: Record<string, number[][]>;
-  const thresh = 100; // Wait for 100 total heartbeats
+  const THRESH = 100; // Wait for 100 total heartbeats. This is high enough to work for standalone, sharded and our typical 3-node replica set topology tests
   const SAMPLING_WINDOW_SIZE = 10;
   let count: number;
   const ee = new EventEmitter();
+
   const listener = (ev: ServerHeartbeatSucceededEvent) => {
     try {
       // @ts-expect-error accessing private fields
@@ -38,7 +39,7 @@ describe('Monitoring rtt tests', function () {
       return;
     }
 
-    if (count >= thresh) {
+    if (count >= THRESH) {
       client.off('serverHeartbeatSucceeded', listener);
       ee.emit('done');
     }
@@ -82,7 +83,7 @@ describe('Monitoring rtt tests', function () {
             // Test that at every point we collect a heartbeat, the rttSampler is not filled with
             // zeroes
             for (const window of windows[s]) {
-              expect(window.reduce((acc, x) => x + acc)).to.be.greaterThanOrEqual(0);
+              expect(window.reduce((acc, x) => x + acc)).to.be.greaterThan(0);
             }
           }
         }

--- a/test/integration/server-discovery-and-monitoring/server_discover_and_monitoring.test.ts
+++ b/test/integration/server-discovery-and-monitoring/server_discover_and_monitoring.test.ts
@@ -1,3 +1,8 @@
+import { EventEmitter, once } from 'node:events';
+
+import { expect } from 'chai';
+
+import { type MongoClient, type ServerHeartbeatSucceededEvent } from '../../mongodb';
 import { loadSpecTests } from '../../spec';
 import { runUnifiedSuite } from '../../tools/unified-spec-runner/runner';
 
@@ -7,4 +12,45 @@ describe('SDAM Unified Tests (Node Driver)', function () {
     '../integration/server-discovery-and-monitoring/unified-sdam-node-specs'
   );
   runUnifiedSuite(clonedAndAlteredSpecTests);
+});
+
+describe('Monitoring rtt tests', function () {
+  let client: MongoClient;
+  let durations: number[];
+  const thresh = 40;
+  const ee = new EventEmitter();
+  const listener = (ev: ServerHeartbeatSucceededEvent) => {
+    durations.push(ev.duration);
+    if (durations.length >= thresh) {
+      client.off('serverHeartbeatSucceeded', listener);
+      ee.emit('done');
+    }
+  };
+
+  beforeEach(function () {
+    durations = [];
+  });
+
+  afterEach(async function () {
+    await client?.close();
+  });
+
+  for (const serverMonitoringMode of ['poll', 'stream']) {
+    context(`when serverMonitoringMode is set to '${serverMonitoringMode}'`, function () {
+      beforeEach(async function () {
+        client = this.configuration.newClient({
+          heartbeatFrequencyMS: 100,
+          serverMonitoringMode
+        });
+        client.on('serverHeartbeatSucceeded', listener);
+
+        await client.connect();
+      });
+
+      it('duration of a successful heartbeat is never reported as 0ms', async function () {
+        await once(ee, 'done');
+        expect(durations.every(x => x !== 0)).to.be.true;
+      });
+    });
+  }
 });

--- a/test/integration/server-discovery-and-monitoring/server_discover_and_monitoring.test.ts
+++ b/test/integration/server-discovery-and-monitoring/server_discover_and_monitoring.test.ts
@@ -110,7 +110,6 @@ describe('Monitoring rtt tests', function () {
             requires: { topology: '!load-balanced' }
           },
           test: async function () {
-            await once(ee, 'done');
             for (const server in heartbeatDurations) {
               const averageDuration =
                 heartbeatDurations[server].reduce((acc, x) => acc + x) /

--- a/test/integration/server-discovery-and-monitoring/server_discover_and_monitoring.test.ts
+++ b/test/integration/server-discovery-and-monitoring/server_discover_and_monitoring.test.ts
@@ -111,9 +111,9 @@ describe('Monitoring rtt tests', function () {
               expect(relevantDurations).to.have.length.gt(0);
               const averageDuration =
                 relevantDurations.reduce((acc, x) => acc + x) / relevantDurations.length;
-              expect(
-                client.topology.description.servers.get(server).roundTripTime
-              ).to.be.approximately(averageDuration, 1);
+              const rtt = client.topology.description.servers.get(server).roundTripTime;
+              expect(rtt).to.not.equal(0);
+              expect(rtt).to.be.approximately(averageDuration, 3);
             }
           }
         });

--- a/test/integration/server-discovery-and-monitoring/server_discover_and_monitoring.test.ts
+++ b/test/integration/server-discovery-and-monitoring/server_discover_and_monitoring.test.ts
@@ -17,7 +17,7 @@ describe('SDAM Unified Tests (Node Driver)', function () {
 describe('Monitoring rtt tests', function () {
   let client: MongoClient;
   let windows: Record<string, number[][]>;
-  const THRESH = 100; // Wait for 100 total heartbeats. This is high enough to work for standalone, sharded and our typical 3-node replica set topology tests
+  const THRESH = 200; // Wait for 100 total heartbeats. This is high enough to work for standalone, sharded and our typical 3-node replica set topology tests
   const SAMPLING_WINDOW_SIZE = 10;
   let count: number;
   const ee = new EventEmitter();
@@ -58,7 +58,7 @@ describe('Monitoring rtt tests', function () {
     context(`when serverMonitoringMode is set to '${serverMonitoringMode}'`, function () {
       beforeEach(async function () {
         client = this.configuration.newClient({
-          heartbeatFrequencyMS: 500,
+          heartbeatFrequencyMS: 100,
           connectTimeoutMS: 1000,
           serverMonitoringMode
         });


### PR DESCRIPTION
### Description

#### What is changing?

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

NODE-6171

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Server Selection performance regression due to incorrect RTT measurement

Starting in version [6.6.0](https://github.com/mongodb/node-mongodb-native/commit/0e3d6ead735ed067bd044c8d0c9c307d970f1986#), when using the `stream` server monitoring mode, heartbeats were incorrectly timed as having a duration of 0, leading to server selection viewing each server as equally desirable for selection.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [X] Ran `npm run check:lint` script
- [X] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [X] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [X] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
