### PR TITLE
test(NODE-6343): unskip Case 4: KMIP should fail with no TLS

### DIFF
--- a/test/integration/client-side-encryption/client_side_encryption.prose.test.js
+++ b/test/integration/client-side-encryption/client_side_encryption.prose.test.js
@@ -1654,17 +1654,9 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
       const masterKey = {};
 
       it('should fail with no TLS', metadata, async function () {
-        if (gte(coerce(process.version), coerce('19'))) {
-          this.test.skipReason = 'TODO(NODE-4942): fix failing csfle kmip test on Node19+';
-          this.skip();
-        }
-        try {
-          await clientEncryptionNoTls.createDataKey('kmip', { masterKey });
-          expect.fail('it must fail with no tls');
-        } catch (e) {
-          //Expect an error indicating TLS handshake failed.
-          expect(e.cause.message).to.match(/before secure TLS connection|handshake/);
-        }
+        const e = await clientEncryptionNoTls.createDataKey('kmip', { masterKey }).catch(e => e);
+        //Expect an error indicating TLS handshake failed.
+        expect(e.cause.message).to.match(/before secure TLS connection|handshake/);
       });
 
       it('should succeed with valid TLS options', metadata, async function () {

--- a/test/integration/client-side-encryption/client_side_encryption.prose.test.js
+++ b/test/integration/client-side-encryption/client_side_encryption.prose.test.js
@@ -10,7 +10,6 @@ const { EJSON } = BSON;
 const { LEGACY_HELLO_COMMAND, MongoCryptError } = require('../../mongodb');
 const { MongoServerError, MongoServerSelectionError, MongoClient } = require('../../mongodb');
 const { getEncryptExtraOptions } = require('../../tools/utils');
-const { coerce, gte } = require('semver');
 
 const {
   externalSchema


### PR DESCRIPTION
### Description

#### What is changing?

Remove skip on node versions greater than 19

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

More coverage

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
