### PR TITLE
chore(NODE-6212): generate sarif reports in releases and upload sbom lite to s3 [skip-ci]

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "5.x" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "5.x" ]
 
 jobs:
   analyze:

--- a/.github/workflows/release-5.x.yml
+++ b/.github/workflows/release-5.x.yml
@@ -20,7 +20,7 @@ jobs:
         uses: googleapis/release-please-action@v4
         with:
           target-branch: 5.x
-  
+
   compress_sign_and_upload:
     needs: [release_please]
     if: ${{ needs.release_please.outputs.release_created }}
@@ -40,3 +40,43 @@ jobs:
       - run: npm publish --provenance --tag=5x
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  generate_sarif_report:
+    environment: release
+    runs-on: ubuntu-latest
+    needs: [release_please]
+    permissions:
+      # required for all workflows
+      security-events: write
+      id-token: write
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up drivers-github-tools
+        uses: mongodb-labs/drivers-github-tools/setup@v2
+        with:
+          aws_region_name: us-east-1
+          aws_role_arn: ${{ secrets.aws_role_arn }}
+          aws_secret_id: ${{ secrets.aws_secret_id }}
+
+      - name: "Generate Sarif Report"
+        # TODO: Use v2 once it has been re-tagged to include this action
+        uses: mongodb-labs/drivers-github-tools/code-scanning-export@main
+        with:
+          ref: main
+          output-file: sarif-report.json
+
+      - name: Get release version and release package file name
+        id: get_version
+        shell: bash
+        run: |
+          package_version=$(jq --raw-output '.version' package.json)
+          echo "package_version=${package_version}" >> "$GITHUB_OUTPUT"
+      - name: actions/publish_asset_to_s3
+        uses: mongodb-labs/drivers-github-tools/node/publish_asset_to_s3@main
+        with:
+          version: ${{ steps.get_version.outputs.package_version }}
+          product_name: node-mongodb-native
+          file: sarif-report.json
+          dry_run:  ${{ needs.release_please.outputs.release_created == '' }}

--- a/.github/workflows/release-5.x.yml
+++ b/.github/workflows/release-5.x.yml
@@ -80,3 +80,37 @@ jobs:
           product_name: node-mongodb-native
           file: sarif-report.json
           dry_run:  ${{ needs.release_please.outputs.release_created == '' }}
+
+  upload_sbom_lite:
+    environment: release
+    runs-on: ubuntu-latest
+    needs: [release_please]
+    permissions:
+      # required for all workflows
+      security-events: write
+      id-token: write
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up drivers-github-tools
+        uses: mongodb-labs/drivers-github-tools/setup@v2
+        with:
+          aws_region_name: us-east-1
+          aws_role_arn: ${{ secrets.aws_role_arn }}
+          aws_secret_id: ${{ secrets.aws_secret_id }}
+
+      - name: Get release version and release package file name
+        id: get_version
+        shell: bash
+        run: |
+          package_version=$(jq --raw-output '.version' package.json)
+          echo "package_version=${package_version}" >> "$GITHUB_OUTPUT"
+
+      - name: actions/publish_asset_to_s3
+        uses: mongodb-labs/drivers-github-tools/node/publish_asset_to_s3@main
+        with:
+          version: ${{ steps.get_version.outputs.package_version }}
+          product_name: node-mongodb-native
+          file: sbom.json
+          dry_run:  ${{ needs.release_please.outputs.release_created == '' }}

--- a/.github/workflows/release-5.x.yml
+++ b/.github/workflows/release-5.x.yml
@@ -108,7 +108,7 @@ jobs:
           echo "package_version=${package_version}" >> "$GITHUB_OUTPUT"
 
       - name: actions/publish_asset_to_s3
-        uses: mongodb-labs/drivers-github-tools/node/publish_asset_to_s3@main
+        uses: mongodb-labs/drivers-github-tools/node/publish_asset_to_s3@v2
         with:
           version: ${{ steps.get_version.outputs.package_version }}
           product_name: node-mongodb-native

