### PR TITLE
fix(NODE-6249): prevent make invocation on falsy responseType

### DIFF
--- a/src/cmap/connection.ts
+++ b/src/cmap/connection.ts
@@ -449,7 +449,7 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
         this.socket.setTimeout(0);
         const bson = response.parse();
 
-        const document = (responseType ?? MongoDBResponse).make(bson);
+        const document = (responseType || MongoDBResponse).make(bson);
 
         yield document;
         this.throwIfAborted();


### PR DESCRIPTION
### Description

By [NODE-6249](https://jira.mongodb.org/browse/NODE-6249) we are receiving a `TypeError` in the `changeStream.on('error') handler`:

```sh
TypeError: responseType ?? responses_1.MongoDBResponse).make is not a function
```

This `TypeError` can occur either because:

* `responseType` is _falsy_ (but not _nullish_); or
* an unexpected `responseType` that doesn't fit the `MongoDBResponseConstructor` type is received

#### What is changing?

This PR proposes a change that makes the `(responseType/MongoDBResponse).make()` more robust, by falling-back to `MongoDBResponse` on all the falsy values rather than only the nullish ones.

##### Is there new documentation needed for these changes?

don't think so

#### What is the motivation for this change?

As said above, we are receiving a TypeError that feels a lot like a programming error; this may help mitigate the issue; I couldn't find a way (if given some help/insight I can try and further investigate) to understand the actual value for responseType.

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fixed change stream cursor error bug that may result in receiving a TypeError

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [X] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [X] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
