### PR TITLE
ci(NODE-6203): fix atlas connectivity tests

### DIFF
--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -440,15 +440,14 @@ functions:
           rm -rf ./node_modules/@aws-sdk/credential-providers
 
   "run atlas tests":
-    - command: shell.exec
-      type: test
+    # This creates secrets-export.sh, which is later sourced by run-tests.sh
+    - command: subprocess.exec
       params:
-        silent: true
         working_dir: "src"
-        script: |
-          cat <<EOT > prepare_atlas_connectivity.sh
-          export ATLAS_CONNECTIVITY='${ATLAS_CONNECTIVITY}'
-          EOT
+        binary: bash
+        args:
+          - -c
+          - ${DRIVERS_TOOLS}/.evergreen/secrets_handling/setup-secrets.sh drivers/atlas_connect
     - command: shell.exec
       type: test
       params:
@@ -456,8 +455,7 @@ functions:
         script: |
           # Disable xtrace (just in case it was accidentally set).
           set +x
-          . ./prepare_atlas_connectivity.sh
-          rm -f ./prepare_atlas_connectivity.sh
+          source secrets-export.sh
 
           export PROJECT_DIRECTORY="$(pwd)"
           export NODE_LTS_VERSION='${NODE_LTS_VERSION}'

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -440,23 +440,12 @@ functions:
           rm -rf ./node_modules/@aws-sdk/credential-providers
 
   "run atlas tests":
-    # This creates secrets-export.sh, which is later sourced by run-tests.sh
-    - command: subprocess.exec
-      params:
-        working_dir: "src"
-        binary: bash
-        args:
-          - -c
-          - ${DRIVERS_TOOLS}/.evergreen/secrets_handling/setup-secrets.sh drivers/atlas_connect
     - command: shell.exec
       type: test
       params:
         working_dir: "src"
+        add_expansions_to_env: true
         script: |
-          # Disable xtrace (just in case it was accidentally set).
-          set +x
-          source secrets-export.sh
-
           export PROJECT_DIRECTORY="$(pwd)"
           export NODE_LTS_VERSION='${NODE_LTS_VERSION}'
 

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -440,16 +440,23 @@ functions:
           rm -rf ./node_modules/@aws-sdk/credential-providers
 
   "run atlas tests":
-    - command: shell.exec
+    # This creates secrets-export.sh, which is later sourced by run-tests.sh
+    - command: subprocess.exec
+      params:
+        working_dir: "src"
+        binary: bash
+        args:
+          - -c
+          - ${DRIVERS_TOOLS}/.evergreen/secrets_handling/setup-secrets.sh drivers/atlas_connect
+    - command: subprocess.exec
       type: test
       params:
         working_dir: "src"
-        add_expansions_to_env: true
-        script: |
-          export PROJECT_DIRECTORY="$(pwd)"
-          export NODE_LTS_VERSION='${NODE_LTS_VERSION}'
-
-          bash ${PROJECT_DIRECTORY}/.evergreen/run-atlas-tests.sh
+        binary: bash
+        env:
+          NODE_LTS_VERSION: ${NODE_LTS_VERSION}
+        args:
+          - .evergreen/run-atlas-tests.sh
 
   "run socks5 tests":
     - command: shell.exec

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -395,16 +395,22 @@ functions:
           source "${PROJECT_DIRECTORY}/.evergreen/init-node-and-npm-env.sh"
           rm -rf ./node_modules/@aws-sdk/credential-providers
   run atlas tests:
-    - command: shell.exec
+    - command: subprocess.exec
+      params:
+        working_dir: src
+        binary: bash
+        args:
+          - '-c'
+          - ${DRIVERS_TOOLS}/.evergreen/secrets_handling/setup-secrets.sh drivers/atlas_connect
+    - command: subprocess.exec
       type: test
       params:
         working_dir: src
-        add_expansions_to_env: true
-        script: |
-          export PROJECT_DIRECTORY="$(pwd)"
-          export NODE_LTS_VERSION='${NODE_LTS_VERSION}'
-
-          bash ${PROJECT_DIRECTORY}/.evergreen/run-atlas-tests.sh
+        binary: bash
+        env:
+          NODE_LTS_VERSION: ${NODE_LTS_VERSION}
+        args:
+          - .evergreen/run-atlas-tests.sh
   run socks5 tests:
     - command: shell.exec
       type: test

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -395,22 +395,12 @@ functions:
           source "${PROJECT_DIRECTORY}/.evergreen/init-node-and-npm-env.sh"
           rm -rf ./node_modules/@aws-sdk/credential-providers
   run atlas tests:
-    - command: subprocess.exec
-      params:
-        working_dir: src
-        binary: bash
-        args:
-          - '-c'
-          - ${DRIVERS_TOOLS}/.evergreen/secrets_handling/setup-secrets.sh drivers/atlas_connect
     - command: shell.exec
       type: test
       params:
         working_dir: src
+        add_expansions_to_env: true
         script: |
-          # Disable xtrace (just in case it was accidentally set).
-          set +x
-          source secrets-export.sh
-
           export PROJECT_DIRECTORY="$(pwd)"
           export NODE_LTS_VERSION='${NODE_LTS_VERSION}'
 

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -395,15 +395,13 @@ functions:
           source "${PROJECT_DIRECTORY}/.evergreen/init-node-and-npm-env.sh"
           rm -rf ./node_modules/@aws-sdk/credential-providers
   run atlas tests:
-    - command: shell.exec
-      type: test
+    - command: subprocess.exec
       params:
-        silent: true
         working_dir: src
