### PR TITLE
feat(NODE-6365): pass through `allowPartialTrustChain` TLS flag

### DIFF
--- a/src/cmap/connect.ts
+++ b/src/cmap/connect.ts
@@ -249,6 +249,7 @@ export async function prepareHandshakeDocument(
 
 /** @public */
 export const LEGAL_TLS_SOCKET_OPTIONS = [
+  'allowPartialTrustChain',
   'ALPNProtocols',
   'ca',
   'cert',

--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -1228,7 +1228,8 @@ export const OPTIONS = {
   // Custom types for modifying core behavior
   connectionType: { type: 'any' },
   srvPoller: { type: 'any' },
-  // Accepted NodeJS Options
+  // Accepted Node.js Options
+  allowPartialTrustChain: { type: 'any' },
   minDHSize: { type: 'any' },
   pskCallback: { type: 'any' },
   secureContext: { type: 'any' },

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -93,8 +93,10 @@ export interface PkFactory {
 
 /** @public */
 export type SupportedTLSConnectionOptions = Pick<
-  TLSConnectionOptions,
-  Extract<keyof TLSConnectionOptions, (typeof LEGAL_TLS_SOCKET_OPTIONS)[number]>
+  TLSConnectionOptions & {
+    allowPartialTrustChain?: boolean;
+  },
+  (typeof LEGAL_TLS_SOCKET_OPTIONS)[number]
 >;
 
 /** @public */


### PR DESCRIPTION
~~Will leave this in draft until the upstream Node.js PR is merged.~~

Refs: https://github.com/nodejs/node/pull/54790

### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Allow passing through `allowPartialTrustChain` Node.js TLS option

This option is now exposed through the MongoClient constructor's options parameter and controls the [`X509_V_FLAG_PARTIAL_CHAIN`](https://docs.openssl.org/master/man3/X509_VERIFY_PARAM_set_flags/#verification-flags) OpenSSL flag.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
