### PR TITLE
feat(NODE-6252): insertMany and bulkWrite permit readonly arrays

### DIFF
--- a/src/collection.ts
+++ b/src/collection.ts
@@ -292,7 +292,7 @@ export class Collection<TSchema extends Document = Document> {
    * @param options - Optional settings for the command
    */
   async insertMany(
-    docs: OptionalUnlessRequiredId<TSchema>[],
+    docs: ReadonlyArray<OptionalUnlessRequiredId<TSchema>>,
     options?: BulkWriteOptions
   ): Promise<InsertManyResult<TSchema>> {
     return await executeOperation(
@@ -325,7 +325,7 @@ export class Collection<TSchema extends Document = Document> {
    * @throws MongoDriverError if operations is not an array
    */
   async bulkWrite(
-    operations: AnyBulkWriteOperation<TSchema>[],
+    operations: ReadonlyArray<AnyBulkWriteOperation<TSchema>>,
     options?: BulkWriteOptions
   ): Promise<BulkWriteResult> {
     if (!Array.isArray(operations)) {
@@ -336,7 +336,7 @@ export class Collection<TSchema extends Document = Document> {
       this.client,
       new BulkWriteOperation(
         this as TODO_NODE_3286,
-        operations as TODO_NODE_3286,
+        operations,
         resolveOptions(this, options ?? { ordered: true })
       )
     );

--- a/src/operations/bulk_write.ts
+++ b/src/operations/bulk_write.ts
@@ -13,11 +13,11 @@ import { AbstractOperation, Aspect, defineAspects } from './operation';
 export class BulkWriteOperation extends AbstractOperation<BulkWriteResult> {
   override options: BulkWriteOptions;
   collection: Collection;
-  operations: AnyBulkWriteOperation[];
+  operations: ReadonlyArray<AnyBulkWriteOperation>;
 
   constructor(
     collection: Collection,
-    operations: AnyBulkWriteOperation[],
+    operations: ReadonlyArray<AnyBulkWriteOperation>,
     options: BulkWriteOptions
   ) {
     super(options);

--- a/src/operations/insert.ts
+++ b/src/operations/insert.ts
@@ -104,9 +104,9 @@ export interface InsertManyResult<TSchema = Document> {
 export class InsertManyOperation extends AbstractOperation<InsertManyResult> {
   override options: BulkWriteOptions;
   collection: Collection;
-  docs: Document[];
+  docs: ReadonlyArray<Document>;
 
-  constructor(collection: Collection, docs: Document[], options: BulkWriteOptions) {
+  constructor(collection: Collection, docs: ReadonlyArray<Document>, options: BulkWriteOptions) {
     super(options);
 
     if (!Array.isArray(docs)) {

--- a/test/types/community/collection/bulkWrite.test-d.ts
+++ b/test/types/community/collection/bulkWrite.test-d.ts
@@ -1,6 +1,12 @@
 import { expectError } from 'tsd';
 
-import { type Collection, type Document, MongoClient, ObjectId } from '../../../mongodb';
+import {
+  type AnyBulkWriteOperation,
+  type Collection,
+  type Document,
+  MongoClient,
+  ObjectId
+} from '../../../mongodb';
 
 // TODO(NODE-3347): Improve these tests to use more expect assertions
 
@@ -44,6 +50,9 @@ const testDocument: TestSchema = {
   subInterfaceArray: []
 };
 const { ...testDocumentWithoutId } = testDocument;
+
+const rd_array: ReadonlyArray<AnyBulkWriteOperation<TestSchema>> = [];
+collectionType.bulkWrite(rd_array);
 
 // insertOne
 

--- a/test/types/community/collection/insertX.test-d.ts
+++ b/test/types/community/collection/insertX.test-d.ts
@@ -46,6 +46,9 @@ const collection = db.collection<TestModel>('testCollection');
 const testDoc: OptionalId<TestModelWithId> = { stringField: 'a', fruitTags: [] };
 expectType<Parameters<(typeof collection)['insertOne']>[0]>(testDoc);
 
+const rd_array: ReadonlyArray<TestModel> = [];
+await collection.insertMany(rd_array);
+
 const resultOne = await collection.insertOne({
   stringField: 'hola',
   fruitTags: ['Strawberry']


### PR DESCRIPTION
### Description

#### What is changing?

- `insertMany` and `bulkWrite` on the Collection class accept readonly arrays

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

Readonly data structures in TS can be narrowed and index checked, improving DX.

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### `insertMany` and `bulkWrite` accept ReadonlyArray inputs

This improves the typescript developer expirence, developers tend to use ReadonlyArray because it can help understand where mutations are made and when enabling `noUncheckedIndexedAccess` leads to a better type narrowing expirence. 

Please note, that the array is readonly but not the documents, the driver adds _id fields to your documents unless you request that the server generate the _ids with `forceServerObjectId`

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
