### PR TITLE
fix(NODE-6259): replace dynamically assigned length property with a static getter

### DIFF
--- a/src/bulk/common.ts
+++ b/src/bulk/common.ts
@@ -911,8 +911,6 @@ export class BulkWriteShimOperation extends AbstractOperation {
 /** @public */
 export abstract class BulkOperationBase {
   isOrdered: boolean;
-  // Declare dynamically assigned property
-  declare length: number;
   /** @internal */
   s: BulkOperationPrivate;
   operationId?: number;
@@ -1180,6 +1178,10 @@ export abstract class BulkOperationBase {
     );
   }
 
+  get length(): number {
+    return this.s.currentIndex;
+  }
+
   get bsonOptions(): BSONSerializeOptions {
     return this.s.bsonOptions;
   }
@@ -1275,13 +1277,6 @@ export abstract class BulkOperationBase {
     );
   }
 }
-
-Object.defineProperty(BulkOperationBase.prototype, 'length', {
-  enumerable: true,
-  get() {
-    return this.s.currentIndex;
-  }
-});
 
 function isInsertBatch(batch: Batch): boolean {
   return batch.batchType === BatchType.INSERT;

--- a/src/bulk/common.ts
+++ b/src/bulk/common.ts
@@ -911,6 +911,8 @@ export class BulkWriteShimOperation extends AbstractOperation {
 /** @public */
 export abstract class BulkOperationBase {
   isOrdered: boolean;
+  // Declare dynamically assigned property
+  declare length: number;
   /** @internal */
   s: BulkOperationPrivate;
   operationId?: number;


### PR DESCRIPTION
### Description

The length property was declared on the `BulkOperationBase` interface in the `@types/mongodb` package. With version 4.0, installing `@types/mongodb` is no longer required. However, the declarations generated in the `mongodb` package don't have the `length` property.

#### What is changing?

The `BulkOperationBase` type now has a `length` property. This was the behaviour when using `@types/mongodb`.

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

See [this discussion](https://www.mongodb.com/community/forums/t/how-to-check-if-bulkop-is-empty-or-not/287055/4) in the Community Forums.

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### `BulkOperationBase` (super class of `UnorderedBulkOperation` and `OrderedBulkOperation`) now reports `length` property in Typescript

The `length` getter for these classes was defined manually using `Object.defineProperty` which hid it from typescript. Thanks to @sis0k0 we now have the getter defined on the class, which is functionally the same, but a greatly improved DX when working with types. 🎉  

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [X] Ran `npm run check:lint` script
- [X] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [X] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [X] Changes are covered by tests
- [X] New TODOs have a related JIRA ticket
