### PR TITLE
docs(NODE-6192): clarify that operations should not be parallelized in transactions

### DIFF
--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -362,6 +362,11 @@ export class ClientSession extends TypedEventEmitter<ClientSessionEvents> {
   /**
    * Starts a new transaction with the given options.
    *
+   * @remarks
+   * **IMPORTANT**: Running operations in parallel is not supported during a transaction. The use of `Promise.all`,
+   * `Promise.allSettled`, `Promise.race`, etc to parallelize operations inside a transaction is
+   * undefined behaviour.
+   *
    * @param options - Options for the transaction
    */
   startTransaction(options?: TransactionOptions): void {
@@ -438,6 +443,10 @@ export class ClientSession extends TypedEventEmitter<ClientSessionEvents> {
    *
    * **IMPORTANT:** This method requires the user to return a Promise, and `await` all operations.
    * Any callbacks that do not return a Promise will result in undefined behavior.
+   *
+   * **IMPORTANT**: Running operations in parallel is not supported during a transaction. The use of `Promise.all`,
+   * `Promise.allSettled`, `Promise.race`, etc to parallelize operations inside a transaction is
+   * undefined behaviour.
    *
    * @remarks
    * This function:


### PR DESCRIPTION
### Description

#### What is changing?

Add inline documentation detailing that Promise.all and other concurrency mechanisms should not be used to parallelize transaction operations

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

NODE-6192

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [X] Ran `npm run check:lint` script
- [X] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [X] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
