### PR TITLE
feat(NODE-6225): add property ownership check before referencing `mongocryptdSpawnPath` and `mongocryptdSpawnArgs`

### DIFF
--- a/src/client-side-encryption/mongocryptd_manager.ts
+++ b/src/client-side-encryption/mongocryptd_manager.ts
@@ -24,10 +24,9 @@ export class MongocryptdManager {
 
     this.bypassSpawn = !!extraOptions.mongocryptdBypassSpawn;
 
-    if (Object.hasOwn(extraOptions, 'mongocryptdSpawnPath')) {
-      this.spawnPath = extraOptions.mongocryptdSpawnPath || '';
+    if (Object.hasOwn(extraOptions, 'mongocryptdSpawnPath') && extraOptions.mongocryptdSpawnPath) {
+      this.spawnPath = extraOptions.mongocryptdSpawnPath;
     }
-    this.spawnArgs = [];
     if (
       Object.hasOwn(extraOptions, 'mongocryptdSpawnArgs') &&
       Array.isArray(extraOptions.mongocryptdSpawnArgs)

--- a/src/client-side-encryption/mongocryptd_manager.ts
+++ b/src/client-side-encryption/mongocryptd_manager.ts
@@ -24,9 +24,11 @@ export class MongocryptdManager {
 
     this.bypassSpawn = !!extraOptions.mongocryptdBypassSpawn;
 
-    this.spawnPath = extraOptions.mongocryptdSpawnPath || '';
+    if (Object.keys(extraOptions).includes('mongocryptdSpawnPath')) {
+      this.spawnPath = extraOptions.mongocryptdSpawnPath || '';
+    } else this.spawnPath = '';
     this.spawnArgs = [];
-    if (Array.isArray(extraOptions.mongocryptdSpawnArgs)) {
+    if (Object.keys(extraOptions).includes('mongocryptdSpawnArgs') && Array.isArray(extraOptions.mongocryptdSpawnArgs)) {
       this.spawnArgs = this.spawnArgs.concat(extraOptions.mongocryptdSpawnArgs);
     }
     if (

--- a/src/client-side-encryption/mongocryptd_manager.ts
+++ b/src/client-side-encryption/mongocryptd_manager.ts
@@ -12,8 +12,8 @@ export class MongocryptdManager {
 
   uri: string;
   bypassSpawn: boolean;
-  spawnPath: string;
-  spawnArgs: Array<string>;
+  spawnPath = '';
+  spawnArgs: Array<string> = [];
   _child?: ChildProcess;
 
   constructor(extraOptions: AutoEncryptionExtraOptions = {}) {
@@ -24,11 +24,14 @@ export class MongocryptdManager {
 
     this.bypassSpawn = !!extraOptions.mongocryptdBypassSpawn;
 
-    if (Object.keys(extraOptions).includes('mongocryptdSpawnPath')) {
+    if (Object.hasOwn(extraOptions, 'mongocryptdSpawnPath')) {
       this.spawnPath = extraOptions.mongocryptdSpawnPath || '';
-    } else this.spawnPath = '';
+    }
     this.spawnArgs = [];
-    if (Object.keys(extraOptions).includes('mongocryptdSpawnArgs') && Array.isArray(extraOptions.mongocryptdSpawnArgs)) {
+    if (
+      Object.hasOwn(extraOptions, 'mongocryptdSpawnArgs') &&
+      Array.isArray(extraOptions.mongocryptdSpawnArgs)
+    ) {
       this.spawnArgs = this.spawnArgs.concat(extraOptions.mongocryptdSpawnArgs);
     }
     if (

--- a/test/unit/client-side-encryption/mongocryptd_manager.test.ts
+++ b/test/unit/client-side-encryption/mongocryptd_manager.test.ts
@@ -28,7 +28,7 @@ describe('MongocryptdManager', function () {
   });
 
   it('does not allow prototype pollution on spawn args', function () {
-    const mcdm = new MongocryptdManager({ __proto__: { mongocryptdSpawnArgs: 'test' } });
+    const mcdm = new MongocryptdManager({ __proto__: { mongocryptdSpawnArgs: ['test'] } });
     expect(mcdm.spawnArgs).to.deep.equal(['--idleShutdownTimeoutSecs', '60']);
   });
 

--- a/test/unit/client-side-encryption/mongocryptd_manager.test.ts
+++ b/test/unit/client-side-encryption/mongocryptd_manager.test.ts
@@ -22,6 +22,16 @@ describe('MongocryptdManager', function () {
     expect(mcdm.spawnArgs).to.deep.equal(['--idleShutdownTimeoutSecs', '12']);
   });
 
+  it('does not allow prototype pollution on spawn path', function () {
+    const mcdm = new MongocryptdManager({ __proto__: { mongocryptdSpawnPath: 'test' } });
+    expect(mcdm.spawnPath).to.equal('');
+  });
+
+  it('does not allow prototype pollution on spawn args', function () {
+    const mcdm = new MongocryptdManager({ __proto__: { mongocryptdSpawnArgs: 'test' } });
+    expect(mcdm.spawnArgs).to.deep.equal(['--idleShutdownTimeoutSecs', '60']);
+  });
+
   it('should not override `idleShutdownTimeoutSecs` if the user sets it using `key=value` form', function () {
     const mcdm = new MongocryptdManager({
       mongocryptdSpawnArgs: ['--idleShutdownTimeoutSecs=12']

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
     "skipLibCheck": true,
     "lib": [
       "es2021",
-      "ES2022.Error"
+      "ES2022.Error",
+      "ES2022.Object"
     ],
     // We don't make use of tslib helpers, all syntax used is supported by target engine
     "importHelpers": false,


### PR DESCRIPTION
To prevent prototype pollution gadget, added a check to ensure that 'mongocryptSpawnPath' and 'mongocryptSpawnArgs' properties exist in 'extraOptions' object before assigning them to 'this.spawnPath' and 'this.spawnArgs', which are passed to 'spawn' function in line 53. 

HackerOne report: https://hackerone.com/bugs?subject=user&report_id=2522466

### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Only permit mongocryptd spawn path and arguments to be own properties

We have added some defensive programming to the options that specify spawn path and spawn arguments for `mongocryptd` due to the sensitivity of the system resource they control, namely, launching a process. Now, `mongocryptdSpawnPath` and `mongocryptdSpawnArgs` **must** be [own properties](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn) of `autoEncryption.extraOptions`. This makes it more difficult for a global prototype pollution bug related to these options to occur.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
