### PR TITLE
test(NODE-6323): add performance no-op baseline test

### DIFF
--- a/test/benchmarks/mongoBench/suites/singleBench.js
+++ b/test/benchmarks/mongoBench/suites/singleBench.js
@@ -21,8 +21,22 @@ function makeSingleBench(suite) {
           return this.doc;
         })
     )
+    .benchmark('ping', benchmark =>
+      benchmark
+        .taskSize(0.15) // { ping: 1 } is 15 bytes of BSON x 10,000 iterations
+        .setup(makeClient)
+        .setup(connectClient)
+        .setup(initDb)
+        .task(async function () {
+          for (let i = 0; i < 10000; ++i) {
+            await this.db.command({ ping: 1 });
+          }
+        })
+        .teardown(disconnectClient)
+    )
     .benchmark('runCommand', benchmark =>
       benchmark
+        // { hello: true } is 13 bytes. However the legacy hello was 16 bytes, to preserve history comparison data we leave this value as is.
         .taskSize(0.16)
         .setup(makeClient)
         .setup(connectClient)

--- a/test/benchmarks/mongoBench/suites/singleBench.js
+++ b/test/benchmarks/mongoBench/suites/singleBench.js
@@ -13,6 +13,7 @@ const {
 
 function makeSingleBench(suite) {
   suite
+    .benchmark('emptyAsyncFunction', benchmark => benchmark.taskSize(1).task(async function () {}))
     .benchmark('runCommand', benchmark =>
       benchmark
         .taskSize(0.16)

--- a/test/benchmarks/mongoBench/suites/singleBench.js
+++ b/test/benchmarks/mongoBench/suites/singleBench.js
@@ -13,7 +13,14 @@ const {
 
 function makeSingleBench(suite) {
   suite
-    .benchmark('emptyAsyncFunction', benchmark => benchmark.taskSize(1).task(async function () {}))
+    .benchmark('returnDocument', benchmark =>
+      benchmark
+        .taskSize(1.531e-3) // One tweet is 1,531 bytes or 0.001531 MB
+        .setup(makeLoadJSON('tweet.json'))
+        .task(async function () {
+          return this.doc;
+        })
+    )
     .benchmark('runCommand', benchmark =>
       benchmark
         .taskSize(0.16)


### PR DESCRIPTION
### Description

#### What is changing?

- We check what returning a document "costs" to compare against our APIs

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

- Because it _should_ never change this would indicate if something external has changed

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
