### PR TITLE
chore(NODE-6341): followup fix remove node18+ dns resolution order hooks

### DIFF
--- a/test/integration/client-side-encryption/client_side_encryption.prose.23.range_encryption_defaults.test.ts
+++ b/test/integration/client-side-encryption/client_side_encryption.prose.23.range_encryption_defaults.test.ts
@@ -3,7 +3,6 @@ import { expect } from 'chai';
 /* eslint-disable @typescript-eslint/no-restricted-imports */
 import { ClientEncryption } from '../../../src/client-side-encryption/client_encryption';
 import { type Binary, EJSON, Int32, Long } from '../../mongodb';
-import { installNodeDNSWorkaroundHooks } from '../../tools/runner/hooks/configuration';
 
 const metaData: MongoDBMetadataUI = {
   requires: {
@@ -27,8 +26,6 @@ const getKmsProviders = (): { local: { key: string } } => {
 };
 
 describe('Range Explicit Encryption Defaults', function () {
-  installNodeDNSWorkaroundHooks();
-
   let clientEncryption: ClientEncryption;
   let keyId;
   let keyVaultClient;

--- a/test/integration/client-side-encryption/driver.test.ts
+++ b/test/integration/client-side-encryption/driver.test.ts
@@ -404,8 +404,6 @@ describe('Client Side Encryption Functional', function () {
 });
 
 describe('Range Explicit Encryption with JS native types', function () {
-  installNodeDNSWorkaroundHooks();
-
   const metaData: MongoDBMetadataUI = {
     requires: {
       clientSideEncryption: '>=6.1.0',


### PR DESCRIPTION
### Description

#### What is changing?

The merged commit on main wasn't included in #4202, this finishes the removal

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

CI 💥  -> CI ✅

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
