### PR TITLE
refactor(NODE-6335): remove recursion from transaction APIs

### DIFF
--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -494,6 +494,7 @@ export class ClientSession
 
     try {
       await executeOperation(this.client, operation);
+      return;
     } catch (firstCommitError) {
       if (firstCommitError instanceof MongoError && isRetryableWriteError(firstCommitError)) {
         // SPEC-1185: apply majority write concern when retrying commitTransaction
@@ -503,6 +504,7 @@ export class ClientSession
 
         try {
           await executeOperation(this.client, operation);
+          return;
         } catch (retryCommitError) {
           // If the retry failed, we process that error instead of the original
           if (shouldAddUnknownTransactionCommitResultLabel(retryCommitError)) {
@@ -582,12 +584,14 @@ export class ClientSession
     try {
       await executeOperation(this.client, operation);
       this.unpin();
+      return;
     } catch (firstAbortError) {
       this.unpin();
 
       if (firstAbortError instanceof MongoError && isRetryableWriteError(firstAbortError)) {
         try {
           await executeOperation(this.client, operation);
+          return;
         } catch (secondAbortError) {
           // we do not retry the retry
         }


### PR DESCRIPTION
### Description

#### What is changing?

- expirementing with simpilifying Txn logic

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

CSOT requires errors to be handled differently and the recursion and nesting of the existing implementation, which is mainly callback inspired, was difficult to adapt.

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
