### PR TITLE
fix(NODE-6346): import performance from perf_hooks for better nodejs compatibility

### DIFF
--- a/src/timeout.ts
+++ b/src/timeout.ts
@@ -1,3 +1,5 @@
+import { performance } from 'node:perf_hooks';
+
 import { clearTimeout, setTimeout } from 'timers';
 
 import { MongoInvalidArgumentError } from './error';


### PR DESCRIPTION
### Description

#### What is changing?

Importing `performance` from `perf_hooks`.

##### Is there new documentation needed for these changes?

No.

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

In Node.js app bundled with webpack, when using `mongodb` to connect to a database the following error occurs:

```
TypeError: Cannot read properties of undefined (reading 'now')
    at new Timeout (/path/to/project/node_modules/.pnpm/mongodb@6.7.0_socks@2.8.3/node_modules/mongodb/src/timeout.ts:58:41)
```

Importing `performance` from `perf_hooks` provides better compatibility.

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
