### PR TITLE
fix(NODE-6242): close becomes true after calling close when documents still remain

### DIFF
--- a/test/integration/change-streams/change_stream.test.ts
+++ b/test/integration/change-streams/change_stream.test.ts
@@ -1060,7 +1060,8 @@ describe('Change Streams', function () {
             await changeStreamIterator.next();
             await changeStreamIterator.return();
             expect(changeStream.closed).to.be.true;
-            expect(changeStream.cursor).property('closed', true);
+            expect(changeStream.cursor).property('isClosed', true);
+            expect(changeStream.cursor).nested.property('session.hasEnded', true);
           }
         );
 

--- a/test/integration/node-specific/abstract_cursor.test.ts
+++ b/test/integration/node-specific/abstract_cursor.test.ts
@@ -7,7 +7,6 @@ import { inspect } from 'util';
 import {
   type Collection,
   type FindCursor,
-  Long,
   MongoAPIError,
   type MongoClient,
   MongoServerError
@@ -194,7 +193,9 @@ describe('class AbstractCursor', function () {
         const error = await cursor.toArray().catch(e => e);
 
         expect(error).be.instanceOf(MongoAPIError);
-        expect(cursor.closed).to.be.true;
+        expect(cursor.id.isZero()).to.be.true;
+        // The first batch exhausted the cursor, the only thing to clean up is the session
+        expect(cursor.session.hasEnded).to.be.true;
       });
     });
 
@@ -226,7 +227,9 @@ describe('class AbstractCursor', function () {
           }
         } catch (error) {
           expect(error).to.be.instanceOf(MongoAPIError);
-          expect(cursor.closed).to.be.true;
+          expect(cursor.id.isZero()).to.be.true;
+          // The first batch exhausted the cursor, the only thing to clean up is the session
+          expect(cursor.session.hasEnded).to.be.true;
         }
       });
     });
@@ -260,7 +263,9 @@ describe('class AbstractCursor', function () {
 
         const error = await cursor.forEach(iterator).catch(e => e);
         expect(error).to.be.instanceOf(MongoAPIError);
-        expect(cursor.closed).to.be.true;
+        expect(cursor.id.isZero()).to.be.true;
+        // The first batch exhausted the cursor, the only thing to clean up is the session
+        expect(cursor.session.hasEnded).to.be.true;
       });
     });
   });

--- a/test/integration/node-specific/cursor_async_iterator.test.js
+++ b/test/integration/node-specific/cursor_async_iterator.test.js
@@ -95,7 +95,7 @@ describe('Cursor Async Iterator Tests', function () {
       }
 
       expect(count).to.equal(1);
-      expect(cursor.closed).to.be.true;
+      expect(cursor.killed).to.be.true;
     });
 
     it('cleans up cursor when breaking out of for await of loops', async function () {
@@ -106,7 +106,8 @@ describe('Cursor Async Iterator Tests', function () {
         break;
       }
 
-      expect(cursor.closed).to.be.true;
+      // The expectation is that we have "cleaned" up the cursor on the server side
+      expect(cursor.killed).to.be.true;
     });
 
     it('returns when attempting to reuse the cursor after a break', async function () {
@@ -118,7 +119,7 @@ describe('Cursor Async Iterator Tests', function () {
         break;
       }
 
-      expect(cursor.closed).to.be.true;
+      expect(cursor.killed).to.be.true;
 
       for await (const doc of cursor) {
         expect.fail('Async generator returns immediately if cursor is closed', doc);


### PR DESCRIPTION
### Description

#### What is changing?

Fix a change in behavior to close introduced in a recent cursor refactor. The expectation was that close became true when no more documents remain locally.

##### Is there new documentation needed for these changes?

Yes, API docs updated.

#### What is the motivation for this change?

The closed flag is used to determine if there are docs remaing in mongosh

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Clarified cursor state properties

The cursor has a few properties that represent the current state from the perspective of the driver and server. This PR corrects an issue that never made it to a release but we would like to take the opportunity to re-highlight what each of these properties mean.

- `cursor.closed` - `cursor.close()` has been called, and there are no more documents stored in the cursor.
- `cursor.killed` - `cursor.close()` was called while the cursor still had a non-zero id, and the driver sent a killCursors command to free server-side resources
- `cursor.id == null` - The cursor has yet to send it's first command (ex. `find`, `aggregate`)
- `cursor.id.isZero()` - The server sent the driver a cursor id of `0` indicating a cursor no longer exists on the server side because all data has been returned to the driver.
- `cursor.bufferedCount()` - The amount of documents stored locally in the cursor. 

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
