### PR TITLE
feat(NODE-6327): new client bulk write types and builders

### DIFF
--- a/src/operations/client_bulk_write/command_builder.ts
+++ b/src/operations/client_bulk_write/command_builder.ts
@@ -60,8 +60,9 @@ export class ClientBulkWriteCommandBuilder {
     const namespaces = new Map<string, number>();
     for (const model of this.models) {
       const ns = model.namespace;
-      if (namespaces.has(ns)) {
-        operations.push(buildOperation(model, namespaces.get(ns) as number));
+      const index = namespaces.get(ns);
+      if (index != null) {
+        operations.push(buildOperation(model, index));
       } else {
         namespaces.set(ns, currentNamespaceIndex);
         operations.push(buildOperation(model, currentNamespaceIndex));
@@ -92,7 +93,7 @@ export class ClientBulkWriteCommandBuilder {
 }
 
 /** @internal */
-export interface InsertOperation<TSchema extends Document = Document> {
+interface ClientInsertOperation<TSchema extends Document = Document> {
   insert: number;
   document: OptionalId<TSchema>;
 }
@@ -103,8 +104,11 @@ export interface InsertOperation<TSchema extends Document = Document> {
  * @param index - The namespace index.
  * @returns the operation.
  */
-export const buildInsertOneOperation = (model: ClientInsertOneModel, index: number): Document => {
-  const document: InsertOperation = {
+export const buildInsertOneOperation = (
+  model: ClientInsertOneModel,
+  index: number
+): ClientInsertOperation => {
+  const document: ClientInsertOperation = {
     insert: index,
     document: model.document
   };
@@ -112,7 +116,7 @@ export const buildInsertOneOperation = (model: ClientInsertOneModel, index: numb
 };
 
 /** @internal */
-export interface DeleteOperation<TSchema extends Document = Document> {
+export interface ClientDeleteOperation<TSchema extends Document = Document> {
   delete: number;
   multi: boolean;
   filter: Filter<TSchema>;
@@ -147,8 +151,8 @@ function createDeleteOperation(
   model: ClientDeleteOneModel | ClientDeleteManyModel,
   index: number,
   multi: boolean
-): DeleteOperation {
-  const document: DeleteOperation = {
+): ClientDeleteOperation {
+  const document: ClientDeleteOperation = {
     delete: index,
     multi: multi,
     filter: model.filter
@@ -163,7 +167,7 @@ function createDeleteOperation(
 }
 
 /** @internal */
-export interface UpdateOperation<TSchema extends Document = Document> {
+export interface ClientUpdateOperation<TSchema extends Document = Document> {
   update: number;
   multi: boolean;
   filter: Filter<TSchema>;
@@ -182,7 +186,7 @@ export interface UpdateOperation<TSchema extends Document = Document> {
 export const buildUpdateOneOperation = (
   model: ClientUpdateOneModel,
   index: number
-): UpdateOperation => {
+): ClientUpdateOperation => {
   return createUpdateOperation(model, index, false);
 };
 
@@ -195,7 +199,7 @@ export const buildUpdateOneOperation = (
 export const buildUpdateManyOperation = (
   model: ClientUpdateManyModel,
   index: number
-): UpdateOperation => {
+): ClientUpdateOperation => {
   return createUpdateOperation(model, index, true);
 };
 
@@ -206,8 +210,8 @@ function createUpdateOperation(
   model: ClientUpdateOneModel | ClientUpdateManyModel,
   index: number,
   multi: boolean
-): UpdateOperation {
-  const document: UpdateOperation = {
+): ClientUpdateOperation {
+  const document: ClientUpdateOperation = {
     update: index,
     multi: multi,
     filter: model.filter,
@@ -226,7 +230,7 @@ function createUpdateOperation(
 }
 
 /** @internal */
-export interface ReplaceOneOperation<TSchema extends Document = Document> {
+export interface ClientReplaceOneOperation<TSchema extends Document = Document> {
   update: number;
   multi: boolean;
   filter: Filter<TSchema>;
@@ -244,8 +248,8 @@ export interface ReplaceOneOperation<TSchema extends Document = Document> {
 export const buildReplaceOneOperation = (
   model: ClientReplaceOneModel,
   index: number
-): ReplaceOneOperation => {
-  const document: ReplaceOneOperation = {
+): ClientReplaceOneOperation => {
+  const document: ClientReplaceOneOperation = {
     update: index,
     multi: false,
     filter: model.filter,

--- a/src/operations/client_bulk_write/command_builder.ts
+++ b/src/operations/client_bulk_write/command_builder.ts
@@ -1,0 +1,302 @@
+import { type Document } from '../../bson';
+import { DocumentSequence } from '../../cmap/commands';
+import { MongoInvalidArgumentError } from '../../error';
+import type {
+  AnyClientBulkWriteModel,
+  ClientBulkWriteOptions,
+  ClientDeleteManyModel,
+  ClientDeleteOneModel,
+  ClientInsertOneModel,
+  ClientReplaceOneModel,
+  ClientUpdateManyModel,
+  ClientUpdateOneModel
+} from './common';
+
+/** @internal */
+export class ClientBulkWriteCommandBuilder {
+  models: AnyClientBulkWriteModel[];
+  options: ClientBulkWriteOptions;
+
+  /**
+   * Create the command builder.
+   * @param models - The client write models.
+   */
+  constructor(models: AnyClientBulkWriteModel[], options: ClientBulkWriteOptions) {
+    this.models = models;
+    this.options = options;
+  }
+
+  /**
+   * Gets the errorsOnly value for the command, which is the inverse of the
+   * user provided verboseResults option. Defaults to true.
+   */
+  get errorsOnly(): boolean {
+    if ('verboseResults' in this.options) {
+      return !this.options.verboseResults;
+    }
+    return true;
+  }
+
+  /**
+   * Build the bulk write commands from the models.
+   */
+  buildCommands(): Document[] {
+    // The base command.
+    const command: Document = {
+      bulkWrite: 1,
+      errorsOnly: this.errorsOnly,
+      ordered: this.options.ordered ?? true
+    };
+    // Add bypassDocumentValidation if it was present in the options.
+    if ('bypassDocumentValidation' in this.options) {
+      command.bypassDocumentValidation = this.options.bypassDocumentValidation;
+    }
+    // Add let if it was present in the options.
+    if ('let' in this.options) {
+      command.let = this.options.let;
+    }
+
+    // Iterate the models to build the ops and nsInfo fields.
+    const operations = [];
+    let currentNamespaceIndex = 0;
+    const namespaces = new Map<string, number>();
+    for (const model of this.models) {
+      const ns = model.namespace;
+      if (namespaces.has(ns)) {
+        operations.push(builderFor(model).buildOperation(namespaces.get(ns) as number));
+      } else {
+        namespaces.set(ns, currentNamespaceIndex);
+        operations.push(builderFor(model).buildOperation(currentNamespaceIndex));
+        currentNamespaceIndex++;
+      }
+    }
+
+    const nsInfo = Array.from(namespaces.keys()).map(ns => {
+      return { ns: ns };
+    });
+    command.ops = new DocumentSequence(operations);
+    command.nsInfo = new DocumentSequence(nsInfo);
+    return [command];
+  }
+}
+
+/** @internal */
+export interface OperationBuilder {
+  buildOperation(index: number): Document;
+}
+
+/**
+ * Builds insert one operations given the model.
+ * @internal
+ */
+export class InsertOneOperationBuilder implements OperationBuilder {
+  model: ClientInsertOneModel;
+
+  /**
+   * Instantiate the builder.
+   * @param model - The client insert one model.
+   */
+  constructor(model: ClientInsertOneModel) {
+    this.model = model;
+  }
+
+  /**
+   * Build the operation.
+   * @param index - The namespace index.
+   * @returns the operation.
+   */
+  buildOperation(index: number): Document {
+    const document: Document = {
+      insert: index,
+      document: this.model.document
+    };
+    return document;
+  }
+}
+
+/** @internal */
+export class DeleteOneOperationBuilder implements OperationBuilder {
+  model: ClientDeleteOneModel;
+
+  /**
+   * Instantiate the builder.
+   * @param model - The client delete one model.
+   */
+  constructor(model: ClientDeleteOneModel) {
+    this.model = model;
+  }
+
+  /**
+   * Build the operation.
+   * @param index - The namespace index.
+   * @returns the operation.
+   */
+  buildOperation(index: number): Document {
+    return createDeleteOperation(this.model, index, false);
+  }
+}
+
+/** @internal */
+export class DeleteManyOperationBuilder implements OperationBuilder {
+  model: ClientDeleteManyModel;
+
+  /**
+   * Instantiate the builder.
+   * @param model - The client delete many model.
+   */
+  constructor(model: ClientDeleteManyModel) {
+    this.model = model;
+  }
+
+  /**
+   * Build the operation.
+   * @param index - The namespace index.
+   * @returns the operation.
+   */
+  buildOperation(index: number): Document {
+    return createDeleteOperation(this.model, index, true);
+  }
+}
+
+/**
+ * Creates a delete operation based on the parameters.
+ */
+function createDeleteOperation(
+  model: ClientDeleteOneModel | ClientDeleteManyModel,
+  index: number,
+  multi: boolean
+): Document {
+  const document: Document = {
+    delete: index,
+    multi: multi,
+    filter: model.filter
+  };
+  if (model.hint) {
+    document.hint = model.hint;
+  }
+  if (model.collation) {
+    document.collation = model.collation;
+  }
+  return document;
+}
+
+/** @internal */
+export class UpdateOneOperationBuilder implements OperationBuilder {
+  model: ClientUpdateOneModel;
+
+  /**
+   * Instantiate the builder.
+   * @param model - The client update one model.
+   */
+  constructor(model: ClientUpdateOneModel) {
+    this.model = model;
+  }
+
+  /**
+   * Build the operation.
+   * @param index - The namespace index.
+   * @returns the operation.
+   */
+  buildOperation(index: number): Document {
+    return createUpdateOperation(this.model, index, false);
+  }
+}
+
+/** @internal */
+export class UpdateManyOperationBuilder implements OperationBuilder {
+  model: ClientUpdateManyModel;
+
+  /**
+   * Instantiate the builder.
+   * @param model - The client update many model.
+   */
+  constructor(model: ClientUpdateManyModel) {
+    this.model = model;
+  }
+
+  /**
+   * Build the operation.
+   * @param index - The namespace index.
+   * @returns the operation.
+   */
+  buildOperation(index: number): Document {
+    return createUpdateOperation(this.model, index, true);
+  }
+}
+
+/**
+ * Creates a delete operation based on the parameters.
+ */
+function createUpdateOperation(
+  model: ClientUpdateOneModel | ClientUpdateManyModel,
+  index: number,
+  multi: boolean
+): Document {
+  const document: Document = {
+    update: index,
+    multi: multi,
+    filter: model.filter,
+    updateMods: model.update
+  };
+  if (model.hint) {
+    document.hint = model.hint;
+  }
+  if (model.upsert) {
+    document.upsert = model.upsert;
+  }
+  if (model.arrayFilters) {
+    document.arrayFilters = model.arrayFilters;
+  }
+  return document;
+}
+
+/** @internal */
+export class ReplaceOneOperationBuilder implements OperationBuilder {
+  model: ClientReplaceOneModel;
+
+  /**
+   * Instantiate the builder.
+   * @param model - The client replace one model.
+   */
+  constructor(model: ClientReplaceOneModel) {
+    this.model = model;
+  }
+
+  /**
+   * Build the operation.
+   * @param index - The namespace index.
+   * @returns the operation.
+   */
+  buildOperation(index: number): Document {
+    const document: Document = {
+      update: index,
+      multi: false,
+      filter: this.model.filter,
+      updateMods: this.model.replacement
+    };
+    if (this.model.hint) {
+      document.hint = this.model.hint;
+    }
+    if (this.model.upsert) {
+      document.upsert = this.model.upsert;
+    }
+    return document;
+  }
+}
+
+const BUILDERS: Map<string, (model: AnyClientBulkWriteModel) => OperationBuilder> = new Map();
+BUILDERS.set('insertOne', model => new InsertOneOperationBuilder(model as ClientInsertOneModel));
+BUILDERS.set('deleteMany', model => new DeleteManyOperationBuilder(model as ClientDeleteManyModel));
+BUILDERS.set('deleteOne', model => new DeleteOneOperationBuilder(model as ClientDeleteOneModel));
+BUILDERS.set('updateMany', model => new UpdateManyOperationBuilder(model as ClientUpdateManyModel));
+BUILDERS.set('updateOne', model => new UpdateOneOperationBuilder(model as ClientUpdateOneModel));
+BUILDERS.set('replaceOne', model => new ReplaceOneOperationBuilder(model as ClientReplaceOneModel));
+
+/** @internal */
+export function builderFor(model: AnyClientBulkWriteModel): OperationBuilder {
+  const builder = BUILDERS.get(model.name)?.(model);
+  if (!builder) {
+    throw new MongoInvalidArgumentError(`Could not load builder for model ${model.name}`);
+  }
+  return builder;
+}

--- a/src/operations/client_bulk_write/command_builder.ts
+++ b/src/operations/client_bulk_write/command_builder.ts
@@ -81,7 +81,7 @@ export class ClientBulkWriteCommandBuilder {
       nsInfo: new DocumentSequence(nsInfo)
     };
     // Add bypassDocumentValidation if it was present in the options.
-    if ('bypassDocumentValidation' in this.options) {
+    if (this.options.bypassDocumentValidation != null) {
       command.bypassDocumentValidation = this.options.bypassDocumentValidation;
     }
     // Add let if it was present in the options.
@@ -93,9 +93,9 @@ export class ClientBulkWriteCommandBuilder {
 }
 
 /** @internal */
-interface ClientInsertOperation<TSchema extends Document = Document> {
+interface ClientInsertOperation {
   insert: number;
-  document: OptionalId<TSchema>;
+  document: OptionalId<Document>;
 }
 
 /**
@@ -116,10 +116,10 @@ export const buildInsertOneOperation = (
 };
 
 /** @internal */
-export interface ClientDeleteOperation<TSchema extends Document = Document> {
+export interface ClientDeleteOperation {
   delete: number;
   multi: boolean;
-  filter: Filter<TSchema>;
+  filter: Filter<Document>;
   hint?: Hint;
   collation?: CollationOptions;
 }
@@ -167,11 +167,11 @@ function createDeleteOperation(
 }
 
 /** @internal */
-export interface ClientUpdateOperation<TSchema extends Document = Document> {
+export interface ClientUpdateOperation {
   update: number;
   multi: boolean;
-  filter: Filter<TSchema>;
-  updateMods: UpdateFilter<TSchema> | Document[];
+  filter: Filter<Document>;
+  updateMods: UpdateFilter<Document> | Document[];
   hint?: Hint;
   upsert?: boolean;
   arrayFilters?: Document[];
@@ -230,11 +230,11 @@ function createUpdateOperation(
 }
 
 /** @internal */
-export interface ClientReplaceOneOperation<TSchema extends Document = Document> {
+export interface ClientReplaceOneOperation {
   update: number;
   multi: boolean;
-  filter: Filter<TSchema>;
-  updateMods: WithoutId<TSchema>;
+  filter: Filter<Document>;
+  updateMods: WithoutId<Document>;
   hint?: Hint;
   upsert?: boolean;
 }

--- a/src/operations/client_bulk_write/common.ts
+++ b/src/operations/client_bulk_write/common.ts
@@ -1,0 +1,133 @@
+import { type Document } from '../../bson';
+import type { Filter, OptionalId, UpdateFilter, WithoutId } from '../../mongo_types';
+import type { CollationOptions, CommandOperationOptions } from '../../operations/command';
+import type { Hint } from '../../operations/operation';
+
+/** @public */
+export interface ClientBulkWriteOptions extends CommandOperationOptions {
+  /**
+   * If true, when an insert fails, don't execute the remaining writes.
+   * If false, continue with remaining inserts when one fails.
+   * @defaultValue `true` - inserts are ordered by default
+   */
+  ordered?: boolean;
+  /**
+   * Allow driver to bypass schema validation.
+   * @defaultValue `false` - documents will be validated by default
+   **/
+  bypassDocumentValidation?: boolean;
+  /** Map of parameter names and values that can be accessed using $$var (requires MongoDB 5.0). */
+  let?: Document;
+  /**
+   * Whether detailed results for each successful operation should be included in the returned
+   * BulkWriteResult.
+   */
+  verboseResults?: boolean;
+}
+
+/** @public */
+export interface ClientWriteModel {
+  /** The namespace for the write. */
+  namespace: string;
+}
+
+/** @public */
+export interface ClientInsertOneModel<TSchema extends Document = Document>
+  extends ClientWriteModel {
+  name: 'insertOne';
+  /** The document to insert. */
+  document: OptionalId<TSchema>;
+}
+
+/** @public */
+export interface ClientDeleteOneModel<TSchema extends Document = Document>
+  extends ClientWriteModel {
+  name: 'deleteOne';
+  /** The filter to limit the deleted documents. */
+  filter: Filter<TSchema>;
+  /** Specifies a collation. */
+  collation?: CollationOptions;
+  /** The index to use. If specified, then the query system will only consider plans using the hinted index. */
+  hint?: Hint;
+}
+
+/** @public */
+export interface ClientDeleteManyModel<TSchema extends Document = Document>
+  extends ClientWriteModel {
+  name: 'deleteMany';
+  /** The filter to limit the deleted documents. */
+  filter: Filter<TSchema>;
+  /** Specifies a collation. */
+  collation?: CollationOptions;
+  /** The index to use. If specified, then the query system will only consider plans using the hinted index. */
+  hint?: Hint;
+}
+
+/** @public */
+export interface ClientReplaceOneModel<TSchema extends Document = Document>
+  extends ClientWriteModel {
+  name: 'replaceOne';
+  /** The filter to limit the replaced document. */
+  filter: Filter<TSchema>;
+  /** The document with which to replace the matched document. */
+  replacement: WithoutId<TSchema>;
+  /** Specifies a collation. */
+  collation?: CollationOptions;
+  /** The index to use. If specified, then the query system will only consider plans using the hinted index. */
+  hint?: Hint;
+  /** When true, creates a new document if no document matches the query. */
+  upsert?: boolean;
+}
+
+/** @public */
+export interface ClientUpdateOneModel<TSchema extends Document = Document>
+  extends ClientWriteModel {
+  name: 'updateOne';
+  /** The filter to limit the updated documents. */
+  filter: Filter<TSchema>;
+  /**
+   * The modifications to apply. The value can be either:
+   * UpdateFilter<TSchema> - A document that contains update operator expressions,
+   * Document[] - an aggregation pipeline.
+   */
+  update: UpdateFilter<TSchema> | Document[];
+  /** A set of filters specifying to which array elements an update should apply. */
+  arrayFilters?: Document[];
+  /** Specifies a collation. */
+  collation?: CollationOptions;
+  /** The index to use. If specified, then the query system will only consider plans using the hinted index. */
+  hint?: Hint;
+  /** When true, creates a new document if no document matches the query. */
+  upsert?: boolean;
+}
+
+/** @public */
+export interface ClientUpdateManyModel<TSchema extends Document = Document>
+  extends ClientWriteModel {
+  name: 'updateMany';
+  /** The filter to limit the updated documents. */
+  filter: Filter<TSchema>;
+  /**
+   * The modifications to apply. The value can be either:
+   * UpdateFilter<TSchema> - A document that contains update operator expressions,
+   * Document[] - an aggregation pipeline.
+   */
+  update: UpdateFilter<TSchema> | Document[];
+  /** A set of filters specifying to which array elements an update should apply. */
+  arrayFilters?: Document[];
+  /** Specifies a collation. */
+  collation?: CollationOptions;
+  /** The index to use. If specified, then the query system will only consider plans using the hinted index. */
+  hint?: Hint;
+  /** When true, creates a new document if no document matches the query. */
+  upsert?: boolean;
+}
+
+/** @public */
+export type AnyClientBulkWriteModel<TSchema extends Document = Document> =
+  | ClientInsertOneModel<TSchema>
+  | ClientReplaceOneModel<TSchema>
+  | ClientUpdateOneModel<TSchema>
+  | ClientUpdateManyModel<TSchema>
+  | ClientDeleteOneModel<TSchema>
+  | ClientDeleteManyModel<TSchema>;

--- a/src/operations/client_bulk_write/common.ts
+++ b/src/operations/client_bulk_write/common.ts
@@ -60,7 +60,7 @@ export interface ClientDeleteManyModel<TSchema extends Document = Document>
   name: 'deleteMany';
   /**
    * The filter used to determine if a document should be deleted.
-   * For a deleteOne operation, all matches are removed.
+   * For a deleteMany operation, all matches are removed.
    */
   filter: Filter<TSchema>;
   /** Specifies a collation. */

--- a/src/operations/client_bulk_write/common.ts
+++ b/src/operations/client_bulk_write/common.ts
@@ -43,7 +43,10 @@ export interface ClientInsertOneModel<TSchema extends Document = Document>
 export interface ClientDeleteOneModel<TSchema extends Document = Document>
   extends ClientWriteModel {
   name: 'deleteOne';
-  /** The filter to limit the deleted documents. */
+  /**
+   * The filter used to determine if a document should be deleted.
+   * For a deleteOne operation, the first match is removed.
+   */
   filter: Filter<TSchema>;
   /** Specifies a collation. */
   collation?: CollationOptions;
@@ -55,7 +58,10 @@ export interface ClientDeleteOneModel<TSchema extends Document = Document>
 export interface ClientDeleteManyModel<TSchema extends Document = Document>
   extends ClientWriteModel {
   name: 'deleteMany';
-  /** The filter to limit the deleted documents. */
+  /**
+   * The filter used to determine if a document should be deleted.
+   * For a deleteOne operation, all matches are removed.
+   */
   filter: Filter<TSchema>;
   /** Specifies a collation. */
   collation?: CollationOptions;
@@ -67,7 +73,10 @@ export interface ClientDeleteManyModel<TSchema extends Document = Document>
 export interface ClientReplaceOneModel<TSchema extends Document = Document>
   extends ClientWriteModel {
   name: 'replaceOne';
-  /** The filter to limit the replaced document. */
+  /**
+   * The filter used to determine if a document should be replaced.
+   * For a replaceOne operation, the first match is replaced.
+   */
   filter: Filter<TSchema>;
   /** The document with which to replace the matched document. */
   replacement: WithoutId<TSchema>;
@@ -83,7 +92,10 @@ export interface ClientReplaceOneModel<TSchema extends Document = Document>
 export interface ClientUpdateOneModel<TSchema extends Document = Document>
   extends ClientWriteModel {
   name: 'updateOne';
-  /** The filter to limit the updated documents. */
+  /**
+   * The filter used to determine if a document should be updated.
+   * For an updateOne operation, the first match is updated.
+   */
   filter: Filter<TSchema>;
   /**
    * The modifications to apply. The value can be either:
@@ -105,7 +117,10 @@ export interface ClientUpdateOneModel<TSchema extends Document = Document>
 export interface ClientUpdateManyModel<TSchema extends Document = Document>
   extends ClientWriteModel {
   name: 'updateMany';
-  /** The filter to limit the updated documents. */
+  /**
+   * The filter used to determine if a document should be updated.
+   * For an updateMany operation, all matches are updated.
+   */
   filter: Filter<TSchema>;
   /**
    * The modifications to apply. The value can be either:

--- a/src/operations/client_bulk_write/common.ts
+++ b/src/operations/client_bulk_write/common.ts
@@ -32,22 +32,20 @@ export interface ClientWriteModel {
 }
 
 /** @public */
-export interface ClientInsertOneModel<TSchema extends Document = Document>
-  extends ClientWriteModel {
+export interface ClientInsertOneModel extends ClientWriteModel {
   name: 'insertOne';
   /** The document to insert. */
-  document: OptionalId<TSchema>;
+  document: OptionalId<Document>;
 }
 
 /** @public */
-export interface ClientDeleteOneModel<TSchema extends Document = Document>
-  extends ClientWriteModel {
+export interface ClientDeleteOneModel extends ClientWriteModel {
   name: 'deleteOne';
   /**
    * The filter used to determine if a document should be deleted.
    * For a deleteOne operation, the first match is removed.
    */
-  filter: Filter<TSchema>;
+  filter: Filter<Document>;
   /** Specifies a collation. */
   collation?: CollationOptions;
   /** The index to use. If specified, then the query system will only consider plans using the hinted index. */
@@ -55,14 +53,13 @@ export interface ClientDeleteOneModel<TSchema extends Document = Document>
 }
 
 /** @public */
-export interface ClientDeleteManyModel<TSchema extends Document = Document>
-  extends ClientWriteModel {
+export interface ClientDeleteManyModel extends ClientWriteModel {
   name: 'deleteMany';
   /**
    * The filter used to determine if a document should be deleted.
    * For a deleteMany operation, all matches are removed.
    */
-  filter: Filter<TSchema>;
+  filter: Filter<Document>;
   /** Specifies a collation. */
   collation?: CollationOptions;
   /** The index to use. If specified, then the query system will only consider plans using the hinted index. */
@@ -70,16 +67,15 @@ export interface ClientDeleteManyModel<TSchema extends Document = Document>
 }
 
 /** @public */
-export interface ClientReplaceOneModel<TSchema extends Document = Document>
-  extends ClientWriteModel {
+export interface ClientReplaceOneModel extends ClientWriteModel {
   name: 'replaceOne';
   /**
    * The filter used to determine if a document should be replaced.
    * For a replaceOne operation, the first match is replaced.
    */
-  filter: Filter<TSchema>;
+  filter: Filter<Document>;
   /** The document with which to replace the matched document. */
-  replacement: WithoutId<TSchema>;
+  replacement: WithoutId<Document>;
   /** Specifies a collation. */
   collation?: CollationOptions;
   /** The index to use. If specified, then the query system will only consider plans using the hinted index. */
@@ -89,20 +85,19 @@ export interface ClientReplaceOneModel<TSchema extends Document = Document>
 }
 
 /** @public */
-export interface ClientUpdateOneModel<TSchema extends Document = Document>
-  extends ClientWriteModel {
+export interface ClientUpdateOneModel extends ClientWriteModel {
   name: 'updateOne';
   /**
    * The filter used to determine if a document should be updated.
    * For an updateOne operation, the first match is updated.
    */
-  filter: Filter<TSchema>;
+  filter: Filter<Document>;
   /**
    * The modifications to apply. The value can be either:
-   * UpdateFilter<TSchema> - A document that contains update operator expressions,
+   * UpdateFilter<Document> - A document that contains update operator expressions,
    * Document[] - an aggregation pipeline.
    */
-  update: UpdateFilter<TSchema> | Document[];
+  update: UpdateFilter<Document> | Document[];
   /** A set of filters specifying to which array elements an update should apply. */
   arrayFilters?: Document[];
   /** Specifies a collation. */
@@ -114,20 +109,19 @@ export interface ClientUpdateOneModel<TSchema extends Document = Document>
 }
 
 /** @public */
-export interface ClientUpdateManyModel<TSchema extends Document = Document>
-  extends ClientWriteModel {
+export interface ClientUpdateManyModel extends ClientWriteModel {
   name: 'updateMany';
   /**
    * The filter used to determine if a document should be updated.
    * For an updateMany operation, all matches are updated.
    */
-  filter: Filter<TSchema>;
+  filter: Filter<Document>;
   /**
    * The modifications to apply. The value can be either:
-   * UpdateFilter<TSchema> - A document that contains update operator expressions,
+   * UpdateFilter<Document> - A document that contains update operator expressions,
    * Document[] - an aggregation pipeline.
    */
-  update: UpdateFilter<TSchema> | Document[];
+  update: UpdateFilter<Document> | Document[];
   /** A set of filters specifying to which array elements an update should apply. */
   arrayFilters?: Document[];
   /** Specifies a collation. */
@@ -140,16 +134,13 @@ export interface ClientUpdateManyModel<TSchema extends Document = Document>
 
 /**
  * Used to represent any of the client bulk write models that can be passed as an array
- * to MongoClient#bulkWrite. TSchema can be different on each of the individual models
- * and must always match the appropriate namespace that it defines provided to each of the models.
- * The schema is used on ClientInsertOneModel for the document field getting inserted, while all other
- * models use it for the filter document field.
+ * to MongoClient#bulkWrite.
  * @public
  */
-export type AnyClientBulkWriteModel<TSchema extends Document = Document> =
-  | ClientInsertOneModel<TSchema>
-  | ClientReplaceOneModel<TSchema>
-  | ClientUpdateOneModel<TSchema>
-  | ClientUpdateManyModel<TSchema>
-  | ClientDeleteOneModel<TSchema>
-  | ClientDeleteManyModel<TSchema>;
+export type AnyClientBulkWriteModel =
+  | ClientInsertOneModel
+  | ClientReplaceOneModel
+  | ClientUpdateOneModel
+  | ClientUpdateManyModel
+  | ClientDeleteOneModel
+  | ClientDeleteManyModel;

--- a/src/operations/client_bulk_write/common.ts
+++ b/src/operations/client_bulk_write/common.ts
@@ -138,7 +138,14 @@ export interface ClientUpdateManyModel<TSchema extends Document = Document>
   upsert?: boolean;
 }
 
-/** @public */
+/**
+ * Used to represent any of the client bulk write models that can be passed as an array
+ * to MongoClient#bulkWrite. TSchema can be different on each of the individual models
+ * and must always match the appropriate namespace that it defines provided to each of the models.
+ * The schema is used on ClientInsertOneModel for the document field getting inserted, while all other
+ * models use it for the filter document field.
+ * @public
+ */
 export type AnyClientBulkWriteModel<TSchema extends Document = Document> =
   | ClientInsertOneModel<TSchema>
   | ClientReplaceOneModel<TSchema>

--- a/test/mongodb.ts
+++ b/test/mongodb.ts
@@ -157,6 +157,8 @@ export * from '../src/mongo_logger';
 export * from '../src/mongo_types';
 export * from '../src/operations/aggregate';
 export * from '../src/operations/bulk_write';
+export * from '../src/operations/client_bulk_write/command_builder';
+export * from '../src/operations/client_bulk_write/common';
 export * from '../src/operations/collections';
 export * from '../src/operations/command';
 export * from '../src/operations/count';

--- a/test/unit/operations/client_bulk_write/command_builder.test.ts
+++ b/test/unit/operations/client_bulk_write/command_builder.test.ts
@@ -1,7 +1,12 @@
 import { expect } from 'chai';
 
 import {
-  builderFor,
+  buildDeleteManyOperation,
+  buildDeleteOneOperation,
+  buildInsertOneOperation,
+  buildReplaceOneOperation,
+  buildUpdateManyOperation,
+  buildUpdateOneOperation,
   ClientBulkWriteCommandBuilder,
   type ClientDeleteManyModel,
   type ClientDeleteOneModel,
@@ -9,13 +14,7 @@ import {
   type ClientReplaceOneModel,
   type ClientUpdateManyModel,
   type ClientUpdateOneModel,
-  DeleteManyOperationBuilder,
-  DeleteOneOperationBuilder,
-  DocumentSequence,
-  InsertOneOperationBuilder,
-  ReplaceOneOperationBuilder,
-  UpdateManyOperationBuilder,
-  UpdateOneOperationBuilder
+  DocumentSequence
 } from '../../../mongodb';
 
 describe('ClientBulkWriteCommandBuilder', function () {
@@ -205,333 +204,222 @@ describe('ClientBulkWriteCommandBuilder', function () {
     });
   });
 
-  describe('.builderFor', function () {
-    context('when the model is an insert one', function () {
-      const model: ClientInsertOneModel = {
-        name: 'insertOne',
-        namespace: 'test.coll',
-        document: { name: 1 }
-      };
+  describe('#buildInsertOneOperation', function () {
+    const model: ClientInsertOneModel = {
+      name: 'insertOne',
+      namespace: 'test.coll',
+      document: { name: 1 }
+    };
+    const operation = buildInsertOneOperation(model, 5);
 
-      it('returns an insert one operation builder', function () {
-        expect(builderFor(model)).to.be.instanceOf(InsertOneOperationBuilder);
+    it('generates the insert operation', function () {
+      expect(operation).to.deep.equal({ insert: 5, document: { name: 1 } });
+    });
+  });
+
+  describe('#buildDeleteOneOperation', function () {
+    context('with only required fields', function () {
+      const model: ClientDeleteOneModel = {
+        name: 'deleteOne',
+        namespace: 'test.coll',
+        filter: { name: 1 }
+      };
+      const operation = buildDeleteOneOperation(model, 5);
+
+      it('generates the delete operation', function () {
+        expect(operation).to.deep.equal({ delete: 5, filter: { name: 1 }, multi: false });
       });
     });
 
-    context('when the model is an update one', function () {
+    context('with optional fields', function () {
+      const model: ClientDeleteOneModel = {
+        name: 'deleteOne',
+        namespace: 'test.coll',
+        filter: { name: 1 },
+        hint: 'test',
+        collation: { locale: 'de' }
+      };
+      const operation = buildDeleteOneOperation(model, 5);
+
+      it('generates the delete operation', function () {
+        expect(operation).to.deep.equal({
+          delete: 5,
+          filter: { name: 1 },
+          multi: false,
+          hint: 'test',
+          collation: { locale: 'de' }
+        });
+      });
+    });
+  });
+
+  describe('#buildDeleteManyOperation', function () {
+    context('with only required fields', function () {
+      const model: ClientDeleteManyModel = {
+        name: 'deleteMany',
+        namespace: 'test.coll',
+        filter: { name: 1 }
+      };
+      const operation = buildDeleteManyOperation(model, 5);
+
+      it('generates the delete operation', function () {
+        expect(operation).to.deep.equal({ delete: 5, filter: { name: 1 }, multi: true });
+      });
+    });
+
+    context('with optional fields', function () {
+      const model: ClientDeleteManyModel = {
+        name: 'deleteMany',
+        namespace: 'test.coll',
+        filter: { name: 1 },
+        hint: 'test',
+        collation: { locale: 'de' }
+      };
+      const operation = buildDeleteManyOperation(model, 5);
+
+      it('generates the delete operation', function () {
+        expect(operation).to.deep.equal({
+          delete: 5,
+          filter: { name: 1 },
+          multi: true,
+          hint: 'test',
+          collation: { locale: 'de' }
+        });
+      });
+    });
+  });
+
+  describe('#buildUpdateOneOperation', function () {
+    context('with only required fields', function () {
       const model: ClientUpdateOneModel = {
         name: 'updateOne',
         namespace: 'test.coll',
         filter: { name: 1 },
         update: { $set: { name: 2 } }
       };
+      const operation = buildUpdateOneOperation(model, 5);
 
-      it('returns an update one operation builder', function () {
-        expect(builderFor(model)).to.be.instanceOf(UpdateOneOperationBuilder);
+      it('generates the update operation', function () {
+        expect(operation).to.deep.equal({
+          update: 5,
+          filter: { name: 1 },
+          updateMods: { $set: { name: 2 } },
+          multi: false
+        });
       });
     });
 
-    context('when the model is an update many', function () {
+    context('with optional fields', function () {
+      const model: ClientUpdateOneModel = {
+        name: 'updateOne',
+        namespace: 'test.coll',
+        filter: { name: 1 },
+        update: { $set: { name: 2 } },
+        hint: 'test',
+        upsert: true,
+        arrayFilters: [{ test: 1 }]
+      };
+      const operation = buildUpdateOneOperation(model, 5);
+
+      it('generates the update operation', function () {
+        expect(operation).to.deep.equal({
+          update: 5,
+          filter: { name: 1 },
+          updateMods: { $set: { name: 2 } },
+          multi: false,
+          hint: 'test',
+          upsert: true,
+          arrayFilters: [{ test: 1 }]
+        });
+      });
+    });
+  });
+
+  describe('#buildUpdateManyOperation', function () {
+    context('with only required fields', function () {
       const model: ClientUpdateManyModel = {
         name: 'updateMany',
         namespace: 'test.coll',
         filter: { name: 1 },
         update: { $set: { name: 2 } }
       };
+      const operation = buildUpdateManyOperation(model, 5);
 
-      it('returns an update many operation builder', function () {
-        expect(builderFor(model)).to.be.instanceOf(UpdateManyOperationBuilder);
+      it('generates the update operation', function () {
+        expect(operation).to.deep.equal({
+          update: 5,
+          filter: { name: 1 },
+          updateMods: { $set: { name: 2 } },
+          multi: true
+        });
       });
     });
 
-    context('when the model is a replace one', function () {
+    context('with optional fields', function () {
+      const model: ClientUpdateManyModel = {
+        name: 'updateMany',
+        namespace: 'test.coll',
+        filter: { name: 1 },
+        update: { $set: { name: 2 } },
+        hint: 'test',
+        upsert: true,
+        arrayFilters: [{ test: 1 }]
+      };
+      const operation = buildUpdateManyOperation(model, 5);
+
+      it('generates the update operation', function () {
+        expect(operation).to.deep.equal({
+          update: 5,
+          filter: { name: 1 },
+          updateMods: { $set: { name: 2 } },
+          multi: true,
+          hint: 'test',
+          upsert: true,
+          arrayFilters: [{ test: 1 }]
+        });
+      });
+    });
+  });
+
+  describe('#buildReplaceOneOperation', function () {
+    context('with only required fields', function () {
       const model: ClientReplaceOneModel = {
         name: 'replaceOne',
         namespace: 'test.coll',
         filter: { name: 1 },
         replacement: { name: 2 }
       };
+      const operation = buildReplaceOneOperation(model, 5);
 
-      it('returns an replace one operation builder', function () {
-        expect(builderFor(model)).to.be.instanceOf(ReplaceOneOperationBuilder);
+      it('generates the update operation', function () {
+        expect(operation).to.deep.equal({
+          update: 5,
+          filter: { name: 1 },
+          updateMods: { name: 2 },
+          multi: false
+        });
       });
     });
 
-    context('when the model is a delete one', function () {
-      const model: ClientDeleteOneModel = {
-        name: 'deleteOne',
+    context('with optional fields', function () {
+      const model: ClientReplaceOneModel = {
+        name: 'replaceOne',
         namespace: 'test.coll',
-        filter: { name: 1 }
+        filter: { name: 1 },
+        replacement: { name: 2 },
+        hint: 'test',
+        upsert: true
       };
+      const operation = buildReplaceOneOperation(model, 5);
 
-      it('returns an delete one operation builder', function () {
-        expect(builderFor(model)).to.be.instanceOf(DeleteOneOperationBuilder);
-      });
-    });
-
-    context('when the model is a delete many', function () {
-      const model: ClientDeleteManyModel = {
-        name: 'deleteMany',
-        namespace: 'test.coll',
-        filter: { name: 1 }
-      };
-
-      it('returns an delete many operation builder', function () {
-        expect(builderFor(model)).to.be.instanceOf(DeleteManyOperationBuilder);
-      });
-    });
-  });
-
-  describe('InsertOneOperationBuilder', function () {
-    const model: ClientInsertOneModel = {
-      name: 'insertOne',
-      namespace: 'test.coll',
-      document: { name: 1 }
-    };
-
-    describe('#buildOperation', function () {
-      const builder = new InsertOneOperationBuilder(model);
-      const operation = builder.buildOperation(5);
-
-      it('generates the insert operation', function () {
-        expect(operation).to.deep.equal({ insert: 5, document: { name: 1 } });
-      });
-    });
-  });
-
-  describe('DeleteOneOperationBuilder', function () {
-    describe('#buildOperation', function () {
-      context('with only required fields', function () {
-        const model: ClientDeleteOneModel = {
-          name: 'deleteOne',
-          namespace: 'test.coll',
-          filter: { name: 1 }
-        };
-
-        const builder = new DeleteOneOperationBuilder(model);
-        const operation = builder.buildOperation(5);
-
-        it('generates the delete operation', function () {
-          expect(operation).to.deep.equal({ delete: 5, filter: { name: 1 }, multi: false });
-        });
-      });
-
-      context('with optional fields', function () {
-        const model: ClientDeleteOneModel = {
-          name: 'deleteOne',
-          namespace: 'test.coll',
+      it('generates the update operation', function () {
+        expect(operation).to.deep.equal({
+          update: 5,
           filter: { name: 1 },
-          hint: 'test',
-          collation: { locale: 'de' }
-        };
-
-        const builder = new DeleteOneOperationBuilder(model);
-        const operation = builder.buildOperation(5);
-
-        it('generates the delete operation', function () {
-          expect(operation).to.deep.equal({
-            delete: 5,
-            filter: { name: 1 },
-            multi: false,
-            hint: 'test',
-            collation: { locale: 'de' }
-          });
-        });
-      });
-    });
-  });
-
-  describe('DeleteManyOperationBuilder', function () {
-    describe('#buildOperation', function () {
-      context('with only required fields', function () {
-        const model: ClientDeleteManyModel = {
-          name: 'deleteMany',
-          namespace: 'test.coll',
-          filter: { name: 1 }
-        };
-
-        const builder = new DeleteManyOperationBuilder(model);
-        const operation = builder.buildOperation(5);
-
-        it('generates the delete operation', function () {
-          expect(operation).to.deep.equal({ delete: 5, filter: { name: 1 }, multi: true });
-        });
-      });
-
-      context('with optional fields', function () {
-        const model: ClientDeleteManyModel = {
-          name: 'deleteMany',
-          namespace: 'test.coll',
-          filter: { name: 1 },
-          hint: 'test',
-          collation: { locale: 'de' }
-        };
-
-        const builder = new DeleteManyOperationBuilder(model);
-        const operation = builder.buildOperation(5);
-
-        it('generates the delete operation', function () {
-          expect(operation).to.deep.equal({
-            delete: 5,
-            filter: { name: 1 },
-            multi: true,
-            hint: 'test',
-            collation: { locale: 'de' }
-          });
-        });
-      });
-    });
-  });
-
-  describe('UpdateOneOperationBuilder', function () {
-    describe('#buildOperation', function () {
-      context('with only required fields', function () {
-        const model: ClientUpdateOneModel = {
-          name: 'updateOne',
-          namespace: 'test.coll',
-          filter: { name: 1 },
-          update: { $set: { name: 2 } }
-        };
-
-        const builder = new UpdateOneOperationBuilder(model);
-        const operation = builder.buildOperation(5);
-
-        it('generates the update operation', function () {
-          expect(operation).to.deep.equal({
-            update: 5,
-            filter: { name: 1 },
-            updateMods: { $set: { name: 2 } },
-            multi: false
-          });
-        });
-      });
-
-      context('with optional fields', function () {
-        const model: ClientUpdateOneModel = {
-          name: 'updateOne',
-          namespace: 'test.coll',
-          filter: { name: 1 },
-          update: { $set: { name: 2 } },
-          hint: 'test',
-          upsert: true,
-          arrayFilters: [{ test: 1 }]
-        };
-
-        const builder = new UpdateOneOperationBuilder(model);
-        const operation = builder.buildOperation(5);
-
-        it('generates the update operation', function () {
-          expect(operation).to.deep.equal({
-            update: 5,
-            filter: { name: 1 },
-            updateMods: { $set: { name: 2 } },
-            multi: false,
-            hint: 'test',
-            upsert: true,
-            arrayFilters: [{ test: 1 }]
-          });
-        });
-      });
-    });
-  });
-
-  describe('UpdateManyOperationBuilder', function () {
-    describe('#buildOperation', function () {
-      context('with only required fields', function () {
-        const model: ClientUpdateManyModel = {
-          name: 'updateMany',
-          namespace: 'test.coll',
-          filter: { name: 1 },
-          update: { $set: { name: 2 } }
-        };
-
-        const builder = new UpdateManyOperationBuilder(model);
-        const operation = builder.buildOperation(5);
-
-        it('generates the update operation', function () {
-          expect(operation).to.deep.equal({
-            update: 5,
-            filter: { name: 1 },
-            updateMods: { $set: { name: 2 } },
-            multi: true
-          });
-        });
-      });
-
-      context('with optional fields', function () {
-        const model: ClientUpdateManyModel = {
-          name: 'updateMany',
-          namespace: 'test.coll',
-          filter: { name: 1 },
-          update: { $set: { name: 2 } },
-          hint: 'test',
-          upsert: true,
-          arrayFilters: [{ test: 1 }]
-        };
-
-        const builder = new UpdateManyOperationBuilder(model);
-        const operation = builder.buildOperation(5);
-
-        it('generates the update operation', function () {
-          expect(operation).to.deep.equal({
-            update: 5,
-            filter: { name: 1 },
-            updateMods: { $set: { name: 2 } },
-            multi: true,
-            hint: 'test',
-            upsert: true,
-            arrayFilters: [{ test: 1 }]
-          });
-        });
-      });
-    });
-  });
-
-  describe('ReplaceOneOperationBuilder', function () {
-    describe('#buildOperation', function () {
-      context('with only required fields', function () {
-        const model: ClientReplaceOneModel = {
-          name: 'replaceOne',
-          namespace: 'test.coll',
-          filter: { name: 1 },
-          replacement: { name: 2 }
-        };
-
-        const builder = new ReplaceOneOperationBuilder(model);
-        const operation = builder.buildOperation(5);
-
-        it('generates the update operation', function () {
-          expect(operation).to.deep.equal({
-            update: 5,
-            filter: { name: 1 },
-            updateMods: { name: 2 },
-            multi: false
-          });
-        });
-      });
-
-      context('with optional fields', function () {
-        const model: ClientReplaceOneModel = {
-          name: 'replaceOne',
-          namespace: 'test.coll',
-          filter: { name: 1 },
-          replacement: { name: 2 },
+          updateMods: { name: 2 },
+          multi: false,
           hint: 'test',
           upsert: true
-        };
-
-        const builder = new ReplaceOneOperationBuilder(model);
-        const operation = builder.buildOperation(5);
-
-        it('generates the update operation', function () {
-          expect(operation).to.deep.equal({
-            update: 5,
-            filter: { name: 1 },
-            updateMods: { name: 2 },
-            multi: false,
-            hint: 'test',
-            upsert: true
-          });
         });
       });
     });

--- a/test/unit/operations/client_bulk_write/command_builder.test.ts
+++ b/test/unit/operations/client_bulk_write/command_builder.test.ts
@@ -1,0 +1,539 @@
+import { expect } from 'chai';
+
+import {
+  builderFor,
+  ClientBulkWriteCommandBuilder,
+  type ClientDeleteManyModel,
+  type ClientDeleteOneModel,
+  type ClientInsertOneModel,
+  type ClientReplaceOneModel,
+  type ClientUpdateManyModel,
+  type ClientUpdateOneModel,
+  DeleteManyOperationBuilder,
+  DeleteOneOperationBuilder,
+  DocumentSequence,
+  InsertOneOperationBuilder,
+  ReplaceOneOperationBuilder,
+  UpdateManyOperationBuilder,
+  UpdateOneOperationBuilder
+} from '../../../mongodb';
+
+describe('ClientBulkWriteCommandBuilder', function () {
+  describe('#buildCommand', function () {
+    context('when custom options are provided', function () {
+      const model: ClientInsertOneModel = {
+        name: 'insertOne',
+        namespace: 'test.coll',
+        document: { name: 1 }
+      };
+      const builder = new ClientBulkWriteCommandBuilder([model], {
+        verboseResults: true,
+        bypassDocumentValidation: true,
+        ordered: false
+      });
+      const commands = builder.buildCommands();
+
+      it('sets the bulkWrite command', function () {
+        expect(commands[0].bulkWrite).to.equal(1);
+      });
+
+      it('sets the errorsOnly field to the inverse of verboseResults', function () {
+        expect(commands[0].errorsOnly).to.be.false;
+      });
+
+      it('sets the ordered field', function () {
+        expect(commands[0].ordered).to.be.false;
+      });
+
+      it('sets the bypassDocumentValidation field', function () {
+        expect(commands[0].bypassDocumentValidation).to.be.true;
+      });
+
+      it('sets the ops document sequence', function () {
+        expect(commands[0].ops).to.be.instanceOf(DocumentSequence);
+        expect(commands[0].ops.documents[0]).to.deep.equal({ insert: 0, document: { name: 1 } });
+      });
+
+      it('sets the nsInfo document sequence', function () {
+        expect(commands[0].nsInfo).to.be.instanceOf(DocumentSequence);
+        expect(commands[0].nsInfo.documents[0]).to.deep.equal({ ns: 'test.coll' });
+      });
+    });
+
+    context('when no options are provided', function () {
+      context('when a single model is provided', function () {
+        const model: ClientInsertOneModel = {
+          name: 'insertOne',
+          namespace: 'test.coll',
+          document: { name: 1 }
+        };
+        const builder = new ClientBulkWriteCommandBuilder([model], {});
+        const commands = builder.buildCommands();
+
+        it('sets the bulkWrite command', function () {
+          expect(commands[0].bulkWrite).to.equal(1);
+        });
+
+        it('sets the default errorsOnly field', function () {
+          expect(commands[0].errorsOnly).to.be.true;
+        });
+
+        it('sets the default ordered field', function () {
+          expect(commands[0].ordered).to.be.true;
+        });
+
+        it('sets the ops document sequence', function () {
+          expect(commands[0].ops).to.be.instanceOf(DocumentSequence);
+          expect(commands[0].ops.documents[0]).to.deep.equal({ insert: 0, document: { name: 1 } });
+        });
+
+        it('sets the nsInfo document sequence', function () {
+          expect(commands[0].nsInfo).to.be.instanceOf(DocumentSequence);
+          expect(commands[0].nsInfo.documents[0]).to.deep.equal({ ns: 'test.coll' });
+        });
+      });
+
+      context('when multiple models are provided', function () {
+        context('when the namespace is the same', function () {
+          const modelOne: ClientInsertOneModel = {
+            name: 'insertOne',
+            namespace: 'test.coll',
+            document: { name: 1 }
+          };
+          const modelTwo: ClientInsertOneModel = {
+            name: 'insertOne',
+            namespace: 'test.coll',
+            document: { name: 2 }
+          };
+          const builder = new ClientBulkWriteCommandBuilder([modelOne, modelTwo], {});
+          const commands = builder.buildCommands();
+
+          it('sets the bulkWrite command', function () {
+            expect(commands[0].bulkWrite).to.equal(1);
+          });
+
+          it('sets the ops document sequence', function () {
+            expect(commands[0].ops).to.be.instanceOf(DocumentSequence);
+            expect(commands[0].ops.documents).to.deep.equal([
+              { insert: 0, document: { name: 1 } },
+              { insert: 0, document: { name: 2 } }
+            ]);
+          });
+
+          it('sets the nsInfo document sequence', function () {
+            expect(commands[0].nsInfo).to.be.instanceOf(DocumentSequence);
+            expect(commands[0].nsInfo.documents).to.deep.equal([{ ns: 'test.coll' }]);
+          });
+        });
+
+        context('when the namespace differs', function () {
+          const modelOne: ClientInsertOneModel = {
+            name: 'insertOne',
+            namespace: 'test.coll',
+            document: { name: 1 }
+          };
+          const modelTwo: ClientInsertOneModel = {
+            name: 'insertOne',
+            namespace: 'test.coll2',
+            document: { name: 2 }
+          };
+          const builder = new ClientBulkWriteCommandBuilder([modelOne, modelTwo], {});
+          const commands = builder.buildCommands();
+
+          it('sets the bulkWrite command', function () {
+            expect(commands[0].bulkWrite).to.equal(1);
+          });
+
+          it('sets the ops document sequence', function () {
+            expect(commands[0].ops).to.be.instanceOf(DocumentSequence);
+            expect(commands[0].ops.documents).to.deep.equal([
+              { insert: 0, document: { name: 1 } },
+              { insert: 1, document: { name: 2 } }
+            ]);
+          });
+
+          it('sets the nsInfo document sequence', function () {
+            expect(commands[0].nsInfo).to.be.instanceOf(DocumentSequence);
+            expect(commands[0].nsInfo.documents).to.deep.equal([
+              { ns: 'test.coll' },
+              { ns: 'test.coll2' }
+            ]);
+          });
+        });
+
+        context('when the namespaces are intermixed', function () {
+          const modelOne: ClientInsertOneModel = {
+            name: 'insertOne',
+            namespace: 'test.coll',
+            document: { name: 1 }
+          };
+          const modelTwo: ClientInsertOneModel = {
+            name: 'insertOne',
+            namespace: 'test.coll2',
+            document: { name: 2 }
+          };
+          const modelThree: ClientInsertOneModel = {
+            name: 'insertOne',
+            namespace: 'test.coll',
+            document: { name: 2 }
+          };
+          const builder = new ClientBulkWriteCommandBuilder([modelOne, modelTwo, modelThree], {});
+          const commands = builder.buildCommands();
+
+          it('sets the bulkWrite command', function () {
+            expect(commands[0].bulkWrite).to.equal(1);
+          });
+
+          it('sets the ops document sequence', function () {
+            expect(commands[0].ops).to.be.instanceOf(DocumentSequence);
+            expect(commands[0].ops.documents).to.deep.equal([
+              { insert: 0, document: { name: 1 } },
+              { insert: 1, document: { name: 2 } },
+              { insert: 0, document: { name: 2 } }
+            ]);
+          });
+
+          it('sets the nsInfo document sequence', function () {
+            expect(commands[0].nsInfo).to.be.instanceOf(DocumentSequence);
+            expect(commands[0].nsInfo.documents).to.deep.equal([
+              { ns: 'test.coll' },
+              { ns: 'test.coll2' }
+            ]);
+          });
+        });
+      });
+    });
+  });
+
+  describe('.builderFor', function () {
+    context('when the model is an insert one', function () {
+      const model: ClientInsertOneModel = {
+        name: 'insertOne',
+        namespace: 'test.coll',
+        document: { name: 1 }
+      };
+
+      it('returns an insert one operation builder', function () {
+        expect(builderFor(model)).to.be.instanceOf(InsertOneOperationBuilder);
+      });
+    });
+
+    context('when the model is an update one', function () {
+      const model: ClientUpdateOneModel = {
+        name: 'updateOne',
+        namespace: 'test.coll',
+        filter: { name: 1 },
+        update: { $set: { name: 2 } }
+      };
+
+      it('returns an update one operation builder', function () {
+        expect(builderFor(model)).to.be.instanceOf(UpdateOneOperationBuilder);
+      });
+    });
+
+    context('when the model is an update many', function () {
+      const model: ClientUpdateManyModel = {
+        name: 'updateMany',
+        namespace: 'test.coll',
+        filter: { name: 1 },
+        update: { $set: { name: 2 } }
+      };
+
+      it('returns an update many operation builder', function () {
+        expect(builderFor(model)).to.be.instanceOf(UpdateManyOperationBuilder);
+      });
+    });
+
+    context('when the model is a replace one', function () {
+      const model: ClientReplaceOneModel = {
+        name: 'replaceOne',
+        namespace: 'test.coll',
+        filter: { name: 1 },
+        replacement: { name: 2 }
+      };
+
+      it('returns an replace one operation builder', function () {
+        expect(builderFor(model)).to.be.instanceOf(ReplaceOneOperationBuilder);
+      });
+    });
+
+    context('when the model is a delete one', function () {
+      const model: ClientDeleteOneModel = {
+        name: 'deleteOne',
+        namespace: 'test.coll',
+        filter: { name: 1 }
+      };
+
+      it('returns an delete one operation builder', function () {
+        expect(builderFor(model)).to.be.instanceOf(DeleteOneOperationBuilder);
+      });
+    });
+
+    context('when the model is a delete many', function () {
+      const model: ClientDeleteManyModel = {
+        name: 'deleteMany',
+        namespace: 'test.coll',
+        filter: { name: 1 }
+      };
+
+      it('returns an delete many operation builder', function () {
+        expect(builderFor(model)).to.be.instanceOf(DeleteManyOperationBuilder);
+      });
+    });
+  });
+
+  describe('InsertOneOperationBuilder', function () {
+    const model: ClientInsertOneModel = {
+      name: 'insertOne',
+      namespace: 'test.coll',
+      document: { name: 1 }
+    };
+
+    describe('#buildOperation', function () {
+      const builder = new InsertOneOperationBuilder(model);
+      const operation = builder.buildOperation(5);
+
+      it('generates the insert operation', function () {
+        expect(operation).to.deep.equal({ insert: 5, document: { name: 1 } });
+      });
+    });
+  });
+
+  describe('DeleteOneOperationBuilder', function () {
+    describe('#buildOperation', function () {
+      context('with only required fields', function () {
+        const model: ClientDeleteOneModel = {
+          name: 'deleteOne',
+          namespace: 'test.coll',
+          filter: { name: 1 }
+        };
+
+        const builder = new DeleteOneOperationBuilder(model);
+        const operation = builder.buildOperation(5);
+
+        it('generates the delete operation', function () {
+          expect(operation).to.deep.equal({ delete: 5, filter: { name: 1 }, multi: false });
+        });
+      });
+
+      context('with optional fields', function () {
+        const model: ClientDeleteOneModel = {
+          name: 'deleteOne',
+          namespace: 'test.coll',
+          filter: { name: 1 },
+          hint: 'test',
+          collation: { locale: 'de' }
+        };
+
+        const builder = new DeleteOneOperationBuilder(model);
+        const operation = builder.buildOperation(5);
+
+        it('generates the delete operation', function () {
+          expect(operation).to.deep.equal({
+            delete: 5,
+            filter: { name: 1 },
+            multi: false,
+            hint: 'test',
+            collation: { locale: 'de' }
+          });
+        });
+      });
+    });
+  });
+
+  describe('DeleteManyOperationBuilder', function () {
+    describe('#buildOperation', function () {
+      context('with only required fields', function () {
+        const model: ClientDeleteManyModel = {
+          name: 'deleteMany',
+          namespace: 'test.coll',
+          filter: { name: 1 }
+        };
+
+        const builder = new DeleteManyOperationBuilder(model);
+        const operation = builder.buildOperation(5);
+
+        it('generates the delete operation', function () {
+          expect(operation).to.deep.equal({ delete: 5, filter: { name: 1 }, multi: true });
+        });
+      });
+
+      context('with optional fields', function () {
+        const model: ClientDeleteManyModel = {
+          name: 'deleteMany',
+          namespace: 'test.coll',
+          filter: { name: 1 },
+          hint: 'test',
+          collation: { locale: 'de' }
+        };
+
+        const builder = new DeleteManyOperationBuilder(model);
+        const operation = builder.buildOperation(5);
+
+        it('generates the delete operation', function () {
+          expect(operation).to.deep.equal({
+            delete: 5,
+            filter: { name: 1 },
+            multi: true,
+            hint: 'test',
+            collation: { locale: 'de' }
+          });
+        });
+      });
+    });
+  });
+
+  describe('UpdateOneOperationBuilder', function () {
+    describe('#buildOperation', function () {
+      context('with only required fields', function () {
+        const model: ClientUpdateOneModel = {
+          name: 'updateOne',
+          namespace: 'test.coll',
+          filter: { name: 1 },
+          update: { $set: { name: 2 } }
+        };
+
+        const builder = new UpdateOneOperationBuilder(model);
+        const operation = builder.buildOperation(5);
+
+        it('generates the update operation', function () {
+          expect(operation).to.deep.equal({
+            update: 5,
+            filter: { name: 1 },
+            updateMods: { $set: { name: 2 } },
+            multi: false
+          });
+        });
+      });
+
+      context('with optional fields', function () {
+        const model: ClientUpdateOneModel = {
+          name: 'updateOne',
+          namespace: 'test.coll',
+          filter: { name: 1 },
+          update: { $set: { name: 2 } },
+          hint: 'test',
+          upsert: true,
+          arrayFilters: [{ test: 1 }]
+        };
+
+        const builder = new UpdateOneOperationBuilder(model);
+        const operation = builder.buildOperation(5);
+
+        it('generates the update operation', function () {
+          expect(operation).to.deep.equal({
+            update: 5,
+            filter: { name: 1 },
+            updateMods: { $set: { name: 2 } },
+            multi: false,
+            hint: 'test',
+            upsert: true,
+            arrayFilters: [{ test: 1 }]
+          });
+        });
+      });
+    });
+  });
+
+  describe('UpdateManyOperationBuilder', function () {
+    describe('#buildOperation', function () {
+      context('with only required fields', function () {
+        const model: ClientUpdateManyModel = {
+          name: 'updateMany',
+          namespace: 'test.coll',
+          filter: { name: 1 },
+          update: { $set: { name: 2 } }
+        };
+
+        const builder = new UpdateManyOperationBuilder(model);
+        const operation = builder.buildOperation(5);
+
+        it('generates the update operation', function () {
+          expect(operation).to.deep.equal({
+            update: 5,
+            filter: { name: 1 },
+            updateMods: { $set: { name: 2 } },
+            multi: true
+          });
+        });
+      });
+
+      context('with optional fields', function () {
+        const model: ClientUpdateManyModel = {
+          name: 'updateMany',
+          namespace: 'test.coll',
+          filter: { name: 1 },
+          update: { $set: { name: 2 } },
+          hint: 'test',
+          upsert: true,
+          arrayFilters: [{ test: 1 }]
+        };
+
+        const builder = new UpdateManyOperationBuilder(model);
+        const operation = builder.buildOperation(5);
+
+        it('generates the update operation', function () {
+          expect(operation).to.deep.equal({
+            update: 5,
+            filter: { name: 1 },
+            updateMods: { $set: { name: 2 } },
+            multi: true,
+            hint: 'test',
+            upsert: true,
+            arrayFilters: [{ test: 1 }]
+          });
+        });
+      });
+    });
+  });
+
+  describe('ReplaceOneOperationBuilder', function () {
+    describe('#buildOperation', function () {
+      context('with only required fields', function () {
+        const model: ClientReplaceOneModel = {
+          name: 'replaceOne',
+          namespace: 'test.coll',
+          filter: { name: 1 },
+          replacement: { name: 2 }
+        };
+
+        const builder = new ReplaceOneOperationBuilder(model);
+        const operation = builder.buildOperation(5);
+
+        it('generates the update operation', function () {
+          expect(operation).to.deep.equal({
+            update: 5,
+            filter: { name: 1 },
+            updateMods: { name: 2 },
+            multi: false
+          });
+        });
+      });
+
+      context('with optional fields', function () {
+        const model: ClientReplaceOneModel = {
+          name: 'replaceOne',
+          namespace: 'test.coll',
+          filter: { name: 1 },
+          replacement: { name: 2 },
+          hint: 'test',
+          upsert: true
+        };
+
+        const builder = new ReplaceOneOperationBuilder(model);
+        const operation = builder.buildOperation(5);
+
+        it('generates the update operation', function () {
+          expect(operation).to.deep.equal({
+            update: 5,
+            filter: { name: 1 },
+            updateMods: { name: 2 },
+            multi: false,
+            hint: 'test',
+            upsert: true
+          });
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
### Description

Creates the new client bulk write model types and options as well as the builders for the bulk write command.

#### What is changing?

- Creates the new client bulk write model types.
- Creates a client bulk write command builder that delegates to the various model builders to build the operations.
- Ensures the `ops` field of the bulk write command is a document sequence
- Ensures the `nsInfo` field of the bulk write command is a unique document sequence.
- Adds a bunch-o-unit-tests

##### Is there new documentation needed for these changes?

None. docs changes will come on the last ticket of the epic as well as the release highlights.

#### What is the motivation for this change?

NODE-6327

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
