### PR TITLE
test: add toArray perf benchmark

### DIFF
--- a/test/benchmarks/mongoBench/suites/multiBench.js
+++ b/test/benchmarks/mongoBench/suites/multiBench.js
@@ -139,6 +139,22 @@ function makeMultiBench(suite) {
         })
         .teardown(dropDb)
         .teardown(disconnectClient)
+    )
+    .benchmark('findManyAndEmptyCursorToArray', benchmark =>
+      benchmark
+        .taskSize(16.22)
+        .setup(makeLoadJSON('tweet.json'))
+        .setup(makeClient)
+        .setup(connectClient)
+        .setup(initDb)
+        .setup(dropDb)
+        .setup(initCollection)
+        .setup(makeLoadTweets(false))
+        .task(async function () {
+          await this.collection.find({}).toArray();
+        })
+        .teardown(dropDb)
+        .teardown(disconnectClient)
     );
 }
 

--- a/test/benchmarks/mongoBench/suites/multiBench.js
+++ b/test/benchmarks/mongoBench/suites/multiBench.js
@@ -140,7 +140,7 @@ function makeMultiBench(suite) {
         .teardown(dropDb)
         .teardown(disconnectClient)
     )
-    .benchmark('findManyAndEmptyCursorToArray', benchmark =>
+    .benchmark('findManyAndToArray', benchmark =>
       benchmark
         .taskSize(16.22)
         .setup(makeLoadJSON('tweet.json'))


### PR DESCRIPTION
### Description
Add perf benchmark for `AbstractCursor.toArray`

#### What is changing?
New perf benchmark.

##### Is there new documentation needed for these changes?
None.

#### What is the motivation for this change?
To test perf optimizations in NODE-5906 (Optimize toArray).

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### 

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
