### PR TITLE
chore: quote branch names to avoid numeric conversion

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -2,7 +2,7 @@ name: Build and commit docs
 
 on:
   push:
-    branches: [main]
+    branches: ['main']
 
 permissions:
   contents: write

--- a/.github/workflows/release-5.x.yml
+++ b/.github/workflows/release-5.x.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: [5.x]
+    branches: ['5.x']
   workflow_dispatch: {}
 
 permissions:
@@ -19,7 +19,7 @@ jobs:
       - id: release
         uses: googleapis/release-please-action@v4
         with:
-          target-branch: 5.x
+          target-branch: '5.x'
 
   build:
     needs: [release_please]
@@ -75,7 +75,7 @@ jobs:
         with:
           release_version: ${{ env.package_version }}
           product_name: mongodb
-          sarif_report_target_ref: 5.x
+          sarif_report_target_ref: '5.x'
           third_party_dependency_tool: n/a
           dist_filenames: artifacts/*
           token: ${{ github.token }}

--- a/.github/workflows/release-6.8.yml
+++ b/.github/workflows/release-6.8.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: [6.8]
+    branches: ['6.8']
   workflow_dispatch: {}
 
 permissions:
@@ -19,11 +19,11 @@ jobs:
       - id: release
         uses: googleapis/release-please-action@v4
         with:
-          target-branch: 6.8
+          target-branch: '6.8'
 
   build:
     needs: [release_please]
-    name: "Perform any build or bundling steps, as necessary."
+    name: 'Perform any build or bundling steps, as necessary.'
     uses: ./.github/workflows/build.yml
 
   ssdlc:
@@ -75,7 +75,7 @@ jobs:
         with:
           release_version: ${{ env.package_version }}
           product_name: mongodb
-          sarif_report_target_ref: 6.8
+          sarif_report_target_ref: '6.8'
           third_party_dependency_tool: n/a
           dist_filenames: artifacts/*
           token: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: [main]
+    branches: ['main']
   workflow_dispatch: {}
 
 permissions:
@@ -19,7 +19,7 @@ jobs:
       - id: release
         uses: googleapis/release-please-action@v4
         with:
-          target-branch: main
+          target-branch: 'main'
 
   build:
     needs: [release_please]
@@ -75,7 +75,7 @@ jobs:
         with:
           release_version: ${{ env.package_version }}
           product_name: mongodb
-          sarif_report_target_ref: main
+          sarif_report_target_ref: 'main'
           third_party_dependency_tool: n/a
           dist_filenames: artifacts/*
           token: ${{ github.token }}


### PR DESCRIPTION
### Description

#### What is changing?

- Added quotes to all the branch names I could find.
  - Only necessary when branch name is numeric but if we put it everywhere when we copy pasta we will be less likely to omit it

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

Correctness

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
