### PR TITLE
chore(NODE-6167): fix server matrix and test against new binding location

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1239,12 +1239,12 @@ tasks:
             - {key: NPM_VERSION, value: '9'}
             - {key: VERSION, value: '5.0'}
             - {key: TOPOLOGY, value: replica_set}
-            - {key: CSFLE_GIT_REF, value: 51e172622a0ddf2bf761e4d1e26ca267359086dd}
+            - {key: CSFLE_GIT_REF, value: 38f1be60e3f8d24b066642f742c90d0ffdd0cdc0}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: bootstrap kms servers
       - func: run custom csfle tests
-  - name: run-custom-csfle-tests-5.0-master
+  - name: run-custom-csfle-tests-5.0-main
     tags:
       - run-custom-dependency-tests
       - csfle
@@ -1257,12 +1257,12 @@ tasks:
             - {key: NPM_VERSION, value: '9'}
             - {key: VERSION, value: '5.0'}
             - {key: TOPOLOGY, value: replica_set}
-            - {key: CSFLE_GIT_REF, value: master}
+            - {key: CSFLE_GIT_REF, value: main}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: bootstrap kms servers
       - func: run custom csfle tests
-  - name: run-custom-csfle-tests-rapid-pinned-commit
+  - name: run-custom-csfle-tests-6.0-pinned-commit
     tags:
       - run-custom-dependency-tests
       - csfle
@@ -1273,14 +1273,14 @@ tasks:
           updates:
             - {key: NODE_LTS_VERSION, value: '16'}
             - {key: NPM_VERSION, value: '9'}
-            - {key: VERSION, value: rapid}
+            - {key: VERSION, value: '6.0'}
             - {key: TOPOLOGY, value: replica_set}
-            - {key: CSFLE_GIT_REF, value: 51e172622a0ddf2bf761e4d1e26ca267359086dd}
+            - {key: CSFLE_GIT_REF, value: 38f1be60e3f8d24b066642f742c90d0ffdd0cdc0}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: bootstrap kms servers
       - func: run custom csfle tests
-  - name: run-custom-csfle-tests-rapid-master
+  - name: run-custom-csfle-tests-6.0-main
     tags:
       - run-custom-dependency-tests
       - csfle
@@ -1291,45 +1291,9 @@ tasks:
           updates:
             - {key: NODE_LTS_VERSION, value: '16'}
             - {key: NPM_VERSION, value: '9'}
-            - {key: VERSION, value: rapid}
+            - {key: VERSION, value: '6.0'}
             - {key: TOPOLOGY, value: replica_set}
-            - {key: CSFLE_GIT_REF, value: master}
-      - func: install dependencies
-      - func: bootstrap mongo-orchestration
-      - func: bootstrap kms servers
-      - func: run custom csfle tests
-  - name: run-custom-csfle-tests-latest-pinned-commit
-    tags:
-      - run-custom-dependency-tests
-      - csfle
-    commands:
-      - command: expansions.update
-        type: setup
-        params:
-          updates:
-            - {key: NODE_LTS_VERSION, value: '16'}
-            - {key: NPM_VERSION, value: '9'}
-            - {key: VERSION, value: latest}
-            - {key: TOPOLOGY, value: replica_set}
-            - {key: CSFLE_GIT_REF, value: 51e172622a0ddf2bf761e4d1e26ca267359086dd}
-      - func: install dependencies
-      - func: bootstrap mongo-orchestration
-      - func: bootstrap kms servers
-      - func: run custom csfle tests
-  - name: run-custom-csfle-tests-latest-master
-    tags:
-      - run-custom-dependency-tests
-      - csfle
-    commands:
-      - command: expansions.update
-        type: setup
-        params:
-          updates:
-            - {key: NODE_LTS_VERSION, value: '16'}
-            - {key: NPM_VERSION, value: '9'}
-            - {key: VERSION, value: latest}
-            - {key: TOPOLOGY, value: replica_set}
-            - {key: CSFLE_GIT_REF, value: master}
+            - {key: CSFLE_GIT_REF, value: main}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: bootstrap kms servers
@@ -1530,8 +1494,6 @@ buildvariants:
       - csfle
     tasks:
       - run-custom-csfle-tests-5.0-pinned-commit
-      - run-custom-csfle-tests-5.0-master
-      - run-custom-csfle-tests-rapid-pinned-commit
-      - run-custom-csfle-tests-rapid-master
-      - run-custom-csfle-tests-latest-pinned-commit
-      - run-custom-csfle-tests-latest-master
+      - run-custom-csfle-tests-5.0-main
+      - run-custom-csfle-tests-6.0-pinned-commit
+      - run-custom-csfle-tests-6.0-main

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -20,7 +20,7 @@ const csfleTasks = [];
 
 const FLE_PINNED_COMMIT = '38f1be60e3f8d24b066642f742c90d0ffdd0cdc0';
 
-for (const version of ['5.0', '6.0', /* TODO: RangePreview question '7.0' */]) {
+for (const version of ['5.0', '6.0']) {
   for (const ref of [FLE_PINNED_COMMIT, 'main']) {
     csfleTasks.push({
       name: `run-custom-csfle-tests-${version}-${ref === 'main' ? ref : 'pinned-commit'}`,

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -18,12 +18,12 @@ function updateExpansions(expansions) {
 
 const csfleTasks = [];
 
-const FLE_PINNED_COMMIT = '51e172622a0ddf2bf761e4d1e26ca267359086dd';
+const FLE_PINNED_COMMIT = '38f1be60e3f8d24b066642f742c90d0ffdd0cdc0';
 
-for (const version of ['5.0', 'rapid', 'latest']) {
-  for (const ref of [FLE_PINNED_COMMIT, 'master']) {
+for (const version of ['5.0', '6.0', /* TODO: RangePreview question '7.0' */]) {
+  for (const ref of [FLE_PINNED_COMMIT, 'main']) {
     csfleTasks.push({
-      name: `run-custom-csfle-tests-${version}-${ref === 'master' ? ref : 'pinned-commit'}`,
+      name: `run-custom-csfle-tests-${version}-${ref === 'main' ? ref : 'pinned-commit'}`,
       tags: ['run-custom-dependency-tests', 'csfle'],
       commands: [
         updateExpansions({

--- a/.evergreen/run-custom-csfle-tests.sh
+++ b/.evergreen/run-custom-csfle-tests.sh
@@ -32,16 +32,13 @@ rm -rf "$DEP_WORKSPACE"
 mkdir -p "$DEP_WORKSPACE"
 
 pushd "$DEP_WORKSPACE"
-
-rm -rf mongodb-client-encryption
-
 git clone https://github.com/mongodb-js/mongodb-client-encryption.git
 
 pushd mongodb-client-encryption
 git fetch --tags
 git checkout "$CSFLE_GIT_REF" -b csfle-custom
 echo "checked out mongodb-client-encryption at $(git rev-parse HEAD)"
-npm run install:libmongocrypt -- --fastDownload
+npm run install:libmongocrypt
 npm install --ignore-scripts
 popd # mongodb-client-encryption
 


### PR DESCRIPTION
### Description

#### What is changing?

- Pulls bindings from our new repo
- Remove rapid and latest, replace with 6.0 and (after slack convo) 7.0

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

Maintain support for driver 6.0.0+ with latest bindings version

We no longer need to support `rangePreview` so I left out testing on 7.0

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
