### PR TITLE
fix(NODE-6374): MongoOperationTimeoutError inherits MongoRuntimeError

### DIFF
--- a/etc/notes/errors.md
+++ b/etc/notes/errors.md
@@ -67,7 +67,7 @@ Children of `MongoError` include:
 ### `MongoDriverError`
 
 This class represents errors which originate in the driver itself or when the user incorrectly uses the driver. This class should **never** be directly instantiated.
-Its children are the main classes of errors that most users will interact with: [**`MongoAPIError`**](#MongoAPIError) and [**`MongoRuntimeError`**](#MongoRuntimeError).
+Its children are the main classes of errors that most users will interact with: [**`MongoAPIError`**](#MongoAPIError), [**`MongoRuntimeError`**](#MongoRuntimeError) and [**`MongoOperationTimeoutError`**](#MongoOperationTimeoutError).
 
 ### `MongoAPIError`
 
@@ -108,6 +108,10 @@ This class should **never** be directly instantiated.
 | **MongoGridFSStreamError**  | Thrown when an unexpected state is reached when operating on a GridFS Stream.              |
 | **MongoGridFSChunkError**   | Thrown when a malformed or invalid chunk is encountered when reading from a GridFS Stream. |
 | **MongoUnexpectedServerResponseError**   | Thrown when the driver receives a **parsable** response it did not expect from the server. |
+
+### `MongoOperationTimeoutError`
+
+- TODO(NODE-5688): Add MongoOperationTimeoutError documentation
 
 ### MongoUnexpectedServerResponseError
 

--- a/src/error.ts
+++ b/src/error.ts
@@ -310,7 +310,7 @@ export class MongoAPIError extends MongoDriverError {
 
 /**
  * An error generated when the driver encounters unexpected input
- * or reaches an unexpected/invalid internal state
+ * or reaches an unexpected/invalid internal state.
  *
  * @privateRemarks
  * Should **never** be directly instantiated.
@@ -765,9 +765,24 @@ export class MongoUnexpectedServerResponseError extends MongoRuntimeError {
 }
 
 /**
- * @internal
+ * @public
+ * @category Error
+ *
+ * This error is thrown when an operation could not be completed within the specified `timeoutMS`.
+ * TODO(NODE-5688): expand this documentation.
+ *
+ * @example
+ * ```ts
+ * try {
+ *   await blogs.insertOne(blogPost, { timeoutMS: 60_000 })
+ * } catch (error) {
+ *   if (error instanceof MongoOperationTimeoutError) {
+ *     console.log(`Oh no! writer's block!`, error);
+ *   }
+ * }
+ * ```
  */
-export class MongoOperationTimeoutError extends MongoRuntimeError {
+export class MongoOperationTimeoutError extends MongoDriverError {
   override get name(): string {
     return 'MongoOperationTimeoutError';
   }

--- a/test/unit/error.test.ts
+++ b/test/unit/error.test.ts
@@ -14,12 +14,15 @@ import {
   LEGACY_NOT_PRIMARY_OR_SECONDARY_ERROR_MESSAGE,
   LEGACY_NOT_WRITABLE_PRIMARY_ERROR_MESSAGE,
   MONGODB_ERROR_CODES,
+  MongoDriverError,
   MongoError,
   MongoErrorLabel,
   MongoMissingDependencyError,
   MongoNetworkError,
   MongoNetworkTimeoutError,
+  MongoOperationTimeoutError,
   MongoParseError,
+  MongoRuntimeError,
   MongoServerError,
   MongoSystemError,
   MongoWriteConcernError,
@@ -170,6 +173,23 @@ describe('MongoErrors', () => {
         const error = new MongoSystemError('something went wrong', topologyDescription);
         expect(error).to.haveOwnProperty('code', undefined);
       });
+    });
+  });
+
+  describe('class MongoOperationTimeoutError', () => {
+    it('has a name property equal to MongoOperationTimeoutError', () => {
+      const error = new MongoOperationTimeoutError('time out!');
+      expect(error).to.have.property('name', 'MongoOperationTimeoutError');
+    });
+
+    it('is instanceof MongoDriverError', () => {
+      const error = new MongoOperationTimeoutError('time out!');
+      expect(error).to.be.instanceOf(MongoDriverError);
+    });
+
+    it('is not instanceof MongoRuntimeError', () => {
+      const error = new MongoOperationTimeoutError('time out!');
+      expect(error).to.not.be.instanceOf(MongoRuntimeError);
     });
   });
 


### PR DESCRIPTION
### Description

#### What is changing?

- Fix error inheritance

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

Runtime errors indicate surprising outcomes, running out of time may be surprising but it is the intended outcome of an API that is given a deadline. 

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
