### PR TITLE
fix(NODE-6362): cache cursor deserialization options across deserialize calls

### DIFF
--- a/src/bson.ts
+++ b/src/bson.ts
@@ -132,3 +132,14 @@ export function resolveBSONOptions(
       options?.enableUtf8Validation ?? parentOptions?.enableUtf8Validation ?? true
   };
 }
+
+/** @internal */
+export function parseUtf8ValidationOption(options?: { enableUtf8Validation?: boolean }): {
+  utf8: { writeErrors: false } | false;
+} {
+  const enableUtf8Validation = options?.enableUtf8Validation;
+  if (enableUtf8Validation === false) {
+    return { utf8: false };
+  }
+  return { utf8: { writeErrors: false } };
+}

--- a/src/cmap/connection.ts
+++ b/src/cmap/connection.ts
@@ -1,3 +1,4 @@
+import { type DeserializeOptions } from 'bson';
 import { type Readable, Transform, type TransformCallback } from 'stream';
 import { clearTimeout, setTimeout } from 'timers';
 
@@ -487,7 +488,7 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
 
     // If `documentsReturnedIn` not set or raw is not enabled, use input bson options
     // Otherwise, support raw flag. Raw only works for cursors that hardcode firstBatch/nextBatch fields
-    const bsonOptions =
+    const bsonOptions: DeserializeOptions =
       options.documentsReturnedIn == null || !options.raw
         ? options
         : {

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -1,6 +1,7 @@
 import { Readable, Transform } from 'stream';
 
 import { type BSONSerializeOptions, type Document, Long, pluckBSONSerializeOptions } from '../bson';
+import { type OnDemandDocumentDeserializeOptions } from '../cmap/wire_protocol/on_demand/document';
 import { type CursorResponse } from '../cmap/wire_protocol/responses';
 import {
   MongoAPIError,
@@ -158,6 +159,9 @@ export abstract class AbstractCursor<
   static readonly CLOSE = 'close' as const;
 
   /** @internal */
+  protected deserializationOptions: OnDemandDocumentDeserializeOptions;
+
+  /** @internal */
   protected constructor(
     client: MongoClient,
     namespace: MongoDBNamespace,
@@ -211,6 +215,13 @@ export abstract class AbstractCursor<
     } else {
       this.cursorSession = this.cursorClient.startSession({ owner: this, explicit: false });
     }
+
+    this.deserializationOptions = {
+      ...this.cursorOptions,
+      validation: {
+        utf8: options?.enableUtf8Validation === false ? false : true
+      }
+    };
   }
 
   /**
@@ -304,7 +315,7 @@ export abstract class AbstractCursor<
     );
 
     for (let count = 0; count < documentsToRead; count++) {
-      const document = this.documents?.shift(this.cursorOptions);
+      const document = this.documents?.shift(this.deserializationOptions);
       if (document != null) {
         bufferedDocs.push(document);
       }
@@ -406,7 +417,7 @@ export abstract class AbstractCursor<
     }
 
     do {
-      const doc = this.documents?.shift(this.cursorOptions);
+      const doc = this.documents?.shift(this.deserializationOptions);
       if (doc != null) {
         if (this.transform != null) return await this.transformDocument(doc);
         return doc;
@@ -425,7 +436,7 @@ export abstract class AbstractCursor<
       throw new MongoCursorExhaustedError();
     }
 
-    let doc = this.documents?.shift(this.cursorOptions);
+    let doc = this.documents?.shift(this.deserializationOptions);
     if (doc != null) {
       if (this.transform != null) return await this.transformDocument(doc);
       return doc;
@@ -433,7 +444,7 @@ export abstract class AbstractCursor<
 
     await this.fetchBatch();
 
-    doc = this.documents?.shift(this.cursorOptions);
+    doc = this.documents?.shift(this.deserializationOptions);
     if (doc != null) {
       if (this.transform != null) return await this.transformDocument(doc);
       return doc;

--- a/src/cursor/aggregation_cursor.ts
+++ b/src/cursor/aggregation_cursor.ts
@@ -76,7 +76,7 @@ export class AggregationCursor<TSchema = any> extends AbstractCursor<TSchema> {
           explain: verbosity ?? true
         })
       )
-    ).shift(this.aggregateOptions);
+    ).shift(this.deserializationOptions);
   }
 
   /** Add a stage to the aggregation pipeline

--- a/src/cursor/find_cursor.ts
+++ b/src/cursor/find_cursor.ts
@@ -143,7 +143,7 @@ export class FindCursor<TSchema = any> extends AbstractCursor<TSchema> {
           explain: verbosity ?? true
         })
       )
-    ).shift(this.findOptions);
+    ).shift(this.deserializationOptions);
   }
 
   /** Set the cursor query */

--- a/src/index.ts
+++ b/src/index.ts
@@ -302,7 +302,11 @@ export type { ClientMetadata, ClientMetadataOptions } from './cmap/handshake/cli
 export type { ConnectionPoolMetrics } from './cmap/metrics';
 export type { StreamDescription, StreamDescriptionOptions } from './cmap/stream_description';
 export type { CompressorName } from './cmap/wire_protocol/compression';
-export type { JSTypeOf, OnDemandDocument } from './cmap/wire_protocol/on_demand/document';
+export type {
+  JSTypeOf,
+  OnDemandDocument,
+  OnDemandDocumentDeserializeOptions
+} from './cmap/wire_protocol/on_demand/document';
 export type {
   CursorResponse,
   MongoDBResponse,

--- a/test/integration/node-specific/bson-options/utf8_validation.test.ts
+++ b/test/integration/node-specific/bson-options/utf8_validation.test.ts
@@ -1,7 +1,6 @@
 import { expect } from 'chai';
 import * as net from 'net';
 import * as sinon from 'sinon';
-import { inspect } from 'util';
 
 import {
   BSON,
@@ -9,7 +8,6 @@ import {
   type Collection,
   type MongoClient,
   MongoServerError,
-  OnDemandDocument,
   OpMsgResponse
 } from '../../../mongodb';
 

--- a/test/integration/node-specific/bson-options/utf8_validation.test.ts
+++ b/test/integration/node-specific/bson-options/utf8_validation.test.ts
@@ -7,159 +7,78 @@ import {
   BSON,
   BSONError,
   type Collection,
-  deserialize,
   type MongoClient,
   MongoServerError,
   OnDemandDocument,
   OpMsgResponse
 } from '../../../mongodb';
 
-const EXPECTED_VALIDATION_DISABLED_ARGUMENT = {
-  utf8: false
-};
-
-const EXPECTED_VALIDATION_ENABLED_ARGUMENT = {
-  utf8: {
-    writeErrors: false
-  }
-};
-
 describe('class MongoDBResponse', () => {
-  let bsonSpy: sinon.SinonSpy;
-
-  beforeEach(() => {
-    // @ts-expect-error private function
-    bsonSpy = sinon.spy(OnDemandDocument.prototype, 'parseBsonSerializationOptions');
-  });
-
-  afterEach(() => {
-    bsonSpy?.restore();
-    bsonSpy = null;
-  });
-
   let client;
 
   afterEach(async () => {
+    sinon.restore();
     if (client) await client.close();
   });
 
-  describe('enableUtf8Validation option set to false', () => {
-    const option = { enableUtf8Validation: false };
-
-    for (const passOptionTo of ['client', 'db', 'collection', 'operation']) {
-      it(`should disable validation with option passed to ${passOptionTo}`, async function () {
-        client = this.configuration.newClient(passOptionTo === 'client' ? option : undefined);
-
-        const db = client.db('bson_utf8Validation_db', passOptionTo === 'db' ? option : undefined);
-        const collection = db.collection(
-          'bson_utf8Validation_coll',
-          passOptionTo === 'collection' ? option : undefined
-        );
-
-        await collection.insertOne(
-          { name: 'John Doe' },
-          passOptionTo === 'operation' ? option : {}
-        );
-
-        expect(bsonSpy).to.have.been.called;
-        const result = bsonSpy.lastCall.returnValue;
-        expect(result).to.deep.equal(EXPECTED_VALIDATION_DISABLED_ARGUMENT);
-      });
-    }
-  });
-
-  describe('enableUtf8Validation option set to true', () => {
-    // define client and option for tests to use
-    const option = { enableUtf8Validation: true };
-    for (const passOptionTo of ['client', 'db', 'collection', 'operation']) {
-      it(`should enable validation with option passed to ${passOptionTo}`, async function () {
-        client = this.configuration.newClient(passOptionTo === 'client' ? option : undefined);
-        await client.connect();
-
-        const db = client.db('bson_utf8Validation_db', passOptionTo === 'db' ? option : undefined);
-        const collection = db.collection(
-          'bson_utf8Validation_coll',
-          passOptionTo === 'collection' ? option : undefined
-        );
-
-        await collection.insertOne(
-          { name: 'John Doe' },
-          passOptionTo === 'operation' ? option : {}
-        );
-
-        expect(bsonSpy).to.have.been.called;
-        const result = bsonSpy.lastCall.returnValue;
-        expect(result).to.deep.equal(EXPECTED_VALIDATION_ENABLED_ARGUMENT);
-      });
-    }
-  });
-
-  describe('enableUtf8Validation option not set', () => {
-    const option = {};
-    for (const passOptionTo of ['client', 'db', 'collection', 'operation']) {
-      it(`should default to enabled with option passed to ${passOptionTo}`, async function () {
-        client = this.configuration.newClient(passOptionTo === 'client' ? option : undefined);
-        await client.connect();
-
-        const db = client.db('bson_utf8Validation_db', passOptionTo === 'db' ? option : undefined);
-        const collection = db.collection(
-          'bson_utf8Validation_coll',
-          passOptionTo === 'collection' ? option : undefined
-        );
-
-        await collection.insertOne(
-          { name: 'John Doe' },
-          passOptionTo === 'operation' ? option : {}
-        );
-
-        expect(bsonSpy).to.have.been.called;
-        const result = bsonSpy.lastCall.returnValue;
-        expect(result).to.deep.equal(EXPECTED_VALIDATION_ENABLED_ARGUMENT);
-      });
-    }
-  });
-
   context(
-    'when the server is given a long multibyte utf sequence and there is a writeError',
+    'when the server is given a long multibyte utf sequence and there is a writeError that includes invalid utf8',
     () => {
       let client: MongoClient;
-      beforeEach(async function () {
-        client = this.configuration.newClient();
-      });
+      let error: MongoServerError;
+      for (const { optionDescription, options } of [
+        { optionDescription: 'explicitly enabled', options: { enableUtf8Validation: true } },
+        { optionDescription: 'explicitly disabled', options: { enableUtf8Validation: false } },
+        { optionDescription: 'omitted', options: {} }
+      ]) {
+        context('when utf8 validation is ' + optionDescription, function () {
+          beforeEach(async function () {
+            client = this.configuration.newClient();
 
-      afterEach(async function () {
-        sinon.restore();
-        await client.db('parsing').dropDatabase();
-        await client.close();
-      });
+            async function generateWriteErrorWithInvalidUtf8() {
+              // Insert a large string of multibyte UTF-8 characters
+              const _id = '\u{1F92A}'.repeat(100);
 
-      it('does not throw a UTF-8 parsing error', async () => {
-        // Insert a large string of multibyte UTF-8 characters
-        const _id = '\u{1F92A}'.repeat(100);
+              const test = client.db('parsing').collection<{ _id: string }>('parsing');
+              await test.insertOne({ _id }, options);
 
-        const test = client.db('parsing').collection<{ _id: string }>('parsing');
-        await test.insertOne({ _id });
+              const spy = sinon.spy(OpMsgResponse.prototype, 'parse');
 
-        const spy = sinon.spy(OpMsgResponse.prototype, 'parse');
+              error = await test.insertOne({ _id }).catch(error => error);
 
-        const error = await test.insertOne({ _id }).catch(error => error);
+              // Check that the server sent us broken BSON (bad UTF)
+              expect(() => {
+                BSON.deserialize(spy.returnValues[0], { validation: { utf8: true } });
+              }).to.throw(
+                BSON.BSONError,
+                /Invalid UTF/i,
+                'did not generate error with invalid utf8'
+              );
+            }
 
-        // Check that the server sent us broken BSON (bad UTF)
-        expect(() => {
-          BSON.deserialize(spy.returnValues[0], { validation: { utf8: true } });
-        }).to.throw(BSON.BSONError, /Invalid UTF/i);
+            await generateWriteErrorWithInvalidUtf8();
+          });
 
-        // Assert the driver squashed it
-        expect(error).to.be.instanceOf(MongoServerError);
-        expect(error.message).to.match(/duplicate/i);
-        expect(error.message).to.not.match(/utf/i);
-        expect(error.errmsg).to.include('\uFFFD');
-      });
+          afterEach(async function () {
+            sinon.restore();
+            await client.db('parsing').dropDatabase();
+            await client.close();
+          });
+
+          it('does not throw a UTF-8 parsing error', function () {
+            // Assert the driver squashed it
+            expect(error).to.be.instanceOf(MongoServerError);
+            expect(error.message).to.match(/duplicate/i);
+            expect(error.message).to.not.match(/utf/i);
+            expect(error.errmsg).to.include('\uFFFD');
+          });
+        });
+      }
     }
   );
 });
 
-describe('utf8 validation with cursors', function () {
+describe('parsing of utf8-invalid documents wish cursors', function () {
   let client: MongoClient;
   let collection: Collection;
 
@@ -176,7 +95,9 @@ describe('utf8 validation with cursors', function () {
       if (providedBuffer.includes(targetBytes)) {
         if (providedBuffer.split(targetBytes).length !== 2) {
           sinon.restore();
-          const message = `too many target bytes sequences: received ${providedBuffer.split(targetBytes).length}\n.  command: ${inspect(deserialize(args[0]), { depth: Infinity })}`;
+          const message = `too many target bytes sequences: received ${
+            providedBuffer.split(targetBytes).length
+          }`;
           throw new Error(message);
         }
         const buffer = Buffer.from(providedBuffer.replace(targetBytes, 'c301'.repeat(8)), 'hex');
@@ -254,7 +175,7 @@ describe('utf8 validation with cursors', function () {
   }
 
   context('when utf-8 validation is explicitly enabled', function () {
-    it('a for-await loop throw a BSON error', async function () {
+    it('a for-await loop throws a BSON error', async function () {
       await expectReject(async () => {
         for await (const _doc of collection.find({}, { enableUtf8Validation: true }));
       });
@@ -295,7 +216,7 @@ describe('utf8 validation with cursors', function () {
   });
 
   context('utf-8 validation defaults to enabled', function () {
-    it('a for-await loop throw a BSON error', async function () {
+    it('a for-await loop throws a BSON error', async function () {
       await expectReject(async () => {
         for await (const _doc of collection.find({}));
       });

--- a/test/integration/node-specific/bson-options/utf8_validation.test.ts
+++ b/test/integration/node-specific/bson-options/utf8_validation.test.ts
@@ -76,7 +76,7 @@ describe('class MongoDBResponse', () => {
   );
 });
 
-describe('parsing of utf8-invalid documents wish cursors', function () {
+describe('parsing of utf8-invalid documents with cursors', function () {
   let client: MongoClient;
   let collection: Collection;
 

--- a/test/unit/cmap/wire_protocol/responses.test.ts
+++ b/test/unit/cmap/wire_protocol/responses.test.ts
@@ -1,5 +1,4 @@
 import { expect } from 'chai';
-import * as sinon from 'sinon';
 
 // to spy on the bson module, we must import it from the driver
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports
@@ -16,74 +15,6 @@ import {
 describe('class MongoDBResponse', () => {
   it('is a subclass of OnDemandDocument', () => {
     expect(new MongoDBResponse(serialize({ ok: 1 }))).to.be.instanceOf(OnDemandDocument);
-  });
-
-  context('utf8 validation', () => {
-    let deseriailzeSpy: sinon.SinonStub<Parameters<typeof mdb.deserialize>>;
-    beforeEach(function () {
-      const deserialize = mdb.deserialize;
-      deseriailzeSpy = sinon.stub<Parameters<typeof deserialize>>().callsFake(deserialize);
-      sinon.stub(mdb, 'deserialize').get(() => {
-        return deseriailzeSpy;
-      });
-    });
-    afterEach(function () {
-      sinon.restore();
-    });
-
-    context('when enableUtf8Validation is not specified', () => {
-      const options = { enableUtf8Validation: undefined };
-      it('calls BSON deserialize with writeErrors validation turned off', () => {
-        const res = new MongoDBResponse(serialize({}));
-        res.toObject(options);
-
-        expect(deseriailzeSpy).to.have.been.called;
-
-        const [
-          {
-            args: [_buffer, { validation }]
-          }
-        ] = deseriailzeSpy.getCalls();
-
-        expect(validation).to.deep.equal({ utf8: { writeErrors: false } });
-      });
-    });
-
-    context('when enableUtf8Validation is true', () => {
-      const options = { enableUtf8Validation: true };
-      it('calls BSON deserialize with writeErrors validation turned off', () => {
-        const res = new MongoDBResponse(serialize({}));
-        res.toObject(options);
-
-        expect(deseriailzeSpy).to.have.been.called;
-
-        const [
-          {
-            args: [_buffer, { validation }]
-          }
-        ] = deseriailzeSpy.getCalls();
-
-        expect(validation).to.deep.equal({ utf8: { writeErrors: false } });
-      });
-    });
-
-    context('when enableUtf8Validation is false', () => {
-      const options = { enableUtf8Validation: false };
-      it('calls BSON deserialize with all validation disabled', () => {
-        const res = new MongoDBResponse(serialize({}));
-        res.toObject(options);
-
-        expect(deseriailzeSpy).to.have.been.called;
-
-        const [
-          {
-            args: [_buffer, { validation }]
-          }
-        ] = deseriailzeSpy.getCalls();
-
-        expect(validation).to.deep.equal({ utf8: false });
-      });
-    });
   });
 });
 

--- a/test/unit/cmap/wire_protocol/responses.test.ts
+++ b/test/unit/cmap/wire_protocol/responses.test.ts
@@ -1,8 +1,5 @@
 import { expect } from 'chai';
 
-// to spy on the bson module, we must import it from the driver
-// eslint-disable-next-line @typescript-eslint/no-restricted-imports
-import * as mdb from '../../../../src/bson';
 import {
   CursorResponse,
   Int32,


### PR DESCRIPTION
### Description

#### What is changing?

Forward-port of https://github.com/mongodb/node-mongodb-native/pull/4220.

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fixed `enableUtf8Validation` option

Starting in v6.8.0 we inadvertently removed the ability to disable UTF-8 validation when deserializing BSON. Validation is normally a good thing, but it was always meant to be configurable and the [recent Node.js runtime issues (v22.7.0)](https://github.com/nodejs/node/issues/54543) make this option indispensable for avoiding errors from mistakenly generated invalid UTF-8 bytes.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
