### PR TITLE
chore: print drivers evergreen tools commit

### DIFF
--- a/.evergreen/prepare-shell.sh
+++ b/.evergreen/prepare-shell.sh
@@ -34,7 +34,7 @@ if [ ! -d "$DRIVERS_TOOLS" ]; then
   git clone --depth=1 "https://github.com/mongodb-labs/drivers-evergreen-tools.git" "${DRIVERS_TOOLS}"
 fi
 
-echo "installed DRIVERS_EVERGREEN_TOOLS from commit $(git -C "${DRIVERS_TOOLS}" rev-parse HEAD)"
+echo "installed DRIVERS_TOOLS from commit $(git -C "${DRIVERS_TOOLS}" rev-parse HEAD)"
 
 cat <<EOT > "$MONGO_ORCHESTRATION_HOME/orchestration.config"
 {

--- a/.evergreen/prepare-shell.sh
+++ b/.evergreen/prepare-shell.sh
@@ -34,7 +34,7 @@ if [ ! -d "$DRIVERS_TOOLS" ]; then
   git clone --depth=1 "https://github.com/mongodb-labs/drivers-evergreen-tools.git" "${DRIVERS_TOOLS}"
 fi
 
-echo "installed DRIVERS_EVERGREEN_TOOLS from commit $(git -C $DRIVERS_EVERGREEN_TOOLS rev-parse HEAD)"
+echo "installed DRIVERS_EVERGREEN_TOOLS from commit $(git -C "${DRIVERS_TOOLS}" rev-parse HEAD)"
 
 cat <<EOT > "$MONGO_ORCHESTRATION_HOME/orchestration.config"
 {


### PR DESCRIPTION
### Description

#### What is changing?

- print the commit used for tools

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

for debugging what version of tools used


### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
