### PR TITLE
test(NODE-6318): utf runner withTransaction callback propagates errors from operations

### DIFF
--- a/test/integration/unified-test-format/unified_test_format.test.ts
+++ b/test/integration/unified-test-format/unified_test_format.test.ts
@@ -19,7 +19,7 @@ describe('Unified Test Runner', () => {
       { client: { id: 'failPointClient', useMultipleMongoses: false } }
     ])
     .test(
-      TestBuilder.it('should propagation the error to the withTransaction API')
+      TestBuilder.it('should propagate the error to the withTransaction API')
         .operation({
           name: 'failPoint',
           object: 'testRunner',

--- a/test/integration/unified-test-format/unified_test_format.test.ts
+++ b/test/integration/unified-test-format/unified_test_format.test.ts
@@ -1,0 +1,74 @@
+import { type FailPoint, TestBuilder, UnifiedTestSuiteBuilder } from '../../tools/utils';
+
+describe('Unified Test Runner', () => {
+  UnifiedTestSuiteBuilder.describe('withTransaction error propagation')
+    .runOnRequirement({ topologies: ['replicaset'], minServerVersion: '4.4.0' })
+    .createEntities([
+      {
+        client: {
+          id: 'client',
+          useMultipleMongoses: true,
+          uriOptions: { appName: 'bob' },
+          observeEvents: ['commandStartedEvent', 'commandSucceededEvent', 'commandFailedEvent']
+        }
+      },
+      { database: { id: 'database', client: 'client', databaseName: 'test' } },
+      { collection: { id: 'collection', database: 'database', collectionName: 'coll' } },
+      { session: { id: 'session', client: 'client' } },
+
+      { client: { id: 'failPointClient', useMultipleMongoses: false } }
+    ])
+    .test(
+      TestBuilder.it('should propagation the error to the withTransaction API')
+        .operation({
+          name: 'failPoint',
+          object: 'testRunner',
+          arguments: {
+            client: 'failPointClient',
+            failPoint: {
+              configureFailPoint: 'failCommand',
+              mode: { times: 1 },
+              data: { failCommands: ['insert'], errorCode: 50, appName: 'bob' }
+            } as FailPoint
+          }
+        })
+        .operation({
+          name: 'withTransaction',
+          object: 'session',
+          arguments: {
+            callback: [
+              {
+                name: 'insertOne',
+                object: 'collection',
+                arguments: { session: 'session', document: { _id: 1 } },
+                expectError: { isClientError: false }
+              }
+            ]
+          },
+          expectError: { isClientError: false }
+        })
+        .expectEvents({
+          client: 'client',
+          events: [
+            {
+              commandStartedEvent: {
+                commandName: 'insert',
+                databaseName: 'test',
+                command: { insert: 'coll' }
+              }
+            },
+            { commandFailedEvent: { commandName: 'insert' } },
+            {
+              commandStartedEvent: {
+                commandName: 'abortTransaction',
+                databaseName: 'admin',
+                command: { abortTransaction: 1 }
+              }
+            },
+            { commandFailedEvent: { commandName: 'abortTransaction' } }
+          ]
+        })
+        .toJSON()
+    )
+    .run();
+});

--- a/test/tools/unified-spec-runner/schema.ts
+++ b/test/tools/unified-spec-runner/schema.ts
@@ -386,6 +386,7 @@ export interface StoreEventsAsEntity {
 }
 export interface ExpectedError {
   isError?: true;
+  isTimeoutError?: boolean;
   isClientError?: boolean;
   errorContains?: string;
   errorCode?: number;

--- a/test/tools/unified-spec-runner/schema.ts
+++ b/test/tools/unified-spec-runner/schema.ts
@@ -386,7 +386,6 @@ export interface StoreEventsAsEntity {
 }
 export interface ExpectedError {
   isError?: true;
-  isTimeoutError?: boolean;
   isClientError?: boolean;
   errorContains?: string;
   errorCode?: number;


### PR DESCRIPTION
### Description

#### What is changing?

- Propagate errors from callback to withTransaction as the specifications say to

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

It is needed to test withTransaction correctly.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
