### PR TITLE
feat(NODE-6387): Add CSOT support to change streams

### DIFF
--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -3,7 +3,7 @@ import type { Readable } from 'stream';
 import type { Binary, Document, Timestamp } from './bson';
 import { Collection } from './collection';
 import { CHANGE, CLOSE, END, ERROR, INIT, MORE, RESPONSE, RESUME_TOKEN_CHANGED } from './constants';
-import type { AbstractCursorEvents, CursorStreamOptions } from './cursor/abstract_cursor';
+import { type CursorStreamOptions, CursorTimeoutContext } from './cursor/abstract_cursor';
 import { ChangeStreamCursor, type ChangeStreamCursorOptions } from './cursor/change_stream_cursor';
 import { Db } from './db';
 import {
@@ -11,6 +11,7 @@ import {
   isResumableError,
   MongoAPIError,
   MongoChangeStreamError,
+  MongoOperationTimeoutError,
   MongoRuntimeError
 } from './error';
 import { MongoClient } from './mongo_client';
@@ -20,6 +21,7 @@ import type { CollationOptions, OperationParent } from './operations/command';
 import type { ReadPreference } from './read_preference';
 import { type AsyncDisposable, configureResourceManagement } from './resource_management';
 import type { ServerSessionId } from './sessions';
+import { CSOTTimeoutContext, type TimeoutContext } from './timeout';
 import { filterOptions, getTopology, type MongoDBNamespace, squashError } from './utils';
 
 /** @internal */
@@ -538,7 +540,13 @@ export type ChangeStreamEvents<
   end(): void;
   error(error: Error): void;
   change(change: TChange): void;
-} & AbstractCursorEvents;
+  /**
+   * @remarks Note that the `close` event is currently emitted whenever the internal `ChangeStreamCursor`
+   * instance is closed, which can occur multiple times for a given `ChangeStream` instance.
+   * When this event is emitted is subject to change outside of major versions.
+   */
+  close(): void;
+};
 
 /**
  * Creates a new Change Stream instance. Normally created using {@link Collection#watch|Collection.watch()}.
@@ -609,6 +617,13 @@ export class ChangeStream<
    */
   static readonly RESUME_TOKEN_CHANGED = RESUME_TOKEN_CHANGED;
 
+  private timeoutContext?: TimeoutContext;
+  /**
+   * Note that this property is here to uniquely identify a ChangeStream instance as the owner of
+   * the {@link CursorTimeoutContext} instance (see {@link ChangeStream._createChangeStreamCursor}) to ensure
+   * that {@link AbstractCursor.close} does not mutate the timeoutContext.
+   */
+  private contextOwner: symbol;
   /**
    * @internal
    *
@@ -624,20 +639,25 @@ export class ChangeStream<
 
     this.pipeline = pipeline;
     this.options = { ...options };
+    let serverSelectionTimeoutMS: number;
     delete this.options.writeConcern;
 
     if (parent instanceof Collection) {
       this.type = CHANGE_DOMAIN_TYPES.COLLECTION;
+      serverSelectionTimeoutMS = parent.s.db.client.options.serverSelectionTimeoutMS;
     } else if (parent instanceof Db) {
       this.type = CHANGE_DOMAIN_TYPES.DATABASE;
+      serverSelectionTimeoutMS = parent.client.options.serverSelectionTimeoutMS;
     } else if (parent instanceof MongoClient) {
       this.type = CHANGE_DOMAIN_TYPES.CLUSTER;
+      serverSelectionTimeoutMS = parent.options.serverSelectionTimeoutMS;
     } else {
       throw new MongoChangeStreamError(
         'Parent provided to ChangeStream constructor must be an instance of Collection, Db, or MongoClient'
       );
     }
 
+    this.contextOwner = Symbol();
     this.parent = parent;
     this.namespace = parent.s.namespace;
     if (!this.options.readPreference && parent.readPreference) {
@@ -662,6 +682,13 @@ export class ChangeStream<
         this[kCursorStream]?.removeAllListeners('data');
       }
     });
+
+    if (this.options.timeoutMS != null) {
+      this.timeoutContext = new CSOTTimeoutContext({
+        timeoutMS: this.options.timeoutMS,
+        serverSelectionTimeoutMS
+      });
+    }
   }
 
   /** @internal */
@@ -681,22 +708,31 @@ export class ChangeStream<
     // This loop continues until either a change event is received or until a resume attempt
     // fails.
 
