### PR TITLE
fix(NODE-6355): respect utf8 validation options when iterating cursors

### DIFF
--- a/.evergreen/install-mongodb-client-encryption.sh
+++ b/.evergreen/install-mongodb-client-encryption.sh
@@ -10,7 +10,7 @@ set -o xtrace   # Write all commands first to stderr
 set -o errexit  # Exit the script with error if any of the commands fail
 
 rm -rf mongodb-client-encryption
-git clone https://github.com/mongodb-js/mongodb-client-encryption.git
+git clone https://github.com/mongodb-js/mongodb-client-encryption.git -b explicit-lifetime-chaining
 pushd mongodb-client-encryption
 
 if [ -n "${LIBMONGOCRYPT_VERSION}" ]; then

--- a/.evergreen/install-mongodb-client-encryption.sh
+++ b/.evergreen/install-mongodb-client-encryption.sh
@@ -10,7 +10,7 @@ set -o xtrace   # Write all commands first to stderr
 set -o errexit  # Exit the script with error if any of the commands fail
 
 rm -rf mongodb-client-encryption
-git clone https://github.com/mongodb-js/mongodb-client-encryption.git -b explicit-lifetime-chaining
+git clone https://github.com/mongodb-js/mongodb-client-encryption.git
 pushd mongodb-client-encryption
 
 if [ -n "${LIBMONGOCRYPT_VERSION}" ]; then

