### PR TITLE
test: remove empty skipped context blocks

### DIFF
--- a/test/integration/client-side-operations-timeout/node_csot.test.ts
+++ b/test/integration/client-side-operations-timeout/node_csot.test.ts
@@ -576,11 +576,6 @@ describe('CSOT driver tests', metadata, () => {
     });
   });
 
-  describe.skip('Tailable non-awaitData cursors').skipReason =
-    'TODO(NODE-6305): implement CSOT for Tailable cursors';
-  describe.skip('Tailable awaitData cursors').skipReason =
-    'TODO(NODE-6305): implement CSOT for Tailable cursors';
-
   describe('when using an explicit session', () => {
     const metadata: MongoDBMetadataUI = {
       requires: { topology: ['replicaset'], mongodb: '>=4.4' }


### PR DESCRIPTION
### Description

#### What is changing?

Remove empty context blocks that unintentionally skipped tests that should have been running

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

Test coverage
<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->
<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [X] Ran `npm run check:lint` script
- [X] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [X] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [X] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
