### PR TITLE
feat(NODE-6278): deprecate 3.6 servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,11 @@ Change history can be found in [`HISTORY.md`](https://github.com/mongodb/node-mo
 
 ### Compatibility
 
-For server and runtime version compatibility matrices, please refer to the following links:
+The driver currently supports 3.6+ servers.
+
+** 3.6 support is deprecated and support will be removed in a future version **
+
+For exhaustive server and runtime version compatibility matrices, please refer to the following links:
 
 - [MongoDB](https://www.mongodb.com/docs/drivers/node/current/compatibility/#mongodb-compatibility)
 - [NodeJS](https://www.mongodb.com/docs/drivers/node/current/compatibility/#language-compatibility)


### PR DESCRIPTION
### Description

#### What is changing?

This PR adds a readme change primarily so that we have a PR for which to add release highlights.  We must communicate to users at least a minor version ahead of dropping support for a server version.

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### 3.6 Server Support Deprecated

Support for 3.6 servers is deprecated and will be removed in a future version.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
