### PR TITLE
feat(NODE-6313): add CSOT support to sessions and transactions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "mocha": "^10.4.0",
         "mocha-sinon": "^2.1.2",
         "mongodb-client-encryption": "^6.1.0",
-        "mongodb-legacy": "^6.0.1",
+        "mongodb-legacy": "^6.1.1",
         "nyc": "^15.1.0",
         "prettier": "^2.8.8",
         "semver": "^7.6.0",
@@ -7754,10 +7754,11 @@
       }
     },
     "node_modules/mongodb-legacy": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/mongodb-legacy/-/mongodb-legacy-6.0.1.tgz",
-      "integrity": "sha512-cbm3UOqAYo6yElNk9CHNp5tQwRl1PCpBpcSkVvlvyg7S+gG6vSt1zrFiEniNaWOwwWnIr/IsAeSo48Nm701B/A==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/mongodb-legacy/-/mongodb-legacy-6.1.1.tgz",
+      "integrity": "sha512-u9Cl8UEzdtf7mhWrAEHHhfU0OCqahaOB5midwtyudWIuEz5t18DJFXfqJq3cbEypVfLkfF3zi6rkolKMU9uPjQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "mongodb": "^6.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "mocha": "^10.4.0",
     "mocha-sinon": "^2.1.2",
     "mongodb-client-encryption": "^6.1.0",
-    "mongodb-legacy": "^6.0.1",
+    "mongodb-legacy": "^6.1.1",
     "nyc": "^15.1.0",
     "prettier": "^2.8.8",
     "semver": "^7.6.0",

--- a/src/cmap/connection.ts
+++ b/src/cmap/connection.ts
@@ -737,6 +737,13 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
           return;
         }
       }
