### PR TITLE
fix(NODE-6394): pause message stream when not listening for events

### DIFF
--- a/src/cmap/connection.ts
+++ b/src/cmap/connection.ts
@@ -237,6 +237,8 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
       .on('error', this.onError.bind(this));
     this.socket.on('close', this.onClose.bind(this));
     this.socket.on('timeout', this.onTimeout.bind(this));
+
+    this.messageStream.pause();
   }
 
   public get hello() {
@@ -651,6 +653,7 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
   private async *readMany(): AsyncGenerator<OpMsgResponse | OpReply> {
     try {
       this.dataEvents = onData(this.messageStream);
+      this.messageStream.resume();
       for await (const message of this.dataEvents) {
         const response = await decompressResponse(message);
         yield response;
@@ -661,6 +664,7 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
       }
     } finally {
       this.dataEvents = null;
+      this.messageStream.pause();
       this.throwIfAborted();
     }
   }


### PR DESCRIPTION
### Description

#### What is changing?

The message stream is paused when we're not reading from it, so we do not miss `data` events.

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fixed indefinite hang bug for high write load scenarios

When performing large and many write operations, the driver will likely encounter buffering at the socket layer. The logic that waited until buffered writes were complete would mistakenly drop `'data'` (reading from the socket), causing the driver to hang indefinitely or until a socket timeout. Using pausing and resuming mechanisms exposed by Node streams we have eliminated the possibility for data events to go unhandled. 

Shout out to @hunkydoryrepair for debugging and finding this issue!

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
