### PR TITLE
fix(NODE-6255): cursor throws exhausted errors after explicit close

### DIFF
--- a/test/integration/change-streams/change_streams.prose.test.ts
+++ b/test/integration/change-streams/change_streams.prose.test.ts
@@ -869,6 +869,7 @@ describe('Change Stream prose tests', function () {
         changeStream.on('change', change => {
           if (change.operationType === 'invalidate') {
             startAfter = change._id;
+            console.log('closing');
             changeStream.close(done);
           }
         });
@@ -890,7 +891,10 @@ describe('Change Stream prose tests', function () {
         const events = [];
         client.on('commandStarted', e => recordEvent(events, e));
         const changeStream = coll.watch([], { startAfter });
-        this.defer(() => changeStream.close());
+        this.defer(() => {
+          console.log('defer');
+          changeStream.close();
+        });
 
         changeStream.once('change', change => {
           expect(change).to.containSubset({

--- a/test/integration/node-specific/abstract_cursor.test.ts
+++ b/test/integration/node-specific/abstract_cursor.test.ts
@@ -348,12 +348,27 @@ describe('class AbstractCursor', function () {
       });
     });
 
+    context('when the cursor is closed', function () {
+      context('when calling next()', function () {
+        it('raises a cursor exhausted error', async function () {
+          cursor = client.db().collection('test').find({});
+          await cursor.next();
+          await cursor.close();
+          const error = await cursor.next().catch(error => error);
+          expect(error).to.be.instanceOf(MongoCursorExhaustedError);
+          expect(cursor.id.isZero()).to.be.true;
+          expect(cursor).to.have.property('closed', true);
+          expect(cursor).to.have.property('killed', false);
+        });
+      });
+    });
+
     describe('when some documents have been iterated and the cursor is closed', () => {
-      it('has a zero id and is not closed and is killed', async function () {
+      it('has a zero id and is closed and is killed', async function () {
         cursor = client.db().collection('test').find({}, { batchSize: 2 });
         await cursor.next();
         await cursor.close();
-        expect(cursor).to.have.property('closed', false);
+        expect(cursor).to.have.property('closed', true);
         expect(cursor).to.have.property('killed', true);
         expect(cursor.id.isZero()).to.be.true;
         const error = await cursor.next().catch(error => error);


### PR DESCRIPTION
### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
