### PR TITLE
fix(NODE-6276): preserve top level error code MongoWriteConcernError

### DIFF
--- a/src/bulk/common.ts
+++ b/src/bulk/common.ts
@@ -616,8 +616,8 @@ function handleMongoWriteConcernError(
   callback(
     new MongoBulkWriteError(
       {
-        message: err?.result.writeConcernError.errmsg,
-        code: err?.result.writeConcernError.code
+        message: err.result.writeConcernError.errmsg,
+        code: err.result.writeConcernError.code
       },
       new BulkWriteResult(bulkResult, isOrdered)
     )

--- a/src/bulk/common.ts
+++ b/src/bulk/common.ts
@@ -616,8 +616,8 @@ function handleMongoWriteConcernError(
   callback(
     new MongoBulkWriteError(
       {
-        message: err.result?.writeConcernError.errmsg,
-        code: err.result?.writeConcernError.result
+        message: err?.result.writeConcernError.errmsg,
+        code: err?.result.writeConcernError.code
       },
       new BulkWriteResult(bulkResult, isOrdered)
     )

--- a/src/error.ts
+++ b/src/error.ts
@@ -1196,10 +1196,9 @@ export class MongoWriteConcernError extends MongoServerError {
    * @public
    **/
   constructor(result: WriteConcernErrorResult) {
-    super({ ...result, ...result.writeConcernError });
+    super({ ...result.writeConcernError, ...result });
     this.errInfo = result.writeConcernError.errInfo;
     this.result = result;
-    this.code = result.code ?? result.writeConcernError.code ?? undefined;
   }
 
   override get name(): string {
@@ -1247,7 +1246,7 @@ export function needsRetryableWriteLabel(error: Error, maxWireVersion: number): 
   }
 
   if (error instanceof MongoWriteConcernError) {
-    return RETRYABLE_WRITE_ERROR_CODES.has(error.result?.code ?? error.code ?? 0);
+    return RETRYABLE_WRITE_ERROR_CODES.has(error.result.writeConcernError.code ?? error?.code ?? 0);
   }
 
   if (error instanceof MongoError && typeof error.code === 'number') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,7 +73,8 @@ export {
   MongoTopologyClosedError,
   MongoTransactionError,
   MongoUnexpectedServerResponseError,
-  MongoWriteConcernError
+  MongoWriteConcernError,
+  WriteConcernErrorResult
 } from './error';
 export {
   AbstractCursor,

--- a/test/unit/error.test.ts
+++ b/test/unit/error.test.ts
@@ -30,8 +30,7 @@ import {
   setDifference,
   type TopologyDescription,
   type TopologyOptions,
-  WaitQueueTimeoutError as MongoWaitQueueTimeoutError,
-  WriteConcernErrorResult
+  WaitQueueTimeoutError as MongoWaitQueueTimeoutError
 } from '../mongodb';
 import { ReplSetFixture } from '../tools/common';
 import { cleanup } from '../tools/mongodb-mock/index';
@@ -743,22 +742,22 @@ describe('MongoErrors', () => {
   });
 
   describe('MongoWriteConcernError constructor', function () {
-    context('when no top-level code is provided and writeConcernError.code exists', function () {
-      it('error.code remains undefined', function () {
-        const res: WriteConcernErrorResult = {
+    context('when no top-level code is provided', function () {
+      it('error.code is set to writeConcernError.code', function () {
+        const res = {
           writeConcernError: {
             code: 81, // nested code
             errmsg: 'fake msg'
           },
           ok: 1
         };
-        expect(new MongoWriteConcernError(res).code).to.equal(undefined);
+        expect(new MongoWriteConcernError(res).code).to.equal(81);
       });
     });
     context('when top-level code is provided and  writeConcernError.code exists', function () {
       it('error.code equals the top-level code', function () {
         const topLevelCode = 10;
-        const res: WriteConcernErrorResult = {
+        const res = {
           writeConcernError: {
             code: 81, // nested code
             errmsg: 'fake msg'

--- a/test/unit/error.test.ts
+++ b/test/unit/error.test.ts
@@ -30,7 +30,8 @@ import {
   setDifference,
   type TopologyDescription,
   type TopologyOptions,
-  WaitQueueTimeoutError as MongoWaitQueueTimeoutError
+  WaitQueueTimeoutError as MongoWaitQueueTimeoutError,
+  WriteConcernErrorResult
 } from '../mongodb';
 import { ReplSetFixture } from '../tools/common';
 import { cleanup } from '../tools/mongodb-mock/index';
@@ -737,6 +738,35 @@ describe('MongoErrors', () => {
     context('when passed a string', function () {
       it('returns the string', function () {
         expect(MongoError.buildErrorMessage('message')).to.deep.equal('message');
+      });
+    });
+  });
+
+  describe('MongoWriteConcernError constructor', function () {
+    context('when no top-level code is provided and writeConcernError.code exists', function () {
+      it('error.code remains undefined', function () {
+        const res: WriteConcernErrorResult = {
+          writeConcernError: {
+            code: 81, // nested code
+            errmsg: 'fake msg'
+          },
+          ok: 1
+        };
+        expect(new MongoWriteConcernError(res).code).to.equal(undefined);
+      });
+    });
+    context('when top-level code is provided and  writeConcernError.code exists', function () {
+      it('error.code equals the top-level code', function () {
+        const topLevelCode = 10;
+        const res: WriteConcernErrorResult = {
+          writeConcernError: {
+            code: 81, // nested code
+            errmsg: 'fake msg'
+          },
+          ok: 1,
+          code: topLevelCode
+        };
+        expect(new MongoWriteConcernError(res).code).to.equal(topLevelCode);
       });
     });
   });

--- a/test/unit/index.test.ts
+++ b/test/unit/index.test.ts
@@ -108,6 +108,7 @@ const EXPECTED_EXPORTS = [
   'MongoTransactionError',
   'MongoUnexpectedServerResponseError',
   'MongoWriteConcernError',
+  'WriteConcernErrorResult',
   'ObjectId',
   'OrderedBulkOperation',
   'ProfilingLevel',

--- a/test/unit/mongo_client.test.ts
+++ b/test/unit/mongo_client.test.ts
@@ -737,7 +737,7 @@ describe('MongoClient', function () {
     expect(error).to.have.property('code', 'EBADNAME');
   });
 
-  it.only('srvServiceName should not error if it is greater than 15 characters as long as the DNS query limit is not surpassed', async () => {
+  it('srvServiceName should not error if it is greater than 15 characters as long as the DNS query limit is not surpassed', async () => {
     const options = parseOptions('mongodb+srv://localhost.a.com', {
       srvServiceName: 'a'.repeat(16)
     });

--- a/test/unit/mongo_client.test.ts
+++ b/test/unit/mongo_client.test.ts
@@ -737,7 +737,7 @@ describe('MongoClient', function () {
     expect(error).to.have.property('code', 'EBADNAME');
   });
 
-  it('srvServiceName should not error if it is greater than 15 characters as long as the DNS query limit is not surpassed', async () => {
+  it.only('srvServiceName should not error if it is greater than 15 characters as long as the DNS query limit is not surpassed', async () => {
     const options = parseOptions('mongodb+srv://localhost.a.com', {
       srvServiceName: 'a'.repeat(16)
     });


### PR DESCRIPTION
### Description
Preserve top level error code MongoWriteConcernError

#### What is changing?
Ensure that MongoWriteConcernError is correctly formed such that the original top-level code is preserved
- If no top-level code exists, MongoWriteConcernError.code should be set to the nested code
- If a top-level code is passed into the constructor, it shouldn't be changed or overwritten by the nested writeConcernError.code

##### Is there new documentation needed for these changes?
No

#### What is the motivation for this change?
Bug fix

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### `MongoWriteConcernError.code` is overwritten by nested code within `MongoWriteConcernError.result.writeConcernError.code`

`MongoWriteConcernError` is now correctly formed such that the original top-level code is preserved
- If no top-level code exists, `MongoWriteConcernError.code` should be set to `MongoWriteConcernError.result.writeConcernError.code`
- If a top-level code is passed into the constructor, it shouldn't be changed or overwritten by the nested `writeConcernError.code`

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
