### PR TITLE
chore: add a 6.8 release process workflow

### DIFF
--- a/.github/workflows/release-6.8.yml
+++ b/.github/workflows/release-6.8.yml
@@ -101,7 +101,9 @@ jobs:
 
         # Just picking a string to put here so that releases from this branch are not marked "latest",
         # we should go and rm-dist-tag after this is published, no reason to keep it tagged.
-      - run: npm publish --provenance --tag=stable
+      - run: |
+          npm publish --provenance --tag=tag-for-publishing-older-releases
+          npm dist-tag rm mongodb tag-for-publishing-older-releases
         if: ${{ needs.release_please.outputs.release_created }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-6.8.yml
+++ b/.github/workflows/release-6.8.yml
@@ -1,0 +1,107 @@
+on:
+  push:
+    branches: [6.8]
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write
+
+name: release-68
+
+jobs:
+  release_please:
+    runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+    steps:
+      - id: release
+        uses: googleapis/release-please-action@v4
+        with:
+          target-branch: 6.8
+
+  build:
+    needs: [release_please]
+    name: "Perform any build or bundling steps, as necessary."
+    uses: ./.github/workflows/build.yml
+
+  ssdlc:
+    needs: [release_please, build]
+    permissions:
+      # required for all workflows
+      security-events: write
+      id-token: write
+      contents: write
+    environment: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Node and dependencies
+        uses: mongodb-labs/drivers-github-tools/node/setup@v2
+        with:
+          ignore_install_scripts: false
+
+      - name: Load version and package info
+        uses: mongodb-labs/drivers-github-tools/node/get_version_info@v2
+        with:
+          npm_package_name: mongodb
+
+      - name: actions/compress_sign_and_upload
+        uses: mongodb-labs/drivers-github-tools/node/sign_node_package@v2
+        with:
+          aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
+          aws_region_name: us-east-1
+          aws_secret_id: ${{ secrets.AWS_SECRET_ID }}
+          npm_package_name: mongodb
+          dry_run: ${{ needs.release_please.outputs.release_created == '' }}
+
+      - name: Copy sbom file to release assets
+        shell: bash
+        if: ${{ '' == '' }}
+        run: cp sbom.json ${{ env.S3_ASSETS }}/sbom.json
+
+      # only used for mongodb-client-encryption
+      - name: Augment SBOM and copy to release assets
+        if: ${{ '' != '' }}
+        uses: mongodb-labs/drivers-github-tools/sbom@v2
+        with:
+          silk_asset_group: ''
+          sbom_file_name: sbom.json
+
+      - name: Generate authorized pub report
+        uses: mongodb-labs/drivers-github-tools/full-report@v2
+        with:
+          release_version: ${{ env.package_version }}
+          product_name: mongodb
+          sarif_report_target_ref: 6.8
+          third_party_dependency_tool: n/a
+          dist_filenames: artifacts/*
+          token: ${{ github.token }}
+          sbom_file_name: sbom.json
+          evergreen_project: mongo-node-driver-next
+          evergreen_commit: ${{ env.commit }}
+
+      - uses: mongodb-labs/drivers-github-tools/upload-s3-assets@v2
+        with:
+          version: ${{ env.package_version }}
+          product_name: mongodb
+          dry_run: ${{ needs.release_please.outputs.release_created == '' }}
+
+  publish:
+    needs: [release_please, ssdlc, build]
+    environment: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Node and dependencies
+        uses: mongodb-labs/drivers-github-tools/node/setup@v2
+
+        # Just picking a string to put here so that releases from this branch are not marked "latest",
+        # we should go and rm-dist-tag after this is published, no reason to keep it tagged.
+      - run: npm publish --provenance --tag=stable
+        if: ${{ needs.release_please.outputs.release_created }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
### Description

#### What is changing?

- Add a workflow for releasing from 6.8

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

Automated releases from 6.8

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