-    while (true) {
-      try {
-        const hasNext = await this.cursor.hasNext();
-        return hasNext;
-      } catch (error) {
+    this.timeoutContext?.refresh();
+    try {
+      while (true) {
+        const cursorInitialized = this.cursor.id != null;
         try {
-          await this._processErrorIteratorMode(error);
+          const hasNext = await this.cursor.hasNext();
+          return hasNext;
         } catch (error) {
           try {
-            await this.close();
+            await this._processErrorIteratorMode(error, cursorInitialized);
           } catch (error) {
-            squashError(error);
+            if (error instanceof MongoOperationTimeoutError && cursorInitialized) {
+              throw error;
+            }
+            try {
+              await this.close();
+            } catch (error) {
+              squashError(error);
+            }
+            throw error;
           }
-          throw error;
         }
       }
+    } finally {
+      this.timeoutContext?.clear();
     }
   }
 
@@ -706,24 +742,33 @@ export class ChangeStream<
     // Change streams must resume indefinitely while each resume event succeeds.
     // This loop continues until either a change event is received or until a resume attempt
     // fails.
+    this.timeoutContext?.refresh();
 
-    while (true) {
-      try {
-        const change = await this.cursor.next();
-        const processedChange = this._processChange(change ?? null);
-        return processedChange;
-      } catch (error) {
+    try {
+      while (true) {
+        const cursorInitialized = this.cursor.id != null;
         try {
-          await this._processErrorIteratorMode(error);
+          const change = await this.cursor.next();
+          const processedChange = this._processChange(change ?? null);
+          return processedChange;
         } catch (error) {
           try {
-            await this.close();
+            await this._processErrorIteratorMode(error, cursorInitialized);
           } catch (error) {
-            squashError(error);
+            if (error instanceof MongoOperationTimeoutError && cursorInitialized) {
+              throw error;
+            }
+            try {
+              await this.close();
+            } catch (error) {
+              squashError(error);
+            }
+            throw error;
           }
-          throw error;
         }
       }
+    } finally {
+      this.timeoutContext?.clear();
     }
   }
 
@@ -735,23 +780,30 @@ export class ChangeStream<
     // Change streams must resume indefinitely while each resume event succeeds.
     // This loop continues until either a change event is received or until a resume attempt
     // fails.
+    this.timeoutContext?.refresh();
 
-    while (true) {
-      try {
-        const change = await this.cursor.tryNext();
-        return change ?? null;
-      } catch (error) {
+    try {
+      while (true) {
+        const cursorInitialized = this.cursor.id != null;
         try {
-          await this._processErrorIteratorMode(error);
+          const change = await this.cursor.tryNext();
+          return change ?? null;
         } catch (error) {
           try {
-            await this.close();
+            await this._processErrorIteratorMode(error, cursorInitialized);
           } catch (error) {
-            squashError(error);
+            if (error instanceof MongoOperationTimeoutError && cursorInitialized) throw error;
+            try {
+              await this.close();
+            } catch (error) {
+              squashError(error);
+            }
+            throw error;
           }
-          throw error;
         }
       }
+    } finally {
+      this.timeoutContext?.clear();
     }
   }
 
@@ -784,6 +836,8 @@ export class ChangeStream<
    * Frees the internal resources used by the change stream.
    */
   async close(): Promise<void> {
+    this.timeoutContext?.clear();
+    this.timeoutContext = undefined;
     this[kClosed] = true;
 
     const cursor = this.cursor;
@@ -866,7 +920,12 @@ export class ChangeStream<
       client,
       this.namespace,
       pipeline,
-      options
+      {
+        ...options,
+        timeoutContext: this.timeoutContext
+          ? new CursorTimeoutContext(this.timeoutContext, this.contextOwner)
+          : undefined
+      }
     );
 
     for (const event of CHANGE_STREAM_EVENTS) {
@@ -900,7 +959,7 @@ export class ChangeStream<
         this.emit(ChangeStream.ERROR, error);
       }
     });
-    stream.on('error', error => this._processErrorStreamMode(error));
+    stream.on('error', error => this._processErrorStreamMode(error, this.cursor.id != null));
   }
 
   /** @internal */
@@ -942,24 +1001,30 @@ export class ChangeStream<
   }
 
   /** @internal */