--- a/src/cmap/wire_protocol/on_demand/document.ts
+++ b/src/cmap/wire_protocol/on_demand/document.ts
@@ -47,6 +47,13 @@ type CachedBSONElement = { element: BSONElement; value: any | undefined };
 /** @internal */
 export class OnDemandDocument {
   /**
+   * @internal
+   *
+   * Used for testing purposes.
+   */
+  private static BSON: typeof BSON = BSON;
+
+  /**
    * Maps JS strings to elements and jsValues for speeding up subsequent lookups.
    * - If `false` then name does not exist in the BSON document
    * - If `CachedBSONElement` instance name exists
@@ -337,7 +344,7 @@ export class OnDemandDocument {
       index: this.offset,
       allowObjectSmallerThanBufferSize: true
     };
-    return BSON.deserialize(this.bson, exactBSONOptions);
+    return OnDemandDocument.BSON.deserialize(this.bson, exactBSONOptions);
   }
 
   private parseBsonSerializationOptions(options?: { enableUtf8Validation?: boolean }): {

--- a/src/cmap/wire_protocol/on_demand/document.ts
+++ b/src/cmap/wire_protocol/on_demand/document.ts
@@ -1,10 +1,10 @@
 import {
   Binary,
-  BSON,
   type BSONElement,
   BSONError,
   type BSONSerializeOptions,
   BSONType,
+  deserialize,
   getBigInt64LE,
   getFloat64LE,
   getInt32LE,
@@ -46,13 +46,6 @@ type CachedBSONElement = { element: BSONElement; value: any | undefined };
 
 /** @internal */
 export class OnDemandDocument {
-  /**
-   * @internal
-   *
-   * Used for testing purposes.
-   */
-  private static BSON: typeof BSON = BSON;
-
   /**
    * Maps JS strings to elements and jsValues for speeding up subsequent lookups.
    * - If `false` then name does not exist in the BSON document
@@ -344,7 +337,7 @@ export class OnDemandDocument {
       index: this.offset,
       allowObjectSmallerThanBufferSize: true
     };
-    return OnDemandDocument.BSON.deserialize(this.bson, exactBSONOptions);
+    return deserialize(this.bson, exactBSONOptions);
   }
 
   private parseBsonSerializationOptions(options?: { enableUtf8Validation?: boolean }): {

--- a/src/cmap/wire_protocol/responses.ts
+++ b/src/cmap/wire_protocol/responses.ts
@@ -5,7 +5,6 @@ import {
   type Document,
   Long,
   parseToElementsToArray,
-  pluckBSONSerializeOptions,
   type Timestamp
 } from '../../bson';
 import { MongoUnexpectedServerResponseError } from '../../error';
@@ -165,24 +164,6 @@ export class MongoDBResponse extends OnDemandDocument {
       this.clusterTime = { clusterTime, signature };
     }
     return this.clusterTime ?? null;
-  }
-
-  public override toObject(options?: BSONSerializeOptions): Record<string, any> {
-    const exactBSONOptions = {
-      ...pluckBSONSerializeOptions(options ?? {}),
-      validation: this.parseBsonSerializationOptions(options)
-    };
-    return super.toObject(exactBSONOptions);
-  }
-
-  private parseBsonSerializationOptions(options?: { enableUtf8Validation?: boolean }): {
-    utf8: { writeErrors: false } | false;
-  } {
-    const enableUtf8Validation = options?.enableUtf8Validation;
-    if (enableUtf8Validation === false) {
-      return { utf8: false };
-    }
-    return { utf8: { writeErrors: false } };
   }
 }
 

--- a/test/integration/node-specific/bson-options/utf8_validation.test.ts
+++ b/test/integration/node-specific/bson-options/utf8_validation.test.ts
@@ -167,13 +167,12 @@ describe('utf8 validation with cursors', function () {
    * bytes of the character 'é', to produce invalid utf8.
    */
   async function insertDocumentWithInvalidUTF8() {
-    const targetCharacter = Buffer.from('é').toString('hex');
-
     const stub = sinon.stub(net.Socket.prototype, 'write').callsFake(function (...args) {
       const providedBuffer = args[0].toString('hex');
-      const targetCharacter = Buffer.from('é').toString('hex');
-      if (providedBuffer.includes(targetCharacter)) {
-        if (providedBuffer.split(targetCharacter).length !== 2) {
+      const targetBytes = Buffer.from('é').toString('hex');
+
+      if (providedBuffer.includes(targetBytes)) {
+        if (providedBuffer.split(targetBytes).length !== 2) {
           throw new Error('received buffer more than one `c3a9` sequences.  or perhaps none?');
         }
         const buffer = Buffer.from(providedBuffer.replace('c3a9', 'c301'), 'hex');
@@ -186,7 +185,7 @@ describe('utf8 validation with cursors', function () {
     });
 
     const document = {
-      field: targetCharacter
+      field: 'é'
     };
 
     await collection.insertOne(document);

--- a/test/integration/node-specific/bson-options/utf8_validation.test.ts
+++ b/test/integration/node-specific/bson-options/utf8_validation.test.ts
@@ -8,7 +8,6 @@ import {
   type Collection,
   type MongoClient,
   MongoDBResponse,
-  MongoError,
   MongoServerError,
   OpMsgResponse
 } from '../../../mongodb';
@@ -240,127 +239,95 @@ describe('utf8 validation with cursors', function () {
     });
   });
 
-  async function expectReject(fn: () => Promise<void>, options?: { regex?: RegExp; errorClass }) {
-    const regex = options?.regex ?? /.*/;
-    const errorClass = options?.errorClass ?? MongoError;
+  async function expectReject(fn: () => Promise<void>) {
     try {
       await fn();
       expect.fail('expected the provided callback function to reject, but it did not.');
     } catch (error) {
-      expect(error).to.match(regex);
-      expect(error).to.be.instanceOf(errorClass);
+      expect(error).to.match(/Invalid UTF-8 string in BSON document/);
+      expect(error).to.be.instanceOf(BSONError);
     }
   }
 
   context('when utf-8 validation is explicitly enabled', function () {
     it('a for-await loop throw a BSON error', async function () {
-      await expectReject(
-        async () => {
-          for await (const _doc of collection.find({}, { enableUtf8Validation: true }));
-        },
-        { errorClass: BSONError, regex: /Invalid UTF-8 string in BSON document/ }
-      );
+      await expectReject(async () => {
+        for await (const _doc of collection.find({}, { enableUtf8Validation: true }));
+      });
     });
     it('next() throws a BSON error', async function () {
-      await expectReject(
-        async () => {
-          const cursor = collection.find({}, { enableUtf8Validation: true });
+      await expectReject(async () => {
+        const cursor = collection.find({}, { enableUtf8Validation: true });
 
-          while (await cursor.hasNext()) {
-            await cursor.next();
-          }
-        },
-        { errorClass: BSONError, regex: /Invalid UTF-8 string in BSON document/ }
-      );
+        while (await cursor.hasNext()) {
+          await cursor.next();
+        }
+      });
     });
 
     it('toArray() throws a BSON error', async function () {
-      await expectReject(
-        async () => {
-          const cursor = collection.find({}, { enableUtf8Validation: true });
-          await cursor.toArray();
-        },
-        { errorClass: BSONError, regex: /Invalid UTF-8 string in BSON document/ }
-      );
+      await expectReject(async () => {
+        const cursor = collection.find({}, { enableUtf8Validation: true });
+        await cursor.toArray();
+      });
     });
 
     it('.stream() throws a BSONError', async function () {
-      await expectReject(
-        async () => {
-          const cursor = collection.find({}, { enableUtf8Validation: true });
-          await cursor.stream().toArray();
-        },
-        { errorClass: BSONError, regex: /Invalid UTF-8 string in BSON document/ }
-      );
+      await expectReject(async () => {
+        const cursor = collection.find({}, { enableUtf8Validation: true });
+        await cursor.stream().toArray();
+      });
     });
 
     it('tryNext() throws a BSONError', async function () {
-      await expectReject(
-        async () => {
-          const cursor = collection.find({}, { enableUtf8Validation: true });
+      await expectReject(async () => {
+        const cursor = collection.find({}, { enableUtf8Validation: true });
 
-          while (await cursor.hasNext()) {
-            await cursor.tryNext();
-          }
-        },
-        { errorClass: BSONError, regex: /Invalid UTF-8 string in BSON document/ }
-      );
+        while (await cursor.hasNext()) {
+          await cursor.tryNext();
+        }
+      });
     });
   });
 
   context('utf-8 validation defaults to enabled', function () {
     it('a for-await loop throw a BSON error', async function () {
-      await expectReject(
-        async () => {
-          for await (const _doc of collection.find({}));
-        },
-        { errorClass: BSONError, regex: /Invalid UTF-8 string in BSON document/ }
-      );
+      await expectReject(async () => {
+        for await (const _doc of collection.find({}));
+      });
     });
     it('next() throws a BSON error', async function () {
-      await expectReject(
-        async () => {
-          const cursor = collection.find({});
+      await expectReject(async () => {
+        const cursor = collection.find({});
 
-          while (await cursor.hasNext()) {
-            await cursor.next();
-          }
-        },
-        { errorClass: BSONError, regex: /Invalid UTF-8 string in BSON document/ }
-      );
+        while (await cursor.hasNext()) {
+          await cursor.next();
+        }
+      });
     });
 
     it('toArray() throws a BSON error', async function () {
-      await expectReject(
-        async () => {
-          const cursor = collection.find({});
-          await cursor.toArray();
-        },
-        { errorClass: BSONError, regex: /Invalid UTF-8 string in BSON document/ }
-      );
+      await expectReject(async () => {
+        const cursor = collection.find({});
+        await cursor.toArray();
+      });
     });
 
     it('.stream() throws a BSONError', async function () {
-      await expectReject(
-        async () => {
-          const cursor = collection.find({});
-          await cursor.stream().toArray();
-        },
-        { errorClass: BSONError, regex: /Invalid UTF-8 string in BSON document/ }
-      );
+      await expectReject(async () => {
+        const cursor = collection.find({});
+        await cursor.stream().toArray();
+      });
     });
 
     it('tryNext() throws a BSONError', async function () {
-      await expectReject(
-        async () => {
-          const cursor = collection.find({}, { enableUtf8Validation: true });
+      await expectReject(async () => {
+        const cursor = collection.find({}, { enableUtf8Validation: true });
 
-          while (await cursor.hasNext()) {
-            await cursor.tryNext();
-          }
-        },
-        { errorClass: BSONError, regex: /Invalid UTF-8 string in BSON document/ }
-      );
+        while (await cursor.hasNext()) {
+          await cursor.tryNext();
+        }
+      });
     });
   });
 });

--- a/test/integration/node-specific/bson-options/utf8_validation.test.ts
+++ b/test/integration/node-specific/bson-options/utf8_validation.test.ts
@@ -1,11 +1,13 @@
 import { expect } from 'chai';
 import * as net from 'net';
 import * as sinon from 'sinon';
+import { inspect } from 'util';
 
 import {
   BSON,
   BSONError,
   type Collection,
+  deserialize,
   type MongoClient,
   MongoDBResponse,
   MongoServerError,
@@ -173,7 +175,9 @@ describe('utf8 validation with cursors', function () {
 
       if (providedBuffer.includes(targetBytes)) {
         if (providedBuffer.split(targetBytes).length !== 2) {
-          throw new Error('received buffer more than one `c3a9` sequences.  or perhaps none?');
+          sinon.restore();
+          const message = `expected exactly one c3a9 sequence, received ${providedBuffer.split(targetBytes).length}\n.  command: ${inspect(deserialize(args[0]), { depth: Infinity })}`;
+          throw new Error(message);
         }
         const buffer = Buffer.from(providedBuffer.replace('c3a9', 'c301'), 'hex');
         const result = stub.wrappedMethod.apply(this, [buffer]);

--- a/test/integration/node-specific/bson-options/utf8_validation.test.ts
+++ b/test/integration/node-specific/bson-options/utf8_validation.test.ts
@@ -9,8 +9,8 @@ import {
   type Collection,
   deserialize,
   type MongoClient,
-  MongoDBResponse,
   MongoServerError,
+  OnDemandDocument,
   OpMsgResponse
 } from '../../../mongodb';
 
@@ -28,12 +28,12 @@ describe('class MongoDBResponse', () => {
   let bsonSpy: sinon.SinonSpy;
 
   beforeEach(() => {
-    bsonSpy = sinon.spy(MongoDBResponse.prototype, 'parseBsonSerializationOptions');
+    // @ts-expect-error private function
+    bsonSpy = sinon.spy(OnDemandDocument.prototype, 'parseBsonSerializationOptions');
   });
 
   afterEach(() => {
     bsonSpy?.restore();
-    // @ts-expect-error: Allow this to be garbage collected
     bsonSpy = null;
   });
 
@@ -159,7 +159,7 @@ describe('class MongoDBResponse', () => {
   );
 });
 
-describe('utf8 validation with cursors' + i, function () {
+describe('utf8 validation with cursors', function () {
   let client: MongoClient;
   let collection: Collection;
 

--- a/test/integration/node-specific/bson-options/utf8_validation.test.ts
+++ b/test/integration/node-specific/bson-options/utf8_validation.test.ts
@@ -204,6 +204,7 @@ describe('utf8 validation with cursors', function () {
   });
 
   afterEach(async function () {
+    sinon.restore();
     await client.close();
   });
 

--- a/test/unit/cmap/wire_protocol/responses.test.ts
+++ b/test/unit/cmap/wire_protocol/responses.test.ts
@@ -1,28 +1,31 @@
-import * as SPYABLE_BSON from 'bson';
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 
+// to spy on the bson module, we must import it from the driver
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
+import * as mdb from '../../../../src/bson';
 import {
-  BSON,
   CursorResponse,
   Int32,
   MongoDBResponse,
   MongoUnexpectedServerResponseError,
-  OnDemandDocument
+  OnDemandDocument,
+  serialize
 } from '../../../mongodb';
 
 describe('class MongoDBResponse', () => {
   it('is a subclass of OnDemandDocument', () => {
-    expect(new MongoDBResponse(BSON.serialize({ ok: 1 }))).to.be.instanceOf(OnDemandDocument);
+    expect(new MongoDBResponse(serialize({ ok: 1 }))).to.be.instanceOf(OnDemandDocument);
   });
 
   context('utf8 validation', () => {
-    let deseriailzeSpy: sinon.SinonSpy;
+    let deseriailzeSpy: sinon.SinonStub<Parameters<typeof mdb.deserialize>>;
     beforeEach(function () {
-      // @ts-expect-error accessing internal property.
-      OnDemandDocument.BSON = SPYABLE_BSON;
-
-      deseriailzeSpy = sinon.spy(SPYABLE_BSON, 'deserialize');
+      const deserialize = mdb.deserialize;
+      deseriailzeSpy = sinon.stub<Parameters<typeof deserialize>>().callsFake(deserialize);
+      sinon.stub(mdb, 'deserialize').get(() => {
+        return deseriailzeSpy;
+      });
     });
     afterEach(function () {
       sinon.restore();
@@ -31,7 +34,7 @@ describe('class MongoDBResponse', () => {
     context('when enableUtf8Validation is not specified', () => {
       const options = { enableUtf8Validation: undefined };
       it('calls BSON deserialize with writeErrors validation turned off', () => {
-        const res = new MongoDBResponse(BSON.serialize({}));
+        const res = new MongoDBResponse(serialize({}));
         res.toObject(options);
 
         expect(deseriailzeSpy).to.have.been.called;
@@ -49,7 +52,7 @@ describe('class MongoDBResponse', () => {
     context('when enableUtf8Validation is true', () => {
       const options = { enableUtf8Validation: true };
       it('calls BSON deserialize with writeErrors validation turned off', () => {
-        const res = new MongoDBResponse(BSON.serialize({}));
+        const res = new MongoDBResponse(serialize({}));
         res.toObject(options);
 
         expect(deseriailzeSpy).to.have.been.called;
@@ -67,7 +70,7 @@ describe('class MongoDBResponse', () => {
     context('when enableUtf8Validation is false', () => {
       const options = { enableUtf8Validation: false };
       it('calls BSON deserialize with all validation disabled', () => {
-        const res = new MongoDBResponse(BSON.serialize({}));
+        const res = new MongoDBResponse(serialize({}));
         res.toObject(options);
 
         expect(deseriailzeSpy).to.have.been.called;
@@ -87,7 +90,7 @@ describe('class MongoDBResponse', () => {
 describe('class CursorResponse', () => {
   describe('get cursor()', () => {
     it('throws if input does not contain cursor embedded document', () => {
-      expect(() => new CursorResponse(BSON.serialize({ ok: 1 })).cursor).to.throw(
+      expect(() => new CursorResponse(serialize({ ok: 1 })).cursor).to.throw(
         MongoUnexpectedServerResponseError,
         /"cursor" is missing/
       );
@@ -96,7 +99,7 @@ describe('class CursorResponse', () => {
 
   describe('get id()', () => {
     it('throws if input does not contain cursor.id int64', () => {
-      expect(() => new CursorResponse(BSON.serialize({ ok: 1, cursor: {} })).id).to.throw(
+      expect(() => new CursorResponse(serialize({ ok: 1, cursor: {} })).id).to.throw(
         MongoUnexpectedServerResponseError,
         /"id" is missing/
       );
@@ -107,22 +110,22 @@ describe('class CursorResponse', () => {
     it('throws if input does not contain firstBatch nor nextBatch', () => {
       expect(
         // @ts-expect-error: testing private getter
-        () => new CursorResponse(BSON.serialize({ ok: 1, cursor: { id: 0n, batch: [] } })).batch
+        () => new CursorResponse(serialize({ ok: 1, cursor: { id: 0n, batch: [] } })).batch
       ).to.throw(MongoUnexpectedServerResponseError, /did not contain a batch/);
     });
   });
 
   describe('get ns()', () => {
     it('sets namespace to null if input does not contain cursor.ns', () => {
-      expect(new CursorResponse(BSON.serialize({ ok: 1, cursor: { id: 0n, firstBatch: [] } })).ns)
-        .to.be.null;
+      expect(new CursorResponse(serialize({ ok: 1, cursor: { id: 0n, firstBatch: [] } })).ns).to.be
+        .null;
     });
   });
 
   describe('get batchSize()', () => {
     it('reports the returned batch size', () => {
       const response = new CursorResponse(
-        BSON.serialize({ ok: 1, cursor: { id: 0n, nextBatch: [{}, {}, {}] } })
+        serialize({ ok: 1, cursor: { id: 0n, nextBatch: [{}, {}, {}] } })
       );
       expect(response.batchSize).to.equal(3);
       expect(response.shift()).to.deep.equal({});
@@ -133,7 +136,7 @@ describe('class CursorResponse', () => {
   describe('get length()', () => {
     it('reports number of documents remaining in the batch', () => {
       const response = new CursorResponse(
-        BSON.serialize({ ok: 1, cursor: { id: 0n, nextBatch: [{}, {}, {}] } })
+        serialize({ ok: 1, cursor: { id: 0n, nextBatch: [{}, {}, {}] } })
       );
       expect(response).to.have.lengthOf(3);
       expect(response.shift()).to.deep.equal({});
@@ -146,7 +149,7 @@ describe('class CursorResponse', () => {
 
     beforeEach(async function () {
       response = new CursorResponse(
-        BSON.serialize({
+        serialize({
           ok: 1,
           cursor: { id: 0n, nextBatch: [{ _id: 1 }, { _id: 2 }, { _id: 3 }] }
         })
@@ -173,7 +176,7 @@ describe('class CursorResponse', () => {
 
     beforeEach(async function () {
       response = new CursorResponse(
-        BSON.serialize({
+        serialize({
           ok: 1,
           cursor: { id: 0n, nextBatch: [{ _id: 1 }, { _id: 2 }, { _id: 3 }] }
         })

--- a/test/unit/cmap/wire_protocol/responses.test.ts
+++ b/test/unit/cmap/wire_protocol/responses.test.ts
@@ -36,7 +36,11 @@ describe('class MongoDBResponse', () => {
 
         expect(deseriailzeSpy).to.have.been.called;
 
-        const [_buffer, { validation }] = deseriailzeSpy.getCalls()[0].args;
+        const [
+          {
+            args: [_buffer, { validation }]
+          }
+        ] = deseriailzeSpy.getCalls();
 
         expect(validation).to.deep.equal({ utf8: { writeErrors: false } });
       });
@@ -50,7 +54,11 @@ describe('class MongoDBResponse', () => {
 
         expect(deseriailzeSpy).to.have.been.called;
 
-        const [_buffer, { validation }] = deseriailzeSpy.getCalls()[0].args;
+        const [
+          {
+            args: [_buffer, { validation }]
+          }
+        ] = deseriailzeSpy.getCalls();
 
         expect(validation).to.deep.equal({ utf8: { writeErrors: false } });
       });
@@ -64,7 +72,11 @@ describe('class MongoDBResponse', () => {
 
         expect(deseriailzeSpy).to.have.been.called;
 
-        const [_buffer, { validation }] = deseriailzeSpy.getCalls()[0].args;
+        const [
+          {
+            args: [_buffer, { validation }]
+          }
+        ] = deseriailzeSpy.getCalls();
 
         expect(validation).to.deep.equal({ utf8: false });
       });


### PR DESCRIPTION
### Description

#### What is changing?

This PR ensures that any BSON utf8 validation options are provided to the deserializer when deserializing cursors.

Since on-demand BSON, cursors are deserialized on-demand.  Documents are pulled out of the cursor using `MongoDBResponse.get()`, which returns an unparsed on-demand document.  We then deserialize it using `toObject()`.

However, although `MongoDBResponse` correctly applies BSON utf8 options to its deserialization logic, the on-demand document does not.  This results in documents retrieved from a cursor being deserialized without the utf8 validation options.

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
