### PR TITLE
docs: update legacy drivers section and fix drop down

### DIFF
--- a/etc/docs/build.ts
+++ b/etc/docs/build.ts
@@ -10,11 +10,11 @@ import {
   confirm,
   customSemverCompare,
   getCommandLineArguments,
-  JsonVersionSchema,
+  type JsonVersionSchema,
   LATEST_TAG,
   log,
-  TomlVersionSchema,
-  VersionSchema
+  type TomlVersionSchema,
+  type VersionSchema
 } from './utils';
 
 const exec = promisify(execCb);
@@ -94,8 +94,7 @@ async function main() {
 
   if (!skipPrompts) {
     await confirm(`
-      Generating docs for the following configuration.
-  ${JSON.stringify(newVersion, null, 2)}
+      Generating docs for the following configuration.\n${JSON.stringify(newVersion, null, 2)}
       Does this look right? [y/n] `);
   }
 

--- a/etc/docs/template/data/releases.toml
+++ b/etc/docs/template/data/releases.toml
@@ -136,140 +136,140 @@ tag = "5.0"
 
 [[versions]]
 version = "4.17 Driver"
-status = "supported"
+status = "not-supported"
 api = "./4.17"
 usesMongoDBManual = true
 tag = "4.17"
 
 [[versions]]
 version = "4.16 Driver"
-status = "supported"
+status = "not-supported"
 api = "./4.16"
 usesMongoDBManual = true
 tag = "4.16"
 
 [[versions]]
 version = "4.15 Driver"
-status = "supported"
+status = "not-supported"
 api = "./4.15"
 usesMongoDBManual = true
 tag = "4.15"
 
 [[versions]]
 version = "4.14 Driver"
-status = "supported"
+status = "not-supported"
 api = "./4.14"
 usesMongoDBManual = true
 tag = "4.14"
 
 [[versions]]
 version = "4.13 Driver"
-status = "supported"
+status = "not-supported"
 api = "./4.13"
 usesMongoDBManual = true
 tag = "4.13"
 
 [[versions]]
 version = "4.12 Driver"
-status = "supported"
+status = "not-supported"
 api = "./4.12"
 usesMongoDBManual = true
 tag = "4.12"
 
 [[versions]]
 version = "4.11 Driver"
-status = "supported"
+status = "not-supported"
 api = "./4.11"
 usesMongoDBManual = true
 tag = "4.11"
 
 [[versions]]
 version = "4.10 Driver"
-status = "supported"
+status = "not-supported"
 api = "./4.10"
 usesMongoDBManual = true
 tag = "4.10"
 
 [[versions]]
 version = "4.9 Driver"
-status = "supported"
+status = "not-supported"
 api = "./4.9"
 usesMongoDBManual = true
 tag = "4.9"
 
 [[versions]]
 version = "4.8 Driver"
-status = "supported"
+status = "not-supported"
 api = "./4.8"
 usesMongoDBManual = true
 tag = "4.8"
 
 [[versions]]
 version = "4.7 Driver"
-status = "supported"
+status = "not-supported"
 api = "./4.7"
 usesMongoDBManual = true
 tag = "4.7"
 
 [[versions]]
 version = "4.6 Driver"
-status = "supported"
+status = "not-supported"
 api = "./4.6"
 usesMongoDBManual = true
 tag = "4.6"
 
 [[versions]]
 version = "4.5 Driver"
-status = "supported"
+status = "not-supported"
 api = "./4.5"
 usesMongoDBManual = true
 tag = "4.5"
 
 [[versions]]
 version = "4.4 Driver"
-status = "supported"
+status = "not-supported"
 api = "./4.4"
 usesMongoDBManual = true
 tag = "4.4"
 
 [[versions]]
 version = "4.3 Driver"
-status = "supported"
+status = "not-supported"
 api = "./4.3"
 usesMongoDBManual = true
 tag = "4.3"
 
 [[versions]]
 version = "4.2 Driver"
-status = "supported"
+status = "not-supported"
 api = "./4.2"
 usesMongoDBManual = true
 tag = "4.2"
 
 [[versions]]
 version = "4.1 Driver"
-status = "supported"
+status = "not-supported"
 api = "./4.1"
 usesMongoDBManual = true
 tag = "4.1"
 
 [[versions]]
 version = "4.0 Driver"
-status = "supported"
+status = "not-supported"
 api = "./4.0"
 usesMongoDBManual = true
 tag = "4.0"
 
 [[versions]]
 version = "3.7 Driver"
-status = "supported"
+status = "not-supported"
 docs = "./3.7"
 api = "./3.7/api"
 tag = "3.7"
 
 [[versions]]
 version = "3.6 Driver"
-status = "supported"
+status = "not-supported"
 docs = "./3.6"
 api = "./3.6/api"
 tag = "3.6"

--- a/etc/docs/template/layouts/partials/releases.html
+++ b/etc/docs/template/layouts/partials/releases.html
@@ -26,7 +26,8 @@
   </table>
 
   <details>
-    <summary><h2>Legacy Versions</h2></summary>
+    <summary class="legacy-summary">Legacy Versions</summary>
+    <p>⚠️ The following versions are no longer maintained. For the latest bug fixes and features, please upgrade to a version listed above.</p>
     <table class="table table-striped">
       <thead><tr><th>Release</th><th>Documentation</th></tr></thead>
       <tbody>

--- a/etc/docs/template/static/s/css/frontpage.css
+++ b/etc/docs/template/static/s/css/frontpage.css
@@ -403,3 +403,15 @@ code {
   background-color: #ddd;
   color: #494747;
 }
+
+.legacy-summary {
+  font-family: "PT Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-weight: normal;
+  color: #313030;
+  font-size: 30px;
+  margin-top: 20px;
+  margin-bottom: 10px;
+  line-height: 1.1;
+  box-sizing: border-box;
+  display: list-item;
+}

--- a/etc/docs/utils.ts
+++ b/etc/docs/utils.ts
@@ -1,4 +1,5 @@
 import { createInterface } from 'readline';
+import * as util from 'util';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 
@@ -26,6 +27,8 @@ export interface TomlVersionSchema {
 const capitalize = (s: string) =>
   s.length === 0 ? s : s[0].toUpperCase() + s.slice(1).toLowerCase();
 
+util.inspect.defaultOptions.breakLength = 1000;
+util.inspect.defaultOptions.depth = 1000;
 // eslint-disable-next-line no-console
 export const log = (...args: any[]) => console.error(args);
 


### PR DESCRIPTION
### Description

#### What is changing?

- Fixed: The drop down arrow was not displaying correctly next to "Legacy Versions"
- Fixed: The Legacy versions section didn't accurately list which versions were out of support
- Added a notice about legacy driver versions.

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

Nicer docs landing page

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
