### PR TITLE
chore(NODE-6341): remove node18+ dns resolution order hooks

### DIFF
--- a/test/integration/client-side-encryption/client_side_encryption.prose.06.corpus.test.ts
+++ b/test/integration/client-side-encryption/client_side_encryption.prose.06.corpus.test.ts
@@ -8,7 +8,6 @@ import * as path from 'path';
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { ClientEncryption } from '../../../src/client-side-encryption/client_encryption';
 import { type MongoClient, WriteConcern } from '../../mongodb';
-import { installNodeDNSWorkaroundHooks } from '../../tools/runner/hooks/configuration';
 import { getEncryptExtraOptions } from '../../tools/utils';
 
 describe('Client Side Encryption Prose Corpus Test', function () {
@@ -145,8 +144,6 @@ describe('Client Side Encryption Prose Corpus Test', function () {
       throw new Error('Unexpected value for allowed: ' + expected.allowed);
     }
   }
-
-  installNodeDNSWorkaroundHooks();
 
   let client: MongoClient;
 

--- a/test/integration/client-side-encryption/client_side_encryption.prose.12.deadlock.test.ts
+++ b/test/integration/client-side-encryption/client_side_encryption.prose.12.deadlock.test.ts
@@ -6,7 +6,6 @@ import * as path from 'path';
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { ClientEncryption } from '../../../src/client-side-encryption/client_encryption';
 import { type CommandStartedEvent, MongoClient, type MongoClientOptions } from '../../mongodb';
-import { installNodeDNSWorkaroundHooks } from '../../tools/runner/hooks/configuration';
 import { getEncryptExtraOptions } from '../../tools/utils';
 import { dropCollection } from '../shared';
 
@@ -104,8 +103,6 @@ const metadata = {
   }
 };
 describe('Connection Pool Deadlock Prevention', function () {
-  installNodeDNSWorkaroundHooks();
-
   beforeEach(async function () {
     const url: string = this.configuration.url();
 

--- a/test/integration/client-side-encryption/client_side_encryption.prose.14.decryption_events.test.ts
+++ b/test/integration/client-side-encryption/client_side_encryption.prose.14.decryption_events.test.ts
@@ -10,7 +10,6 @@ import {
   type MongoClient,
   MongoNetworkError
 } from '../../mongodb';
-import { installNodeDNSWorkaroundHooks } from '../../tools/runner/hooks/configuration';
 import { getEncryptExtraOptions } from '../../tools/utils';
 
 const metadata: MongoDBMetadataUI = {
@@ -27,8 +26,6 @@ const LOCAL_KEY = Buffer.from(
 );
 
 describe('14. Decryption Events', metadata, function () {
-  installNodeDNSWorkaroundHooks();
-
   let setupClient: MongoClient;
   let clientEncryption;
   let keyId: Binary;

--- a/test/integration/client-side-encryption/client_side_encryption.prose.21.automatic_data_encryption_keys.test.ts
+++ b/test/integration/client-side-encryption/client_side_encryption.prose.21.automatic_data_encryption_keys.test.ts
@@ -5,7 +5,6 @@ import { ClientEncryption } from '../../../src/client-side-encryption/client_enc
 /* eslint-disable @typescript-eslint/no-restricted-imports */
 import { MongoCryptCreateEncryptedCollectionError } from '../../../src/client-side-encryption/errors';
 import { BSON, Collection, type Db, MongoServerError } from '../../mongodb';
-import { installNodeDNSWorkaroundHooks } from '../../tools/runner/hooks/configuration';
 
 const metadata: MongoDBMetadataUI = {
   requires: {
@@ -19,8 +18,6 @@ const documentValidationFailureCode = 121;
 const typeMismatchCode = 14;
 
 describe('21. Automatic Data Encryption Keys', () => {
-  installNodeDNSWorkaroundHooks();
-
   let db: Db;
   let clientEncryption;
   let client;

--- a/test/integration/client-side-encryption/client_side_encryption.prose.22.range_explicit_encryption.test.ts
+++ b/test/integration/client-side-encryption/client_side_encryption.prose.22.range_explicit_encryption.test.ts
@@ -8,7 +8,6 @@ import { Decimal128, type Document, Double, Long, type MongoClient } from '../..
 import { ClientEncryption } from '../../../src/client-side-encryption/client_encryption';
 /* eslint-disable @typescript-eslint/no-restricted-imports */
 import { MongoCryptError } from '../../../src/client-side-encryption/errors';
-import { installNodeDNSWorkaroundHooks } from '../../tools/runner/hooks/configuration';
 
 const getKmsProviders = () => {
   const result = EJSON.parse(process.env.CSFLE_KMS_PROVIDERS || '{}') as unknown as {
@@ -135,8 +134,6 @@ const readEncryptedFieldsFile = (dataType: string): Promise<string> =>
   });
 
 describe('Range Explicit Encryption', function () {
-  installNodeDNSWorkaroundHooks();
-
   let clientEncryption;
   let keyId;
   let keyVaultClient;

--- a/test/integration/client-side-encryption/client_side_encryption.prose.test.js
+++ b/test/integration/client-side-encryption/client_side_encryption.prose.test.js
@@ -10,7 +10,6 @@ const { EJSON } = BSON;
 const { LEGACY_HELLO_COMMAND, MongoCryptError } = require('../../mongodb');
 const { MongoServerError, MongoServerSelectionError, MongoClient } = require('../../mongodb');
 const { getEncryptExtraOptions } = require('../../tools/utils');
-const { installNodeDNSWorkaroundHooks } = require('../../tools/runner/hooks/configuration');
 const { coerce, gte } = require('semver');
 
 const {
@@ -78,8 +77,6 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
     'Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk',
     'base64'
   );
-
-  installNodeDNSWorkaroundHooks();
 
   describe('Data key and double encryption', function () {
     // Data key and double encryption

--- a/test/integration/client-side-encryption/client_side_encryption.spec.test.ts
+++ b/test/integration/client-side-encryption/client_side_encryption.spec.test.ts
@@ -2,7 +2,6 @@ import * as path from 'path';
 
 import { loadSpecTests } from '../../spec';
 import { ClientSideEncryptionFilter } from '../../tools/runner/filters/client_encryption_filter';
-import { installNodeDNSWorkaroundHooks } from '../../tools/runner/hooks/configuration';
 import {
   gatherTestSuites,
   generateTopologyTests,
@@ -70,8 +69,6 @@ describe('Client Side Encryption (Legacy)', function () {
     testContext
   );
 
-  installNodeDNSWorkaroundHooks();
-
   after(() => testContext.teardown());
 
   before(function () {
@@ -124,8 +121,6 @@ describe('Client Side Encryption (Legacy)', function () {
 });
 
 describe('Client Side Encryption (Unified)', function () {
-  installNodeDNSWorkaroundHooks();
-
   before(async function () {
     await filter.initializeFilter({} as any, {});
   });

--- a/test/integration/client-side-encryption/driver.test.ts
+++ b/test/integration/client-side-encryption/driver.test.ts
@@ -6,7 +6,6 @@ import * as crypto from 'crypto';
 import { ClientEncryption } from '../../../src/client-side-encryption/client_encryption';
 import { type Collection, type CommandStartedEvent, type MongoClient } from '../../mongodb';
 import * as BSON from '../../mongodb';
-import { installNodeDNSWorkaroundHooks } from '../../tools/runner/hooks/configuration';
 import { getEncryptExtraOptions } from '../../tools/utils';
 
 const metadata = {
@@ -22,8 +21,6 @@ describe('Client Side Encryption Functional', function () {
   const keyVaultDbName = 'keyvault';
   const keyVaultCollName = 'datakeys';
   const keyVaultNamespace = `${keyVaultDbName}.${keyVaultCollName}`;
-
-  installNodeDNSWorkaroundHooks();
 
   it('CSFLE_KMS_PROVIDERS should be valid EJSON', function () {
     const CSFLE_KMS_PROVIDERS = process.env.CSFLE_KMS_PROVIDERS;

--- a/test/manual/socks5.test.ts
+++ b/test/manual/socks5.test.ts
@@ -2,7 +2,6 @@ import { expect } from 'chai';
 import ConnectionString from 'mongodb-connection-string-url';
 
 import { LEGACY_HELLO_COMMAND, MongoClient, MongoParseError } from '../mongodb';
-import { installNodeDNSWorkaroundHooks } from '../tools/runner/hooks/configuration';
 
 /**
  * The SOCKS5_CONFIG environment variable is either a JSON 4-tuple
@@ -33,8 +32,6 @@ describe('Socks5 Connectivity', function () {
   rsConnectionString.searchParams.set('serverSelectionTimeoutMS', '2000');
   singleConnectionString.searchParams.set('serverSelectionTimeoutMS', '2000');
   singleConnectionString.searchParams.set('readPreference', 'primaryPreferred');
-
-  installNodeDNSWorkaroundHooks();
 
   context((proxyUsername ? 'with' : 'without') + ' Socks5 auth required', function () {
     context('with missing required Socks5 auth configuration', function () {

--- a/test/tools/runner/hooks/configuration.ts
+++ b/test/tools/runner/hooks/configuration.ts
@@ -207,28 +207,6 @@ const beforeAllPluginImports = () => {
   require('mocha-sinon');
 };
 
-/**
- * @remarks TODO(NODE-4884): once happy eyeballs support is added, we no longer need to set
- * the default dns resolution order for CI
- */
-export function installNodeDNSWorkaroundHooks() {
-  if (gte(coerce(process.version), coerce('18'))) {
-    // We set before hooks because some tests connect in before hooks
-    before(() => {
-      setDefaultResultOrder('ipv4first');
-    });
-
-    // We set beforeEach hooks to make this resilient to test ordering and
-    // ensure each affected test has the correct ip address resolution setting
-    beforeEach(() => {
-      setDefaultResultOrder('ipv4first');
-    });
-    afterEach(() => {
-      setDefaultResultOrder('verbatim');
-    });
-  }
-}
-
 export const mochaHooks = {
   beforeAll: [beforeAllPluginImports, testConfigBeforeHook],
   beforeEach: [testSkipBeforeEachHook],

--- a/test/tools/runner/hooks/configuration.ts
+++ b/test/tools/runner/hooks/configuration.ts
@@ -11,8 +11,6 @@ import { AstrolabeTestConfiguration, TestConfiguration } from '../config';
 import { getEnvironmentalOptions } from '../../utils';
 import * as mock from '../../mongodb-mock/index';
 import { inspect } from 'util';
-import { setDefaultResultOrder } from 'dns';
-import { coerce, gte } from 'semver';
 
 import { ApiVersionFilter } from '../filters/api_version_filter';
 import { AuthFilter } from '../filters/auth_filter';


### PR DESCRIPTION
### Description

#### What is changing?

Now that [NODE-5754](https://jira.mongodb.org/browse/NODE-5754) is implemented, the driver connects to both ipv4 and ipv6 hosts without additional configuration. This makes installNodeDNSWorkaroundHooks, added when Node18 changed the default DNS resolution order, unnecessary.

This PR removes installNodeDNSWorkaroundHooks.

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
