### PR TITLE
test(NODE-5788): rework change stream close rejection test

### DIFF
--- a/test/integration/change-streams/change_stream.test.ts
+++ b/test/integration/change-streams/change_stream.test.ts
@@ -830,8 +830,8 @@ describe('Change Streams', function () {
             status === 'rejected'
               ? reason.message
               : value.operationType === 'insert'
-              ? `insert count = ${value.fullDocument.insertCount}`
-              : null;
+                ? `insert count = ${value.fullDocument.insertCount}`
+                : null;
           return `${status}:${res}`;
         });
 
@@ -858,8 +858,8 @@ describe('Change Streams', function () {
             status === 'rejected'
               ? reason.message
               : value.operationType === 'insert'
-              ? `insert count = ${value.fullDocument.insertCount}`
-              : null;
+                ? `insert count = ${value.fullDocument.insertCount}`
+                : null;
           return `${status}:${res}`;
         });
 
@@ -890,8 +890,8 @@ describe('Change Streams', function () {
             status === 'rejected'
               ? reason.message
               : value.operationType === 'insert'
-              ? `insert count = ${value.fullDocument.insertCount}`
-              : null;
+                ? `insert count = ${value.fullDocument.insertCount}`
+                : null;
           return `${status}:${res}`;
         });
 


### PR DESCRIPTION
### Description

#### What is changing?

- The change stream tests removed were flaky, I recaptured what I think is the intended behavior, pending promises are rejected by a close call
- Further clarity will be worked on in NODE-5221

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

Reduce flaky tests.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
