### PR TITLE
chore: add TS/types version matrix to CI

### DIFF
--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -348,6 +348,7 @@ functions:
           PROJECT_DIRECTORY: ${PROJECT_DIRECTORY}
           TS_VERSION: ${TS_VERSION}
           TS_CHECK: CHECK_TYPES
+          TYPES_VERSION: ${TYPES_VERSION}
         binary: bash
         args:
           - "${PROJECT_DIRECTORY}/.evergreen/run-typescript.sh"
@@ -362,6 +363,7 @@ functions:
           PROJECT_DIRECTORY: ${PROJECT_DIRECTORY}
           TS_VERSION: ${TS_VERSION}
           TS_CHECK: COMPILE_DRIVER
+          TYPES_VERSION: ${TYPES_VERSION}
         binary: bash
         args:
           - "${PROJECT_DIRECTORY}/.evergreen/run-typescript.sh"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -312,6 +312,7 @@ functions:
           PROJECT_DIRECTORY: ${PROJECT_DIRECTORY}
           TS_VERSION: ${TS_VERSION}
           TS_CHECK: CHECK_TYPES
+          TYPES_VERSION: ${TYPES_VERSION}
         binary: bash
         args:
           - ${PROJECT_DIRECTORY}/.evergreen/run-typescript.sh
@@ -325,6 +326,7 @@ functions:
           PROJECT_DIRECTORY: ${PROJECT_DIRECTORY}
           TS_VERSION: ${TS_VERSION}
           TS_CHECK: COMPILE_DRIVER
+          TYPES_VERSION: ${TYPES_VERSION}
         binary: bash
         args:
           - ${PROJECT_DIRECTORY}/.evergreen/run-typescript.sh
@@ -3459,7 +3461,7 @@ tasks:
             - {key: NPM_VERSION, value: '9'}
       - func: install dependencies
       - func: run lint checks
-  - name: check-types-typescript-next
+  - name: check-types-typescript-next-node-types-18.19.39
     tags:
       - check-types-typescript-next
       - typescript-compilation
@@ -3471,23 +3473,10 @@ tasks:
             - {key: NODE_LTS_VERSION, value: '16'}
             - {key: NPM_VERSION, value: '9'}
             - {key: TS_VERSION, value: next}
+            - {key: TYPES_VERSION, value: 18.19.39}
       - func: install dependencies
       - func: check types
-  - name: compile-driver-typescript-current
-    tags:
-      - compile-driver-typescript-current
-      - typescript-compilation
-    commands:
-      - command: expansions.update
-        type: setup
-        params:
-          updates:
-            - {key: NODE_LTS_VERSION, value: '16'}
-            - {key: NPM_VERSION, value: '9'}
-            - {key: TS_VERSION, value: current}
-      - func: install dependencies
-      - func: compile driver
-  - name: check-types-typescript-current
+  - name: check-types-typescript-current-node-types-18.19.39
     tags:
       - check-types-typescript-current
       - typescript-compilation
@@ -3499,9 +3488,40 @@ tasks:
             - {key: NODE_LTS_VERSION, value: '16'}
             - {key: NPM_VERSION, value: '9'}
             - {key: TS_VERSION, value: current}
+            - {key: TYPES_VERSION, value: 18.19.39}
       - func: install dependencies
       - func: check types
-  - name: check-types-typescript-4.4
+  - name: check-types-typescript-next-node-types-16.x
+    tags:
+      - check-types-typescript-next
+      - typescript-compilation
+    commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NODE_LTS_VERSION, value: '16'}
+            - {key: NPM_VERSION, value: '9'}
+            - {key: TS_VERSION, value: next}
+            - {key: TYPES_VERSION, value: 16.x}
+      - func: install dependencies
+      - func: check types
+  - name: check-types-typescript-current-node-types-16.x
+    tags:
+      - check-types-typescript-current
+      - typescript-compilation
+    commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NODE_LTS_VERSION, value: '16'}
+            - {key: NPM_VERSION, value: '9'}
+            - {key: TS_VERSION, value: current}
+            - {key: TYPES_VERSION, value: 16.x}
+      - func: install dependencies
+      - func: check types
+  - name: check-types-typescript-4.4-node-types-18.11.9
     tags:
       - check-types-typescript-4.4
       - typescript-compilation
@@ -3513,8 +3533,39 @@ tasks:
             - {key: NODE_LTS_VERSION, value: '16'}
             - {key: NPM_VERSION, value: '9'}
             - {key: TS_VERSION, value: '4.4'}
+            - {key: TYPES_VERSION, value: 18.11.9}
       - func: install dependencies
       - func: check types
+  - name: compile-driver-typescript-current-node-types-18.19.39
+    tags:
+      - compile-driver-typescript-current
+      - typescript-compilation
+    commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NODE_LTS_VERSION, value: '16'}
+            - {key: NPM_VERSION, value: '9'}
+            - {key: TS_VERSION, value: current}
+            - {key: TYPES_VERSION, value: 18.19.39}
+      - func: install dependencies
+      - func: compile driver
+  - name: compile-driver-typescript-current-node-types-16.x
+    tags:
+      - compile-driver-typescript-current
+      - typescript-compilation
+    commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NODE_LTS_VERSION, value: '16'}
+            - {key: NPM_VERSION, value: '9'}
+            - {key: TS_VERSION, value: current}
+            - {key: TYPES_VERSION, value: 16.x}
+      - func: install dependencies
+      - func: compile driver
   - name: download-and-merge-coverage
     tags: []
     commands:


### PR DESCRIPTION
### Description

#### What is changing?

Working on the spike for explicit resource management, I realized we didn't have any sort of matrix coverage for TS version x Node types version, so I added one.  The matrix here doesn't change existing compatibility, it just tests what we already supported.  

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
