### PR TITLE
docs(NODE-6234): update release integrity section

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ The official [MongoDB](https://www.mongodb.com/) driver for Node.js.
 
 ### Release Integrity
 
+Releases are created automatically and signed using the [Node team's GPG key](https://pgp.mongodb.com/node-driver.asc). This applies to the git tag as well as all release packages provided as part of a GitHub release. To verify the provided packages, download the key and import it using gpg:
+
+```shell
+gpg --import node-driver.asc
+```
+
 The GitHub release contains a detached signature file for the NPM package (named
 `mongodb-X.Y.Z.tgz.sig`).
 
@@ -38,6 +44,9 @@ To verify the integrity of the downloaded package, run the following command:
 ```shell
 gpg --verify mongodb-X.Y.Z.tgz.sig mongodb-X.Y.Z.tgz
 ```
+
+>[!Note]
+No verification is done when using npm to install the package. To ensure release integrity when using npm, download the tarball manually from the GitHub release, verify the signature, then install the package from the downloaded tarball using `npm install mongodb-X.Y.Z.tgz`.
 
 ### Bugs / Feature Requests
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ gpg --verify mongodb-X.Y.Z.tgz.sig mongodb-X.Y.Z.tgz
 ```
 
 >[!Note]
-No verification is done when using npm to install the package. To ensure release integrity when using npm, download the tarball manually from the GitHub release, verify the signature, then install the package from the downloaded tarball using `npm install mongodb-X.Y.Z.tgz`.
+No verification is done when using npm to install the package. The contents of the Github tarball and npm's tarball are identical.
 
 ### Bugs / Feature Requests
 


### PR DESCRIPTION
### Description

Updates the release integrity section with links to the GPG key and npm note.

#### What is changing?

README.md

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-6234

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
