### PR TITLE
fix(NODE-6367):  enable mixed use of iteration APIs

### DIFF
--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -412,7 +412,7 @@ export abstract class AbstractCursor<
 
   /** Get the next available document from the cursor, returns null if no more documents are available. */
   async next(): Promise<TSchema | null> {
-    if (this.cursorId === Long.ZERO) {
+    if (this.cursorId === Long.ZERO && (this.documents?.length ?? 0) === 0) {
       throw new MongoCursorExhaustedError();
     }
 

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -314,11 +314,9 @@ export abstract class AbstractCursor<
   }
 
   async *[Symbol.asyncIterator](): AsyncGenerator<TSchema, void, void> {
-    /*
     if (this.isClosed) {
       return;
     }
-    */
 
     try {
       while (true) {
@@ -468,6 +466,7 @@ export abstract class AbstractCursor<
    * Frees any client-side resources used by the cursor.
    */
   async close(): Promise<void> {
+    this.isClosed = true;
     await this.cleanup();
   }
 
@@ -783,7 +782,6 @@ export abstract class AbstractCursor<
 
   /** @internal */
   private async cleanup(error?: Error) {
-    this.isClosed = true;
     const session = this.cursorSession;
     try {
       if (

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -314,7 +314,7 @@ export abstract class AbstractCursor<
   }
 
   async *[Symbol.asyncIterator](): AsyncGenerator<TSchema, void, void> {
-    if (this.isClosed) {
+    if (this.closed) {
       return;
     }
 
@@ -466,7 +466,6 @@ export abstract class AbstractCursor<
    * Frees any client-side resources used by the cursor.
    */
   async close(): Promise<void> {
-    this.isClosed = true;
     await this.cleanup();
   }
 
@@ -782,6 +781,7 @@ export abstract class AbstractCursor<
 
   /** @internal */
   private async cleanup(error?: Error) {
+    this.isClosed = true;
     const session = this.cursorSession;
     try {
       if (

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -412,7 +412,7 @@ export abstract class AbstractCursor<
 
   /** Get the next available document from the cursor, returns null if no more documents are available. */
   async next(): Promise<TSchema | null> {
-    if (this.cursorId === Long.ZERO && (this.documents?.length ?? 0) === 0) {
+    if (this.cursorId === Long.ZERO) {
       throw new MongoCursorExhaustedError();
     }
 

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -314,10 +314,6 @@ export abstract class AbstractCursor<
   }
 
   async *[Symbol.asyncIterator](): AsyncGenerator<TSchema, void, void> {
-    if (this.isClosed) {
-      return;
-    }
-
     try {
       while (true) {
         if (this.isKilled) {

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -314,6 +314,10 @@ export abstract class AbstractCursor<
   }
 
   async *[Symbol.asyncIterator](): AsyncGenerator<TSchema, void, void> {
+    if (this.isClosed) {
+      return;
+    }
+
     try {
       while (true) {
         if (this.isKilled) {

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -314,9 +314,11 @@ export abstract class AbstractCursor<
   }
 
   async *[Symbol.asyncIterator](): AsyncGenerator<TSchema, void, void> {
+    /*
     if (this.isClosed) {
       return;
     }
+    */
 
     try {
       while (true) {

--- a/test/integration/crud/find_cursor_methods.test.js
+++ b/test/integration/crud/find_cursor_methods.test.js
@@ -451,10 +451,6 @@ describe('Find Cursor', function () {
               resolve(v);
             });
 
-            stream.once('end', v => {
-              resolve(v);
-            });
-
             stream.once('error', v => {
               reject(v);
             });
@@ -473,10 +469,6 @@ describe('Find Cursor', function () {
           const { promise, resolve, reject } = promiseWithResolvers();
 
           stream.once('data', v => {
-            resolve(v);
-          });
-
-          stream.once('end', v => {
             resolve(v);
           });
 
@@ -499,10 +491,6 @@ describe('Find Cursor', function () {
             const { promise, resolve, reject } = promiseWithResolvers();
 
             stream.once('data', v => {
-              resolve(v);
-            });
-
-            stream.once('end', v => {
               resolve(v);
             });
 
@@ -578,10 +566,10 @@ describe('Find Cursor', function () {
           await cursor.toArray();
 
           const s = cursor.stream();
-          const { promise, resolve } = promiseWithResolvers();
+          const { promise, resolve, reject } = promiseWithResolvers();
 
           s.once('data', d => {
-            resolve(d);
+            reject(d);
           });
 
           s.once('end', d => {
@@ -650,95 +638,6 @@ describe('Find Cursor', function () {
         });
       });
 
-      context('when cursor.next() is called after cursor.stream()', function () {
-        it('throws a MongoExpiredSessionError', async function () {
-          cursor = collection.find({}, { batchSize: 1 });
-
-          const stream = cursor.stream();
-          const { promise, resolve, reject } = promiseWithResolvers();
-
-          stream.once('data', v => {
-            resolve(v);
-          });
-
-          stream.once('end', v => {
-            resolve(v);
-          });
-
-          stream.once('error', v => {
-            reject(v);
-          });
-          await promise;
-
-          const maybeError = await cursor.next().then(
-            () => null,
-            e => e
-          );
-
-          expect(maybeError).to.be.instanceof(MongoExpiredSessionError);
-        });
-      });
-
-      context('when cursor.tryNext() is called after cursor.stream()', function () {
-        it('throws a MongoExpiredSessionError', async function () {
-          cursor = collection.find({}, { batchSize: 1 });
-
-          const stream = cursor.stream();
-          const { promise, resolve, reject } = promiseWithResolvers();
-
-          stream.once('data', v => {
-            resolve(v);
-          });
-
-          stream.once('end', v => {
-            resolve(v);
-          });
-
-          stream.once('error', v => {
-            reject(v);
-          });
-          await promise;
-
-          const maybeError = await cursor.tryNext().then(
-            () => null,
-            e => e
-          );
-
-          expect(maybeError).to.be.instanceof(MongoExpiredSessionError);
-        });
-      });
-
-      context('when cursor.[Symbol.asyncIterator] is called after cursor.stream()', function () {
-        it('throws a MongoExpiredSessionError', async function () {
-          cursor = collection.find({}, { batchSize: 1 });
-
-          const stream = cursor.stream();
-          const { promise, resolve, reject } = promiseWithResolvers();
-
-          stream.once('data', v => {
-            resolve(v);
-          });
-
-          stream.once('end', v => {
-            resolve(v);
-          });
-
-          stream.once('error', v => {
-            reject(v);
-          });
-          await promise;
-
-          try {
-            // eslint-disable-next-line no-unused-vars, no-empty
-            for await (const _ of cursor) {
-            }
-            expect.fail('expected to throw');
-          } catch (err) {
-            expect(err).to.be.instanceof(MongoExpiredSessionError);
-          }
-        });
-      });
-
       context('when cursor.readBufferedDocuments() is called after cursor.next()', function () {
         it('returns an empty array', async function () {
           cursor = collection.find({}, { batchSize: 1 });
@@ -795,10 +694,10 @@ describe('Find Cursor', function () {
           await cursor.toArray();
 
           const s = cursor.stream();
-          const { promise, resolve } = promiseWithResolvers();
+          const { promise, resolve, reject } = promiseWithResolvers();
 
           s.once('data', d => {
-            resolve(d);
+            reject(d);
           });
 
           s.once('end', d => {

--- a/test/integration/crud/find_cursor_methods.test.js
+++ b/test/integration/crud/find_cursor_methods.test.js
@@ -416,7 +416,7 @@ describe('Find Cursor', function () {
     });
 
     context('when there are documents are not retrieved in the first batch', function () {
-      it('allows combining iteration modes', async function () {
+      it('allows combining next() and for await syntax', async function () {
         let count = 0;
         cursor = collection.find({}, { batchSize: 1 }).map(doc => {
           count++;
@@ -428,6 +428,24 @@ describe('Find Cursor', function () {
         for await (const _ of cursor) {
           /* empty */
         }
+
+        expect(count).to.equal(2);
+      });
+
+      it.only('allows partial iteration with for await syntax and then calling .next()', async function () {
+        let count = 0;
+        cursor = collection.find({}, { batchSize: 2 }).map(doc => {
+          count++;
+          return doc;
+        });
+
+        for await (const doc of cursor) {
+          console.log(doc);
+          /* empty */
+          break;
+        }
+
+        await cursor.next();
 
         expect(count).to.equal(2);
       });

--- a/test/integration/crud/find_cursor_methods.test.js
+++ b/test/integration/crud/find_cursor_methods.test.js
@@ -432,7 +432,7 @@ describe('Find Cursor', function () {
         expect(count).to.equal(2);
       });
 
-      it.only('allows partial iteration with for await syntax and then calling .next()', async function () {
+      it('allows partial iteration with for await syntax and then calling .next()', async function () {
         let count = 0;
         cursor = collection.find({}, { batchSize: 2 }).map(doc => {
           count++;

--- a/test/integration/crud/find_cursor_methods.test.js
+++ b/test/integration/crud/find_cursor_methods.test.js
@@ -1,11 +1,7 @@
 'use strict';
 const { expect } = require('chai');
 const { filterForCommands } = require('../shared');
-const {
-  promiseWithResolvers,
-  MongoExpiredSessionError,
-  MongoCursorExhaustedError
-} = require('../../mongodb');
+const { promiseWithResolvers, MongoCursorExhaustedError } = require('../../mongodb');
 
 describe('Find Cursor', function () {
   let client;

--- a/test/integration/crud/find_cursor_methods.test.js
+++ b/test/integration/crud/find_cursor_methods.test.js
@@ -389,6 +389,7 @@ describe('Find Cursor', function () {
         });
 
         await cursor.next();
+        // eslint-disable-next-line no-unused-vars
         for await (const _ of cursor) {
           /* empty */
         }
@@ -423,6 +424,7 @@ describe('Find Cursor', function () {
         });
 
         await cursor.next();
+        // eslint-disable-next-line no-unused-vars
         for await (const _ of cursor) {
           /* empty */
         }


### PR DESCRIPTION
### Description

#### What is changing?

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

Fixing mixed use of `cursor.next` and `for await (const doc of cursor)`.

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Restore mixed use of `cursor.next()` and `cursor[Symbol.asyncIterator]`

In 6.8.0, we inadvertently prevented the use of `cursor.next()` along with using `for await` syntax to iterate cursors. This use-case has now been restored.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [X] Ran `npm run check:lint` script
- [X] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [X] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [X] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
