### PR TITLE
refactor(NODE-6325): implement document sequence support

### DIFF
--- a/src/cmap/commands.ts
+++ b/src/cmap/commands.ts
@@ -412,6 +412,17 @@ export interface OpMsgOptions {
 }
 
 /** @internal */
+export class DocumentSequence {
+  field: string;
+  documents: Document[];
+
+  constructor(field: string, documents: Document[]) {
+    this.field = field;
+    this.documents = documents;
+  }
+}
+
+/** @internal */
 export class OpMsgRequest {
   requestId: number;
   serializeFunctions: boolean;
@@ -480,7 +491,7 @@ export class OpMsgRequest {
 
     let totalLength = header.length;
     const command = this.command;
-    totalLength += this.makeDocumentSegment(buffers, command);
+    totalLength += this.makeSections(buffers, command);
 
     header.writeInt32LE(totalLength, 0); // messageLength
     header.writeInt32LE(this.requestId, 4); // requestID
@@ -490,15 +501,66 @@ export class OpMsgRequest {
     return buffers;
   }
 
-  makeDocumentSegment(buffers: Uint8Array[], document: Document): number {
+  /**
+   * Add the sections to the OP_MSG request's buffers and returns the length.
+   */
+  makeSections(buffers: Uint8Array[], document: Document): number {
+    const sequencesBuffer = this.extractDocumentSequences(document);
     const payloadTypeBuffer = Buffer.alloc(1);
     payloadTypeBuffer[0] = 0;
 
     const documentBuffer = this.serializeBson(document);
+    // First section, type 0
     buffers.push(payloadTypeBuffer);
     buffers.push(documentBuffer);
+    // Subsequent sections, type 1
+    buffers.push(sequencesBuffer);
 
-    return payloadTypeBuffer.length + documentBuffer.length;
+    return payloadTypeBuffer.length + documentBuffer.length + sequencesBuffer.length;
+  }
+
+  /**
+   * Extracts the document sequences from the command document and returns
+   * a buffer to be added as multiple sections after the initial type 0
+   * section in the message.
+   */
+  extractDocumentSequences(document: Document): Uint8Array {
+    // Pull out any field in the command document that's value is a document sequence.
+    const chunks = [];
+    for (const [key, value] of Object.entries(document)) {
+      if (value instanceof DocumentSequence) {
+        // Document sequences starts with type 1 at the first byte.
+        const payloadTypeBuffer = Buffer.alloc(1);
+        payloadTypeBuffer[0] = 1;
+        chunks.push(payloadTypeBuffer);
+        // Second part of the sequence is the length;
+        const lengthBuffer = Buffer.alloc(4);
+        chunks.push(lengthBuffer);
+        // Third part is the field name.
+        const fieldBuffer = Buffer.from(key);
+        chunks.push(fieldBuffer);
+        // Fourth part are the documents' bytes.
+        let docsLength = 0;
+        for (const doc of value.documents) {
+          const docBson = this.serializeBson(doc);
+          docsLength += docBson.length;
+          chunks.push(docBson);
+        }
+        lengthBuffer.writeInt32LE(fieldBuffer.length + docsLength);
+        // Why are we removing the field from the command? This is because it needs to be
+        // removed in the OP_MSG request first section, and DocumentSequence is not a
+        // BSON type and is specific to the MongoDB wire protocol so there's nothing
+        // our BSON serializer can do about this. Since DocumentSequence is not exposed
+        // in the public API and only used internally, we are never mutating an original
+        // command provided by the user, just our own, and it's cheaper to delete from
+        // our own command than copying it.
+        delete document[key];
+      }
+    }
+    if (chunks.length > 0) {
+      return Buffer.concat(chunks);
+    }
+    return Buffer.alloc(0);
   }
 
   serializeBson(document: Document): Uint8Array {

--- a/test/unit/cmap/commands.test.ts
+++ b/test/unit/cmap/commands.test.ts
@@ -1,3 +1,4 @@
+import * as BSON from 'bson';
 import { expect } from 'chai';
 
 import { DocumentSequence, OpMsgRequest, OpReply } from '../../mongodb';
@@ -14,10 +15,20 @@ describe('commands', function () {
         context('when there is one document sequence', function () {
           const command = {
             test: 1,
-            field: new DocumentSequence('test', [{ test: 1 }])
+            field: new DocumentSequence([{ test: 1 }])
           };
           const msg = new OpMsgRequest('admin', command, {});
           const buffers = msg.toBin();
+
+          it('keeps the first section as type 0', function () {
+            // The type byte for the first section is at index 1.
+            expect(buffers[1][0]).to.equal(0);
+          });
+
+          it('does not serialize the document sequences in the first section', function () {
+            // Buffer at index 2 is the type 0 section - one document.
+            expect(BSON.deserialize(buffers[2])).to.deep.equal({ test: 1, $db: 'admin' });
+          });
 
           it('removes the document sequence fields from the command', function () {
             expect(command).to.not.haveOwnProperty('field');
@@ -42,11 +53,21 @@ describe('commands', function () {
         context('when there are multiple document sequences', function () {
           const command = {
             test: 1,
-            fieldOne: new DocumentSequence('test', [{ test: 1 }]),
-            fieldTwo: new DocumentSequence('test', [{ test: 1 }])
+            fieldOne: new DocumentSequence([{ test: 1 }]),
+            fieldTwo: new DocumentSequence([{ test: 1 }])
           };
           const msg = new OpMsgRequest('admin', command, {});
           const buffers = msg.toBin();
+
+          it('keeps the first section as type 0', function () {
+            // The type byte for the first section is at index 1.
+            expect(buffers[1][0]).to.equal(0);
+          });
+
+          it('does not serialize the document sequences in the first section', function () {
+            // Buffer at index 2 is the type 0 section - one document.
+            expect(BSON.deserialize(buffers[2])).to.deep.equal({ test: 1, $db: 'admin' });
+          });
 
           it('removes the document sequence fields from the command', function () {
             expect(command).to.not.haveOwnProperty('fieldOne');


### PR DESCRIPTION
### Description

Implements OP_MSG type 1 sections for document sequences.

#### What is changing?

- Adds a `DocumentSequence` object that can be added to commands internally to leverage type 1 sections.
- Updates `OpMsgRequest` to properly handle document sequences in commands.
- Adds unit tests on `OpMsgRequest#toBin` 

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-6325

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