--- a/.github/workflows/release-5.x.yml
+++ b/.github/workflows/release-5.x.yml
@@ -61,8 +61,7 @@ jobs:
           aws_secret_id: ${{ secrets.aws_secret_id }}
 
       - name: "Generate Sarif Report"
-        # TODO: Use v2 once it has been re-tagged to include this action
-        uses: mongodb-labs/drivers-github-tools/code-scanning-export@main
+        uses: mongodb-labs/drivers-github-tools/code-scanning-export@v2
         with:
           ref: 5.x
           output-file: sarif-report.json

--- a/.github/workflows/release-5.x.yml
+++ b/.github/workflows/release-5.x.yml
@@ -64,7 +64,7 @@ jobs:
         # TODO: Use v2 once it has been re-tagged to include this action
         uses: mongodb-labs/drivers-github-tools/code-scanning-export@main
         with:
-          ref: main
+          ref: 5.x
           output-file: sarif-report.json
 
       - name: Get release version and release package file name

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
   upload_sbom_lite:
     environment: release
     runs-on: ubuntu-latest
-    needs: [release_please]
+    # needs: [release_please]
     permissions:
       # required for all workflows
       security-events: write
@@ -112,4 +112,5 @@ jobs:
           version: ${{ steps.get_version.outputs.package_version }}
           product_name: node-mongodb-native
           file: sbom.json
-          dry_run:  ${{ needs.release_please.outputs.release_created == '' }}
+          # dry_run:  ${{ needs.release_please.outputs.release_created == '' }}
+          dry_run: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
   generate_sarif_report:
     environment: release
     runs-on: ubuntu-latest
-    # needs: [release_please]
+    needs: [release_please]
     permissions:
       # required for all workflows
       security-events: write
@@ -77,5 +77,4 @@ jobs:
           version: ${{ steps.get_version.outputs.package_version }}
           product_name: node-mongodb-native
           file: sarif-report.json