-        script: |
-          cat <<EOT > prepare_atlas_connectivity.sh
-          export ATLAS_CONNECTIVITY='${ATLAS_CONNECTIVITY}'
-          EOT
+        binary: bash
+        args:
+          - '-c'
+          - ${DRIVERS_TOOLS}/.evergreen/secrets_handling/setup-secrets.sh drivers/atlas_connect
     - command: shell.exec
       type: test
       params:
@@ -411,8 +409,7 @@ functions:
         script: |
           # Disable xtrace (just in case it was accidentally set).
           set +x
-          . ./prepare_atlas_connectivity.sh
-          rm -f ./prepare_atlas_connectivity.sh
+          source secrets-export.sh
 
           export PROJECT_DIRECTORY="$(pwd)"
           export NODE_LTS_VERSION='${NODE_LTS_VERSION}'

--- a/.evergreen/run-atlas-tests.sh
+++ b/.evergreen/run-atlas-tests.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-if [ -z ${DRIVERS_TOOLS+omitted} ]; then echo "DRIVERS_TOOLS is unset" && exit 1; fi
-
 set -o errexit  # Exit the script with error if any of the commands fail
 
-source "${PROJECT_DIRECTORY}/.evergreen/init-node-and-npm-env.sh"
+if test -f secrets-export.sh; then
+	source secrets-export.sh
+fi
 
-bash ${DRIVERS_TOOLS}/.evergreen/secrets_handling/setup-secrets.sh drivers/atlas_connect
-source secrets-export.sh
+PROJECT_DIRECTORY=${PROJECT_DIRECTORY:-"."}
+source "${PROJECT_DIRECTORY}/.evergreen/init-node-and-npm-env.sh"
 
 node -v
 

--- a/.evergreen/run-atlas-tests.sh
+++ b/.evergreen/run-atlas-tests.sh
@@ -3,7 +3,7 @@
 set -o errexit  # Exit the script with error if any of the commands fail
 
 if test -f secrets-export.sh; then
-	source secrets-export.sh
+  source secrets-export.sh
 fi
 
 PROJECT_DIRECTORY=${PROJECT_DIRECTORY:-"."}

--- a/.evergreen/run-atlas-tests.sh
+++ b/.evergreen/run-atlas-tests.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 
+if [ -z ${DRIVERS_TOOLS+omitted} ]; then echo "DRIVERS_TOOLS is unset" && exit 1; fi
+
 set -o errexit  # Exit the script with error if any of the commands fail
 
 source "${PROJECT_DIRECTORY}/.evergreen/init-node-and-npm-env.sh"
 
-set -o xtrace
+bash ${DRIVERS_TOOLS}/.evergreen/secrets_handling/setup-secrets.sh drivers/atlas_connect
+source secrets-export.sh
 
 node -v
 

--- a/test/manual/atlas_connectivity.test.ts
+++ b/test/manual/atlas_connectivity.test.ts
@@ -15,47 +15,37 @@ import { LEGACY_HELLO_COMMAND, MongoClient } from '../mongodb';
  */
 
 describe('Atlas Connectivity', function () {
-  const { ATLAS_CONNECTIVITY = '' } = process.env;
-  if (ATLAS_CONNECTIVITY === '') throw new Error('ATLAS_CONNECTIVITY not defined in env');
-
-  const CONFIGS: Record<string, [normalUri: string, srvUri: string]> =
-    JSON.parse(ATLAS_CONNECTIVITY);
-
   let client: MongoClient;
 
   afterEach(async function () {
-    await client.close();
+    await client?.close();
   });
 
-  for (const configName of Object.keys(CONFIGS)) {
-    context(configName, function () {
-      for (const connectionString of CONFIGS[configName]) {
-        const name = connectionString.includes('mongodb+srv') ? 'mongodb+srv' : 'normal';
+  const environments = [
+    'ATLAS_SERVERLESS',
+    'ATLAS_SRV_SERVERLESS',
+    'ATLAS_FREE',
+    'ATLAS_SRV_FREE',
+    'ATLAS_REPL',
+    'ATLAS_SRV_REPL',
+    'ATLAS_SHRD',
+    'ATLAS_SRV_SHRD',
+    'ATLAS_TLS11',
+    'ATLAS_SRV_TLS11',
+    'ATLAS_TLS12',
+    'ATLAS_SRV_TLS12'
+  ];
 
-        beforeEach(function () {
-          if (configName === 'replica_set_4_4_free') {
-            const today = new Date();
-            // Making this April 1st so it is a monday
-            const april1st2024 = new Date('2024-04-01');
-            if (today < april1st2024) {
-              if (this.currentTest)
-                this.currentTest.skipReason =
-                  'TODO(NODE-6027): Un-skip replica_set_4_4_free after March 29th 2024';
-              this.skip();
-            }
-          }
-        });
+  for (const environment of environments) {
+    it(`${environment} connects successfully`, async function () {
+      this.timeout(40000);
 
-        it(name, async function () {
-          this.timeout(40000);
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      client = new MongoClient(process.env[environment]!);
 
-          client = new MongoClient(connectionString);
-
-          await client.connect();
-          await client.db('admin').command({ [LEGACY_HELLO_COMMAND]: 1 });
-          await client.db('test').collection('test').findOne({});
-        });
-      }
+      await client.connect();
+      await client.db('admin').command({ [LEGACY_HELLO_COMMAND]: 1 });
+      await client.db('test').collection('test').findOne({});
     });
   }
 });


### PR DESCRIPTION
### Description

#### What is changing?

Atlas connectivity test URIs are now obtained from aws secrets manager.

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
