### PR TITLE
chore: use new mongodb-client-encryption and update filter to support versions

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -8,7 +8,14 @@ declare global {
       mongodb?: string;
       os?: NodeJS.Platform | `!${NodeJS.Platform}`;
       apiVersion?: '1' | boolean;
-      clientSideEncryption?: boolean;
+
+      /**
+       * require FLE to be set up to run the test
+       *
+       * A semver range may be provided as well to enforce a particular version range
+       * of mongodb-client-encryption.  Ex: `clientSideEncryption: '>=6.0.1'`
+       */
+      clientSideEncryption?: string | true;
       serverless?: 'forbid' | 'allow' | 'require';
       auth?: 'enabled' | 'disabled';
       idmsMockServer?: true;

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "js-yaml": "^4.1.0",
         "mocha": "^10.4.0",
         "mocha-sinon": "^2.1.2",
-        "mongodb-client-encryption": "^6.0.0",
+        "mongodb-client-encryption": "^6.0.1",
         "mongodb-legacy": "^6.0.1",
         "nyc": "^15.1.0",
         "prettier": "^2.8.8",
@@ -4402,9 +4402,9 @@
       }
     },
     "node_modules/detect-libc": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
-      "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
+      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -7776,15 +7776,15 @@
       }
     },
     "node_modules/mongodb-client-encryption": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-6.0.0.tgz",
-      "integrity": "sha512-GtqkqlSq19acX006/U1odA3l+gwhvABeoTUlvvgtvSs6qcN3qSHPnur3Z5N4oKOv6fZ7EtT8rIsWP2riI0+Eyg==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-6.0.1.tgz",
+      "integrity": "sha512-u6pKu9plR7hQH6VtsfYonC9dwWAM3HFEpi+Xy3EJIdUyoH6dlFgaxX8TnKx/Ycfi2I1cxTXq2IbhSpg157vVgg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "node-addon-api": "^4.3.0",
-        "prebuild-install": "^7.1.1"
+        "prebuild-install": "^7.1.2"
       },
       "engines": {
         "node": ">=16.20.1"
@@ -7909,9 +7909,9 @@
       "dev": true
     },
     "node_modules/node-abi": {
-      "version": "3.45.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.45.0.tgz",
-      "integrity": "sha512-iwXuFrMAcFVi/ZoZiqq8BzAdsLw9kxDfTC0HMyjXfSL/6CSDAGD5UmR7azrAgWV1zKYq7dUUMj4owusBWKLsiQ==",
+      "version": "3.63.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.63.0.tgz",
+      "integrity": "sha512-vAszCsOUrUxjGAmdnM/pq7gUgie0IRteCQMX6d4A534fQCR93EJU5qgzBvU6EkFfK27s0T3HEV3BOyJIr7OMYw==",
       "dev": true,
       "dependencies": {
         "semver": "^7.3.5"
@@ -8572,9 +8572,9 @@
       }
     },
     "node_modules/prebuild-install": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
-      "integrity": "sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.2.tgz",
+      "integrity": "sha512-UnNke3IQb6sgarcZIDU3gbMeTp/9SSU1DAIkil7PrqG1vZlBtY5msYccSKSHDqa3hNg436IXK+SNImReuA1wEQ==",
       "dev": true,
       "dependencies": {
         "detect-libc": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "js-yaml": "^4.1.0",
     "mocha": "^10.4.0",
     "mocha-sinon": "^2.1.2",
-    "mongodb-client-encryption": "^6.0.0",
+    "mongodb-client-encryption": "^6.0.1",
     "mongodb-legacy": "^6.0.1",
     "nyc": "^15.1.0",
     "prettier": "^2.8.8",

--- a/test/tools/runner/filters/client_encryption_filter.ts
+++ b/test/tools/runner/filters/client_encryption_filter.ts
@@ -1,6 +1,7 @@
 import { readFile } from 'fs/promises';
 import { dirname, resolve } from 'path';
 import * as process from 'process';
+import { satisfies } from 'semver';
 
 import { type MongoClient } from '../../../mongodb';
 import { Filter } from './filter';
@@ -59,15 +60,18 @@ export class ClientSideEncryptionFilter extends Filter {
       return true;
     }
 
-    if (clientSideEncryption !== true) {
-      throw new Error('ClientSideEncryptionFilter can only be set to true');
+    if (clientSideEncryption === false) {
+      throw new Error(
+        'ClientSideEncryptionFilter can only be set to true or a semver version range.'
+      );
     }
 
     // TODO(NODE-3401): unskip csfle tests on windows
     if (process.env.TEST_CSFLE && !this.enabled && process.platform !== 'win32') {
       throw new Error('Expected CSFLE to be enabled in the CI');
     }
+    const validRange = typeof clientSideEncryption === 'string' ? clientSideEncryption : '>=0.0.0';
 
-    return this.enabled;
+    return this.enabled && satisfies(ClientSideEncryptionFilter.version, validRange);
   }
 }


### PR DESCRIPTION
### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

going forward, we'll have FLE tests that make use of newer libmongocrypt features. We haven't had this issue in the past, because we've always tested with latest mongodb-client-encryption, but now that we ensure compatibility between mongodb-client-encryption@6.0.0 and latest driver, we'll need to start skipping tests on versions of our bindings that don't support the features under test.

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