-          dry_run:  false
-          # dry_run:  ${{ needs.release_please.outputs.release_created == '' }}
+          dry_run:  ${{ needs.release_please.outputs.release_created == '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
   upload_sbom_lite:
     environment: release
     runs-on: ubuntu-latest
-    # needs: [release_please]
+    needs: [release_please]
     permissions:
       # required for all workflows
       security-events: write
@@ -112,5 +112,4 @@ jobs:
           version: ${{ steps.get_version.outputs.package_version }}
           product_name: node-mongodb-native
           file: sbom.json
-          # dry_run:  ${{ needs.release_please.outputs.release_created == '' }}
-          dry_run: false
+          dry_run:  ${{ needs.release_please.outputs.release_created == '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,8 +59,7 @@ jobs:
           aws_secret_id: ${{ secrets.aws_secret_id }}
 
       - name: "Generate Sarif Report"
-        # TODO: Use v2 once it has been re-tagged to include this action
-        uses: mongodb-labs/drivers-github-tools/code-scanning-export@main
+        uses: mongodb-labs/drivers-github-tools/code-scanning-export@v2
         with:
           ref: main
           output-file: sarif-report.json
@@ -72,7 +71,7 @@ jobs:
           package_version=$(jq --raw-output '.version' package.json)
           echo "package_version=${package_version}" >> "$GITHUB_OUTPUT"
       - name: actions/publish_asset_to_s3
-        uses: mongodb-labs/drivers-github-tools/node/publish_asset_to_s3@main
+        uses: mongodb-labs/drivers-github-tools/node/publish_asset_to_s3@v2
         with:
           version: ${{ steps.get_version.outputs.package_version }}
           product_name: node-mongodb-native
@@ -107,7 +106,7 @@ jobs:
           echo "package_version=${package_version}" >> "$GITHUB_OUTPUT"
 
       - name: actions/publish_asset_to_s3
-        uses: mongodb-labs/drivers-github-tools/node/publish_asset_to_s3@main
+        uses: mongodb-labs/drivers-github-tools/node/publish_asset_to_s3@v2
         with:
           version: ${{ steps.get_version.outputs.package_version }}
           product_name: node-mongodb-native

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
   upload_sbom_lite:
     environment: release
     runs-on: ubuntu-latest
-    # needs: [release_please]
+    needs: [release_please]
     permissions:
       # required for all workflows
       security-events: write
@@ -112,4 +112,4 @@ jobs:
           version: ${{ steps.get_version.outputs.package_version }}
           product_name: node-mongodb-native
           file: sbom.json
-          dry_run:  false
+          dry_run:  ${{ needs.release_please.outputs.release_created == '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,3 +78,38 @@ jobs:
           product_name: node-mongodb-native
           file: sarif-report.json
           dry_run:  ${{ needs.release_please.outputs.release_created == '' }}
+
+
+  upload_sbom_lite:
+    environment: release
+    runs-on: ubuntu-latest
+    # needs: [release_please]
+    permissions:
+      # required for all workflows
+      security-events: write
+      id-token: write
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up drivers-github-tools
+        uses: mongodb-labs/drivers-github-tools/setup@v2
+        with:
+          aws_region_name: us-east-1
+          aws_role_arn: ${{ secrets.aws_role_arn }}
+          aws_secret_id: ${{ secrets.aws_secret_id }}
+
+      - name: Get release version and release package file name
+        id: get_version
+        shell: bash
+        run: |
+          package_version=$(jq --raw-output '.version' package.json)
+          echo "package_version=${package_version}" >> "$GITHUB_OUTPUT"
+
+      - name: actions/publish_asset_to_s3
+        uses: mongodb-labs/drivers-github-tools/node/publish_asset_to_s3@main
+        with:
+          version: ${{ steps.get_version.outputs.package_version }}
+          product_name: node-mongodb-native
+          file: sbom.json
+          dry_run:  false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
         uses: ./.github/actions/setup
       - name: actions/compress_sign_and_upload
         uses: ./.github/actions/compress_sign_and_upload
-        with: 
+        with:
           aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
           aws_region_name: 'us-east-1'
           aws_secret_id: ${{ secrets.AWS_SECRET_ID }}
@@ -38,3 +38,44 @@ jobs:
       - run: npm publish --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  generate_sarif_report:
+    environment: release
+    runs-on: ubuntu-latest
+    # needs: [release_please]
+    permissions:
+      # required for all workflows
+      security-events: write
+      id-token: write
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up drivers-github-tools
+        uses: mongodb-labs/drivers-github-tools/setup@v2
+        with:
+          aws_region_name: us-east-1
+          aws_role_arn: ${{ secrets.aws_role_arn }}
+          aws_secret_id: ${{ secrets.aws_secret_id }}
+
+      - name: "Generate Sarif Report"
+        # TODO: Use v2 once it has been re-tagged to include this action
+        uses: mongodb-labs/drivers-github-tools/code-scanning-export@main
+        with:
+          ref: main
+          output-file: sarif-report.json
+
+      - name: Get release version and release package file name
+        id: get_version
+        shell: bash
+        run: |
+          package_version=$(jq --raw-output '.version' package.json)
+          echo "package_version=${package_version}" >> "$GITHUB_OUTPUT"
+      - name: actions/publish_asset_to_s3
+        uses: mongodb-labs/drivers-github-tools/node/publish_asset_to_s3@main
+        with:
+          version: ${{ steps.get_version.outputs.package_version }}
+          product_name: node-mongodb-native
+          file: sarif-report.json
+          dry_run:  false
+          # dry_run:  ${{ needs.release_please.outputs.release_created == '' }}


### PR DESCRIPTION
### Description

#### What is changing?

Sarif reports are generated and upload to s3 upon release.

Our sbom.json file is also uploaded with releases.

Example upload to s3 from main: 

<img width="748" alt="Screenshot 2024-06-12 at 1 13 46 PM" src="https://github.com/mongodb/node-mongodb-native/assets/23407842/c093a066-ab77-4ea7-bf78-dd4c1a206c36">

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--

Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
