### PR TITLE
chore: convert mocha hooks cjs exports to esm exports

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -3,7 +3,7 @@
   "require": [
     "source-map-support/register",
     "ts-node/register",
-    "test/tools/runner/chai-addons.js",
+    "test/tools/runner/chai_addons.ts",
     "test/tools/runner/hooks/unhandled_checker.ts"
   ],
   "extension": [

--- a/test/mocha_mongodb.json
+++ b/test/mocha_mongodb.json
@@ -3,7 +3,7 @@
   "require": [
     "source-map-support/register",
     "ts-node/register",
-    "test/tools/runner/chai-addons.js",
+    "test/tools/runner/chai_addons.ts",
     "test/tools/runner/hooks/configuration.ts",
     "test/tools/runner/hooks/unhandled_checker.ts",
     "test/tools/runner/hooks/leak_checker.ts",

--- a/test/tools/runner/chai_addons.ts
+++ b/test/tools/runner/chai_addons.ts
@@ -1,7 +1,7 @@
-'use strict';
+/* eslint-disable @typescript-eslint/no-var-requires */
 
-// configure chai
-const chai = require('chai');
+import chai = require('chai');
+
 chai.use(require('sinon-chai'));
 chai.use(require('chai-subset'));
 chai.use(require('../spec-runner/matcher').default);

--- a/test/tools/runner/hooks/configuration.ts
+++ b/test/tools/runner/hooks/configuration.ts
@@ -107,7 +107,7 @@ const testSkipBeforeEachHook = async function () {
  * @param skippedTests - define list of tests to skip
  * @returns
  */
-const skipBrokenAuthTestBeforeEachHook = function (
+export const skipBrokenAuthTestBeforeEachHook = function (
   { skippedTests }: { skippedTests: string[] } = { skippedTests: [] }
 ) {
   return function () {
@@ -222,12 +222,8 @@ export function installNodeDNSWorkaroundHooks() {
   }
 }
 
-module.exports = {
-  mochaHooks: {
-    beforeAll: [beforeAllPluginImports, testConfigBeforeHook],
-    beforeEach: [testSkipBeforeEachHook],
-    afterAll: [cleanUpMocksAfterHook]
-  },
-  skipBrokenAuthTestBeforeEachHook,
-  installNodeDNSWorkaroundHooks
+export const mochaHooks = {
+  beforeAll: [beforeAllPluginImports, testConfigBeforeHook],
+  beforeEach: [testSkipBeforeEachHook],
+  afterAll: [cleanUpMocksAfterHook]
 };

--- a/test/tools/runner/hooks/unhandled_checker.ts
+++ b/test/tools/runner/hooks/unhandled_checker.ts
@@ -41,4 +41,4 @@ function afterEachUnhandled() {
   unhandled.unknown = [];
 }
 
-module.exports = { mochaHooks: { beforeEach: beforeEachUnhandled, afterEach: afterEachUnhandled } };
+export const mochaHooks = { beforeEach: beforeEachUnhandled, afterEach: afterEachUnhandled };


### PR DESCRIPTION
### Description

#### What is changing?

- commonjs exports can be replaced with ES syntax.

##### Is there new documentation needed for these changes?

- No

#### What is the motivation for this change?

Proper TS conversion

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
