### PR TITLE
docs(NODE-6191): clarify that operations should not be parallelized in transactions

### DIFF
--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -448,15 +448,17 @@ export class ClientSession extends TypedEventEmitter<ClientSessionEvents> {
    *
    * **IMPORTANT:** This method requires the function passed in to return a Promise. That promise must be made by `await`-ing all operations in such a way that rejections are propagated to the returned promise.
    *
+   * **IMPORTANT:** Running operations in parallel is not supported during a transaction. The use of `Promise.all`,
+   * `Promise.allSettled`, `Promise.race`, etc to parallelize operations inside a transaction is
+   * undefined behaviour.
+   *
+   *
    * @remarks
    * - If all operations successfully complete and the `commitTransaction` operation is successful, then the provided function will return the result of the provided function.
    * - If the transaction is unable to complete or an error is thrown from within the provided function, then the provided function will throw an error.
    *   - If the transaction is manually aborted within the provided function it will not throw.
    * - If the driver needs to attempt to retry the operations, the provided function may be called multiple times.
    *
-   * **IMPORTANT:** Running operations in parallel is not supported during a transaction. The use of `Promise.all`,
-   * `Promise.allSettled`, `Promise.race`, etc to parallelize operations inside a transaction is
-   * undefined behaviour.
    *
    * Checkout a descriptive example here:
    * @see https://www.mongodb.com/blog/post/quick-start-nodejs--mongodb--how-to-implement-transactions

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -459,7 +459,6 @@ export class ClientSession extends TypedEventEmitter<ClientSessionEvents> {
    *   - If the transaction is manually aborted within the provided function it will not throw.
    * - If the driver needs to attempt to retry the operations, the provided function may be called multiple times.
    *
-   *
    * Checkout a descriptive example here:
    * @see https://www.mongodb.com/blog/post/quick-start-nodejs--mongodb--how-to-implement-transactions
    *

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -369,6 +369,11 @@ export class ClientSession extends TypedEventEmitter<ClientSessionEvents> {
   /**
    * Starts a new transaction with the given options.
    *
+   * @remarks
+   * **IMPORTANT**: Running operations in parallel is not supported during a transaction. The use of `Promise.all`,
+   * `Promise.allSettled`, `Promise.race`, etc to parallelize operations inside a transaction is
+   * undefined behaviour.
+   *
    * @param options - Options for the transaction
    */
   startTransaction(options?: TransactionOptions): void {
@@ -448,6 +453,10 @@ export class ClientSession extends TypedEventEmitter<ClientSessionEvents> {
    * - If the transaction is unable to complete or an error is thrown from within the provided function, then the provided function will throw an error.
    *   - If the transaction is manually aborted within the provided function it will not throw.
    * - If the driver needs to attempt to retry the operations, the provided function may be called multiple times.
+   *
+   * **IMPORTANT:** Running operations in parallel is not supported during a transaction. The use of `Promise.all`,
+   * `Promise.allSettled`, `Promise.race`, etc to parallelize operations inside a transaction is
+   * undefined behaviour.
    *
    * Checkout a descriptive example here:
    * @see https://www.mongodb.com/blog/post/quick-start-nodejs--mongodb--how-to-implement-transactions


### PR DESCRIPTION
### Description

#### What is changing?

Add inline documentation detailing that Promise.all and other concurrency mechanisms should not be used to parallelize transaction operations

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

NODE-6191

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [X] Ran `npm run check:lint` script
- [X] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [X] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
