### PR TITLE
test(NODE-6098): enable unified valid fail tests

### DIFF
--- a/test/integration/unified-test-format/unified_test_format.spec.test.ts
+++ b/test/integration/unified-test-format/unified_test_format.spec.test.ts
@@ -41,7 +41,11 @@ const filter: TestFilter = ({ description }) => {
   return false;
 };
 
-describe('Unified test format runner', function unifiedTestRunner() {
+describe('Unified test format runner (valid-pass)', function unifiedTestRunner() {
   // Valid tests that should pass
   runUnifiedSuite(loadSpecTests('unified-test-format/valid-pass'), filter);
+});
+
+describe('Unified test format runner (valid-fail)', function unifiedTestRunner() {
+  runUnifiedSuite(loadSpecTests('unified-test-format/valid-fail'), () => false, true);
 });

--- a/test/spec/unified-test-format/valid-fail/entity-findCursor-malformed.json
+++ b/test/spec/unified-test-format/valid-fail/entity-findCursor-malformed.json
@@ -1,0 +1,44 @@
+{
+  "description": "entity-findCursor-malformed",
+  "schemaVersion": "1.3",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "database0Name"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "databaseName": "database0Name",
+      "collectionName": "coll0",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "createFindCursor fails if filter is not specified",
+      "operations": [
+        {
+          "name": "createFindCursor",
+          "object": "collection0",
+          "saveResultAsEntity": "cursor0"
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/unified-test-format/valid-fail/entity-findCursor-malformed.yml
+++ b/test/spec/unified-test-format/valid-fail/entity-findCursor-malformed.yml
@@ -1,0 +1,31 @@
+# This test is split out into a separate file to accommodate drivers that validate operation structure while decoding
+# from JSON/YML. Such drivers fail to decode any files containing invalid operations. Combining this test in a file
+# with other entity-findCursor valid-fail tests, which test failures that occur during test execution, would prevent
+# such drivers from decoding the file and running any of the tests.
+description: entity-findCursor-malformed
+
+schemaVersion: '1.3'
+
+createEntities:
+  - client:
+      id: &client0 client0
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name database0Name
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData:
+  - databaseName: *database0Name
+    collectionName: *collection0Name
+    documents: []
+
+tests:
+  - description: createFindCursor fails if filter is not specified
+    operations:
+      - name: createFindCursor
+        object: *collection0
+        saveResultAsEntity: &cursor0 cursor0

--- a/test/spec/unified-test-format/valid-fail/entity-findCursor.json
+++ b/test/spec/unified-test-format/valid-fail/entity-findCursor.json
@@ -1,0 +1,52 @@
+{
+  "description": "entity-findCursor",
+  "schemaVersion": "1.3",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "database0Name"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "databaseName": "database0Name",
+      "collectionName": "coll0",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "iterateUntilDocumentOrError fails if it references a nonexistent entity",
+      "operations": [
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "cursor0"
+        }
+      ]
+    },
+    {
+      "description": "close fails if it references a nonexistent entity",
+      "operations": [
+        {
+          "name": "close",
+          "object": "cursor0"
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/unified-test-format/valid-fail/entity-findCursor.yml
+++ b/test/spec/unified-test-format/valid-fail/entity-findCursor.yml
@@ -1,0 +1,31 @@
+description: entity-findCursor
+
+schemaVersion: '1.3'
+
+createEntities:
+  - client:
+      id: &client0 client0
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name database0Name
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData:
+  - databaseName: *database0Name
+    collectionName: *collection0Name
+    documents: []
+
+tests:
+  - description: iterateUntilDocumentOrError fails if it references a nonexistent entity
+    operations:
+      - name: iterateUntilDocumentOrError
+        object: cursor0
+
+  - description: close fails if it references a nonexistent entity
+    operations:
+      - name: close
+        object: cursor0

--- a/test/spec/unified-test-format/valid-fail/ignoreResultAndError-malformed.json
+++ b/test/spec/unified-test-format/valid-fail/ignoreResultAndError-malformed.json
@@ -1,5 +1,5 @@
 {
-  "description": "ignoreResultAndError",
+  "description": "ignoreResultAndError-malformed",
   "schemaVersion": "1.3",
   "createEntities": [
     {
@@ -32,26 +32,15 @@
   ],
   "tests": [
     {
-      "description": "operation errors are not ignored if ignoreResultAndError is false",
+      "description": "malformed operation fails if ignoreResultAndError is true",
       "operations": [
         {
           "name": "insertOne",
           "object": "collection0",
           "arguments": {
-            "document": {
-              "_id": 1
-            }
-          }
-        },
-        {
-          "name": "insertOne",
-          "object": "collection0",
-          "arguments": {
-            "document": {
-              "_id": 1
-            }
+            "foo": "bar"
           },
-          "ignoreResultAndError": false
+          "ignoreResultAndError": true
         }
       ]
     }

--- a/test/spec/unified-test-format/valid-fail/ignoreResultAndError-malformed.yml
+++ b/test/spec/unified-test-format/valid-fail/ignoreResultAndError-malformed.yml
@@ -1,0 +1,34 @@
+# This test is split out into a separate file to accommodate drivers that validate operation structure while decoding
+# from JSON/YML. Such drivers fail to decode any files containing invalid operations. Combining this test in a file
+# with other ignoreResultAndError valid-fail tests, which test failures that occur during test execution, would prevent
+# such drivers from decoding the file and running any of the tests.
+description: ignoreResultAndError-malformed  
+
+schemaVersion: '1.3'
+
+createEntities:
+  - client:
+      id: &client0 client0
+      useMultipleMongoses: true
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name database0Name
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents: []
+
+tests:
+  - description: malformed operation fails if ignoreResultAndError is true
+    operations:
+      - name: insertOne
+        object: *collection0
+        arguments:
+          foo: bar
+        ignoreResultAndError: true

--- a/test/spec/unified-test-format/valid-fail/ignoreResultAndError.yml
+++ b/test/spec/unified-test-format/valid-fail/ignoreResultAndError.yml
@@ -33,11 +33,3 @@ tests:
           # Insert the same document to force a DuplicateKey error.
           document: *insertDocument
         ignoreResultAndError: false
-
-  - description: malformed operation fails if ignoreResultAndError is true
-    operations:
-      - name: insertOne
-        object: *collection0
-        arguments:
-          foo: bar
-        ignoreResultAndError: true

--- a/test/spec/unified-test-format/valid-fail/operation-unsupported.json
+++ b/test/spec/unified-test-format/valid-fail/operation-unsupported.json
@@ -1,0 +1,22 @@
+{
+  "description": "operation-unsupported",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "Unsupported operation",
+      "operations": [
+        {
+          "name": "unsupportedOperation",
+          "object": "client0"
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/unified-test-format/valid-fail/operation-unsupported.yml
+++ b/test/spec/unified-test-format/valid-fail/operation-unsupported.yml
@@ -1,0 +1,13 @@
+description: "operation-unsupported"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+
+tests:
+  - description: "Unsupported operation"
+    operations:
+      - name: unsupportedOperation
+        object: *client0

--- a/test/tools/unified-spec-runner/entities.ts
+++ b/test/tools/unified-spec-runner/entities.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { AssertionError, expect } from 'chai';
 import { EventEmitter } from 'events';
 
 import {
@@ -303,7 +303,7 @@ export class UnifiedMongoClient extends MongoClient {
       case 'all':
         return [...this.commandEvents, ...this.cmapEvents, ...this.sdamEvents];
       default:
-        throw new Error(`Unknown eventType: ${eventType}`);
+        throw new AssertionError(`Unknown eventType: ${eventType}`);
     }
   }
 
@@ -490,7 +490,7 @@ export class EntitiesMap<E = Entity> extends Map<string, E> {
   mapOf(type: EntityTypeId): EntitiesMap<Entity> {
     const ctor = ENTITY_CTORS.get(type);
     if (!ctor) {
-      throw new Error(`Unknown type ${type}`);
+      throw new AssertionError(`Unknown type ${type}`);
     }
     return new EntitiesMap(Array.from(this.entries()).filter(([, e]) => e instanceof ctor));
   }
@@ -522,7 +522,7 @@ export class EntitiesMap<E = Entity> extends Map<string, E> {
   getEntity(type: EntityTypeId, key: string, assertExists = true): Entity | undefined {
     const entity = this.get(key);
     if (!entity) {
-      if (assertExists) throw new Error(`Entity '${key}' does not exist`);
+      if (assertExists) throw new AssertionError(`Entity '${key}' does not exist`);
       return undefined;
     }
     if (NO_INSTANCE_CHECK.includes(type)) {
@@ -531,10 +531,10 @@ export class EntitiesMap<E = Entity> extends Map<string, E> {
     }
     const ctor = ENTITY_CTORS.get(type);
     if (!ctor) {
-      throw new Error(`Unknown type ${type}`);
+      throw new AssertionError(`Unknown type ${type}`);
     }
     if (!(entity instanceof ctor)) {
-      throw new Error(`${key} is not an instance of ${type}`);
+      throw new AssertionError(`${key} is not an instance of ${type}`);
     }
     return entity;
   }
@@ -672,13 +672,13 @@ export class EntitiesMap<E = Entity> extends Map<string, E> {
       } else if ('thread' in entity) {
         map.set(entity.thread.id, new UnifiedThread(entity.thread.id));
       } else if ('stream' in entity) {
-        throw new Error(`Unsupported Entity ${JSON.stringify(entity)}`);
+        throw new AssertionError(`Unsupported Entity ${JSON.stringify(entity)}`);
       } else if ('clientEncryption' in entity) {
         const clientEncryption = await createClientEncryption(map, entity.clientEncryption);
 
         map.set(entity.clientEncryption.id, clientEncryption);
       } else {
-        throw new Error(`Unsupported Entity ${JSON.stringify(entity)}`);
+        throw new AssertionError(`Unsupported Entity ${JSON.stringify(entity)}`);
       }
     }
     return map;

--- a/test/tools/unified-spec-runner/entity_event_registry.ts
+++ b/test/tools/unified-spec-runner/entity_event_registry.ts
@@ -60,11 +60,15 @@ export class EntityEventRegistry {
   register(): void {
     if (this.clientEntity.storeEventsAsEntities) {
       for (const { id, events } of this.clientEntity.storeEventsAsEntities) {
+        if (this.entitiesMap.has(id) || this.clientEntity.id === id) {
+          throw new Error(`Duplicate id ${id} found while storing events as entities`);
+        }
         this.entitiesMap.set(id, []);
         for (const eventName of events) {
           // Need to map the event names to the Node event names.
           this.client.on(MAPPINGS[eventName], () => {
-            this.entitiesMap.getEntity('events', id).push({
+            const events = this.entitiesMap.getEntity('events', id);
+            events.push({
               name: eventName,
               observedAt: Date.now()
             });

--- a/test/tools/unified-spec-runner/entity_event_registry.ts
+++ b/test/tools/unified-spec-runner/entity_event_registry.ts
@@ -1,3 +1,5 @@
+import { AssertionError } from 'chai';
+
 import {
   COMMAND_FAILED,
   COMMAND_STARTED,
@@ -61,7 +63,7 @@ export class EntityEventRegistry {
     if (this.clientEntity.storeEventsAsEntities) {
       for (const { id, events } of this.clientEntity.storeEventsAsEntities) {
         if (this.entitiesMap.has(id) || this.clientEntity.id === id) {
-          throw new Error(`Duplicate id ${id} found while storing events as entities`);
+          throw new AssertionError(`Duplicate id ${id} found while storing events as entities`);
         }
         this.entitiesMap.set(id, []);
         for (const eventName of events) {

--- a/test/tools/unified-spec-runner/runner.ts
+++ b/test/tools/unified-spec-runner/runner.ts
@@ -306,13 +306,21 @@ async function runUnifiedTest(
  */
 export function runUnifiedSuite(
   specTests: uni.UnifiedSuite[],
-  skipFilter: uni.TestFilter = () => false
+  skipFilter: uni.TestFilter = () => false,
+  expectRuntimeError = false
 ): void {
   for (const unifiedSuite of specTests) {
     context(String(unifiedSuite.description), function () {
       for (const [index, test] of unifiedSuite.tests.entries()) {
         it(String(test.description === '' ? `Test ${index}` : test.description), async function () {
-          await runUnifiedTest(this, unifiedSuite, test, skipFilter);
+          if (expectRuntimeError) {
+            const error = await runUnifiedTest(this, unifiedSuite, test, skipFilter).catch(
+              error => error
+            );
+            expect(error).to.exist;
+          } else {
+            await runUnifiedTest(this, unifiedSuite, test, skipFilter);
+          }
         });
       }
     });

--- a/test/tools/unified-spec-runner/runner.ts
+++ b/test/tools/unified-spec-runner/runner.ts
@@ -1,9 +1,16 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import { expect } from 'chai';
+import { AssertionError, expect } from 'chai';
 import { gte as semverGte, satisfies as semverSatisfies } from 'semver';
 
 import type { MongoClient } from '../../mongodb';
-import { MONGODB_ERROR_CODES, ns, ReadPreference, TopologyType } from '../../mongodb';
+import {
+  MONGODB_ERROR_CODES,
+  MongoParseError,
+  MongoServerError,
+  ns,
+  ReadPreference,
+  TopologyType
+} from '../../mongodb';
 import { ejson } from '../utils';
 import { AstrolabeResultsWriter } from './astrolabe_results_writer';
 import { EntitiesMap, type UnifiedMongoClient } from './entities';
@@ -317,7 +324,14 @@ export function runUnifiedSuite(
             const error = await runUnifiedTest(this, unifiedSuite, test, skipFilter).catch(
               error => error
             );
-            expect(error).to.exist;
+            expect(error).to.satisfy(value => {
+              return (
+                value instanceof AssertionError ||
+                value instanceof MongoServerError ||
+                value instanceof TypeError ||
+                value instanceof MongoParseError
+              );
+            });
           } else {
             await runUnifiedTest(this, unifiedSuite, test, skipFilter);
           }

--- a/test/tools/unified-spec-runner/unified-utils.ts
+++ b/test/tools/unified-spec-runner/unified-utils.ts
@@ -1,5 +1,5 @@
 import { EJSON } from 'bson';
-import { expect } from 'chai';
+import { AssertionError, expect } from 'chai';
 import ConnectionString from 'mongodb-connection-string-url';
 import { gte as semverGte, lte as semverLte } from 'semver';
 import { isDeepStrictEqual } from 'util';
@@ -53,7 +53,7 @@ export async function topologySatisfies(
     }[config.topologyType];
 
     if (!Array.isArray(r.topologies)) {
-      throw new Error('Topology specification must be an array');
+      throw new AssertionError('Topology specification must be an array');
     }
 
     if (r.topologies.includes('sharded-replicaset') && topologyType === 'sharded') {
@@ -63,7 +63,7 @@ export async function topologySatisfies(
         skipReason = `requires sharded-replicaset but shards.length=${shards.length}`;
       }
     } else {
-      if (!topologyType) throw new Error(`Topology undiscovered: ${config.topologyType}`);
+      if (!topologyType) throw new AssertionError(`Topology undiscovered: ${config.topologyType}`);
       ok &&= r.topologies.includes(topologyType);
       if (!ok && skipReason == null) {
         skipReason = `requires ${r.topologies} but discovered a ${topologyType} topology`;
@@ -85,7 +85,8 @@ export async function topologySatisfies(
   }
 
   if (r.serverParameters) {
-    if (!config.parameters) throw new Error('Configuration does not have server parameters');
+    if (!config.parameters)
+      throw new AssertionError('Configuration does not have server parameters');
     for (const [name, value] of Object.entries(r.serverParameters)) {
       if (name in config.parameters) {
         ok &&= isDeepStrictEqual(config.parameters[name], value);
@@ -258,7 +259,7 @@ export function getCSFLETestDataFromEnvironment(environment: Record<string, stri
   tlsOptions: AutoEncryptionOptions['tlsOptions'];
 } {
   if (environment.CSFLE_KMS_PROVIDERS == null) {
-    throw new Error(
+    throw new AssertionError(
       'CSFLE_KMS_PROVIDERS is required to run the csfle tests.  Please make sure it is set in the environment.'
     );
   }
@@ -268,17 +269,17 @@ export function getCSFLETestDataFromEnvironment(environment: Record<string, stri
       relaxed: false
     });
   } catch {
-    throw new Error('Malformed CSFLE_KMS_PROVIDERS provided to unified tests.');
+    throw new AssertionError('Malformed CSFLE_KMS_PROVIDERS provided to unified tests.');
   }
 
   if (environment.KMIP_TLS_CA_FILE == null) {
-    throw new Error(
+    throw new AssertionError(
       'KMIP_TLS_CA_FILE is required to run the csfle tests.  Please make sure it is set in the environment.'
     );
   }
 
   if (environment.KMIP_TLS_CERT_FILE == null) {
-    throw new Error(
+    throw new AssertionError(
       'KMIP_TLS_CERT_FILE is required to run the csfle tests.  Please make sure it is set in the environment.'
     );
   }
@@ -351,7 +352,9 @@ export function mergeKMSProviders(
         : test['sessionToken']);
 
     if (!awsProviders['accessKeyId'] || !awsProviders['secretAccessKey']) {
-      throw new Error('AWS KMS providers must constain "accessKeyId" and "secretAccessKey"');
+      throw new AssertionError(
+        'AWS KMS providers must constain "accessKeyId" and "secretAccessKey"'
+      );
     }
 
     return awsProviders;
@@ -385,7 +388,7 @@ export function mergeKMSProviders(
       !azureProviders['clientId'] ||
       !azureProviders['clientSecret']
     ) {
-      throw new Error(
+      throw new AssertionError(
         'Azure KMS providers must contain "tenantId", "clientId", and "clientSecret"'
       );
     }
@@ -409,7 +412,7 @@ export function mergeKMSProviders(
         : test['endPoint']);
 
     if (!gcpProviders['email'] || !gcpProviders['privateKey']) {
-      throw new Error('GCP KMS providers must contain "email" and "privateKey"');
+      throw new AssertionError('GCP KMS providers must contain "email" and "privateKey"');
     }
 
     return gcpProviders;
@@ -514,7 +517,7 @@ export function mergeKMSProviders(
   }
 
   if (Object.keys(providers).length === 0) {
-    throw new Error('Found empty KMS providers in test');
+    throw new AssertionError('Found empty KMS providers in test');
   }
 
   return providers;
@@ -535,7 +538,7 @@ export async function createClientEncryption(
 
   const clientEntity = map.getEntity('client', keyVaultClient, false);
   if (!clientEntity) {
-    throw new Error(
+    throw new AssertionError(
       'unable to get client entity required by client encryption entity in unified test'
     );
   }

--- a/test/unit/tools/unifed-utils.test.ts
+++ b/test/unit/tools/unifed-utils.test.ts
@@ -4,19 +4,16 @@ import { mergeKMSProviders } from '../../tools/unified-spec-runner/unified-utils
 
 describe('parseOptions', function () {
   context('aws providers', function () {
-    it('does not configure the provider if none is given', function () {
-      const parsedProviders = mergeKMSProviders({}, {});
-      expect(parsedProviders).not.to.have.property('aws');
+    it('throws if none is given', function () {
+      expect(() => {
+        mergeKMSProviders({}, {});
+      }).to.throw();
     });
 
-    it('configures the provider without credentials if an empty object is supplied', function () {
-      const parsedProviders = mergeKMSProviders(
-        {
-          aws: {}
-        },
-        {}
-      );
-      expect(parsedProviders.aws).deep.equal({});
+    it('throws if an empty object is supplied', function () {
+      expect(() => {
+        mergeKMSProviders({ aws: {} }, {});
+      }).to.throw();
     });
 
     it('replaces a $$placeholder value with the value from the environment', function () {
@@ -37,18 +34,19 @@ describe('parseOptions', function () {
       });
     });
 
-    it('omits required fields if the field is not present in the kmsProviders', function () {
-      const parsedProviders = mergeKMSProviders(
-        {
-          aws: {
-            accessKeyId: { $$placeholder: 1 }
+    it('throws if required field is not present in the kmsProviders', function () {
+      expect(() => {
+        mergeKMSProviders(
+          {
+            aws: {
+              accessKeyId: { $$placeholder: 1 }
+            }
+          },
+          {
+            aws: { accessKeyId: 'accessKeyId' }
           }
-        },
-        {
-          aws: { accessKeyId: 'accessKeyId' }
-        }
-      );
-      expect(parsedProviders.aws).not.to.have.property('secretAccessKey');
+        );
+      }).to.throw();
     });
 
     it('configures the provider with the exact credentials from the test', function () {
@@ -76,9 +74,10 @@ describe('parseOptions', function () {
     });
   });
   context('local providers', function () {
-    it('does not configure the provider if none is given', function () {
-      const parsedProviders = mergeKMSProviders({}, {});
-      expect(parsedProviders).not.to.have.property('local');
+    it('throws if none is given', function () {
+      expect(() => {
+        mergeKMSProviders({}, {});
+      }).to.throw();
     });
 
     it('configures the provider without credentials if an empty object is supplied', function () {
@@ -127,19 +126,16 @@ describe('parseOptions', function () {
   });
 
   context('azure', function () {
-    it('does not configure the provider if none is given', function () {
-      const parsedProviders = mergeKMSProviders({}, {});
-      expect(parsedProviders).not.to.have.property('azure');
+    it('throws if none is given', function () {
+      expect(() => {
+        mergeKMSProviders({}, {});
+      }).to.throw();
     });
 
-    it('configures the provider without credentials if an empty object is supplied', function () {
-      const parsedProviders = mergeKMSProviders(
-        {
-          azure: {}
-        },
-        {}
-      );
-      expect(parsedProviders.azure).deep.equal({});
+    it('throws if an empty object is supplied', function () {
+      expect(() => {
+        mergeKMSProviders({ azure: {} }, {});
+      }).to.throw();
     });
 
     it('replaces a $$placeholder value with the value from the environment', function () {
@@ -166,18 +162,19 @@ describe('parseOptions', function () {
       });
     });
 
-    it('omits required fields if the field is not present in the kmsProviders', function () {
-      const parsedProviders = mergeKMSProviders(
-        {
-          azure: {
-            tenantId: 'tenantId',
-            clientSecret: 'clientSecret',
-            identityPlatformEndpoint: 'identifyPlatformEndpoint'
-          }
-        },
-        {}
-      );
-      expect(parsedProviders.azure).not.to.have.property('clientId');
+    it('throws if required field is not present in the kmsProviders', function () {
+      expect(() => {
+        mergeKMSProviders(
+          {
+            azure: {
+              tenantId: 'tenantId',
+              clientSecret: 'clientSecret',
+              identityPlatformEndpoint: 'identifyPlatformEndpoint'
+            }
+          },
+          {}
+        );
+      }).to.throw();
     });
 
     it('configures the provider with the exact credentials from the test otherwise', function () {
@@ -209,19 +206,21 @@ describe('parseOptions', function () {
   });
 
   context('gcp', function () {
-    it('does not configure the provider if none is given', function () {
-      const parsedProviders = mergeKMSProviders({}, {});
-      expect(parsedProviders).not.to.have.property('gcp');
+    it('throws if none is given', function () {
+      expect(() => {
+        mergeKMSProviders({}, {});
+      }).throw();
     });
 
-    it('configures the provider without credentials if an empty object is supplied', function () {
-      const parsedProviders = mergeKMSProviders(
-        {
-          gcp: {}
-        },
-        {}
-      );
-      expect(parsedProviders.gcp).deep.equal({});
+    it('throws if an empty object is supplied', function () {
+      expect(() => {
+        mergeKMSProviders(
+          {
+            gcp: {}
+          },
+          {}
+        );
+      }).to.throw();
     });
 
     it('replaces a $$placeholder value with the value from the environment', function () {
@@ -246,17 +245,18 @@ describe('parseOptions', function () {
       });
     });
 
-    it('omits required fields if the field is not present in the kmsProviders', function () {
-      const parsedProviders = mergeKMSProviders(
-        {
-          gcp: {
-            email: 'email',
-            endPoint: 'endPoint'
-          }
-        },
-        {}
-      );
-      expect(parsedProviders.gcp).not.to.have.property('privateKey');
+    it('throws if required field is not present in the kmsProviders', function () {
+      expect(() => {
+        mergeKMSProviders(
+          {
+            gcp: {
+              email: 'email',
+              endPoint: 'endPoint'
+            }
+          },
+          {}
+        );
+      }).to.throw();
     });
 
     it('configures the provider with the exact credentials from the test otherwise', function () {
@@ -285,9 +285,10 @@ describe('parseOptions', function () {
   });
 
   context('kmip', function () {
-    it('does not configure the provider if none is given', function () {
-      const parsedProviders = mergeKMSProviders({}, {});
-      expect(parsedProviders).not.to.have.property('kmip');
+    it('throws if none is given', function () {
+      expect(() => {
+        mergeKMSProviders({}, {});
+      }).to.throw();
     });
 
     it('configures the provider without credentials if an empty object is supplied', function () {


### PR DESCRIPTION
### Description

Enables the unifed test format's valid-fail tests and fixes all failures.

#### What is changing?

- Syncs the valid-fail tests in the specs directory to latest.
- Adds the necessary validation in the unified runner to pass the tests

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-6098

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
