### PR TITLE
feat(NODE-5844): add iscryptd to ServerDescription

### DIFF
--- a/src/sdam/server_description.ts
+++ b/src/sdam/server_description.ts
@@ -69,6 +69,8 @@ export class ServerDescription {
   setVersion: number | null;
   electionId: ObjectId | null;
   logicalSessionTimeoutMinutes: number | null;
+  /** Indicates server is a mongocryptd instance. */
+  iscryptd: boolean;
 
   // NOTE: does this belong here? It seems we should gossip the cluster time at the CMAP level
   $clusterTime?: ClusterTime;
@@ -114,6 +116,7 @@ export class ServerDescription {
     this.primary = hello?.primary ?? null;
     this.me = hello?.me?.toLowerCase() ?? null;
     this.$clusterTime = hello?.$clusterTime ?? null;
+    this.iscryptd = Boolean(hello?.iscryptd);
   }
 
   get hostAddress(): HostAddress {
@@ -167,6 +170,7 @@ export class ServerDescription {
 
     return (
       other != null &&
+      other.iscryptd === this.iscryptd &&
       errorStrictEqual(this.error, other.error) &&
       this.type === other.type &&
       this.minWireVersion === other.minWireVersion &&

--- a/test/integration/server-discovery-and-monitoring/server_description.test.ts
+++ b/test/integration/server-discovery-and-monitoring/server_description.test.ts
@@ -1,0 +1,58 @@
+import { type ChildProcess, spawn } from 'node:child_process';
+
+import { expect } from 'chai';
+
+import { MongoClient } from '../../mongodb';
+
+describe('class ServerDescription', function () {
+  describe('when connecting to mongocryptd', { requires: { mongodb: '>=4.4' } }, function () {
+    let client: MongoClient;
+    const mongocryptdTestPort = '27022';
+    let childProcess: ChildProcess;
+
+    beforeEach(async function () {
+      childProcess = spawn('mongocryptd', ['--port', mongocryptdTestPort, '--ipv6'], {
+        stdio: 'ignore',
+        detached: true
+      });
+
+      childProcess.on('error', error =>
+        console.warn('class ServerDescription when connecting to mongocryptd:', error)
+      );
+      client = new MongoClient(`mongodb://localhost:${mongocryptdTestPort}`);
+    });
+
+    afterEach(async function () {
+      await client?.close();
+      childProcess.kill('SIGKILL');
+    });
+
+    it('iscryptd is set to true ', async function () {
+      const descriptions = [];
+      client.on('serverDescriptionChanged', description => descriptions.push(description));
+      const hello = await client.db().command({ hello: true });
+      expect(hello).to.have.property('iscryptd', true);
+      expect(descriptions.at(-1)).to.have.nested.property('newDescription.iscryptd', true);
+    });
+  });
+
+  describe('when connecting to anything other than mongocryptd', function () {
+    let client: MongoClient;
+
+    beforeEach(async function () {
+      client = this.configuration.newClient();
+    });
+
+    afterEach(async function () {
+      await client?.close();
+    });
+
+    it('iscryptd is set to false ', async function () {
+      const descriptions = [];
+      client.on('serverDescriptionChanged', description => descriptions.push(description));
+      const hello = await client.db().command({ hello: true });
+      expect(hello).to.not.have.property('iscryptd');
+      expect(descriptions.at(-1)).to.have.nested.property('newDescription.iscryptd', false);
+    });
+  });
+});

--- a/test/integration/server-discovery-and-monitoring/server_description.test.ts
+++ b/test/integration/server-discovery-and-monitoring/server_description.test.ts
@@ -16,9 +16,7 @@ describe('class ServerDescription', function () {
         detached: true
       });
 
-      childProcess.on('error', error =>
-        console.warn('class ServerDescription when connecting to mongocryptd:', error)
-      );
+      childProcess.on('error', error => console.warn(this.currentTest?.fullTitle(), error));
       client = new MongoClient(`mongodb://localhost:${mongocryptdTestPort}`);
     });
 


### PR DESCRIPTION
### Description

#### What is changing?

Add iscryptd to serverDescription

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

Need to be able to identify mongocryptd instances

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