+    } catch (readError) {
+      if (TimeoutError.is(readError)) {
+        throw new MongoOperationTimeoutError(
+          `Timed out during socket read (${readError.duration}ms)`
+        );
+      }
+      throw readError;
     } finally {
       this.dataEvents = null;
       this.throwIfAborted();

--- a/src/cmap/wire_protocol/on_data.ts
+++ b/src/cmap/wire_protocol/on_data.ts
@@ -105,7 +105,7 @@ export function onData(
   function errorHandler(err: Error) {
     const promise = unconsumedPromises.shift();
     const timeoutError = TimeoutError.is(err)
-      ? new MongoOperationTimeoutError('Timed out during socket read')
+      ? new MongoOperationTimeoutError(`Timed out during socket read (${err.duration}ms)`)
       : undefined;
 
     if (promise != null) promise.reject(timeoutError ?? err);

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -469,10 +469,14 @@ export class Collection<TSchema extends Document = Document> {
     // Intentionally, we do not inherit options from parent for this operation.
     return await executeOperation(
       this.client,
-      new RenameOperation(this as TODO_NODE_3286, newName, {
-        ...options,
-        readPreference: ReadPreference.PRIMARY
-      }) as TODO_NODE_3286
+      new RenameOperation(
+        this as TODO_NODE_3286,
+        newName,
+        resolveOptions(undefined, {
+          ...options,
+          readPreference: ReadPreference.PRIMARY
+        })
+      ) as TODO_NODE_3286
     );
   }
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -275,12 +275,16 @@ export class Db {
     // Intentionally, we do not inherit options from parent for this operation.
     return await executeOperation(
       this.client,
-      new RunCommandOperation(this, command, {
-        ...resolveBSONOptions(options),
-        timeoutMS: options?.timeoutMS ?? this.timeoutMS,
-        session: options?.session,
-        readPreference: options?.readPreference
-      })
+      new RunCommandOperation(
+        this,
+        command,
+        resolveOptions(undefined, {
+          ...resolveBSONOptions(options),
+          timeoutMS: options?.timeoutMS ?? this.timeoutMS,
+          session: options?.session,
+          readPreference: options?.readPreference
+        })
+      )
     );
   }
 
@@ -385,7 +389,11 @@ export class Db {
       new RenameOperation(
         this.collection<TSchema>(fromCollection) as TODO_NODE_3286,
         toCollection,
-        { ...options, new_collection: true, readPreference: ReadPreference.primary }
+        resolveOptions(undefined, {
+          ...options,
+          new_collection: true,
+          readPreference: ReadPreference.primary
+        })
       ) as TODO_NODE_3286
     );
   }

--- a/src/error.ts
+++ b/src/error.ts
@@ -765,8 +765,21 @@ export class MongoUnexpectedServerResponseError extends MongoRuntimeError {
  * @internal
  */
 export class MongoOperationTimeoutError extends MongoRuntimeError {
+  get [Symbol.toStringTag]() {
+    return 'MongoOperationTimeoutError';
+  }
+
   override get name(): string {
     return 'MongoOperationTimeoutError';
+  }
+
+  static is(error: unknown): error is MongoOperationTimeoutError {
+    return (
+      error != null &&
+      typeof error === 'object' &&
+      Symbol.toStringTag in error &&
+      error[Symbol.toStringTag] === 'MongoOperationTimeoutError'
+    );
   }
 }
 

--- a/src/error.ts
+++ b/src/error.ts
@@ -124,6 +124,9 @@ function isAggregateError(e: unknown): e is Error & { errors: Error[] } {
  * mongodb-client-encryption has a dependency on this error, it uses the constructor with a string argument
  */
 export class MongoError extends Error {
+  get [Symbol.toStringTag]() {
+    return this.name;
+  }
   /** @internal */
   [kErrorLabels]: Set<string>;
   /**
@@ -765,21 +768,8 @@ export class MongoUnexpectedServerResponseError extends MongoRuntimeError {
  * @internal
  */
 export class MongoOperationTimeoutError extends MongoRuntimeError {
-  get [Symbol.toStringTag]() {
-    return 'MongoOperationTimeoutError';
-  }
-
   override get name(): string {
     return 'MongoOperationTimeoutError';
-  }
-
-  static is(error: unknown): error is MongoOperationTimeoutError {
-    return (
-      error != null &&
-      typeof error === 'object' &&
-      Symbol.toStringTag in error &&
-      error[Symbol.toStringTag] === 'MongoOperationTimeoutError'
-    );
   }
 }
 

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -513,7 +513,14 @@ export class ClientSession
         : null;
 
     const timeoutContext =
-      this.timeoutContext ?? TimeoutContext.create({ timeoutMS, ...this.clientOptions });
+      this.timeoutContext ??
+      (typeof timeoutMS === 'number'
+        ? TimeoutContext.create({
+            serverSelectionTimeoutMS: this.clientOptions.serverSelectionTimeoutMS,
+            socketTimeoutMS: this.clientOptions.socketTimeoutMS,
+            timeoutMS
+          })
+        : null);
 
     try {
       await executeOperation(this.client, operation, timeoutContext);

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -512,9 +512,8 @@ export class ClientSession
         ? this.timeoutMS
         : null;
 
-    const timeoutContext = this.timeoutContext?.csotEnabled()
-      ? this.timeoutContext
-      : TimeoutContext.create({ timeoutMS, ...this.clientOptions });
+    const timeoutContext =
+      this.timeoutContext ?? TimeoutContext.create({ timeoutMS, ...this.clientOptions });
 
     try {
       await executeOperation(this.client, operation, timeoutContext);

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -707,8 +707,11 @@ export class ClientSession
     const MAX_TIMEOUT = 120000;
 
     this.timeoutContext =
-      options != null && 'timeoutMS' in options && typeof options.timeoutMS === 'number'
-        ? TimeoutContext.create({ timeoutMS: options.timeoutMS, ...this.clientOptions })
+      typeof options?.timeoutMS === 'number' || typeof this.timeoutMS === 'number'
+        ? TimeoutContext.create({
+            timeoutMS: options?.timeoutMS ?? this.timeoutMS,
+            ...this.clientOptions
+          })
         : null;
 
     const startTime = this.timeoutContext?.csotEnabled() ? this.timeoutContext.start : now();

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -281,9 +281,9 @@ export class ClientSession
     try {
       if (this.inTransaction()) {
         if (typeof options?.timeoutMS === 'number') {
-          await this.abortTransaction({ timeoutMS: options.timeoutMS });
+          await endTransaction(this, 'abortTransaction', { timeoutMS: options.timeoutMS });
         } else {
-          await this.abortTransaction();
+          await endTransaction(this, 'abortTransaction');
         }
       }
       if (!this.hasEnded) {

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -625,7 +625,14 @@ export class ClientSession
         ? this.timeoutMS
         : null;
 
-    const timeoutContext = TimeoutContext.create({ timeoutMS, ...this.clientOptions });
+    const timeoutContext =
+      timeoutMS != null
+        ? TimeoutContext.create({
+            timeoutMS,
+            serverSelectionTimeoutMS: this.clientOptions.serverSelectionTimeoutMS,
+            socketTimeoutMS: this.clientOptions.socketTimeoutMS
+          })
+        : null;
 
     try {
       await executeOperation(this.client, operation, timeoutContext);
@@ -715,11 +722,13 @@ export class ClientSession
   ): Promise<T> {
     const MAX_TIMEOUT = 120000;
 
+    const timeoutMS = options?.timeoutMS ?? this.timeoutMS ?? null;
     this.timeoutContext =
-      typeof options?.timeoutMS === 'number' || typeof this.timeoutMS === 'number'
+      timeoutMS != null
         ? TimeoutContext.create({
-            timeoutMS: options?.timeoutMS ?? this.timeoutMS,
-            ...this.clientOptions
+            timeoutMS,
+            serverSelectionTimeoutMS: this.clientOptions.serverSelectionTimeoutMS,
+            socketTimeoutMS: this.clientOptions.socketTimeoutMS
           })
         : null;
 

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -58,8 +58,11 @@ export interface ClientSessionOptions {
   snapshot?: boolean;
   /** The default TransactionOptions to use for transactions started on this session. */
   defaultTransactionOptions?: TransactionOptions;
-  /** @internal
-   * The value of timeoutMS used for CSOT. Used to override client timeoutMS */
+  /**
+   * @public
+   * An overriding timeoutMS value to use for a client-side timeout.
+   * If not provided the session uses the timeoutMS specified on the MongoClient.
+   */
   defaultTimeoutMS?: number;
 
   /** @internal */

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -693,7 +693,16 @@ export class ClientSession
    */
   async withTransaction<T = any>(
     fn: WithTransactionCallback<T>,
-    options?: TransactionOptions
+    options?: TransactionOptions & {
+      /**
+       * Configures a timeoutMS expiry for the entire withTransactionCallback.
+       *
+       * @remarks
+       * - The remaining timeout will not be applied to callback operations that do not use the ClientSession.
+       * - Overriding timeoutMS for operations executed using the explicit session inside the provided callback will result in a client-side error.
+       */
+      timeoutMS?: number;
+    }
   ): Promise<T> {
     const MAX_TIMEOUT = 120000;
 

--- a/src/timeout.ts
+++ b/src/timeout.ts
@@ -1,6 +1,7 @@
 import { clearTimeout, setTimeout } from 'timers';
 
 import { MongoInvalidArgumentError, MongoOperationTimeoutError, MongoRuntimeError } from './error';
+import { type ClientSession } from './sessions';
 import { csotMin, noop } from './utils';
 
 /** @internal */
@@ -128,7 +129,9 @@ export class Timeout extends Promise<never> {
 }
 
 /** @internal */
-export type TimeoutContextOptions = LegacyTimeoutContextOptions | CSOTTimeoutContextOptions;
+export type TimeoutContextOptions = (LegacyTimeoutContextOptions | CSOTTimeoutContextOptions) & {
+  session?: ClientSession;
+};
 
 /** @internal */
 export type LegacyTimeoutContextOptions = {
@@ -169,6 +172,7 @@ function isCSOTTimeoutContextOptions(v: unknown): v is CSOTTimeoutContextOptions
 /** @internal */
 export abstract class TimeoutContext {
   static create(options: TimeoutContextOptions): TimeoutContext {
+    if (options.session?.timeoutContext != null) return options.session?.timeoutContext;
     if (isCSOTTimeoutContextOptions(options)) return new CSOTTimeoutContext(options);
     else if (isLegacyTimeoutContextOptions(options)) return new LegacyTimeoutContext(options);
     else throw new MongoRuntimeError('Unrecognized options');

--- a/src/timeout.ts
+++ b/src/timeout.ts
@@ -56,15 +56,13 @@ export class Timeout extends Promise<never> {
   /** Create a new timeout that expires in `duration` ms */
   private constructor(
     executor: Executor = () => null,
-    duration: number,
-    unref = true,
-    rejection: Error | null = null
+    { duration, unref, rejection }: { duration: number; unref?: true; rejection?: Error }
   ) {
-    let reject!: Reject;
     if (duration < 0) {
       throw new MongoInvalidArgumentError('Cannot create a Timeout with a negative duration');
     }
 
+    let reject!: Reject;
     super((_, promiseReject) => {
       reject = promiseReject;
 
@@ -104,8 +102,8 @@ export class Timeout extends Promise<never> {
     if (this.timedOut) throw new TimeoutError('Timed out', { duration: this.duration });
   }
 
-  public static expires(durationMS: number, unref?: boolean): Timeout {
-    return new Timeout(undefined, durationMS, unref);
+  public static expires(duration: number, unref?: true): Timeout {
+    return new Timeout(undefined, { duration, unref });
   }
 
   static is(timeout: unknown): timeout is Timeout {
@@ -121,7 +119,7 @@ export class Timeout extends Promise<never> {
   }
 
   static override reject(rejection?: Error): Timeout {
-    return new Timeout(undefined, 0, true, rejection);
+    return new Timeout(undefined, { duration: 0, unref: true, rejection });
   }
 }
 

--- a/src/timeout.ts
+++ b/src/timeout.ts
@@ -184,7 +184,7 @@ export class CSOTTimeoutContext extends TimeoutContext {
   private _serverSelectionTimeout?: Timeout | null;
   private _connectionCheckoutTimeout?: Timeout | null;
   public minRoundTripTime = 0;
-  private start: number;
+  public start: number;
 
   constructor(options: CSOTTimeoutContextOptions) {
     super();

--- a/src/timeout.ts
+++ b/src/timeout.ts
@@ -56,8 +56,12 @@ export class Timeout extends Promise<never> {
   /** Create a new timeout that expires in `duration` ms */
   private constructor(
     executor: Executor = () => null,
-    { duration, unref, rejection }: { duration: number; unref?: true; rejection?: Error }
+    options?: { duration: number; unref?: true; rejection?: Error }
   ) {
+    const duration = options?.duration ?? 0;
+    const unref = !!options?.unref;
+    const rejection = options?.rejection;
+
     if (duration < 0) {
       throw new MongoInvalidArgumentError('Cannot create a Timeout with a negative duration');
     }

--- a/src/timeout.ts
+++ b/src/timeout.ts
@@ -74,7 +74,7 @@ export class Timeout extends Promise<never> {
     this.duration = duration;
     this.start = Math.trunc(performance.now());
 
-    if (this.duration > 0) {
+    if (rejection == null && this.duration > 0) {
       this.id = setTimeout(() => {
         this.ended = Math.trunc(performance.now());
         this.timedOut = true;
@@ -84,9 +84,11 @@ export class Timeout extends Promise<never> {
         // Ensure we do not keep the Node.js event loop running
         this.id.unref();
       }
+    } else if (rejection != null) {
+      this.ended = Math.trunc(performance.now());
+      this.timedOut = true;
+      reject(rejection);
     }
-
-    if (rejection != null) reject(rejection);
   }
 
   /**
@@ -260,10 +262,8 @@ export class CSOTTimeoutContext extends TimeoutContext {
         // null or Timeout
         this._connectionCheckoutTimeout = this._serverSelectionTimeout;
       } else {
-        return Timeout.reject(
-          new MongoRuntimeError(
-            'Unreachable. If you are seeing this error, please file a ticket on the NODE driver project on Jira'
-          )
+        throw new MongoRuntimeError(
+          'Unreachable. If you are seeing this error, please file a ticket on the NODE driver project on Jira'
         );
       }
     }

--- a/src/transactions.ts
+++ b/src/transactions.ts
@@ -69,7 +69,10 @@ export interface TransactionOptions extends CommandOperationOptions {
   writeConcern?: WriteConcern;
   /** A default read preference for commands in this transaction */
   readPreference?: ReadPreferenceLike;
-  /** Specifies the maximum amount of time to allow a commit action on a transaction to run in milliseconds */
+  /**
+   * Specifies the maximum amount of time to allow a commit action on a transaction to run in milliseconds
+   * @deprecated This option is deprecated in favor of `timeoutMS` or `defaultTimeoutMS`.
+   */
   maxCommitTimeMS?: number;
 }
 

--- a/src/transactions.ts
+++ b/src/transactions.ts
@@ -61,7 +61,7 @@ const COMMITTED_STATES: Set<TxnState> = new Set([
  * Configuration options for a transaction.
  * @public
  */
-export interface TransactionOptions extends CommandOperationOptions {
+export interface TransactionOptions extends Omit<CommandOperationOptions, 'timeoutMS'> {
   // TODO(NODE-3344): These options use the proper class forms of these settings, it should accept the basic enum values too
   /** A default read concern for commands in this transaction */
   readConcern?: ReadConcernLike;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -532,7 +532,8 @@ export function resolveOptions<T extends CommandOperationOptions>(
     result.readPreference = readPreference;
   }
 
-  if (session?.explicit && session?.timeoutContext != null && options?.timeoutMS != null) {
+  const isConvenientTransaction = session?.explicit && session?.timeoutContext != null;
+  if (isConvenientTransaction && options?.timeoutMS != null) {
     throw new MongoInvalidArgumentError(
       'An operation cannot be given a timeoutMS setting when inside a withTransaction call that has a timeoutMS setting'
     );

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -528,9 +528,13 @@ export function resolveOptions<T extends CommandOperationOptions>(
     result.readPreference = readPreference;
   }
 
-  const timeoutMS = options?.timeoutMS;
+  if (session?.explicit && session?.timeoutContext != null && options?.timeoutMS != null) {
+    throw new MongoInvalidArgumentError(
+      'An operation cannot be given a timeoutMS setting when inside a withTransaction call that has a timeoutMS setting'
+    );
+  }
 
-  result.timeoutMS = timeoutMS ?? parent?.timeoutMS;
+  result.timeoutMS = options?.timeoutMS ?? parent?.timeoutMS;
 
   return result;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -528,6 +528,12 @@ export function resolveOptions<T extends CommandOperationOptions>(
     result.readPreference = readPreference;
   }
 
+  if (session?.explicit && session.timeoutMS != null && options?.timeoutMS != null) {
+    throw new MongoInvalidArgumentError(
+      'Do not specify timeoutMS on operation if already specified on an explicit session'
+    );
+  }
+
   const timeoutMS = options?.timeoutMS;
 
   result.timeoutMS = timeoutMS ?? parent?.timeoutMS;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -501,6 +501,10 @@ export function hasAtomicOperators(doc: Document | Document[]): boolean {
 /**
  * Merge inherited properties from parent into options, prioritizing values from options,
  * then values from parent.
+ *
+ * @param parent - An optional owning class of the operation being run. ex. Db/Collection/MongoClient.
+ * @param options - The options passed to the operation method.
+ *
  * @internal
  */
 export function resolveOptions<T extends CommandOperationOptions>(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -528,12 +528,6 @@ export function resolveOptions<T extends CommandOperationOptions>(
     result.readPreference = readPreference;
   }
 
-  if (session?.explicit && session.timeoutMS != null && options?.timeoutMS != null) {
-    throw new MongoInvalidArgumentError(
-      'Do not specify timeoutMS on operation if already specified on an explicit session'
-    );
-  }
-
   const timeoutMS = options?.timeoutMS;
 
   result.timeoutMS = timeoutMS ?? parent?.timeoutMS;

--- a/test/integration/client-side-operations-timeout/client_side_operations_timeout.prose.test.ts
+++ b/test/integration/client-side-operations-timeout/client_side_operations_timeout.prose.test.ts
@@ -673,8 +673,8 @@ describe('CSOT spec prose tests', function () {
         const start = performance.now();
         const error = await session.endSession().catch(error => error);
         const end = performance.now();
-        expect(error).to.be.instanceOf(MongoOperationTimeoutError);
         expect(end - start).to.be.within(480, 520);
+        expect(error).to.be.instanceOf(MongoOperationTimeoutError);
       });
     });
 
@@ -688,8 +688,8 @@ describe('CSOT spec prose tests', function () {
         const start = performance.now();
         const error = await session.endSession().catch(error => error);
         const end = performance.now();
-        expect(error).to.be.instanceOf(MongoOperationTimeoutError);
         expect(end - start).to.be.within(480, 520);
+        expect(error).to.be.instanceOf(MongoOperationTimeoutError);
       });
     });
 
@@ -703,8 +703,8 @@ describe('CSOT spec prose tests', function () {
         const start = performance.now();
         const error = await session.endSession({ timeoutMS: 500 }).catch(error => error);
         const end = performance.now();
-        expect(error).to.be.instanceOf(MongoOperationTimeoutError);
         expect(end - start).to.be.within(480, 520);
+        expect(error).to.be.instanceOf(MongoOperationTimeoutError);
       });
     });
   });

--- a/test/integration/client-side-operations-timeout/client_side_operations_timeout.prose.test.ts
+++ b/test/integration/client-side-operations-timeout/client_side_operations_timeout.prose.test.ts
@@ -670,8 +670,11 @@ describe('CSOT spec prose tests', function () {
         const session = client.startSession();
         session.startTransaction();
         await coll.insertOne({ x: 1 }, { session });
+        const start = performance.now();
         const error = await session.endSession().catch(error => error);
+        const end = performance.now();
         expect(error).to.be.instanceOf(MongoOperationTimeoutError);
+        expect(end - start).to.be.within(480, 520);
       });
     });
 
@@ -682,8 +685,11 @@ describe('CSOT spec prose tests', function () {
         const session = client.startSession({ defaultTimeoutMS: 500 });
         session.startTransaction();
         await coll.insertOne({ x: 1 }, { session });
+        const start = performance.now();
         const error = await session.endSession().catch(error => error);
+        const end = performance.now();
         expect(error).to.be.instanceOf(MongoOperationTimeoutError);
+        expect(end - start).to.be.within(480, 520);
       });
     });
 
@@ -694,8 +700,11 @@ describe('CSOT spec prose tests', function () {
         const session = client.startSession();
         session.startTransaction();
         await coll.insertOne({ x: 1 }, { session });
+        const start = performance.now();
         const error = await session.endSession({ timeoutMS: 500 }).catch(error => error);
+        const end = performance.now();
         expect(error).to.be.instanceOf(MongoOperationTimeoutError);
+        expect(end - start).to.be.within(480, 520);
       });
     });
   });

--- a/test/integration/client-side-operations-timeout/client_side_operations_timeout.prose.test.ts
+++ b/test/integration/client-side-operations-timeout/client_side_operations_timeout.prose.test.ts
@@ -636,7 +636,7 @@ describe('CSOT spec prose tests', function () {
       data: {
         failCommands: ['abortTransaction'],
         blockConnection: true,
-        blockTimeMS: 600
+        blockTimeMS: 200
       }
     };
 
@@ -665,7 +665,7 @@ describe('CSOT spec prose tests', function () {
 
     describe('when timeoutMS is provided to the client', () => {
       it('throws a timeout error from endSession', metadata, async function () {
-        client = this.configuration.newClient({ timeoutMS: 500, monitorCommands: true });
+        client = this.configuration.newClient({ timeoutMS: 150, monitorCommands: true });
         const coll = client.db('endSession_db').collection('endSession_coll');
         const session = client.startSession();
         session.startTransaction();
@@ -673,7 +673,7 @@ describe('CSOT spec prose tests', function () {
         const start = performance.now();
         const error = await session.endSession().catch(error => error);
         const end = performance.now();
-        expect(end - start).to.be.within(480, 520);
+        expect(end - start).to.be.within(100, 170);
         expect(error).to.be.instanceOf(MongoOperationTimeoutError);
       });
     });
@@ -682,13 +682,13 @@ describe('CSOT spec prose tests', function () {
       it('throws a timeout error from endSession', metadata, async function () {
         client = this.configuration.newClient();
         const coll = client.db('endSession_db').collection('endSession_coll');
-        const session = client.startSession({ defaultTimeoutMS: 500 });
+        const session = client.startSession({ defaultTimeoutMS: 150 });
         session.startTransaction();
         await coll.insertOne({ x: 1 }, { session });
         const start = performance.now();
         const error = await session.endSession().catch(error => error);
         const end = performance.now();
-        expect(end - start).to.be.within(480, 520);
+        expect(end - start).to.be.within(100, 170);
         expect(error).to.be.instanceOf(MongoOperationTimeoutError);
       });
     });
@@ -701,9 +701,9 @@ describe('CSOT spec prose tests', function () {
         session.startTransaction();
         await coll.insertOne({ x: 1 }, { session });
         const start = performance.now();
-        const error = await session.endSession({ timeoutMS: 500 }).catch(error => error);
+        const error = await session.endSession({ timeoutMS: 150 }).catch(error => error);
         const end = performance.now();
-        expect(end - start).to.be.within(480, 520);
+        expect(end - start).to.be.within(100, 170);
         expect(error).to.be.instanceOf(MongoOperationTimeoutError);
       });
     });
@@ -726,7 +726,7 @@ describe('CSOT spec prose tests', function () {
        *     data: {
        *         failCommands: ["insert", "abortTransaction"],
        *         blockConnection: true,
-       *         blockTimeMS: 15
+       *         blockTimeMS: 200
        *     }
        * }
        * ```
@@ -750,7 +750,7 @@ describe('CSOT spec prose tests', function () {
         data: {
           failCommands: ['insert', 'abortTransaction'],
           blockConnection: true,
-          blockTimeMS: 600
+          blockTimeMS: 200
         }
       };
 
@@ -795,7 +795,7 @@ describe('CSOT spec prose tests', function () {
         const commandsStarted = [];
 
         client = this.configuration
-          .newClient({ timeoutMS: 500, monitorCommands: true })
+          .newClient({ timeoutMS: 150, monitorCommands: true })
           .on('commandStarted', e => commandsStarted.push(e.commandName))
           .on('commandFailed', e => commandsFailed.push(e.commandName));
 

--- a/test/integration/client-side-operations-timeout/client_side_operations_timeout.prose.test.ts
+++ b/test/integration/client-side-operations-timeout/client_side_operations_timeout.prose.test.ts
@@ -1,6 +1,7 @@
 /* Specification prose tests */
 
 import { expect } from 'chai';
+import * as semver from 'semver';
 import * as sinon from 'sinon';
 
 import {
@@ -9,6 +10,7 @@ import {
   MongoServerSelectionError,
   now
 } from '../../mongodb';
+import { type FailPoint } from '../../tools/utils';
 
 // TODO(NODE-5824): Implement CSOT prose tests
 describe('CSOT spec prose tests', function () {
@@ -595,69 +597,192 @@ describe('CSOT spec prose tests', function () {
       'TODO(DRIVERS-2347): Requires this ticket to be implemented before we can assert on connection CSOT behaviour';
   });
 
-  context.skip('9. endSession', () => {
-    /**
-     * This test MUST only be run against replica sets and sharded clusters with server version 4.4 or higher. It MUST be
-     * run three times: once with the timeout specified via the MongoClient `timeoutMS` option, once with the timeout
-     * specified via the ClientSession `defaultTimeoutMS` option, and once more with the timeout specified via the
-     * `timeoutMS` option for the `endSession` operation. In all cases, the timeout MUST be set to 10 milliseconds.
-     *
-     * 1. Using `internalClient`, drop the `db.coll` collection.
-     * 1. Using `internalClient`, set the following fail point:
-     * ```js
-     * {
-     *     configureFailPoint: failCommand,
-     *     mode: { times: 1 },
-     *     data: {
-     *         failCommands: ["abortTransaction"],
-     *         blockConnection: true,
-     *         blockTimeMS: 15
-     *     }
-     * }
-     * ```
-     * 1. Create a new MongoClient (referred to as `client`) and an explicit ClientSession derived from that MongoClient (referred to as `session`).
-     * 1. Execute the following code:
-     * ```ts
-     *   coll = client.database("db").collection("coll")
-     *   session.start_transaction()
-     *   coll.insert_one({x: 1}, session=session)
-     * ```
-     * 1. Using `session`, execute `session.end_session`
-     *    - Expect this to fail with a timeout error after no more than 15ms.
-     */
-  });
-
-  context.skip('10. Convenient Transactions', () => {
-    /** Tests in this section MUST only run against replica sets and sharded clusters with server versions 4.4 or higher. */
-
-    context('timeoutMS is refreshed for abortTransaction if the callback fails', () => {
+  describe(
+    '9. endSession',
+    { requires: { topology: ['replicaset', 'sharded', 'load-balanced'] } },
+    () => {
       /**
+       * This test MUST only be run against replica sets and sharded clusters with server version 4.4 or higher. It MUST be
+       * run three times: once with the timeout specified via the MongoClient `timeoutMS` option, once with the timeout
+       * specified via the ClientSession `defaultTimeoutMS` option, and once more with the timeout specified via the
+       * `timeoutMS` option for the `endSession` operation. In all cases, the timeout MUST be set to 10 milliseconds.
+       *
        * 1. Using `internalClient`, drop the `db.coll` collection.
        * 1. Using `internalClient`, set the following fail point:
        * ```js
        * {
        *     configureFailPoint: failCommand,
-       *     mode: { times: 2 },
+       *     mode: { times: 1 },
        *     data: {
-       *         failCommands: ["insert", "abortTransaction"],
+       *         failCommands: ["abortTransaction"],
        *         blockConnection: true,
        *         blockTimeMS: 15
        *     }
        * }
        * ```
-       * 1. Create a new MongoClient (referred to as `client`) configured with `timeoutMS=10` and an explicit ClientSession derived from that MongoClient (referred to as `session`).
-       * 1. Using `session`, execute a `withTransaction` operation with the following callback:
-       * ```js
-       * function callback() {
+       * 1. Create a new MongoClient (referred to as `client`) and an explicit ClientSession derived from that MongoClient (referred to as `session`).
+       * 1. Execute the following code:
+       * ```ts
        *   coll = client.database("db").collection("coll")
-       *   coll.insert_one({ _id: 1 }, session=session)
-       * }
+       *   session.start_transaction()
+       *   coll.insert_one({x: 1}, session=session)
        * ```
-       * 1. Expect the previous `withTransaction` call to fail with a timeout error.
-       * 1. Verify that the following events were published during the `withTransaction` call:
-       *   1. `command_started` and `command_failed` events for an `insert` command.
-       *   1. `command_started` and `command_failed` events for an `abortTransaction` command.
+       * 1. Using `session`, execute `session.end_session`
+       *    - Expect this to fail with a timeout error after no more than 15ms.
        */
-    });
-  });
+      const failpoint: FailPoint = {
+        configureFailPoint: 'failCommand',
+        mode: { times: 1 },
+        data: { failCommands: ['abortTransaction'], blockConnection: true, blockTimeMS: 15 }
+      };
+
+      beforeEach(async function () {
+        if (!semver.satisfies(this.configuration.version, '>=4.4')) {
+          this.skipReason = 'Requires server version 4.4+';
+          this.skip();
+        }
+        const internalClient = this.configuration.newClient();
+        await internalClient
+          .db('db')
+          .collection('coll')
+          .drop()
+          .catch(() => null);
+        await internalClient.db('admin').command(failpoint);
+        await internalClient.close();
+      });
+
+      let client: MongoClient;
+
+      afterEach(async () => {
+        await client?.close();
+      });
+
+      describe('when timeoutMS is provided to the client', () => {
+        it('throws a timeout error from endSession', async function () {
+          client = this.configuration.newClient({ timeoutMS: 10 });
+          const coll = client.db('db').collection('coll');
+          const session = client.startSession();
+          session.startTransaction();
+          await coll.insertOne({ x: 1 }, { session });
+          const error = await session.endSession().catch(error => error);
+          expect(error).to.be.instanceOf(MongoOperationTimeoutError);
+        });
+      });
+
+      describe('when defaultTimeoutMS is provided to startSession', () => {
+        it('throws a timeout error from endSession', async function () {
+          client = this.configuration.newClient();
+          const coll = client.db('db').collection('coll');
+          const session = client.startSession({ defaultTimeoutMS: 10 });
+          session.startTransaction();
+          await coll.insertOne({ x: 1 }, { session });
+          const error = await session.endSession().catch(error => error);
+          expect(error).to.be.instanceOf(MongoOperationTimeoutError);
+        });
+      });
+
+      describe('when timeoutMS is provided to endSession', () => {
+        it('throws a timeout error from endSession', async function () {
+          client = this.configuration.newClient();
+          const coll = client.db('db').collection('coll');
+          const session = client.startSession();
+          session.startTransaction();
+          await coll.insertOne({ x: 1 }, { session });
+          const error = await session.endSession({ timeoutMS: 10 }).catch(error => error);
+          expect(error).to.be.instanceOf(MongoOperationTimeoutError);
+        });
+      });
+    }
+  );
+
+  describe(
+    '10. Convenient Transactions',
+    { requires: { topology: ['replicaset', 'sharded', 'load-balanced'] } },
+    () => {
+      /** Tests in this section MUST only run against replica sets and sharded clusters with server versions 4.4 or higher. */
+
+      describe('when an operation fails inside withTransaction callback', () => {
+        /**
+         * 1. Using `internalClient`, drop the `db.coll` collection.
+         * 1. Using `internalClient`, set the following fail point:
+         * ```js
+         * {
+         *     configureFailPoint: failCommand,
+         *     mode: { times: 2 },
+         *     data: {
+         *         failCommands: ["insert", "abortTransaction"],
+         *         blockConnection: true,
+         *         blockTimeMS: 15
+         *     }
+         * }
+         * ```
+         * 1. Create a new MongoClient (referred to as `client`) configured with `timeoutMS=10` and an explicit ClientSession derived from that MongoClient (referred to as `session`).
+         * 1. Using `session`, execute a `withTransaction` operation with the following callback:
+         * ```js
+         * function callback() {
+         *   coll = client.database("db").collection("coll")
+         *   coll.insert_one({ _id: 1 }, session=session)
+         * }
+         * ```
+         * 1. Expect the previous `withTransaction` call to fail with a timeout error.
+         * 1. Verify that the following events were published during the `withTransaction` call:
+         *   1. `command_started` and `command_failed` events for an `insert` command.
+         *   1. `command_started` and `command_failed` events for an `abortTransaction` command.
+         */
+
+        const failpoint: FailPoint = {
+          configureFailPoint: 'failCommand',
+          mode: { times: 2 },
+          data: {
+            failCommands: ['insert', 'abortTransaction'],
+            blockConnection: true,
+            blockTimeMS: 15
+          }
+        };
+
+        beforeEach(async function () {
+          if (!semver.satisfies(this.configuration.version, '>=4.4')) {
+            this.skipReason = 'Requires server version 4.4+';
+            this.skip();
+          }
+          const internalClient = this.configuration.newClient();
+          await internalClient
+            .db('db')
+            .collection('coll')
+            .drop()
+            .catch(() => null);
+          await internalClient.db('admin').command(failpoint);
+          await internalClient.close();
+        });
+
+        let client: MongoClient;
+
+        afterEach(async () => {
+          await client?.close();
+        });
+
+        it('timeoutMS is refreshed for abortTransaction', async function () {
+          const commandsFailed = [];
+
+          client = this.configuration
+            .newClient({ timeoutMS: 10, monitorCommands: true })
+            .on('commandFailed', e => commandsFailed.push(e));
+
+          const coll = client.db('db').collection('coll');
+
+          const error = await client
+            .withSession(async session =>
+              session.withTransaction(async session => await coll.insertOne({ x: 1 }, { session }))
+            )
+            .catch(error => error);
+
+          expect(error).to.be.instanceOf(MongoOperationTimeoutError);
+          expect(commandsFailed.map(e => e.commandName)).to.deep.equal([
+            'insert',
+            'abortTransaction'
+          ]);
+        });
+      });
+    }
+  );
 });

--- a/test/integration/client-side-operations-timeout/client_side_operations_timeout.spec.test.ts
+++ b/test/integration/client-side-operations-timeout/client_side_operations_timeout.spec.test.ts
@@ -8,7 +8,10 @@ const enabled = [
   'override-database-timeoutMS',
   'override-operation-timeoutMS',
   'retryability-legacy-timeouts',
-  'retryability-timeoutMS'
+  'retryability-timeoutMS',
+  'sessions-override-operation-timeoutMS',
+  'sessions-override-timeoutMS',
+  'sessions-inherit-timeoutMS'
 ];
 
 const cursorOperations = [

--- a/test/integration/client-side-operations-timeout/client_side_operations_timeout.spec.test.ts
+++ b/test/integration/client-side-operations-timeout/client_side_operations_timeout.spec.test.ts
@@ -1,4 +1,5 @@
 import { join } from 'path';
+import * as semver from 'semver';
 
 import { loadSpecTests } from '../../spec';
 import { runUnifiedSuite } from '../../tools/unified-spec-runner/runner';
@@ -46,5 +47,13 @@ describe('CSOT spec tests', function () {
           'TODO(NODE-6274): update test runner to check errorResponse field of MongoBulkWriteError in isTimeoutError assertion';
     }
   }
-  runUnifiedSuite(specs);
+  runUnifiedSuite(specs, (test, configuration) => {
+    if (
+      configuration.topologyType === 'ReplicaSetWithPrimary' &&
+      semver.satisfies(configuration.version, '<=4.4')
+    ) {
+      return '4.4 replicaset fail point does not blockConnection for requested time';
+    }
+    return false;
+  });
 });

--- a/test/integration/client-side-operations-timeout/client_side_operations_timeout.spec.test.ts
+++ b/test/integration/client-side-operations-timeout/client_side_operations_timeout.spec.test.ts
@@ -48,7 +48,9 @@ describe('CSOT spec tests', function () {
     }
   }
   runUnifiedSuite(specs, (test, configuration) => {
+    const sessionCSOTTests = ['timeoutMS applied to withTransaction'];
     if (
+      sessionCSOTTests.includes(test.description) &&
       configuration.topologyType === 'ReplicaSetWithPrimary' &&
       semver.satisfies(configuration.version, '<=4.4')
     ) {

--- a/test/integration/client-side-operations-timeout/node_csot.test.ts
+++ b/test/integration/client-side-operations-timeout/node_csot.test.ts
@@ -323,7 +323,9 @@ describe('CSOT driver tests', { requires: { mongodb: '>=4.4' } }, () => {
   });
 
   describe('when using an explicit session', () => {
-    const metadata = { requires: { topology: ['replicaset'] } };
+    const metadata: MongoDBMetadataUI = {
+      requires: { topology: ['replicaset'], mongodb: '>=4.4' }
+    };
 
     describe('created for a withTransaction callback', () => {
       describe('passing a timeoutMS and a session with a timeoutContext', () => {

--- a/test/integration/client-side-operations-timeout/node_csot.test.ts
+++ b/test/integration/client-side-operations-timeout/node_csot.test.ts
@@ -322,7 +322,9 @@ describe('CSOT driver tests', { requires: { mongodb: '>=4.4' } }, () => {
     });
   });
 
-  describe.only('when using an explicit session', () => {
+  describe('when using an explicit session', () => {
+    const metadata = { requires: { topology: ['replicaset'] } };
+
     describe('created for a withTransaction callback', () => {
       describe('passing a timeoutMS and a session with a timeoutContext', () => {
         let client: MongoClient;
@@ -335,7 +337,7 @@ describe('CSOT driver tests', { requires: { mongodb: '>=4.4' } }, () => {
           await client.close();
         });
 
-        it('throws a validation error from the operation', async () => {
+        it('throws a validation error from the operation', metadata, async () => {
           // Drivers MUST raise a validation error if an explicit session with a timeout is used and
           // the timeoutMS option is set at the operation level for operations executed as part of a withTransaction callback.
 
@@ -371,7 +373,7 @@ describe('CSOT driver tests', { requires: { mongodb: '>=4.4' } }, () => {
           await client.close();
         });
 
-        it('does not throw a validation error', async () => {
+        it('does not throw a validation error', metadata, async () => {
           const coll = client.db('db').collection('coll');
           const session = client.startSession();
           session.startTransaction();

--- a/test/spec/client-side-operations-timeout/sessions-inherit-timeoutMS.json
+++ b/test/spec/client-side-operations-timeout/sessions-inherit-timeoutMS.json
@@ -21,7 +21,7 @@
       "client": {
         "id": "client",
         "uriOptions": {
-          "timeoutMS": 50
+          "timeoutMS": 500
         },
         "useMultipleMongoses": false,
         "observeEvents": [
@@ -78,7 +78,7 @@
                   "commitTransaction"
                 ],
                 "blockConnection": true,
-                "blockTimeMS": 60
+                "blockTimeMS": 600
               }
             }
           }
@@ -165,7 +165,7 @@
                   "abortTransaction"
                 ],
                 "blockConnection": true,
-                "blockTimeMS": 60
+                "blockTimeMS": 600
               }
             }
           }
@@ -249,7 +249,7 @@
                   "insert"
                 ],
                 "blockConnection": true,
-                "blockTimeMS": 60
+                "blockTimeMS": 600
               }
             }
           }
@@ -301,6 +301,26 @@
             {
               "commandFailedEvent": {
                 "commandName": "insert"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "abortTransaction",
+                "databaseName": "admin",
+                "command": {
+                  "abortTransaction": 1,
+                  "maxTimeMS": {
+                    "$$type": [
+                      "int",
+                      "long"
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "commandFailedEvent": {
+                "commandName": "abortTransaction"
               }
             }
           ]

--- a/test/spec/client-side-operations-timeout/sessions-inherit-timeoutMS.yml
+++ b/test/spec/client-side-operations-timeout/sessions-inherit-timeoutMS.yml
@@ -13,7 +13,7 @@ createEntities:
   - client:
       id: &client client
       uriOptions:
-        timeoutMS: 50
+        timeoutMS: 500
       useMultipleMongoses: false
       observeEvents:
         - commandStartedEvent
@@ -52,7 +52,7 @@ tests:
             data:
               failCommands: ["commitTransaction"]
               blockConnection: true
-              blockTimeMS: 60
+              blockTimeMS: 600
       - name: startTransaction
         object: *session
       - name: insertOne
@@ -95,7 +95,7 @@ tests:
             data:
               failCommands: ["abortTransaction"]
               blockConnection: true
-              blockTimeMS: 60
+              blockTimeMS: 600
       - name: startTransaction
         object: *session
       - name: insertOne
@@ -136,7 +136,7 @@ tests:
             data:
               failCommands: ["insert"]
               blockConnection: true
-              blockTimeMS: 60
+              blockTimeMS: 600
       - name: withTransaction
         object: *session
         arguments:
@@ -153,9 +153,6 @@ tests:
     expectEvents:
       - client: *client
         events:
-          # Because the insert expects an error and gets an error, it technically succeeds, so withTransaction will
-          # try to run commitTransaction. This will fail client-side, though, because the timeout has already expired,
-          # so no command is sent.
           - commandStartedEvent:
               commandName: insert
               databaseName: *databaseName
@@ -166,3 +163,11 @@ tests:
                 maxTimeMS: { $$type: ["int", "long"] }
           - commandFailedEvent:
               commandName: insert
+          - commandStartedEvent:
+              commandName: abortTransaction
+              databaseName: admin
+              command:
+                abortTransaction: 1
+                maxTimeMS: { $$type: [ "int", "long" ] }
+          - commandFailedEvent:
+              commandName: abortTransaction

--- a/test/spec/client-side-operations-timeout/sessions-override-operation-timeoutMS.json
+++ b/test/spec/client-side-operations-timeout/sessions-override-operation-timeoutMS.json
@@ -75,7 +75,7 @@
                   "commitTransaction"
                 ],
                 "blockConnection": true,
-                "blockTimeMS": 60
+                "blockTimeMS": 600
               }
             }
           }
@@ -98,7 +98,7 @@
           "name": "commitTransaction",
           "object": "session",
           "arguments": {
-            "timeoutMS": 50
+            "timeoutMS": 500
           },
           "expectError": {
             "isTimeoutError": true
@@ -165,7 +165,7 @@
                   "abortTransaction"
                 ],
                 "blockConnection": true,
-                "blockTimeMS": 60
+                "blockTimeMS": 600
               }
             }
           }
@@ -188,7 +188,7 @@
           "name": "abortTransaction",
           "object": "session",
           "arguments": {
-            "timeoutMS": 50
+            "timeoutMS": 500
           }
         }
       ],
@@ -252,7 +252,7 @@
                   "insert"
                 ],
                 "blockConnection": true,
-                "blockTimeMS": 60
+                "blockTimeMS": 600
               }
             }
           }
@@ -261,7 +261,7 @@
           "name": "withTransaction",
           "object": "session",
           "arguments": {
-            "timeoutMS": 50,
+            "timeoutMS": 500,
             "callback": [
               {
                 "name": "insertOne",
@@ -305,6 +305,26 @@
             {
               "commandFailedEvent": {
                 "commandName": "insert"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "abortTransaction",
+                "databaseName": "admin",
+                "command": {
+                  "abortTransaction": 1,
+                  "maxTimeMS": {
+                    "$$type": [
+                      "int",
+                      "long"
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "commandFailedEvent": {
+                "commandName": "abortTransaction"
               }
             }
           ]

--- a/test/spec/client-side-operations-timeout/sessions-override-operation-timeoutMS.yml
+++ b/test/spec/client-side-operations-timeout/sessions-override-operation-timeoutMS.yml
@@ -50,7 +50,7 @@ tests:
             data:
               failCommands: ["commitTransaction"]
               blockConnection: true
-              blockTimeMS: 60
+              blockTimeMS: 600
       - name: startTransaction
         object: *session
       - name: insertOne
@@ -61,7 +61,7 @@ tests:
       - name: commitTransaction
         object: *session
         arguments:
-          timeoutMS: 50
+          timeoutMS: 500
         expectError:
           isTimeoutError: true
     expectEvents:
@@ -95,7 +95,7 @@ tests:
             data:
               failCommands: ["abortTransaction"]
               blockConnection: true
-              blockTimeMS: 60
+              blockTimeMS: 600
       - name: startTransaction
         object: *session
       - name: insertOne
@@ -106,7 +106,7 @@ tests:
       - name: abortTransaction
         object: *session
         arguments:
-          timeoutMS: 50
+          timeoutMS: 500
     expectEvents:
       - client: *client
         events:
@@ -138,11 +138,11 @@ tests:
             data:
               failCommands: ["insert"]
               blockConnection: true
-              blockTimeMS: 60
+              blockTimeMS: 600
       - name: withTransaction
         object: *session
         arguments:
-          timeoutMS: 50
+          timeoutMS: 500
           callback:
             - name: insertOne
               object: *collection
@@ -156,9 +156,6 @@ tests:
     expectEvents:
       - client: *client
         events:
-          # Because the insert expects an error and gets an error, it technically succeeds, so withTransaction will
-          # try to run commitTransaction. This will fail client-side, though, because the timeout has already expired,
-          # so no command is sent.
           - commandStartedEvent:
               commandName: insert
               databaseName: *databaseName
@@ -169,3 +166,11 @@ tests:
                 maxTimeMS: { $$type: ["int", "long"] }
           - commandFailedEvent:
               commandName: insert
+          - commandStartedEvent:
+              commandName: abortTransaction
+              databaseName: admin
+              command:
+                abortTransaction: 1
+                maxTimeMS: { $$type: ["int", "long"] }
+          - commandFailedEvent:
+              commandName: abortTransaction

--- a/test/spec/client-side-operations-timeout/sessions-override-timeoutMS.json
+++ b/test/spec/client-side-operations-timeout/sessions-override-timeoutMS.json
@@ -47,7 +47,7 @@
         "id": "session",
         "client": "client",
         "sessionOptions": {
-          "defaultTimeoutMS": 50
+          "defaultTimeoutMS": 500
         }
       }
     }
@@ -78,7 +78,7 @@
                   "commitTransaction"
                 ],
                 "blockConnection": true,
-                "blockTimeMS": 60
+                "blockTimeMS": 600
               }
             }
           }
@@ -165,7 +165,7 @@
                   "abortTransaction"
                 ],
                 "blockConnection": true,
-                "blockTimeMS": 60
+                "blockTimeMS": 600
               }
             }
           }
@@ -249,7 +249,7 @@
                   "insert"
                 ],
                 "blockConnection": true,
-                "blockTimeMS": 60
+                "blockTimeMS": 600
               }
             }
           }
@@ -301,6 +301,26 @@
             {
               "commandFailedEvent": {
                 "commandName": "insert"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "abortTransaction",
+                "databaseName": "admin",
+                "command": {
+                  "abortTransaction": 1,
+                  "maxTimeMS": {
+                    "$$type": [
+                      "int",
+                      "long"
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "commandFailedEvent": {
+                "commandName": "abortTransaction"
               }
             }
           ]

--- a/test/spec/client-side-operations-timeout/sessions-override-timeoutMS.yml
+++ b/test/spec/client-side-operations-timeout/sessions-override-timeoutMS.yml
@@ -29,7 +29,7 @@ createEntities:
       id: &session session
       client: *client
       sessionOptions:
-        defaultTimeoutMS: 50
+        defaultTimeoutMS: 500
 
 initialData:
   - collectionName: *collectionName
@@ -52,7 +52,7 @@ tests:
             data:
               failCommands: ["commitTransaction"]
               blockConnection: true
-              blockTimeMS: 60
+              blockTimeMS: 600
       - name: startTransaction
         object: *session
       - name: insertOne
@@ -95,7 +95,7 @@ tests:
             data:
               failCommands: ["abortTransaction"]
               blockConnection: true
-              blockTimeMS: 60
+              blockTimeMS: 600
       - name: startTransaction
         object: *session
       - name: insertOne
@@ -136,7 +136,7 @@ tests:
             data:
               failCommands: ["insert"]
               blockConnection: true
-              blockTimeMS: 60
+              blockTimeMS: 600
       - name: withTransaction
         object: *session
         arguments:
@@ -153,9 +153,6 @@ tests:
     expectEvents:
       - client: *client
         events:
-          # Because the insert expects an error and gets an error, it technically succeeds, so withTransaction will
-          # try to run commitTransaction. This will fail client-side, though, because the timeout has already expired,
-          # so no command is sent.
           - commandStartedEvent:
               commandName: insert
               databaseName: *databaseName
@@ -166,3 +163,11 @@ tests:
                 maxTimeMS: { $$type: ["int", "long"] }
           - commandFailedEvent:
               commandName: insert
+          - commandStartedEvent:
+              commandName: abortTransaction
+              databaseName: admin
+              command:
+                abortTransaction: 1
+                maxTimeMS: { $$type: [ "int", "long" ] }
+          - commandFailedEvent:
+              commandName: abortTransaction

--- a/test/tools/unified-spec-runner/entities.ts
+++ b/test/tools/unified-spec-runner/entities.ts
@@ -619,6 +619,10 @@ export class EntitiesMap<E = Entity> extends Map<string, E> {
 
         const options = Object.create(null);
 
+        if (entity.session.sessionOptions?.defaultTimeoutMS != null) {
+          options.defaultTimeoutMS = entity.session.sessionOptions?.defaultTimeoutMS;
+        }
+
         if (entity.session.sessionOptions?.causalConsistency) {
           options.causalConsistency = entity.session.sessionOptions?.causalConsistency;
         }

--- a/test/tools/unified-spec-runner/match.ts
+++ b/test/tools/unified-spec-runner/match.ts
@@ -501,6 +501,13 @@ function compareCommandFailedEvents(
   }
 }
 
+function expectInstanceOf<T extends new (...args: any[]) => any>(
+  instance: any,
+  ctor: T
+): asserts instance is InstanceType<T> {
+  expect(instance).to.be.instanceOf(ctor);
+}
+
 function compareEvents(
   actual: CommandEvent[] | CmapEvent[] | SdamEvent[],
   expected: (ExpectedCommandEvent & ExpectedCmapEvent & ExpectedSdamEvent)[],
@@ -515,9 +522,7 @@ function compareEvents(
 
     if (expectedEvent.commandStartedEvent) {
       const path = `${rootPrefix}.commandStartedEvent`;
-      if (!(actualEvent instanceof CommandStartedEvent)) {
-        expect.fail(`expected ${path} to be instanceof CommandStartedEvent`);
-      }
+      expectInstanceOf(actualEvent, CommandStartedEvent);
       compareCommandStartedEvents(actualEvent, expectedEvent.commandStartedEvent, entities, path);
       if (expectedEvent.commandStartedEvent.hasServerConnectionId) {
         expect(actualEvent).property('serverConnectionId').to.be.a('bigint');
@@ -526,9 +531,7 @@ function compareEvents(
       }
     } else if (expectedEvent.commandSucceededEvent) {
       const path = `${rootPrefix}.commandSucceededEvent`;
-      if (!(actualEvent instanceof CommandSucceededEvent)) {
-        expect.fail(`expected ${path} to be instanceof CommandSucceededEvent`);
-      }
+      expectInstanceOf(actualEvent, CommandSucceededEvent);
       compareCommandSucceededEvents(
         actualEvent,
         expectedEvent.commandSucceededEvent,
@@ -542,9 +545,7 @@ function compareEvents(
       }
     } else if (expectedEvent.commandFailedEvent) {
       const path = `${rootPrefix}.commandFailedEvent`;
-      if (!(actualEvent instanceof CommandFailedEvent)) {
-        expect.fail(`expected ${path} to be instanceof CommandFailedEvent`);
-      }
+      expectInstanceOf(actualEvent, CommandFailedEvent);
       compareCommandFailedEvents(actualEvent, expectedEvent.commandFailedEvent, entities, path);
       if (expectedEvent.commandFailedEvent.hasServerConnectionId) {
         expect(actualEvent).property('serverConnectionId').to.be.a('bigint');

--- a/test/tools/unified-spec-runner/operations.ts
+++ b/test/tools/unified-spec-runner/operations.ts
@@ -19,6 +19,7 @@ import {
   ServerType,
   type TopologyDescription,
   type TopologyType,
+  type TransactionOptions,
   WriteConcern
 } from '../../mongodb';
 import { sleep } from '../../tools/utils';
@@ -47,11 +48,6 @@ operations.set('createEntities', async ({ entities, operation, testConfig }) => 
     throw new AssertionError('encountered createEntities operation without entities argument');
   }
   await EntitiesMap.createEntities(testConfig, null, operation.arguments.entities!, entities);
-});
-
-operations.set('abortTransaction', async ({ entities, operation }) => {
-  const session = entities.getEntity('session', operation.object);
-  return session.abortTransaction();
 });
 
 operations.set('aggregate', async ({ entities, operation }) => {
@@ -231,7 +227,16 @@ operations.set('close', async ({ entities, operation }) => {
 
 operations.set('commitTransaction', async ({ entities, operation }) => {
   const session = entities.getEntity('session', operation.object);
-  return session.commitTransaction();
+  if (operation.arguments?.timeoutMS != null)
+    return await session.commitTransaction({ timeoutMS: operation.arguments.timeoutMS });
+  return await session.commitTransaction();
+});
+
+operations.set('abortTransaction', async ({ entities, operation }) => {
+  const session = entities.getEntity('session', operation.object);
+  if (operation.arguments?.timeoutMS != null)
+    return await session.abortTransaction({ timeoutMS: operation.arguments.timeoutMS });
+  return await session.abortTransaction();
 });
 
 operations.set('createChangeStream', async ({ entities, operation }) => {
@@ -361,7 +366,7 @@ operations.set('insertOne', async ({ entities, operation }) => {
   // Looping exposes the fact that we can generate _ids for inserted
   // documents and we don't want the original operation to get modified
   // and use the same _id for each insert.
-  return collection.insertOne({ ...document }, opts);
+  return await collection.insertOne({ ...document }, opts);
 });
 
 operations.set('insertMany', async ({ entities, operation }) => {
@@ -708,12 +713,16 @@ operations.set('waitForThread', async ({ entities, operation }) => {
 operations.set('withTransaction', async ({ entities, operation, client, testConfig }) => {
   const session = entities.getEntity('session', operation.object);
 
-  const options = {
+  const options: TransactionOptions = {
     readConcern: ReadConcern.fromOptions(operation.arguments),
     writeConcern: WriteConcern.fromOptions(operation.arguments),
     readPreference: ReadPreference.fromOptions(operation.arguments),
-    maxCommitTimeMS: operation.arguments!.maxCommitTimeMS
+    maxCommitTimeMS: operation.arguments?.maxCommitTimeMS
   };
+
+  if (typeof operation.arguments?.timeoutMS === 'number') {
+    options.timeoutMS = operation.arguments.timeoutMS;
+  }
 
   await session.withTransaction(async () => {
     for (const callbackOperation of operation.arguments!.callback) {
@@ -935,7 +944,7 @@ export async function executeOperationAndCheck(
   rethrow = false
 ): Promise<void> {
   const opFunc = operations.get(operation.name);
-  expect(opFunc, `Unknown operation: ${operation.name}`).to.exist;
+  if (opFunc == null) expect.fail(`Unknown operation: ${operation.name}`);
 
   if (operation.arguments && operation.arguments.session) {
     // The session could need to be either pulled from the entity map or in the case where
@@ -949,7 +958,7 @@ export async function executeOperationAndCheck(
   let result;
 
   try {
-    result = await opFunc!({ entities, operation, client, testConfig });
+    result = await opFunc({ entities, operation, client, testConfig });
   } catch (error) {
     if (operation.expectError) {
       expectErrorCheck(error, operation.expectError, entities);

--- a/test/tools/unified-spec-runner/operations.ts
+++ b/test/tools/unified-spec-runner/operations.ts
@@ -227,16 +227,12 @@ operations.set('close', async ({ entities, operation }) => {
 
 operations.set('commitTransaction', async ({ entities, operation }) => {
   const session = entities.getEntity('session', operation.object);
-  if (operation.arguments?.timeoutMS != null)
-    return await session.commitTransaction({ timeoutMS: operation.arguments.timeoutMS });
-  return await session.commitTransaction();
+  return await session.commitTransaction({ timeoutMS: operation.arguments?.timeoutMS });
 });
 
 operations.set('abortTransaction', async ({ entities, operation }) => {
   const session = entities.getEntity('session', operation.object);
-  if (operation.arguments?.timeoutMS != null)
-    return await session.abortTransaction({ timeoutMS: operation.arguments.timeoutMS });
-  return await session.abortTransaction();
+  return await session.abortTransaction({ timeoutMS: operation.arguments?.timeoutMS });
 });
 
 operations.set('createChangeStream', async ({ entities, operation }) => {


### PR DESCRIPTION
### Description

#### What is changing?

- CSOT support for session APIs
  - abort/commit Transaction
  - endSession
  - withTransaction
    - Despite the diff I only: 
      - indented the logic into a try/finally block
      - the timeoutContext is always cleared when withTxn is done
      - the old timeout mechanism is short-circuited away if we have a timeoutContext defined
  - API docs updated.
  
- Some external fixes to timeout handling:
  - Do not synchronously throw from getters that return promises (timeouts) so .then chaining works as expected
  - Move TimeoutError conversion out of onData into readMany so that the stack trace is preserved
  - update mongodb-legacy version to pull in options passing fix
  - Moved duration into timeout error for debugging, it should always be equal to timeoutMS but it is useful when it is not. If we don't like this, we can revert it now or keep it on the CSOT feature, and file a follow up to remove

Testing:
- Pulled in changes to spec test files, all that changed was some bumps to timeouts to make them less flakey
- Implemented the prose tests and following suit with the above spec, the timeouts are a bit longer than suggested as I observed inserts timing out before TXN operations could be reached (the APIs we were aiming to timeout/test)
- A few unified runner changes to support the tests.


TBD: I have to find out what is going on with 4.4 replica sets. I will open the PR now to start review. The same tests pass on all other variants, and the failure is that abortTransaction is not failing despite having a failpoint set. It could be something I am doing wrong, but I am suspicious that the blockConnection failpoint seems to hit our timeout logic in all other servers. :thinking:

##### Is there new documentation needed for these changes?

Yes

#### What is the motivation for this change?

Transactions can be conveniently timed out. And sessions respect a single timeout setting from either the client or defaultTimeoutMS to deadline the completion of a Txn

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