-  private _processErrorStreamMode(changeStreamError: AnyError) {
+  private _processErrorStreamMode(changeStreamError: AnyError, cursorInitialized: boolean) {
     // If the change stream has been closed explicitly, do not process error.
     if (this[kClosed]) return;
 
-    if (this.cursor.id != null && isResumableError(changeStreamError, this.cursor.maxWireVersion)) {
+    if (
+      cursorInitialized &&
+      (isResumableError(changeStreamError, this.cursor.maxWireVersion) ||
+        changeStreamError instanceof MongoOperationTimeoutError)
+    ) {
       this._endStream();
 
-      this.cursor.close().then(undefined, squashError);
-
-      const topology = getTopology(this.parent);
-      topology
-        .selectServer(this.cursor.readPreference, {
-          operationName: 'reconnect topology in change stream'
-        })
-
+      this.cursor
+        .close()
+        .then(
+          () => this._resume(changeStreamError),
+          e => {
+            squashError(e);
+            return this._resume(changeStreamError);
+          }
+        )
         .then(
           () => {
-            this.cursor = this._createChangeStreamCursor(this.cursor.resumeOptions);
+            if (changeStreamError instanceof MongoOperationTimeoutError)
+              this.emit(ChangeStream.ERROR, changeStreamError);
           },
           () => this._closeEmitterModeWithError(changeStreamError)
         );
@@ -969,33 +1034,44 @@ export class ChangeStream<
   }
 
   /** @internal */
-  private async _processErrorIteratorMode(changeStreamError: AnyError) {
+  private async _processErrorIteratorMode(changeStreamError: AnyError, cursorInitialized: boolean) {
     if (this[kClosed]) {
       // TODO(NODE-3485): Replace with MongoChangeStreamClosedError
       throw new MongoAPIError(CHANGESTREAM_CLOSED_ERROR);
     }
 
     if (
-      this.cursor.id == null ||
-      !isResumableError(changeStreamError, this.cursor.maxWireVersion)
+      cursorInitialized &&
+      (isResumableError(changeStreamError, this.cursor.maxWireVersion) ||
+        changeStreamError instanceof MongoOperationTimeoutError)
     ) {
+      try {
+        await this.cursor.close();
+      } catch (error) {
+        squashError(error);
+      }
+
+      await this._resume(changeStreamError);
+
+      if (changeStreamError instanceof MongoOperationTimeoutError) throw changeStreamError;
+    } else {
       try {
         await this.close();
       } catch (error) {
         squashError(error);
       }
+
       throw changeStreamError;
     }
+  }
 
-    try {
-      await this.cursor.close();
-    } catch (error) {
-      squashError(error);
-    }
+  private async _resume(changeStreamError: AnyError) {
+    this.timeoutContext?.refresh();
     const topology = getTopology(this.parent);
     try {
       await topology.selectServer(this.cursor.readPreference, {
-        operationName: 'reconnect topology in change stream'
+        operationName: 'reconnect topology in change stream',
+        timeoutContext: this.timeoutContext
       });
       this.cursor = this._createChangeStreamCursor(this.cursor.resumeOptions);
     } catch {

--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -711,15 +711,14 @@ export class ChangeStream<
     this.timeoutContext?.refresh();
     try {
       while (true) {
-        const cursorInitialized = this.cursor.id != null;
         try {
           const hasNext = await this.cursor.hasNext();
           return hasNext;
         } catch (error) {
           try {
-            await this._processErrorIteratorMode(error, cursorInitialized);
+            await this._processErrorIteratorMode(error, this.cursor.id != null);
           } catch (error) {
-            if (error instanceof MongoOperationTimeoutError && cursorInitialized) {
+            if (error instanceof MongoOperationTimeoutError && this.cursor.id != null) {
               throw error;
             }
             try {
@@ -746,16 +745,15 @@ export class ChangeStream<
 
     try {
       while (true) {
-        const cursorInitialized = this.cursor.id != null;
         try {
           const change = await this.cursor.next();
           const processedChange = this._processChange(change ?? null);
           return processedChange;
         } catch (error) {
           try {
-            await this._processErrorIteratorMode(error, cursorInitialized);
+            await this._processErrorIteratorMode(error, this.cursor.id != null);
           } catch (error) {
-            if (error instanceof MongoOperationTimeoutError && cursorInitialized) {
+            if (error instanceof MongoOperationTimeoutError && this.cursor.id != null) {
               throw error;
             }
             try {
@@ -784,15 +782,14 @@ export class ChangeStream<
 
     try {
       while (true) {
-        const cursorInitialized = this.cursor.id != null;
         try {
           const change = await this.cursor.tryNext();
           return change ?? null;
         } catch (error) {
           try {
-            await this._processErrorIteratorMode(error, cursorInitialized);
+            await this._processErrorIteratorMode(error, this.cursor.id != null);
           } catch (error) {
-            if (error instanceof MongoOperationTimeoutError && cursorInitialized) throw error;
+            if (error instanceof MongoOperationTimeoutError && this.cursor.id != null) throw error;
             try {
               await this.close();
             } catch (error) {

--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -543,7 +543,6 @@ export type ChangeStreamEvents<
   /**
    * @remarks Note that the `close` event is currently emitted whenever the internal `ChangeStreamCursor`
    * instance is closed, which can occur multiple times for a given `ChangeStream` instance.
-   * When this event is emitted is subject to change outside of major versions.
    */
   close(): void;
 };

--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -718,7 +718,7 @@ export class ChangeStream<
           try {
             await this._processErrorIteratorMode(error, this.cursor.id != null);
           } catch (error) {
-            if (error instanceof MongoOperationTimeoutError && this.cursor.id != null) {
+            if (error instanceof MongoOperationTimeoutError && this.cursor.id == null) {
               throw error;
             }
             try {
@@ -753,7 +753,7 @@ export class ChangeStream<
           try {
             await this._processErrorIteratorMode(error, this.cursor.id != null);
           } catch (error) {
-            if (error instanceof MongoOperationTimeoutError && this.cursor.id != null) {
+            if (error instanceof MongoOperationTimeoutError && this.cursor.id == null) {
               throw error;
             }
             try {
@@ -789,7 +789,7 @@ export class ChangeStream<
           try {
             await this._processErrorIteratorMode(error, this.cursor.id != null);
           } catch (error) {
-            if (error instanceof MongoOperationTimeoutError && this.cursor.id != null) throw error;
+            if (error instanceof MongoOperationTimeoutError && this.cursor.id == null) throw error;
             try {
               await this.close();
             } catch (error) {

--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -955,6 +955,7 @@ export class ChangeStream<
       } catch (error) {
         this.emit(ChangeStream.ERROR, error);
       }
+      this.timeoutContext?.refresh();
     });
     stream.on('error', error => this._processErrorStreamMode(error, this.cursor.id != null));
   }

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -248,7 +248,7 @@ export abstract class AbstractCursor<
         this.cursorOptions.timeoutMode = options.timeoutMode;
       }
     } else {
-      if (options.timeoutMode != null)
+      if (this.cursorOptions.timeoutMode != null)
         throw new MongoInvalidArgumentError('Cannot set timeoutMode without setting timeoutMS');
     }
 
@@ -1134,6 +1134,10 @@ export class CursorTimeoutContext extends TimeoutContext {
   }
   override get maxTimeMS(): number | null {
     return this.timeoutContext.maxTimeMS;
+  }
+
+  get timeoutMS(): number | null {
+    return this.timeoutContext.csotEnabled() ? this.timeoutContext.timeoutMS : null;
   }
 
   override refreshed(): CursorTimeoutContext {

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -248,7 +248,7 @@ export abstract class AbstractCursor<
         this.cursorOptions.timeoutMode = options.timeoutMode;
       }
     } else {
-      if (this.cursorOptions.timeoutMode != null)
+      if (options.timeoutMode != null)
         throw new MongoInvalidArgumentError('Cannot set timeoutMode without setting timeoutMS');
     }
 

--- a/src/cursor/change_stream_cursor.ts
+++ b/src/cursor/change_stream_cursor.ts
@@ -55,7 +55,7 @@ export class ChangeStreamCursor<
     pipeline: Document[] = [],
     options: ChangeStreamCursorOptions = {}
   ) {
-    super(client, namespace, options);
+    super(client, namespace, { ...options, tailable: true, awaitData: true });
 
     this.pipeline = pipeline;
     this.changeStreamCursorOptions = options;

--- a/test/integration/client-side-operations-timeout/client_side_operations_timeout.prose.test.ts
+++ b/test/integration/client-side-operations-timeout/client_side_operations_timeout.prose.test.ts
@@ -444,32 +444,38 @@ describe('CSOT spec prose tests', function () {
        *    - Expect this to fail with a timeout error.
        * 1. Verify that an `aggregate` command and two `getMore` commands were executed against the `db.coll` collection during the test.
        */
-      it('sends correct number of aggregate and getMores', metadata, async function () {
-        // NOTE: we don't check for a non-zero ID since we lazily send the initial aggregate to the
-        // server. See ChangeStreamCursor._initialize
-        const changeStream = client
-          .db('db')
-          .collection('coll')
-          .watch([], { timeoutMS: 120, maxAwaitTimeMS: 10 });
+      it(
+        'sends correct number of aggregate and getMores',
+        { requires: { mongodb: '>=4.4', topology: '!single' } },
+        async function () {
+          // NOTE: we don't check for a non-zero ID since we lazily send the initial aggregate to the
+          // server. See ChangeStreamCursor._initialize
+          const changeStream = client
+            .db('db')
+            .collection('coll')
+            .watch([], { timeoutMS: 120, maxAwaitTimeMS: 10 });
 
-        // @ts-expect-error private method
-        await changeStream.cursor.cursorInit();
+          // @ts-expect-error private method
+          await changeStream.cursor.cursorInit();
 
-        const maybeError = await changeStream.next().then(
-          () => null,
-          e => e
-        );
+          const maybeError = await changeStream.next().then(
+            () => null,
+            e => e
+          );
 
-        expect(maybeError).to.be.instanceof(MongoOperationTimeoutError);
-        const aggregates = commandStarted
-          .filter(e => e.command.aggregate != null)
-          .map(e => e.command);
-        const getMores = commandStarted.filter(e => e.command.getMore != null).map(e => e.command);
-        // Expect 1 aggregate
-        expect(aggregates).to.have.lengthOf(1);
-        // Expect 2 getMores
-        expect(getMores).to.have.lengthOf(2);
-      });
+          expect(maybeError).to.be.instanceof(MongoOperationTimeoutError);
+          const aggregates = commandStarted
+            .filter(e => e.command.aggregate != null)
+            .map(e => e.command);
+          const getMores = commandStarted
+            .filter(e => e.command.getMore != null)
+            .map(e => e.command);
+          // Expect 1 aggregate
+          expect(aggregates).to.have.lengthOf(1);
+          // Expect 2 getMores
+          expect(getMores).to.have.lengthOf(2);
+        }
+      );
     });
   });
 

--- a/test/integration/client-side-operations-timeout/client_side_operations_timeout.prose.test.ts
+++ b/test/integration/client-side-operations-timeout/client_side_operations_timeout.prose.test.ts
@@ -444,11 +444,17 @@ describe('CSOT spec prose tests', function () {
        *    - Expect this to fail with a timeout error.
        * 1. Verify that an `aggregate` command and two `getMore` commands were executed against the `db.coll` collection during the test.
        */
-      it.skip('sends correct number of aggregate and getMores', metadata, async function () {
+      it('sends correct number of aggregate and getMores', metadata, async function () {
+        // NOTE: we don't check for a non-zero ID since we lazily send the initial aggregate to the
+        // server. See ChangeStreamCursor._initialize
         const changeStream = client
           .db('db')
           .collection('coll')
-          .watch([], { timeoutMS: 20, maxAwaitTimeMS: 19 });
+          .watch([], { timeoutMS: 120, maxAwaitTimeMS: 10 });
+
+        // @ts-expect-error private method
+        await changeStream.cursor.cursorInit();
+
         const maybeError = await changeStream.next().then(
           () => null,
           e => e
@@ -463,7 +469,7 @@ describe('CSOT spec prose tests', function () {
         expect(aggregates).to.have.lengthOf(1);
         // Expect 2 getMores
         expect(getMores).to.have.lengthOf(2);
-      }).skipReason = 'TODO(NODE-6387)';
+      });
     });
   });
 

--- a/test/integration/client-side-operations-timeout/client_side_operations_timeout.spec.test.ts
+++ b/test/integration/client-side-operations-timeout/client_side_operations_timeout.spec.test.ts
@@ -26,7 +26,7 @@ const skippedTests = {
   'timeoutMS is refreshed for getMore - failure':
     'TODO(DRIVERS-2965): see modified test in unified-csot-node-specs', // Skipping for both tailable awaitData and tailable non-awaitData cursors
   'timeoutMS applies to full resume attempt in a next call': 'TODO(DRIVERS-3006)',
-  'timeoutMS is refreshed for getMore if maxAwaitTimeMS is set': 'TODO(DRIVERS-XXXX)'
+  'timeoutMS is refreshed for getMore if maxAwaitTimeMS is set': 'TODO(DRIVERS-3018)'
 };
 
 describe('CSOT spec tests', function () {

--- a/test/integration/client-side-operations-timeout/client_side_operations_timeout.spec.test.ts
+++ b/test/integration/client-side-operations-timeout/client_side_operations_timeout.spec.test.ts
@@ -1,8 +1,11 @@
+import * as util from 'node:util';
+
 import { join } from 'path';
 import * as semver from 'semver';
 
 import { loadSpecTests } from '../../spec';
 import { runUnifiedSuite } from '../../tools/unified-spec-runner/runner';
+util.inspect.defaultOptions.depth = 5;
 
 const skippedSpecs = {};
 
@@ -22,7 +25,8 @@ const skippedTests = {
     'TODO(DRIVERS-2970): see modified test in unified-csot-node-specs',
   'timeoutMS is refreshed for getMore - failure':
     'TODO(DRIVERS-2965): see modified test in unified-csot-node-specs', // Skipping for both tailable awaitData and tailable non-awaitData cursors
-  'timeoutMS applies to full resume attempt in a next call': 'TODO(DRIVERS-3006)'
+  'timeoutMS applies to full resume attempt in a next call': 'TODO(DRIVERS-3006)',
+  'timeoutMS is refreshed for getMore if maxAwaitTimeMS is set': 'TODO(DRIVERS-XXXX)'
 };
 
 describe('CSOT spec tests', function () {

--- a/test/integration/client-side-operations-timeout/client_side_operations_timeout.spec.test.ts
+++ b/test/integration/client-side-operations-timeout/client_side_operations_timeout.spec.test.ts
@@ -1,11 +1,8 @@
-import * as util from 'node:util';
-
 import { join } from 'path';
 import * as semver from 'semver';
 
 import { loadSpecTests } from '../../spec';
 import { runUnifiedSuite } from '../../tools/unified-spec-runner/runner';
-util.inspect.defaultOptions.depth = 5;
 
 const skippedSpecs = {};
 

--- a/test/integration/client-side-operations-timeout/client_side_operations_timeout.spec.test.ts
+++ b/test/integration/client-side-operations-timeout/client_side_operations_timeout.spec.test.ts
@@ -4,12 +4,7 @@ import * as semver from 'semver';
 import { loadSpecTests } from '../../spec';
 import { runUnifiedSuite } from '../../tools/unified-spec-runner/runner';
 
-const skippedSpecs = {
-  'change-streams': 'TODO(NODE-6035)',
-  'convenient-transactions': 'TODO(NODE-5687)',
-  'tailable-awaitData': 'TODO(NODE-6035)',
-  'tailable-non-awaitData': 'TODO(NODE-6035)'
-};
+const skippedSpecs = {};
 
 const skippedTests = {
   'timeoutMS can be configured on a MongoClient - createChangeStream on client': 'TODO(NODE-6305)',
@@ -25,11 +20,9 @@ const skippedTests = {
     'TODO(DRIVERS-2965)',
   'maxTimeMS value in the command is less than timeoutMS':
     'TODO(DRIVERS-2970): see modified test in unified-csot-node-specs',
-  'Tailable cursor awaitData iteration timeoutMS is refreshed for getMore - failure':
-    'TODO(DRIVERS-2965)',
-  'Tailable cursor iteration timeoutMS is refreshed for getMore - failure': 'TODO(DRIVERS-2965)',
   'timeoutMS is refreshed for getMore - failure':
-    'TODO(DRIVERS-2965): see modified test in unified-csot-node-specs' // Skipping for both tailable awaitData and tailable non-awaitData cursors
+    'TODO(DRIVERS-2965): see modified test in unified-csot-node-specs', // Skipping for both tailable awaitData and tailable non-awaitData cursors
+  'timeoutMS applies to full resume attempt in a next call': 'TODO(DRIVERS-3006)'
 };
 
 describe('CSOT spec tests', function () {

--- a/test/integration/client-side-operations-timeout/node_csot.test.ts
+++ b/test/integration/client-side-operations-timeout/node_csot.test.ts
@@ -832,19 +832,6 @@ describe('CSOT driver tests', metadata, () => {
         .db('db')
         .dropCollection('coll')
         .catch(() => null);
-      const updater = async function () {
-        for await (const _ of setInterval(200)) {
-          try {
-            await internalClient
-              .db('db')
-              .collection('coll')
-              .updateOne({ x: { $exists: true } }, { $inc: { x: 1 } }, { upsert: true });
-          } catch {
-            break;
-          }
-        }
-      };
-      updater();
       commandsStarted = [];
 
       client = await this.configuration.newClient(undefined, { monitorCommands: true }).connect();
@@ -956,6 +943,7 @@ describe('CSOT driver tests', metadata, () => {
 
           cs.once('error', reject);
 
+          await internalClient.db('db').collection('coll').insertOne({ x: 1 });
           const change = await changePromise;
           expect(change).to.have.ownProperty('operationType', 'insert');
         });

--- a/test/integration/client-side-operations-timeout/node_csot.test.ts
+++ b/test/integration/client-side-operations-timeout/node_csot.test.ts
@@ -2,7 +2,7 @@
 import { on, once } from 'node:events';
 import { Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
-import { setInterval, setTimeout } from 'node:timers/promises';
+import { setTimeout } from 'node:timers/promises';
 
 import { expect } from 'chai';
 import * as semver from 'semver';
@@ -906,7 +906,7 @@ describe('CSOT driver tests', metadata, () => {
             data: {
               failCommands: ['getMore'],
               blockConnection: true,
-              blockTimeMS: onSharded ? 600 : 120
+              blockTimeMS: onSharded ? 1100 : 120
             }
           };
 
@@ -914,7 +914,7 @@ describe('CSOT driver tests', metadata, () => {
           cs = client
             .db('db')
             .collection('coll')
-            .watch([], { timeoutMS: onSharded ? 500 : 100 });
+            .watch([], { timeoutMS: onSharded ? 1000 : 100 });
           errorIter = on(cs, 'error');
           cs.on('change', () => {
             // Add empty listener just to get the change stream running

--- a/test/integration/client-side-operations-timeout/node_csot.test.ts
+++ b/test/integration/client-side-operations-timeout/node_csot.test.ts
@@ -906,7 +906,7 @@ describe('CSOT driver tests', metadata, () => {
             data: {
               failCommands: ['getMore'],
               blockConnection: true,
-              blockTimeMS: onSharded ? 5100 : 120
+              blockTimeMS: onSharded ? 5100 : 520
             }
           };
 
@@ -914,7 +914,7 @@ describe('CSOT driver tests', metadata, () => {
           cs = client
             .db('db')
             .collection('coll')
-            .watch([], { timeoutMS: onSharded ? 5000 : 100 });
+            .watch([], { timeoutMS: onSharded ? 5000 : 500 });
           errorIter = on(cs, 'error');
           cs.on('change', () => {
             // Add empty listener just to get the change stream running

--- a/test/integration/client-side-operations-timeout/node_csot.test.ts
+++ b/test/integration/client-side-operations-timeout/node_csot.test.ts
@@ -906,7 +906,7 @@ describe('CSOT driver tests', metadata, () => {
             data: {
               failCommands: ['getMore'],
               blockConnection: true,
-              blockTimeMS: onSharded ? 1100 : 120
+              blockTimeMS: onSharded ? 5100 : 120
             }
           };
 
@@ -914,7 +914,7 @@ describe('CSOT driver tests', metadata, () => {
           cs = client
             .db('db')
             .collection('coll')
-            .watch([], { timeoutMS: onSharded ? 1000 : 100 });
+            .watch([], { timeoutMS: onSharded ? 5000 : 100 });
           errorIter = on(cs, 'error');
           cs.on('change', () => {
             // Add empty listener just to get the change stream running

--- a/test/integration/client-side-operations-timeout/node_csot.test.ts
+++ b/test/integration/client-side-operations-timeout/node_csot.test.ts
@@ -906,7 +906,7 @@ describe('CSOT driver tests', metadata, () => {
             data: {
               failCommands: ['getMore'],
               blockConnection: true,
-              blockTimeMS: onSharded ? 5100 : 120
+              blockTimeMS: onSharded ? 1100 : 120
             }
           };
 
@@ -914,7 +914,7 @@ describe('CSOT driver tests', metadata, () => {
           cs = client
             .db('db')
             .collection('coll')
-            .watch([], { timeoutMS: onSharded ? 5000 : 100 });
+            .watch([], { timeoutMS: onSharded ? 1000 : 100 });
           errorIter = on(cs, 'error');
           cs.on('change', () => {
             // Add empty listener just to get the change stream running

--- a/test/integration/client-side-operations-timeout/node_csot.test.ts
+++ b/test/integration/client-side-operations-timeout/node_csot.test.ts
@@ -826,6 +826,7 @@ describe('CSOT driver tests', metadata, () => {
     let commandsStarted: CommandStartedEvent[];
 
     beforeEach(async function () {
+      this.configuration.url({ useMultipleMongoses: false });
       internalClient = this.configuration.newClient();
       await internalClient
         .db('db')
@@ -945,12 +946,15 @@ describe('CSOT driver tests', metadata, () => {
 
           await once(cs.cursor, 'resumeTokenChanged');
 
-          const { promise: changePromise, resolve } =
-            promiseWithResolvers<ChangeStreamDocument<BSON.Document>>();
+          const {
+            promise: changePromise,
+            resolve,
+            reject
+          } = promiseWithResolvers<ChangeStreamDocument<BSON.Document>>();
 
-          cs.once('change', change => {
-            resolve(change);
-          });
+          cs.once('change', resolve);
+
+          cs.once('error', reject);
 
           const change = await changePromise;
           expect(change).to.have.ownProperty('operationType', 'insert');

--- a/test/integration/client-side-operations-timeout/node_csot.test.ts
+++ b/test/integration/client-side-operations-timeout/node_csot.test.ts
@@ -977,14 +977,14 @@ describe('CSOT driver tests', metadata, () => {
           await internalClient.db().admin().command(failpoint);
         });
 
-        it('emits an error event', async function () {
+        it('emits an error event', metadata, async function () {
           let [err] = await once(cs, 'error'); // getMore failure
           expect(err).to.be.instanceof(MongoOperationTimeoutError);
           [err] = await once(cs, 'error'); // aggregate failure
           expect(err).to.be.instanceof(MongoOperationTimeoutError);
         });
 
-        it('closes the change stream', async function () {
+        it('closes the change stream', metadata, async function () {
           await once(cs, 'error'); // await the getMore Failure
           await once(cs, 'error'); // await the aggregate failure
           expect(cs.closed).to.be.true;

--- a/test/integration/client-side-operations-timeout/node_csot.test.ts
+++ b/test/integration/client-side-operations-timeout/node_csot.test.ts
@@ -918,7 +918,7 @@ describe('CSOT driver tests', metadata, () => {
             data: {
               failCommands: ['getMore'],
               blockConnection: true,
-              blockTimeMS: onSharded ? 21_000 : 120
+              blockTimeMS: onSharded ? 600 : 120
             }
           };
 
@@ -926,7 +926,7 @@ describe('CSOT driver tests', metadata, () => {
           cs = client
             .db('db')
             .collection('coll')
-            .watch([], { timeoutMS: onSharded ? 20_000 : 100 });
+            .watch([], { timeoutMS: onSharded ? 500 : 100 });
           errorIter = on(cs, 'error');
           cs.on('change', () => {
             // Add empty listener just to get the change stream running

--- a/test/integration/client-side-operations-timeout/unified-csot-node-specs/change-streams.json
+++ b/test/integration/client-side-operations-timeout/unified-csot-node-specs/change-streams.json
@@ -1,0 +1,135 @@
+{
+  "description": "timeoutMS behaves correctly for change streams",
+  "schemaVersion": "1.9",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "4.4",
+      "topologies": [
+        "replicaset",
+        "sharded"
+      ]
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "failPointClient",
+        "useMultipleMongoses": false
+      }
+    },
+    {
+      "client": {
+        "id": "client",
+        "useMultipleMongoses": false,
+        "observeEvents": [
+          "commandStartedEvent"
+        ],
+        "ignoreCommandMonitoringEvents": [
+          "killCursors"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database",
+        "client": "client",
+        "databaseName": "test"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection",
+        "database": "database",
+        "collectionName": "coll"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll",
+      "databaseName": "test",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "timeoutMS is refreshed for getMore if maxAwaitTimeMS is set",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "failPointClient",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 2
+              },
+              "data": {
+                "failCommands": [
+                  "aggregate",
+                  "getMore"
+                ],
+                "blockConnection": true,
+                "blockTimeMS": 150
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection",
+          "arguments": {
+            "pipeline": [],
+            "timeoutMS": 200,
+            "batchSize": 2,
+            "maxAwaitTimeMS": 10
+          },
+          "saveResultAsEntity": "changeStream"
+        },
+        {
+          "name": "iterateOnce",
+          "object": "changeStream"
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "aggregate",
+                "databaseName": "test",
+                "command": {
+                  "aggregate": "coll",
+                  "maxTimeMS": {
+                    "$$type": [
+                      "int",
+                      "long"
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "getMore",
+                "databaseName": "test",
+                "command": {
+                  "getMore": {
+                    "$$type": [
+                      "int",
+                      "long"
+                    ]
+                  },
+                  "collection": "coll",
+                  "maxTimeMS": 10
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/integration/client-side-operations-timeout/unified-csot-node-specs/tailable-awaitData.json
+++ b/test/integration/client-side-operations-timeout/unified-csot-node-specs/tailable-awaitData.json
@@ -141,6 +141,89 @@
           ]
         }
       ]
+    },
+    {
+      "description": "timeoutMS is refreshed for getMore if maxAwaitTimeMS is set",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "failPointClient",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 2
+              },
+              "data": {
+                "failCommands": [
+                  "find",
+                  "getMore"
+                ],
+                "blockConnection": true,
+                "blockTimeMS": 150
+              }
+            }
+          }
+        },
+        {
+          "name": "createFindCursor",
+          "object": "collection",
+          "arguments": {
+            "filter": {},
+            "cursorType": "tailableAwait",
+            "timeoutMS": 250,
+            "batchSize": 1,
+            "maxAwaitTimeMS": 10
+          },
+          "saveResultAsEntity": "tailableCursor"
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "tailableCursor"
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "tailableCursor"
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "find",
+                "databaseName": "test",
+                "command": {
+                  "find": "coll",
+                  "tailable": true,
+                  "awaitData": true,
+                  "maxTimeMS": {
+                    "$$exists": true
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "getMore",
+                "databaseName": "test",
+                "command": {
+                  "getMore": {
+                    "$$type": [
+                      "int",
+                      "long"
+                    ]
+                  },
+                  "collection": "coll",
+                  "maxTimeMS": 10 
+                }
+              }
+            }
+          ]
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
### Description

#### What is changing?

##### `ChangeStream`
* Added support for CSOT to change stream iterator mode methods (`ChangeStream.next()`, `ChangeStream.hasNext()`, `ChangeStream.tryNext()`)
* Added support for CSOT to change stream emitter mode
	* Change streams will now emit an error event with a `MongoOperationTimeoutError` when the internal cursor iteration times out

##### `Connection`
* Close socket when a command times out (temporary change while #4273 is in progress)

##### Testing
* Unskip and fix change stream prose test
* Unskip change stream tests
* Add integration tests to verify that CSOT behviour for ChangeStream emitter mode

##### Is there new documentation needed for these changes?

Yes, punted to NODE-5688

#### What is the motivation for this change?

NODE-6387

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [X] Ran `npm run check:lint` script
- [X] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [X] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [X] Changes are covered by tests
- [X] New TODOs have a related JIRA ticket
