### PR TITLE
refactor: replace symbol properties in cursor classes

### DIFF
--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -532,7 +532,7 @@ export abstract class AbstractCursor<
     const oldTransform = this[kTransform] as (doc: TSchema) => TSchema; // TODO(NODE-3283): Improve transform typing
     if (oldTransform) {
       this[kTransform] = doc => {
-        return transform(oldTransform(doc));
+        return this.makeSafeTransform(transform)(oldTransform(doc));
       };
     } else {
       this[kTransform] = transform;

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -532,7 +532,7 @@ export abstract class AbstractCursor<
     const oldTransform = this[kTransform] as (doc: TSchema) => TSchema; // TODO(NODE-3283): Improve transform typing
     if (oldTransform) {
       this[kTransform] = doc => {
-        return this.makeSafeTransform(transform)(oldTransform(doc));
+        return transform(oldTransform(doc));
       };
     } else {
       this[kTransform] = transform;

--- a/src/cursor/aggregation_cursor.ts
+++ b/src/cursor/aggregation_cursor.ts
@@ -13,11 +13,6 @@ import { AbstractCursor } from './abstract_cursor';
 /** @public */
 export interface AggregationCursorOptions extends AbstractCursorOptions, AggregateOptions {}
 
-/** @internal */
-const kPipeline = Symbol('pipeline');
-/** @internal */
-const kOptions = Symbol('options');
-
 /**
  * The **AggregationCursor** class is an internal class that embodies an aggregation cursor on MongoDB
  * allowing for iteration over the results returned from the underlying query. It supports
@@ -26,10 +21,9 @@ const kOptions = Symbol('options');
  * @public
  */
 export class AggregationCursor<TSchema = any> extends AbstractCursor<TSchema> {
+  public readonly pipeline: Document[];
   /** @internal */
-  [kPipeline]: Document[];
-  /** @internal */
-  [kOptions]: AggregateOptions;
+  private aggregateOptions: AggregateOptions;
 
   /** @internal */
   constructor(
@@ -40,18 +34,14 @@ export class AggregationCursor<TSchema = any> extends AbstractCursor<TSchema> {
   ) {
     super(client, namespace, options);
 
-    this[kPipeline] = pipeline;
-    this[kOptions] = options;
-  }
-
-  get pipeline(): Document[] {
-    return this[kPipeline];
+    this.pipeline = pipeline;
+    this.aggregateOptions = options;
   }
 
   clone(): AggregationCursor<TSchema> {
-    const clonedOptions = mergeOptions({}, this[kOptions]);
+    const clonedOptions = mergeOptions({}, this.aggregateOptions);
     delete clonedOptions.session;
-    return new AggregationCursor(this.client, this.namespace, this[kPipeline], {
+    return new AggregationCursor(this.client, this.namespace, this.pipeline, {
       ...clonedOptions
     });
   }
@@ -62,8 +52,8 @@ export class AggregationCursor<TSchema = any> extends AbstractCursor<TSchema> {
 
   /** @internal */
   async _initialize(session: ClientSession): Promise<ExecutionResult> {
-    const aggregateOperation = new AggregateOperation(this.namespace, this[kPipeline], {
-      ...this[kOptions],
+    const aggregateOperation = new AggregateOperation(this.namespace, this.pipeline, {
+      ...this.aggregateOptions,
       ...this.cursorOptions,
       session
     });
@@ -78,8 +68,8 @@ export class AggregationCursor<TSchema = any> extends AbstractCursor<TSchema> {
   async explain(verbosity?: ExplainVerbosityLike): Promise<Document> {
     return await executeOperation(
       this.client,
-      new AggregateOperation(this.namespace, this[kPipeline], {
-        ...this[kOptions], // NOTE: order matters here, we may need to refine this
+      new AggregateOperation(this.namespace, this.pipeline, {
+        ...this.aggregateOptions, // NOTE: order matters here, we may need to refine this
         ...this.cursorOptions,
         explain: verbosity ?? true
       })
@@ -102,7 +92,7 @@ export class AggregationCursor<TSchema = any> extends AbstractCursor<TSchema> {
   addStage<T = Document>(stage: Document): AggregationCursor<T>;
   addStage<T = Document>(stage: Document): AggregationCursor<T> {
     this.throwIfInitialized();
-    this[kPipeline].push(stage);
+    this.pipeline.push(stage);
     return this as unknown as AggregationCursor<T>;
   }
 

--- a/src/cursor/find_cursor.ts
+++ b/src/cursor/find_cursor.ts
@@ -13,13 +13,6 @@ import { formatSort, type Sort, type SortDirection } from '../sort';
 import { emitWarningOnce, mergeOptions, type MongoDBNamespace, squashError } from '../utils';
 import { AbstractCursor } from './abstract_cursor';
 
-/** @internal */
-const kFilter = Symbol('filter');
-/** @internal */
-const kNumReturned = Symbol('numReturned');
-/** @internal */
-const kBuiltOptions = Symbol('builtOptions');
-
 /** @public Flags allowed for cursor */
 export const FLAGS = [
   'tailable',
@@ -33,11 +26,11 @@ export const FLAGS = [
 /** @public */
 export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
   /** @internal */
-  [kFilter]: Document;
+  private cursorFilter: Document;
   /** @internal */
-  [kNumReturned] = 0;
+  private numReturned = 0;
   /** @internal */
-  [kBuiltOptions]: FindOptions;
+  private readonly findOptions: FindOptions;
 
   /** @internal */
   constructor(
@@ -48,18 +41,18 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
   ) {
     super(client, namespace, options);
 
-    this[kFilter] = filter;
-    this[kBuiltOptions] = options;
+    this.cursorFilter = filter;
+    this.findOptions = options;
 
     if (options.sort != null) {
-      this[kBuiltOptions].sort = formatSort(options.sort);
+      this.findOptions.sort = formatSort(options.sort);
     }
   }
 
   clone(): FindCursor<TSchema> {
-    const clonedOptions = mergeOptions({}, this[kBuiltOptions]);
+    const clonedOptions = mergeOptions({}, this.findOptions);
     delete clonedOptions.session;
-    return new FindCursor(this.client, this.namespace, this[kFilter], {
+    return new FindCursor(this.client, this.namespace, this.cursorFilter, {
       ...clonedOptions
     });
   }
@@ -70,8 +63,8 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
 
   /** @internal */
   async _initialize(session: ClientSession): Promise<ExecutionResult> {
-    const findOperation = new FindOperation(this.namespace, this[kFilter], {
-      ...this[kBuiltOptions], // NOTE: order matters here, we may need to refine this
+    const findOperation = new FindOperation(this.namespace, this.cursorFilter, {
+      ...this.findOptions, // NOTE: order matters here, we may need to refine this
       ...this.cursorOptions,
       session
     });
@@ -80,10 +73,10 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
 
     // the response is not a cursor when `explain` is enabled
     if (CursorResponse.is(response)) {
-      this[kNumReturned] = response.batchSize;
+      this.numReturned = response.batchSize;
     } else {
       // Can be an explain response, hence the ?. on everything
-      this[kNumReturned] = this[kNumReturned] + (response?.cursor?.firstBatch?.length ?? 0);
+      this.numReturned = this.numReturned + (response?.cursor?.firstBatch?.length ?? 0);
     }
 
     // TODO: NODE-2882
@@ -92,10 +85,10 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
 
   /** @internal */
   override async getMore(batchSize: number): Promise<Document | null> {
-    const numReturned = this[kNumReturned];
+    const numReturned = this.numReturned;
     if (numReturned) {
       // TODO(DRIVERS-1448): Remove logic to enforce `limit` in the driver
-      const limit = this[kBuiltOptions].limit;
+      const limit = this.findOptions.limit;
       batchSize =
         limit && limit > 0 && numReturned + batchSize > limit ? limit - numReturned : batchSize;
 
@@ -120,9 +113,9 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
     const response = await super.getMore(batchSize, false);
     // TODO: wrap this in some logic to prevent it from happening if we don't need this support
     if (CursorResponse.is(response)) {
-      this[kNumReturned] = this[kNumReturned] + response.batchSize;
+      this.numReturned = this.numReturned + response.batchSize;
     } else {
-      this[kNumReturned] = this[kNumReturned] + (response?.cursor?.nextBatch?.length ?? 0);
+      this.numReturned = this.numReturned + (response?.cursor?.nextBatch?.length ?? 0);
     }
 
     return response;
@@ -141,8 +134,8 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
     }
     return await executeOperation(
       this.client,
-      new CountOperation(this.namespace, this[kFilter], {
-        ...this[kBuiltOptions], // NOTE: order matters here, we may need to refine this
+      new CountOperation(this.namespace, this.cursorFilter, {
+        ...this.findOptions, // NOTE: order matters here, we may need to refine this
         ...this.cursorOptions,
         ...options
       })
@@ -153,8 +146,8 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
   async explain(verbosity?: ExplainVerbosityLike): Promise<Document> {
     return await executeOperation(
       this.client,
-      new FindOperation(this.namespace, this[kFilter], {
-        ...this[kBuiltOptions], // NOTE: order matters here, we may need to refine this
+      new FindOperation(this.namespace, this.cursorFilter, {
+        ...this.findOptions, // NOTE: order matters here, we may need to refine this
         ...this.cursorOptions,
         explain: verbosity ?? true
       })
@@ -164,7 +157,7 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
   /** Set the cursor query */
   filter(filter: Document): this {
     this.throwIfInitialized();
-    this[kFilter] = filter;
+    this.cursorFilter = filter;
     return this;
   }
 
@@ -175,7 +168,7 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
    */
   hint(hint: Hint): this {
     this.throwIfInitialized();
-    this[kBuiltOptions].hint = hint;
+    this.findOptions.hint = hint;
     return this;
   }
 
@@ -186,7 +179,7 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
    */
   min(min: Document): this {
     this.throwIfInitialized();
-    this[kBuiltOptions].min = min;
+    this.findOptions.min = min;
     return this;
   }
 
@@ -197,7 +190,7 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
    */
   max(max: Document): this {
     this.throwIfInitialized();
-    this[kBuiltOptions].max = max;
+    this.findOptions.max = max;
     return this;
   }
 
@@ -210,7 +203,7 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
    */
   returnKey(value: boolean): this {
     this.throwIfInitialized();
-    this[kBuiltOptions].returnKey = value;
+    this.findOptions.returnKey = value;
     return this;
   }
 
@@ -221,7 +214,7 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
    */
   showRecordId(value: boolean): this {
     this.throwIfInitialized();
-    this[kBuiltOptions].showRecordId = value;
+    this.findOptions.showRecordId = value;
     return this;
   }
 
@@ -243,43 +236,43 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
     // NOTE: consider some TS magic for this
     switch (field) {
       case 'comment':
-        this[kBuiltOptions].comment = value as string | Document;
+        this.findOptions.comment = value as string | Document;
         break;
 
       case 'explain':
-        this[kBuiltOptions].explain = value as boolean;
+        this.findOptions.explain = value as boolean;
         break;
 
       case 'hint':
-        this[kBuiltOptions].hint = value as string | Document;
+        this.findOptions.hint = value as string | Document;
         break;
 
       case 'max':
-        this[kBuiltOptions].max = value as Document;
+        this.findOptions.max = value as Document;
         break;
 
       case 'maxTimeMS':
-        this[kBuiltOptions].maxTimeMS = value as number;
+        this.findOptions.maxTimeMS = value as number;
         break;
 
       case 'min':
-        this[kBuiltOptions].min = value as Document;
+        this.findOptions.min = value as Document;
         break;
 
       case 'orderby':
-        this[kBuiltOptions].sort = formatSort(value as string | Document);
+        this.findOptions.sort = formatSort(value as string | Document);
         break;
 
       case 'query':
-        this[kFilter] = value as Document;
+        this.cursorFilter = value as Document;
         break;
 
       case 'returnKey':
-        this[kBuiltOptions].returnKey = value as boolean;
+        this.findOptions.returnKey = value as boolean;
         break;
 
       case 'showDiskLoc':
-        this[kBuiltOptions].showRecordId = value as boolean;
+        this.findOptions.showRecordId = value as boolean;
         break;
 
       default:
@@ -296,7 +289,7 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
    */
   comment(value: string): this {
     this.throwIfInitialized();
-    this[kBuiltOptions].comment = value;
+    this.findOptions.comment = value;
     return this;
   }
 
@@ -311,7 +304,7 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
       throw new MongoInvalidArgumentError('Argument for maxAwaitTimeMS must be a number');
     }
 
-    this[kBuiltOptions].maxAwaitTimeMS = value;
+    this.findOptions.maxAwaitTimeMS = value;
     return this;
   }
 
@@ -326,7 +319,7 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
       throw new MongoInvalidArgumentError('Argument for maxTimeMS must be a number');
     }
 
-    this[kBuiltOptions].maxTimeMS = value;
+    this.findOptions.maxTimeMS = value;
     return this;
   }
 
@@ -372,7 +365,7 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
    */
   project<T extends Document = Document>(value: Document): FindCursor<T> {
     this.throwIfInitialized();
-    this[kBuiltOptions].projection = value;
+    this.findOptions.projection = value;
     return this as unknown as FindCursor<T>;
   }
 
@@ -384,11 +377,11 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
    */
   sort(sort: Sort | string, direction?: SortDirection): this {
     this.throwIfInitialized();
-    if (this[kBuiltOptions].tailable) {
+    if (this.findOptions.tailable) {
       throw new MongoTailableCursorError('Tailable cursor does not support sorting');
     }
 
-    this[kBuiltOptions].sort = formatSort(sort, direction);
+    this.findOptions.sort = formatSort(sort, direction);
     return this;
   }
 
@@ -401,17 +394,17 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
   allowDiskUse(allow = true): this {
     this.throwIfInitialized();
 
-    if (!this[kBuiltOptions].sort) {
+    if (!this.findOptions.sort) {
       throw new MongoInvalidArgumentError('Option "allowDiskUse" requires a sort specification');
     }
 
     // As of 6.0 the default is true. This allows users to get back to the old behavior.
     if (!allow) {
-      this[kBuiltOptions].allowDiskUse = false;
+      this.findOptions.allowDiskUse = false;
       return this;
     }
 
-    this[kBuiltOptions].allowDiskUse = true;
+    this.findOptions.allowDiskUse = true;
     return this;
   }
 
@@ -422,7 +415,7 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
    */
   collation(value: CollationOptions): this {
     this.throwIfInitialized();
-    this[kBuiltOptions].collation = value;
+    this.findOptions.collation = value;
     return this;
   }
 
@@ -433,7 +426,7 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
    */
   limit(value: number): this {
     this.throwIfInitialized();
-    if (this[kBuiltOptions].tailable) {
+    if (this.findOptions.tailable) {
       throw new MongoTailableCursorError('Tailable cursor does not support limit');
     }
 
@@ -441,7 +434,7 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
       throw new MongoInvalidArgumentError('Operation "limit" requires an integer');
     }
 
-    this[kBuiltOptions].limit = value;
+    this.findOptions.limit = value;
     return this;
   }
 
@@ -452,7 +445,7 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
    */
   skip(value: number): this {
     this.throwIfInitialized();
-    if (this[kBuiltOptions].tailable) {
+    if (this.findOptions.tailable) {
       throw new MongoTailableCursorError('Tailable cursor does not support skip');
     }
 
@@ -460,7 +453,7 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
       throw new MongoInvalidArgumentError('Operation "skip" requires an integer');
     }
 
-    this[kBuiltOptions].skip = value;
+    this.findOptions.skip = value;
     return this;
   }
 }

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -533,7 +533,11 @@ export function maybeClearPinnedConnection(
     const servers = Array.from(topology.s.servers.values());
     const loadBalancer = servers[0];
 
-    if (options?.error == null || options?.force) {
+    if (
+      options?.error == null ||
+      options?.error?.name === 'MongoExpiredSessionError' ||
+      options?.force
+    ) {
       loadBalancer.pool.checkIn(conn);
       session[kPinnedConnection] = undefined;
       conn.emit(

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -533,11 +533,7 @@ export function maybeClearPinnedConnection(
     const servers = Array.from(topology.s.servers.values());
     const loadBalancer = servers[0];
 
-    if (
-      options?.error == null ||
-      options?.error?.name === 'MongoExpiredSessionError' ||
-      options?.force
-    ) {
+    if (options?.error == null || options?.force) {
       loadBalancer.pool.checkIn(conn);
       session[kPinnedConnection] = undefined;
       conn.emit(

--- a/test/integration/change-streams/change_stream.test.ts
+++ b/test/integration/change-streams/change_stream.test.ts
@@ -2018,7 +2018,7 @@ describe('ChangeStream resumability', function () {
           } as FailPoint);
 
           expect(changeStream.cursor)
-            .to.have.property('options')
+            .to.have.property('changeStreamCursorOptions')
             .that.containSubset(changeStreamResumeOptions);
 
           await collection.insertOne({ name: 'bailey' });
@@ -2026,7 +2026,7 @@ describe('ChangeStream resumability', function () {
           await changeStream.next();
 
           expect(changeStream.cursor)
-            .to.have.property('options')
+            .to.have.property('changeStreamCursorOptions')
             .that.containSubset(changeStreamResumeOptions);
         }
       );
@@ -2182,7 +2182,7 @@ describe('ChangeStream resumability', function () {
           } as FailPoint);
 
           expect(changeStream.cursor)
-            .to.have.property('options')
+            .to.have.property('changeStreamCursorOptions')
             .that.containSubset(changeStreamResumeOptions);
 
           await collection.insertOne({ name: 'bailey' });
@@ -2190,7 +2190,7 @@ describe('ChangeStream resumability', function () {
           await changeStream.hasNext();
 
           expect(changeStream.cursor)
-            .to.have.property('options')
+            .to.have.property('changeStreamCursorOptions')
             .that.containSubset(changeStreamResumeOptions);
         }
       );
@@ -2360,7 +2360,7 @@ describe('ChangeStream resumability', function () {
           } as FailPoint);
 
           expect(changeStream.cursor)
-            .to.have.property('options')
+            .to.have.property('changeStreamCursorOptions')
             .that.containSubset(changeStreamResumeOptions);
 
           await collection.insertOne({ name: 'bailey' });
@@ -2368,7 +2368,7 @@ describe('ChangeStream resumability', function () {
           await changeStream.tryNext();
 
           expect(changeStream.cursor)
-            .to.have.property('options')
+            .to.have.property('changeStreamCursorOptions')
             .that.containSubset(changeStreamResumeOptions);
         }
       );
@@ -2504,14 +2504,14 @@ describe('ChangeStream resumability', function () {
           } as FailPoint);
 
           expect(changeStream.cursor)
-            .to.have.property('options')
+            .to.have.property('changeStreamCursorOptions')
             .that.containSubset(changeStreamResumeOptions);
 
           await collection.insertOne({ city: 'New York City' });
           await changeStreamIterator.next();
 
           expect(changeStream.cursor)
-            .to.have.property('options')
+            .to.have.property('changeStreamCursorOptions')
             .that.containSubset(changeStreamResumeOptions);
         }
       );
@@ -2643,7 +2643,7 @@ describe('ChangeStream resumability', function () {
         } as FailPoint);
 
         expect(changeStream.cursor)
-          .to.have.property('options')
+          .to.have.property('changeStreamCursorOptions')
           .that.containSubset(changeStreamResumeOptions);
 
         const changes = once(changeStream, 'change');
@@ -2654,7 +2654,7 @@ describe('ChangeStream resumability', function () {
         await changes;
 
         expect(changeStream.cursor)
-          .to.have.property('options')
+          .to.have.property('changeStreamCursorOptions')
           .that.containSubset(changeStreamResumeOptions);
       }
     );

--- a/test/integration/crud/maxTimeMS.test.ts
+++ b/test/integration/crud/maxTimeMS.test.ts
@@ -30,8 +30,8 @@ describe('MaxTimeMS', function () {
     const col = client.db().collection('max_time_ms');
     await col.insertMany([{ agg_pipe: 1 }], { writeConcern: { w: 1 } });
     const cursor = col.find({ $where: 'sleep(100) || true' }).maxTimeMS(50);
-    const kBuiltOptions = getSymbolFrom(cursor, 'builtOptions');
-    expect(cursor[kBuiltOptions]).to.have.property('maxTimeMS', 50);
+    // @ts-expect-error: findOptions are private
+    expect(cursor.findOptions).to.have.property('maxTimeMS', 50);
 
     const error = await cursor.count().catch(error => error);
     expect(error).to.be.instanceOf(MongoServerError);
@@ -44,8 +44,8 @@ describe('MaxTimeMS', function () {
     const col = client.db().collection('max_time_ms');
     await col.insertMany([{ agg_pipe: 1 }], { writeConcern: { w: 1 } });
     const cursor = col.find({ $where: 'sleep(100) || true' }).maxTimeMS(50);
-    const kBuiltOptions = getSymbolFrom(cursor, 'builtOptions');
-    expect(cursor[kBuiltOptions]).to.have.property('maxTimeMS', 50);
+    // @ts-expect-error: findOptions are private
+    expect(cursor.findOptions).to.have.property('maxTimeMS', 50);
 
     const error = await cursor.toArray().catch(error => error);
     expect(error).to.be.instanceOf(MongoServerError);

--- a/test/integration/crud/maxTimeMS.test.ts
+++ b/test/integration/crud/maxTimeMS.test.ts
@@ -9,7 +9,6 @@ import {
   MongoCursorExhaustedError,
   MongoServerError
 } from '../../mongodb';
-import { getSymbolFrom } from '../../tools/utils';
 
 describe('MaxTimeMS', function () {
   let client: MongoClient;


### PR DESCRIPTION
### Description

#### What is changing?

- `AbstractCursor`
  - Removed all symbol properties in favor of equivalently named strings.
  - Changed "options" to cursorOptions, no need for the getter indirection
  - Added `is` in front of booleans that have getters
- `FindCursor`
  - kFilter -> cursorFilter since there is a "filter" method
  - builtOptions -> findOptions, I think the naming came from TS translation days, it is true that the options are built from all the helpers (if one uses those) but in the end they are options for find
- `AggregationCursor`
  - pipline is a public readonly property which is equivalent to the getter that fetched the symbol property before
- `ChangeStreamCursor`
  - No symbol properties here, but the "options" property shared the same name as AbstractCursor's "options" until I changed it to "cursorOptions". 
  - But that led me to take a look at the class properties, we never set resumeAfter/startAfter on the class, thos remain on the options, unless I missed something.

[patch](https://spruce.mongodb.com/version/6660be9352ce9e00070984f5/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)

##### Is there new documentation needed for these changes?

No.

#### What is the motivation for this change?

Symbol properties served as "private" before we had typescript. We prefer using plain string properties now for better DX, and testing internals. 

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
