### PR TITLE
fix(NODE-6241): allow `Binary` as local KMS provider key

### DIFF
--- a/src/client-side-encryption/providers/index.ts
+++ b/src/client-side-encryption/providers/index.ts
@@ -40,7 +40,7 @@ export interface LocalKMSProviderConfiguration {
    * The master key used to encrypt/decrypt data keys.
    * A 96-byte long Buffer or base64 encoded string.
    */
-  key: Binary | Buffer | string;
+  key: Binary | Uint8Array | string;
 }
 
 /** @public */

--- a/src/client-side-encryption/providers/index.ts
+++ b/src/client-side-encryption/providers/index.ts
@@ -1,3 +1,4 @@
+import type { Binary } from '../../bson';
 import { loadAWSCredentials } from './aws';
 import { loadAzureCredentials } from './azure';
 import { loadGCPCredentials } from './gcp';
@@ -39,7 +40,7 @@ export interface LocalKMSProviderConfiguration {
    * The master key used to encrypt/decrypt data keys.
    * A 96-byte long Buffer or base64 encoded string.
    */
-  key: Buffer | string;
+  key: Binary | Buffer | string;
 }
 
 /** @public */

--- a/test/types/client-side-encryption.test-d.ts
+++ b/test/types/client-side-encryption.test-d.ts
@@ -9,7 +9,7 @@ import type {
   KMSProviders,
   RangeOptions
 } from '../..';
-import type { ClientEncryptionDataKeyProvider } from '../mongodb';
+import { Binary, type ClientEncryptionDataKeyProvider } from '../mongodb';
 
 type RequiredCreateEncryptedCollectionSettings = Parameters<
   ClientEncryption['createEncryptedCollection']
@@ -51,6 +51,10 @@ expectAssignable<RequiredCreateEncryptedCollectionSettings>({
 
 {
   // KMSProviders
+  // local
+  expectAssignable<KMSProviders['local']>({ key: '' });
+  expectAssignable<KMSProviders['local']>({ key: Buffer.alloc(0) });
+  expectAssignable<KMSProviders['local']>({ key: Binary.createFromBase64('') });
   // aws
   expectAssignable<KMSProviders['aws']>({ accessKeyId: '', secretAccessKey: '' });
   expectAssignable<KMSProviders['aws']>({


### PR DESCRIPTION
This aligns the types with actual behavior as well as the shell's expected set of supported types.

### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

Accurate TS

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### The `LocalKMSProviderConfiguration`'s `key` property accepts `Binary`

A `local` KMS provider at runtime accepted a `BSON` `Binary` instance but the Typescript inaccurately only permitted `Buffer` and `string`. 

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
