### PR TITLE
test(NODE-6317): remove flaky unnecessary assertion

### DIFF
--- a/test/integration/server-discovery-and-monitoring/server_discover_and_monitoring.test.ts
+++ b/test/integration/server-discovery-and-monitoring/server_discover_and_monitoring.test.ts
@@ -109,11 +109,8 @@ describe('Monitoring rtt tests', function () {
             for (const [server, durations] of Object.entries(heartbeatDurations)) {
               const relevantDurations = durations.slice(IGNORE_SIZE);
               expect(relevantDurations).to.have.length.gt(0);
-              const averageDuration =
-                relevantDurations.reduce((acc, x) => acc + x) / relevantDurations.length;
               const rtt = client.topology.description.servers.get(server).roundTripTime;
               expect(rtt).to.not.equal(0);
-              expect(rtt).to.be.approximately(averageDuration, 3);
             }
           }
         });


### PR DESCRIPTION
### Description

#### What is changing?

This test is flaky on macos.  

The assertion removed isn't related to the test description and isn't necessary for the correctness of the test.

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
