### PR TITLE
fix(NODE-6085): add TS support for KMIP data key options

### DIFF
--- a/src/client-side-encryption/client_encryption.ts
+++ b/src/client-side-encryption/client_encryption.ts
@@ -773,6 +773,7 @@ export interface ClientEncryptionRewrapManyDataKeyProviderOptions {
     | AWSEncryptionKeyOptions
     | AzureEncryptionKeyOptions
     | GCPEncryptionKeyOptions
+    | KMIPEncryptionKeyOptions
     | undefined;
 }
 
@@ -885,6 +886,26 @@ export interface AzureEncryptionKeyOptions {
   keyVersion?: string | undefined;
 }
 
+
+/**
+ * @public
+ * Configuration options for making an Azure encryption key
+ */
+export interface KMIPEncryptionKeyOptions {
+  /**
+   * keyId is the KMIP Unique Identifier to a 96 byte KMIP Secret Data managed object.
+   *
+   * If keyId is omitted, the driver creates a random 96 byte KMIP Secret Data managed object.
+   */
+  keyId?: string;
+
+  /**
+   * Host with optional port.
+   */
+  endpoint?: string;
+}
+
+
 /**
  * @public
  * Options to provide when creating a new data key.
@@ -897,6 +918,7 @@ export interface ClientEncryptionCreateDataKeyProviderOptions {
     | AWSEncryptionKeyOptions
     | AzureEncryptionKeyOptions
     | GCPEncryptionKeyOptions
+    | KMIPEncryptionKeyOptions
     | undefined;
 
   /**
@@ -907,19 +929,6 @@ export interface ClientEncryptionCreateDataKeyProviderOptions {
 
   /** @experimental */
   keyMaterial?: Buffer | Binary;
-}
-
-/**
- * @public
- * @experimental
- */
-export interface ClientEncryptionRewrapManyDataKeyProviderOptions {
-  provider: ClientEncryptionDataKeyProvider;
-  masterKey?:
-    | AWSEncryptionKeyOptions
-    | AzureEncryptionKeyOptions
-    | GCPEncryptionKeyOptions
-    | undefined;
 }
 
 /**

--- a/src/client-side-encryption/client_encryption.ts
+++ b/src/client-side-encryption/client_encryption.ts
@@ -895,7 +895,7 @@ export interface KMIPEncryptionKeyOptions {
   /**
    * keyId is the KMIP Unique Identifier to a 96 byte KMIP Secret Data managed object.
    *
-   * If keyId is omitted, the driver creates a random 96 byte KMIP Secret Data managed object.
+   * If keyId is omitted, a random 96 byte KMIP Secret Data managed object will be created.
    */
   keyId?: string;
 

--- a/src/client-side-encryption/client_encryption.ts
+++ b/src/client-side-encryption/client_encryption.ts
@@ -886,10 +886,9 @@ export interface AzureEncryptionKeyOptions {
   keyVersion?: string | undefined;
 }
 
-
 /**
  * @public
- * Configuration options for making an Azure encryption key
+ * Configuration options for making a KMIP encryption key
  */
 export interface KMIPEncryptionKeyOptions {
   /**
@@ -904,7 +903,6 @@ export interface KMIPEncryptionKeyOptions {
    */
   endpoint?: string;
 }
-
 
 /**
  * @public

--- a/src/index.ts
+++ b/src/index.ts
@@ -225,6 +225,7 @@ export type {
   ClientEncryptionRewrapManyDataKeyResult,
   DataKey,
   GCPEncryptionKeyOptions,
+  KMIPEncryptionKeyOptions,
   RangeOptions
 } from './client-side-encryption/client_encryption';
 export {


### PR DESCRIPTION
### Description

#### What is changing?

The original KMIP implementation added runtime support for KMIP data key options, but did not add TS support.  This PR adds support for the keyId and endpoint options, with delegated to be added in [NODE-5853](https://jira.mongodb.org/browse/NODE-5853).

Demonstration of the options working as expected: https://github.com/mongodb/node-mongodb-native/blob/db00ac46847563f7d32beb1dd4ecbf18531fd15e/test/integration/client-side-encryption/client_side_encryption.prose.test.js#L1011


##### Is there new documentation needed for these changes?

No.

#### What is the motivation for this change?

Typescript accuracy.

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
