### PR TITLE
feat(NODE-6350): add typescript support to client bulkWrite API

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -479,6 +479,7 @@ export type {
 export type {
   AnyClientBulkWriteModel,
   ClientBulkWriteError,
+  ClientBulkWriteModel,
   ClientBulkWriteOptions,
   ClientBulkWriteResult,
   ClientDeleteManyModel,

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -491,14 +491,18 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> implements
   async bulkWrite<SchemaMap extends Record<string, Document> = Record<string, Document>>(
     models: ReadonlyArray<ClientBulkWriteModel<SchemaMap>>,
     options?: ClientBulkWriteOptions
-  ): Promise<ClientBulkWriteResult | { ok: 1 }> {
+  ): Promise<ClientBulkWriteResult> {
     if (this.autoEncrypter) {
       throw new MongoInvalidArgumentError(
         'MongoClient bulkWrite does not currently support automatic encryption.'
       );
     }
     // We do not need schema type information past this point ("as any" is fine)
-    return await new ClientBulkWriteExecutor(this, models as any, options).execute();
+    return await new ClientBulkWriteExecutor(
+      this,
+      models as any,
+      resolveOptions(this, options)
+    ).execute();
   }
 
   /**

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -31,7 +31,7 @@ import {
 } from './mongo_logger';
 import { TypedEventEmitter } from './mongo_types';
 import {
-  type AnyClientBulkWriteModel,
+  type ClientBulkWriteModel,
   type ClientBulkWriteOptions,
   type ClientBulkWriteResult
 } from './operations/client_bulk_write/common';
@@ -331,7 +331,6 @@ export type MongoClientEvents = Pick<TopologyEvents, (typeof MONGO_CLIENT_EVENTS
 };
 
 /** @internal */
-
 const kOptions = Symbol('options');
 
 /**
@@ -489,8 +488,8 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> implements
    * @param options - The client bulk write options.
    * @returns A ClientBulkWriteResult for acknowledged writes and ok: 1 for unacknowledged writes.
    */
-  async bulkWrite(
-    models: AnyClientBulkWriteModel[],
+  async bulkWrite<SchemaMap extends Record<string, Document> = Record<string, Document>>(
+    models: ReadonlyArray<ClientBulkWriteModel<SchemaMap>>,
     options?: ClientBulkWriteOptions
   ): Promise<ClientBulkWriteResult | { ok: 1 }> {
     if (this.autoEncrypter) {
@@ -498,7 +497,8 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> implements
         'MongoClient bulkWrite does not currently support automatic encryption.'
       );
     }
-    return await new ClientBulkWriteExecutor(this, models, options).execute();
+    // We do not need schema type information past this point ("as any" is fine)
+    return await new ClientBulkWriteExecutor(this, models as any, options).execute();
   }
 
   /**

--- a/src/operations/client_bulk_write/command_builder.ts
+++ b/src/operations/client_bulk_write/command_builder.ts
@@ -36,7 +36,7 @@ const MESSAGE_OVERHEAD_BYTES = 1000;
 
 /** @internal */
 export class ClientBulkWriteCommandBuilder {
-  models: AnyClientBulkWriteModel[];
+  models: ReadonlyArray<AnyClientBulkWriteModel<Document>>;
   options: ClientBulkWriteOptions;
   pkFactory: PkFactory;
   /** The current index in the models array that is being processed. */
@@ -53,7 +53,7 @@ export class ClientBulkWriteCommandBuilder {
    * @param models - The client write models.
    */
   constructor(
-    models: AnyClientBulkWriteModel[],
+    models: ReadonlyArray<AnyClientBulkWriteModel<Document>>,
     options: ClientBulkWriteOptions,
     pkFactory?: PkFactory
   ) {
@@ -248,7 +248,7 @@ interface ClientInsertOperation {
  * @returns the operation.
  */
 export const buildInsertOneOperation = (
-  model: ClientInsertOneModel,
+  model: ClientInsertOneModel<Document>,
   index: number,
   pkFactory: PkFactory
 ): ClientInsertOperation => {
@@ -275,7 +275,10 @@ export interface ClientDeleteOperation {
  * @param index - The namespace index.
  * @returns the operation.
  */
-export const buildDeleteOneOperation = (model: ClientDeleteOneModel, index: number): Document => {
+export const buildDeleteOneOperation = (
+  model: ClientDeleteOneModel<Document>,
+  index: number
+): Document => {
   return createDeleteOperation(model, index, false);
 };
 
@@ -285,7 +288,10 @@ export const buildDeleteOneOperation = (model: ClientDeleteOneModel, index: numb
  * @param index - The namespace index.
  * @returns the operation.
  */
-export const buildDeleteManyOperation = (model: ClientDeleteManyModel, index: number): Document => {
+export const buildDeleteManyOperation = (
+  model: ClientDeleteManyModel<Document>,
+  index: number
+): Document => {
   return createDeleteOperation(model, index, true);
 };
 
@@ -293,7 +299,7 @@ export const buildDeleteManyOperation = (model: ClientDeleteManyModel, index: nu
  * Creates a delete operation based on the parameters.
  */
 function createDeleteOperation(
-  model: ClientDeleteOneModel | ClientDeleteManyModel,
+  model: ClientDeleteOneModel<Document> | ClientDeleteManyModel<Document>,
   index: number,
   multi: boolean
 ): ClientDeleteOperation {
@@ -330,7 +336,7 @@ export interface ClientUpdateOperation {
  * @returns the operation.
  */
 export const buildUpdateOneOperation = (
-  model: ClientUpdateOneModel,
+  model: ClientUpdateOneModel<Document>,
   index: number
 ): ClientUpdateOperation => {
   return createUpdateOperation(model, index, false);
@@ -343,7 +349,7 @@ export const buildUpdateOneOperation = (
  * @returns the operation.
  */
 export const buildUpdateManyOperation = (
-  model: ClientUpdateManyModel,
+  model: ClientUpdateManyModel<Document>,
   index: number
 ): ClientUpdateOperation => {
   return createUpdateOperation(model, index, true);
@@ -365,7 +371,7 @@ function validateUpdate(update: Document) {
  * Creates a delete operation based on the parameters.
  */
 function createUpdateOperation(
-  model: ClientUpdateOneModel | ClientUpdateManyModel,
+  model: ClientUpdateOneModel<Document> | ClientUpdateManyModel<Document>,
   index: number,
   multi: boolean
 ): ClientUpdateOperation {
@@ -413,7 +419,7 @@ export interface ClientReplaceOneOperation {
  * @returns the operation.
  */
 export const buildReplaceOneOperation = (
-  model: ClientReplaceOneModel,
+  model: ClientReplaceOneModel<Document>,
   index: number
 ): ClientReplaceOneOperation => {
   if (hasAtomicOperators(model.replacement)) {
@@ -442,7 +448,7 @@ export const buildReplaceOneOperation = (
 
 /** @internal */
 export function buildOperation(
-  model: AnyClientBulkWriteModel,
+  model: AnyClientBulkWriteModel<Document>,
   index: number,
   pkFactory: PkFactory
 ): Document {

--- a/src/operations/client_bulk_write/common.ts
+++ b/src/operations/client_bulk_write/common.ts
@@ -153,7 +153,7 @@ export type AnyClientBulkWriteModel<TSchema extends Document> =
   | ClientDeleteManyModel<TSchema>;
 
 /**
- * Take a Typescript type that maps namespaces to schema types.
+ * A mapping of namespace strings to collections schemas.
  * @public
  *
  * @example

--- a/src/operations/client_bulk_write/common.ts
+++ b/src/operations/client_bulk_write/common.ts
@@ -27,7 +27,14 @@ export interface ClientBulkWriteOptions extends CommandOperationOptions {
 
 /** @public */
 export interface ClientWriteModel {
-  /** The namespace for the write. */
+  /**
+   * The namespace for the write.
+   *
+   * A namespace is a combination of the database name and the name of the collection: `<database-name>.<collection>`.
+   * All documents belong to a namespace.
+   *
+   * @see https://www.mongodb.com/docs/manual/reference/limits/#std-label-faq-dev-namespace
+   */
   namespace: string;
 }
 

--- a/src/operations/client_bulk_write/common.ts
+++ b/src/operations/client_bulk_write/common.ts
@@ -179,39 +179,39 @@ export interface ClientBulkWriteResult {
   /**
    * Whether the bulk write was acknowledged.
    */
-  acknowledged: boolean;
+  readonly acknowledged: boolean;
   /**
    * The total number of documents inserted across all insert operations.
    */
-  insertedCount: number;
+  readonly insertedCount: number;
   /**
    * The total number of documents upserted across all update operations.
    */
-  upsertedCount: number;
+  readonly upsertedCount: number;
   /**
    * The total number of documents matched across all update operations.
    */
-  matchedCount: number;
+  readonly matchedCount: number;
   /**
    * The total number of documents modified across all update operations.
    */
-  modifiedCount: number;
+  readonly modifiedCount: number;
   /**
    * The total number of documents deleted across all delete operations.
    */
-  deletedCount: number;
+  readonly deletedCount: number;
   /**
    * The results of each individual insert operation that was successfully performed.
    */
-  insertResults?: Map<number, ClientInsertOneResult>;
+  readonly insertResults?: ReadonlyMap<number, ClientInsertOneResult>;
   /**
    * The results of each individual update operation that was successfully performed.
    */
-  updateResults?: Map<number, ClientUpdateResult>;
+  readonly updateResults?: ReadonlyMap<number, ClientUpdateResult>;
   /**
    * The results of each individual delete operation that was successfully performed.
    */
-  deleteResults?: Map<number, ClientDeleteResult>;
+  readonly deleteResults?: ReadonlyMap<number, ClientDeleteResult>;
 }
 
 /** @public */

--- a/src/operations/client_bulk_write/common.ts
+++ b/src/operations/client_bulk_write/common.ts
@@ -32,20 +32,20 @@ export interface ClientWriteModel {
 }
 
 /** @public */
-export interface ClientInsertOneModel extends ClientWriteModel {
+export interface ClientInsertOneModel<TSchema> extends ClientWriteModel {
   name: 'insertOne';
   /** The document to insert. */
-  document: OptionalId<Document>;
+  document: OptionalId<TSchema>;
 }
 
 /** @public */
-export interface ClientDeleteOneModel extends ClientWriteModel {
+export interface ClientDeleteOneModel<TSchema> extends ClientWriteModel {
   name: 'deleteOne';
   /**
    * The filter used to determine if a document should be deleted.
    * For a deleteOne operation, the first match is removed.
    */
-  filter: Filter<Document>;
+  filter: Filter<TSchema>;
   /** Specifies a collation. */
   collation?: CollationOptions;
   /** The index to use. If specified, then the query system will only consider plans using the hinted index. */
@@ -53,13 +53,13 @@ export interface ClientDeleteOneModel extends ClientWriteModel {
 }
 
 /** @public */
-export interface ClientDeleteManyModel extends ClientWriteModel {
+export interface ClientDeleteManyModel<TSchema> extends ClientWriteModel {
   name: 'deleteMany';
   /**
    * The filter used to determine if a document should be deleted.
    * For a deleteMany operation, all matches are removed.
    */
-  filter: Filter<Document>;
+  filter: Filter<TSchema>;
   /** Specifies a collation. */
   collation?: CollationOptions;
   /** The index to use. If specified, then the query system will only consider plans using the hinted index. */
@@ -67,15 +67,15 @@ export interface ClientDeleteManyModel extends ClientWriteModel {
 }
 
 /** @public */
-export interface ClientReplaceOneModel extends ClientWriteModel {
+export interface ClientReplaceOneModel<TSchema> extends ClientWriteModel {
   name: 'replaceOne';
   /**
    * The filter used to determine if a document should be replaced.
    * For a replaceOne operation, the first match is replaced.
    */
-  filter: Filter<Document>;
+  filter: Filter<TSchema>;
   /** The document with which to replace the matched document. */
-  replacement: WithoutId<Document>;
+  replacement: WithoutId<TSchema>;
   /** Specifies a collation. */
   collation?: CollationOptions;
   /** The index to use. If specified, then the query system will only consider plans using the hinted index. */
@@ -85,19 +85,19 @@ export interface ClientReplaceOneModel extends ClientWriteModel {
 }
 
 /** @public */
-export interface ClientUpdateOneModel extends ClientWriteModel {
+export interface ClientUpdateOneModel<TSchema> extends ClientWriteModel {
   name: 'updateOne';
   /**
    * The filter used to determine if a document should be updated.
    * For an updateOne operation, the first match is updated.
    */
-  filter: Filter<Document>;
+  filter: Filter<TSchema>;
   /**
    * The modifications to apply. The value can be either:
    * UpdateFilter<Document> - A document that contains update operator expressions,
    * Document[] - an aggregation pipeline.
    */
-  update: UpdateFilter<Document> | Document[];
+  update: UpdateFilter<TSchema> | Document[];
   /** A set of filters specifying to which array elements an update should apply. */
   arrayFilters?: Document[];
   /** Specifies a collation. */
@@ -109,19 +109,19 @@ export interface ClientUpdateOneModel extends ClientWriteModel {
 }
 
 /** @public */
-export interface ClientUpdateManyModel extends ClientWriteModel {
+export interface ClientUpdateManyModel<TSchema> extends ClientWriteModel {
   name: 'updateMany';
   /**
    * The filter used to determine if a document should be updated.
    * For an updateMany operation, all matches are updated.
    */
-  filter: Filter<Document>;
+  filter: Filter<TSchema>;
   /**
    * The modifications to apply. The value can be either:
    * UpdateFilter<Document> - A document that contains update operator expressions,
    * Document[] - an aggregation pipeline.
    */
-  update: UpdateFilter<Document> | Document[];
+  update: UpdateFilter<TSchema> | Document[];
   /** A set of filters specifying to which array elements an update should apply. */
   arrayFilters?: Document[];
   /** Specifies a collation. */
@@ -137,13 +137,42 @@ export interface ClientUpdateManyModel extends ClientWriteModel {
  * to MongoClient#bulkWrite.
  * @public
  */
-export type AnyClientBulkWriteModel =
-  | ClientInsertOneModel
-  | ClientReplaceOneModel
-  | ClientUpdateOneModel
-  | ClientUpdateManyModel
-  | ClientDeleteOneModel
-  | ClientDeleteManyModel;
+export type AnyClientBulkWriteModel<TSchema extends Document> =
+  | ClientInsertOneModel<TSchema>
+  | ClientReplaceOneModel<TSchema>
+  | ClientUpdateOneModel<TSchema>
+  | ClientUpdateManyModel<TSchema>
+  | ClientDeleteOneModel<TSchema>
+  | ClientDeleteManyModel<TSchema>;
+
+/**
+ * Take a Typescript type that maps namespaces to schema types.
+ * @public
+ *
+ * @example
+ * ```ts
+ * type MongoDBSchemas = {
+ *   'db.books': Book;
+ *   'db.authors': Author;
+ * }
+ *
+ * const model: ClientBulkWriteModel<MongoDBSchemas> = {
+ *   namespace: 'db.books'
+ *   name: 'insertOne',
+ *   document: { title: 'Practical MongoDB Aggregations', authorName: 3 } // error `authorName` cannot be number
+ * };
+ * ```
+ *
+ * The type of the `namespace` field narrows other parts of the BulkWriteModel to use the correct schema for type assertions.
+ *
+ */
+export type ClientBulkWriteModel<
+  SchemaMap extends Record<string, Document> = Record<string, Document>
+> = {
+  [Namespace in keyof SchemaMap]: AnyClientBulkWriteModel<SchemaMap[Namespace]> & {
+    namespace: Namespace;
+  };
+}[keyof SchemaMap];
 
 /** @public */
 export interface ClientBulkWriteResult {

--- a/src/operations/client_bulk_write/common.ts
+++ b/src/operations/client_bulk_write/common.ts
@@ -177,6 +177,10 @@ export type ClientBulkWriteModel<
 /** @public */
 export interface ClientBulkWriteResult {
   /**
+   * Whether the bulk write was acknowledged.
+   */
+  acknowledged: boolean;
+  /**
    * The total number of documents inserted across all insert operations.
    */
   insertedCount: number;

--- a/src/operations/client_bulk_write/executor.ts
+++ b/src/operations/client_bulk_write/executor.ts
@@ -112,7 +112,7 @@ export class ClientBulkWriteExecutor {
               message: 'Mongo client bulk write encountered an error during execution'
             });
             bulkWriteError.cause = error;
-            bulkWriteError.partialResult = resultsMerger.result;
+            bulkWriteError.partialResult = resultsMerger.bulkWriteResult;
             throw bulkWriteError;
           } else {
             // Client side errors are just thrown.
@@ -128,11 +128,11 @@ export class ClientBulkWriteExecutor {
         });
         error.writeConcernErrors = resultsMerger.writeConcernErrors;
         error.writeErrors = resultsMerger.writeErrors;
-        error.partialResult = resultsMerger.result;
+        error.partialResult = resultsMerger.bulkWriteResult;
         throw error;
       }
 
-      return resultsMerger.result;
+      return resultsMerger.bulkWriteResult;
     }
   }
 }

--- a/src/operations/client_bulk_write/executor.ts
+++ b/src/operations/client_bulk_write/executor.ts
@@ -1,3 +1,5 @@
+import { type Document } from 'bson';
+
 import { ClientBulkWriteCursor } from '../../cursor/client_bulk_write_cursor';
 import {
   MongoClientBulkWriteError,
@@ -22,9 +24,9 @@ import { ClientBulkWriteResultsMerger } from './results_merger';
  * @internal
  */
 export class ClientBulkWriteExecutor {
-  client: MongoClient;
-  options: ClientBulkWriteOptions;
-  operations: AnyClientBulkWriteModel[];
+  private readonly client: MongoClient;
+  private readonly options: ClientBulkWriteOptions;
+  private readonly operations: ReadonlyArray<AnyClientBulkWriteModel<Document>>;
 
   /**
    * Instantiate the executor.
@@ -34,7 +36,7 @@ export class ClientBulkWriteExecutor {
    */
   constructor(
     client: MongoClient,
-    operations: AnyClientBulkWriteModel[],
+    operations: ReadonlyArray<AnyClientBulkWriteModel<Document>>,
     options?: ClientBulkWriteOptions
   ) {
     if (operations.length === 0) {

--- a/src/operations/client_bulk_write/executor.ts
+++ b/src/operations/client_bulk_write/executor.ts
@@ -77,7 +77,7 @@ export class ClientBulkWriteExecutor {
    * for each, then merge the results into one.
    * @returns The result.
    */
-  async execute(): Promise<ClientBulkWriteResult | { ok: 1 }> {
+  async execute(): Promise<ClientBulkWriteResult> {
     // The command builder will take the user provided models and potential split the batch
     // into multiple commands due to size.
     const pkFactory = this.client.s.options.pkFactory;
@@ -92,7 +92,7 @@ export class ClientBulkWriteExecutor {
         const operation = new ClientBulkWriteOperation(commandBuilder, this.options);
         await executeOperation(this.client, operation);
       }
-      return { ok: 1 };
+      return ClientBulkWriteResultsMerger.unacknowledged();
     } else {
       const resultsMerger = new ClientBulkWriteResultsMerger(this.options);
       // For each command will will create and exhaust a cursor for the results.

--- a/src/operations/client_bulk_write/results_merger.ts
+++ b/src/operations/client_bulk_write/results_merger.ts
@@ -12,6 +12,21 @@ import {
 } from './common';
 
 /**
+ * Unacknowledged bulk writes are always the same.
+ */
+const UNACKNOWLEDGED = {
+  acknowledged: true,
+  insertedCount: 0,
+  upsertedCount: 0,
+  matchedCount: 0,
+  modifiedCount: 0,
+  deletedCount: 0,
+  insertResults: undefined,
+  updateResults: undefined,
+  deleteResults: undefined
+};
+
+/**
  * Merges client bulk write cursor responses together into a single result.
  * @internal
  */
@@ -23,6 +38,13 @@ export class ClientBulkWriteResultsMerger {
   writeErrors: Map<number, ClientBulkWriteError>;
 
   /**
+   * @returns The standard unacknowledged bulk write result.
+   */
+  static unacknowledged(): ClientBulkWriteResult {
+    return UNACKNOWLEDGED;
+  }
+
+  /**
    * Instantiate the merger.
    * @param options - The options.
    */
@@ -32,6 +54,7 @@ export class ClientBulkWriteResultsMerger {
     this.writeConcernErrors = [];
     this.writeErrors = new Map();
     this.result = {
+      acknowledged: true,
       insertedCount: 0,
       upsertedCount: 0,
       matchedCount: 0,

--- a/src/operations/client_bulk_write/results_merger.ts
+++ b/src/operations/client_bulk_write/results_merger.ts
@@ -15,7 +15,7 @@ import {
  * Unacknowledged bulk writes are always the same.
  */
 const UNACKNOWLEDGED = {
-  acknowledged: true,
+  acknowledged: false,
   insertedCount: 0,
   upsertedCount: 0,
   matchedCount: 0,

--- a/src/operations/client_bulk_write/results_merger.ts
+++ b/src/operations/client_bulk_write/results_merger.ts
@@ -26,7 +26,7 @@ const UNACKNOWLEDGED = {
   deleteResults: undefined
 };
 
-interface InternalResult {
+interface ClientBulkWriteResultAccumulation {
   /**
    * Whether the bulk write was acknowledged.
    */
@@ -70,7 +70,7 @@ interface InternalResult {
  * @internal
  */
 export class ClientBulkWriteResultsMerger {
-  private result: InternalResult;
+  private result: ClientBulkWriteResultAccumulation;
   private options: ClientBulkWriteOptions;
   private currentBatchOffset: number;
   writeConcernErrors: Document[];

--- a/src/operations/client_bulk_write/results_merger.ts
+++ b/src/operations/client_bulk_write/results_merger.ts
@@ -26,14 +26,53 @@ const UNACKNOWLEDGED = {
   deleteResults: undefined
 };
 
+interface InternalResult {
+  /**
+   * Whether the bulk write was acknowledged.
+   */
+  acknowledged: boolean;
+  /**
+   * The total number of documents inserted across all insert operations.
+   */
+  insertedCount: number;
+  /**
+   * The total number of documents upserted across all update operations.
+   */
+  upsertedCount: number;
+  /**
+   * The total number of documents matched across all update operations.
+   */
+  matchedCount: number;
+  /**
+   * The total number of documents modified across all update operations.
+   */
+  modifiedCount: number;
+  /**
+   * The total number of documents deleted across all delete operations.
+   */
+  deletedCount: number;
+  /**
+   * The results of each individual insert operation that was successfully performed.
+   */
+  insertResults?: Map<number, ClientInsertOneResult>;
+  /**
+   * The results of each individual update operation that was successfully performed.
+   */
+  updateResults?: Map<number, ClientUpdateResult>;
+  /**
+   * The results of each individual delete operation that was successfully performed.
+   */
+  deleteResults?: Map<number, ClientDeleteResult>;
+}
+
 /**
  * Merges client bulk write cursor responses together into a single result.
  * @internal
  */
 export class ClientBulkWriteResultsMerger {
-  result: ClientBulkWriteResult;
-  options: ClientBulkWriteOptions;
-  currentBatchOffset: number;
+  private result: InternalResult;
+  private options: ClientBulkWriteOptions;
+  private currentBatchOffset: number;
   writeConcernErrors: Document[];
   writeErrors: Map<number, ClientBulkWriteError>;
 
@@ -70,6 +109,23 @@ export class ClientBulkWriteResultsMerger {
       this.result.updateResults = new Map<number, ClientUpdateResult>();
       this.result.deleteResults = new Map<number, ClientDeleteResult>();
     }
+  }
+
+  /**
+   * Get the bulk write result object.
+   */
+  get bulkWriteResult(): ClientBulkWriteResult {
+    return {
+      acknowledged: this.result.acknowledged,
+      insertedCount: this.result.insertedCount,
+      upsertedCount: this.result.upsertedCount,
+      matchedCount: this.result.matchedCount,
+      modifiedCount: this.result.modifiedCount,
+      deletedCount: this.result.deletedCount,
+      insertResults: this.result.insertResults,
+      updateResults: this.result.updateResults,
+      deleteResults: this.result.deleteResults
+    };
   }
 
   /**

--- a/test/integration/crud/crud.prose.test.ts
+++ b/test/integration/crud/crud.prose.test.ts
@@ -3,7 +3,7 @@ import { once } from 'events';
 
 import { type CommandStartedEvent } from '../../../mongodb';
 import {
-  type AnyClientBulkWriteModel,
+  type ClientBulkWriteModel,
   type ClientSession,
   type Collection,
   type Document,
@@ -176,7 +176,7 @@ describe('CRUD Prose Spec Tests', () => {
     // firstEvent.operationId is equal to secondEvent.operationId.
     let client: MongoClient;
     let maxWriteBatchSize;
-    let models: AnyClientBulkWriteModel<Document>[] = [];
+    let models: ClientBulkWriteModel<Document>[] = [];
     const commands: CommandStartedEvent[] = [];
 
     beforeEach(async function () {
@@ -244,7 +244,7 @@ describe('CRUD Prose Spec Tests', () => {
     let maxBsonObjectSize;
     let maxMessageSizeBytes;
     let numModels;
-    let models: AnyClientBulkWriteModel<Document>[] = [];
+    let models: ClientBulkWriteModel<Document>[] = [];
     const commands: CommandStartedEvent[] = [];
 
     beforeEach(async function () {
@@ -315,7 +315,7 @@ describe('CRUD Prose Spec Tests', () => {
     // Assert that two CommandStartedEvents were observed for the bulkWrite command.
     let client: MongoClient;
     let maxWriteBatchSize;
-    let models: AnyClientBulkWriteModel<Document>[] = [];
+    let models: ClientBulkWriteModel<Document>[] = [];
     const commands: CommandStartedEvent[] = [];
 
     beforeEach(async function () {
@@ -383,7 +383,7 @@ describe('CRUD Prose Spec Tests', () => {
     // Construct a list of write models (referred to as models) with model repeated maxWriteBatchSize + 1 times.
     let client: MongoClient;
     let maxWriteBatchSize;
-    let models: AnyClientBulkWriteModel<Document>[] = [];
+    let models: ClientBulkWriteModel<Document>[] = [];
     const commands: CommandStartedEvent[] = [];
 
     beforeEach(async function () {
@@ -391,7 +391,7 @@ describe('CRUD Prose Spec Tests', () => {
       await client.connect();
       await client.db('db').collection('coll').drop();
       const hello = await client.db('admin').command({ hello: 1 });
-      await client.db('db').collection('coll').insertOne({ _id: 1 });
+      await client.db('db').collection<{ _id?: number }>('coll').insertOne({ _id: 1 });
       maxWriteBatchSize = hello.maxWriteBatchSize;
 
       client.on('commandStarted', filterForCommands('bulkWrite', commands));
@@ -472,7 +472,7 @@ describe('CRUD Prose Spec Tests', () => {
     // Assert that a CommandStartedEvent was observed for the getMore command.
     let client: MongoClient;
     let maxBsonObjectSize;
-    const models: AnyClientBulkWriteModel<Document>[] = [];
+    const models: ClientBulkWriteModel<Document>[] = [];
     const commands: CommandStartedEvent[] = [];
 
     beforeEach(async function () {
@@ -546,7 +546,7 @@ describe('CRUD Prose Spec Tests', () => {
     let client: MongoClient;
     let session: ClientSession;
     let maxBsonObjectSize;
-    const models: AnyClientBulkWriteModel<Document>[] = [];
+    const models: ClientBulkWriteModel<Document>[] = [];
     const commands: CommandStartedEvent[] = [];
 
     beforeEach(async function () {
@@ -633,7 +633,7 @@ describe('CRUD Prose Spec Tests', () => {
     // Assert that a CommandStartedEvent was observed for the killCursors command.
     let client: MongoClient;
     let maxBsonObjectSize;
-    const models: AnyClientBulkWriteModel<Document>[] = [];
+    const models: ClientBulkWriteModel<Document>[] = [];
     const getMoreCommands: CommandStartedEvent[] = [];
     const killCursorsCommands: CommandStartedEvent[] = [];
 
@@ -804,7 +804,7 @@ describe('CRUD Prose Spec Tests', () => {
     let opsBytes;
     let numModels;
     let remainderBytes;
-    let models: AnyClientBulkWriteModel<Document>[] = [];
+    let models: ClientBulkWriteModel<Document>[] = [];
     const commands: CommandStartedEvent[] = [];
 
     beforeEach(async function () {
@@ -860,7 +860,7 @@ describe('CRUD Prose Spec Tests', () => {
       it('executes in a single batch', {
         metadata: { requires: { mongodb: '>=8.0.0', serverless: 'forbid' } },
         async test() {
-          const sameNamespaceModel: AnyClientBulkWriteModel<Document> = {
+          const sameNamespaceModel: ClientBulkWriteModel<Document> = {
             name: 'insertOne',
             namespace: 'db.coll',
             document: { a: 'b' }
@@ -897,7 +897,7 @@ describe('CRUD Prose Spec Tests', () => {
         metadata: { requires: { mongodb: '>=8.0.0', serverless: 'forbid' } },
         async test() {
           const namespace = `db.${'c'.repeat(200)}`;
-          const newNamespaceModel: AnyClientBulkWriteModel<Document> = {
+          const newNamespaceModel: ClientBulkWriteModel<Document> = {
             name: 'insertOne',
             namespace: namespace,
             document: { a: 'b' }
@@ -951,7 +951,7 @@ describe('CRUD Prose Spec Tests', () => {
       it('raises a client error', {
         metadata: { requires: { mongodb: '>=8.0.0', serverless: 'forbid' } },
         async test() {
-          const model: AnyClientBulkWriteModel<Document> = {
+          const model: ClientBulkWriteModel<Document> = {
             name: 'insertOne',
             namespace: 'db.coll',
             document: { a: 'b'.repeat(maxMessageSizeBytes) }
@@ -977,7 +977,7 @@ describe('CRUD Prose Spec Tests', () => {
         metadata: { requires: { mongodb: '>=8.0.0', serverless: 'forbid' } },
         async test() {
           const namespace = `db.${'c'.repeat(maxMessageSizeBytes)}`;
-          const model: AnyClientBulkWriteModel<Document> = {
+          const model: ClientBulkWriteModel<Document> = {
             name: 'insertOne',
             namespace: namespace,
             document: { a: 'b' }
@@ -1034,7 +1034,7 @@ describe('CRUD Prose Spec Tests', () => {
     });
 
     it('raises a client side error', async function () {
-      const model: AnyClientBulkWriteModel<Document> = {
+      const model: ClientBulkWriteModel<Document> = {
         name: 'insertOne',
         namespace: 'db.coll',
         document: { a: 'b' }
@@ -1114,7 +1114,7 @@ describe('CRUD Prose Spec Tests', () => {
     let maxBsonObjectSize;
     let maxMessageSizeBytes;
     let numModels;
-    let models: AnyClientBulkWriteModel<Document>[] = [];
+    let models: ClientBulkWriteModel<Document>[] = [];
     const commands: CommandStartedEvent[] = [];
 
     beforeEach(async function () {

--- a/test/integration/crud/crud.prose.test.ts
+++ b/test/integration/crud/crud.prose.test.ts
@@ -6,6 +6,7 @@ import {
   type AnyClientBulkWriteModel,
   type ClientSession,
   type Collection,
+  type Document,
   MongoBulkWriteError,
   type MongoClient,
   MongoClientBulkWriteError,
@@ -175,7 +176,7 @@ describe('CRUD Prose Spec Tests', () => {
     // firstEvent.operationId is equal to secondEvent.operationId.
     let client: MongoClient;
     let maxWriteBatchSize;
-    const models: AnyClientBulkWriteModel[] = [];
+    let models: AnyClientBulkWriteModel<Document>[] = [];
     const commands: CommandStartedEvent[] = [];
 
     beforeEach(async function () {
@@ -188,12 +189,12 @@ describe('CRUD Prose Spec Tests', () => {
       client.on('commandStarted', filterForCommands('bulkWrite', commands));
       commands.length = 0;
 
-      Array.from({ length: maxWriteBatchSize + 1 }, () => {
-        models.push({
+      models = Array.from({ length: maxWriteBatchSize + 1 }, () => {
+        return {
           namespace: 'db.coll',
           name: 'insertOne',
           document: { a: 'b' }
-        });
+        };
       });
     });
 
@@ -243,7 +244,7 @@ describe('CRUD Prose Spec Tests', () => {
     let maxBsonObjectSize;
     let maxMessageSizeBytes;
     let numModels;
-    const models: AnyClientBulkWriteModel[] = [];
+    let models: AnyClientBulkWriteModel<Document>[] = [];
     const commands: CommandStartedEvent[] = [];
 
     beforeEach(async function () {
@@ -258,14 +259,14 @@ describe('CRUD Prose Spec Tests', () => {
       client.on('commandStarted', filterForCommands('bulkWrite', commands));
       commands.length = 0;
 
-      Array.from({ length: numModels }, () => {
-        models.push({
+      models = Array.from({ length: numModels }, () => {
+        return {
           name: 'insertOne',
           namespace: 'db.coll',
           document: {
             a: 'b'.repeat(maxBsonObjectSize - 500)
           }
-        });
+        };
       });
     });
 
@@ -314,7 +315,7 @@ describe('CRUD Prose Spec Tests', () => {
     // Assert that two CommandStartedEvents were observed for the bulkWrite command.
     let client: MongoClient;
     let maxWriteBatchSize;
-    const models: AnyClientBulkWriteModel[] = [];
+    let models: AnyClientBulkWriteModel<Document>[] = [];
     const commands: CommandStartedEvent[] = [];
 
     beforeEach(async function () {
@@ -338,12 +339,12 @@ describe('CRUD Prose Spec Tests', () => {
       client.on('commandStarted', filterForCommands('bulkWrite', commands));
       commands.length = 0;
 
-      Array.from({ length: maxWriteBatchSize + 1 }, () => {
-        models.push({
+      models = Array.from({ length: maxWriteBatchSize + 1 }, () => {
+        return {
           namespace: 'db.coll',
           name: 'insertOne',
           document: { a: 'b' }
-        });
+        };
       });
     });
 
@@ -382,7 +383,7 @@ describe('CRUD Prose Spec Tests', () => {
     // Construct a list of write models (referred to as models) with model repeated maxWriteBatchSize + 1 times.
     let client: MongoClient;
     let maxWriteBatchSize;
-    const models: AnyClientBulkWriteModel[] = [];
+    let models: AnyClientBulkWriteModel<Document>[] = [];
     const commands: CommandStartedEvent[] = [];
 
     beforeEach(async function () {
@@ -396,12 +397,12 @@ describe('CRUD Prose Spec Tests', () => {
       client.on('commandStarted', filterForCommands('bulkWrite', commands));
       commands.length = 0;
 
-      Array.from({ length: maxWriteBatchSize + 1 }, () => {
-        models.push({
+      models = Array.from({ length: maxWriteBatchSize + 1 }, () => {
+        return {
           namespace: 'db.coll',
           name: 'insertOne',
           document: { _id: 1 }
-        });
+        };
       });
     });
 
@@ -471,7 +472,7 @@ describe('CRUD Prose Spec Tests', () => {
     // Assert that a CommandStartedEvent was observed for the getMore command.
     let client: MongoClient;
     let maxBsonObjectSize;
-    const models: AnyClientBulkWriteModel[] = [];
+    const models: AnyClientBulkWriteModel<Document>[] = [];
     const commands: CommandStartedEvent[] = [];
 
     beforeEach(async function () {
@@ -545,7 +546,7 @@ describe('CRUD Prose Spec Tests', () => {
     let client: MongoClient;
     let session: ClientSession;
     let maxBsonObjectSize;
-    const models: AnyClientBulkWriteModel[] = [];
+    const models: AnyClientBulkWriteModel<Document>[] = [];
     const commands: CommandStartedEvent[] = [];
 
     beforeEach(async function () {
@@ -632,7 +633,7 @@ describe('CRUD Prose Spec Tests', () => {
     // Assert that a CommandStartedEvent was observed for the killCursors command.
     let client: MongoClient;
     let maxBsonObjectSize;
-    const models: AnyClientBulkWriteModel[] = [];
+    const models: AnyClientBulkWriteModel<Document>[] = [];
     const getMoreCommands: CommandStartedEvent[] = [];
     const killCursorsCommands: CommandStartedEvent[] = [];
 
@@ -803,7 +804,7 @@ describe('CRUD Prose Spec Tests', () => {
     let opsBytes;
     let numModels;
     let remainderBytes;
-    let models: AnyClientBulkWriteModel[] = [];
+    let models: AnyClientBulkWriteModel<Document>[] = [];
     const commands: CommandStartedEvent[] = [];
 
     beforeEach(async function () {
@@ -821,12 +822,12 @@ describe('CRUD Prose Spec Tests', () => {
       commands.length = 0;
       models = [];
 
-      Array.from({ length: numModels }, () => {
-        models.push({
+      models = Array.from({ length: numModels }, () => {
+        return {
           namespace: 'db.coll',
           name: 'insertOne',
           document: { a: 'b'.repeat(maxBsonObjectSize - 57) }
-        });
+        };
       });
 
       if (remainderBytes >= 217) {
@@ -859,7 +860,7 @@ describe('CRUD Prose Spec Tests', () => {
       it('executes in a single batch', {
         metadata: { requires: { mongodb: '>=8.0.0', serverless: 'forbid' } },
         async test() {
-          const sameNamespaceModel: AnyClientBulkWriteModel = {
+          const sameNamespaceModel: AnyClientBulkWriteModel<Document> = {
             name: 'insertOne',
             namespace: 'db.coll',
             document: { a: 'b' }
@@ -896,7 +897,7 @@ describe('CRUD Prose Spec Tests', () => {
         metadata: { requires: { mongodb: '>=8.0.0', serverless: 'forbid' } },
         async test() {
           const namespace = `db.${'c'.repeat(200)}`;
-          const newNamespaceModel: AnyClientBulkWriteModel = {
+          const newNamespaceModel: AnyClientBulkWriteModel<Document> = {
             name: 'insertOne',
             namespace: namespace,
             document: { a: 'b' }
@@ -950,7 +951,7 @@ describe('CRUD Prose Spec Tests', () => {
       it('raises a client error', {
         metadata: { requires: { mongodb: '>=8.0.0', serverless: 'forbid' } },
         async test() {
-          const model: AnyClientBulkWriteModel = {
+          const model: AnyClientBulkWriteModel<Document> = {
             name: 'insertOne',
             namespace: 'db.coll',
             document: { a: 'b'.repeat(maxMessageSizeBytes) }
@@ -976,7 +977,7 @@ describe('CRUD Prose Spec Tests', () => {
         metadata: { requires: { mongodb: '>=8.0.0', serverless: 'forbid' } },
         async test() {
           const namespace = `db.${'c'.repeat(maxMessageSizeBytes)}`;
-          const model: AnyClientBulkWriteModel = {
+          const model: AnyClientBulkWriteModel<Document> = {
             name: 'insertOne',
             namespace: namespace,
             document: { a: 'b' }
@@ -1033,7 +1034,7 @@ describe('CRUD Prose Spec Tests', () => {
     });
 
     it('raises a client side error', async function () {
-      const model: AnyClientBulkWriteModel = {
+      const model: AnyClientBulkWriteModel<Document> = {
         name: 'insertOne',
         namespace: 'db.coll',
         document: { a: 'b' }
@@ -1113,7 +1114,7 @@ describe('CRUD Prose Spec Tests', () => {
     let maxBsonObjectSize;
     let maxMessageSizeBytes;
     let numModels;
-    let models: AnyClientBulkWriteModel[] = [];
+    let models: AnyClientBulkWriteModel<Document>[] = [];
     const commands: CommandStartedEvent[] = [];
 
     beforeEach(async function () {

--- a/test/integration/crud/crud.prose.test.ts
+++ b/test/integration/crud/crud.prose.test.ts
@@ -1155,7 +1155,7 @@ describe('CRUD Prose Spec Tests', () => {
       metadata: { requires: { mongodb: '>=8.0.0', serverless: 'forbid' } },
       async test() {
         const result = await client.bulkWrite(models, { ordered: false, writeConcern: { w: 0 } });
-        expect(result).to.deep.equal({ ok: 1 });
+        expect(result.acknowledged).to.be.false;
         expect(commands.length).to.equal(2);
         expect(commands[0].command.ops.length).to.equal(numModels - 1);
         expect(commands[0].command.writeConcern.w).to.equal(0);

--- a/test/integration/crud/crud.prose.test.ts
+++ b/test/integration/crud/crud.prose.test.ts
@@ -315,7 +315,7 @@ describe('CRUD Prose Spec Tests', () => {
     // Assert that two CommandStartedEvents were observed for the bulkWrite command.
     let client: MongoClient;
     let maxWriteBatchSize;
-    let models: ClientBulkWriteModel<Document>[] = [];
+    let models: ClientBulkWriteModel[] = [];
     const commands: CommandStartedEvent[] = [];
 
     beforeEach(async function () {

--- a/test/types/client_bulk_write.test-d.ts
+++ b/test/types/client_bulk_write.test-d.ts
@@ -1,0 +1,258 @@
+import { expectError, expectType } from 'tsd';
+
+import {
+  type ClientBulkWriteModel,
+  type ClientDeleteManyModel,
+  type ClientDeleteOneModel,
+  type ClientInsertOneModel,
+  type ClientReplaceOneModel,
+  type ClientUpdateManyModel,
+  type ClientUpdateOneModel,
+  type Document,
+  type Filter,
+  type MongoClient,
+  type OptionalId,
+  type UpdateFilter,
+  type UUID,
+  type WithoutId
+} from '../mongodb';
+
+declare const client: MongoClient;
+type Book = { title: string; released: Date };
+type Author = { name: string; published: number };
+type Store = { _id: UUID };
+
+// Baseline check that schema modifies the following fields for each type.
+expectType<ClientInsertOneModel<Book>['document']>(null as unknown as OptionalId<Book>);
+
+expectType<ClientReplaceOneModel<Book>['filter']>(null as unknown as Filter<Book>);
+expectType<ClientReplaceOneModel<Book>['replacement']>(null as unknown as WithoutId<Book>);
+
+expectType<ClientUpdateOneModel<Book>['filter']>(null as unknown as Filter<Book>);
+expectType<ClientUpdateOneModel<Book>['update']>(
+  null as unknown as UpdateFilter<Book> | Document[]
+);
+
+expectType<ClientUpdateManyModel<Book>['filter']>(null as unknown as Filter<Book>);
+expectType<ClientUpdateManyModel<Book>['update']>(
+  null as unknown as UpdateFilter<Book> | Document[]
+);
+
+expectType<ClientDeleteOneModel<Book>['filter']>(null as unknown as Filter<Book>);
+expectType<ClientDeleteManyModel<Book>['filter']>(null as unknown as Filter<Book>);
+
+client.bulkWrite([]); // empty should always work
+
+// No schemas - all correct use
+client.bulkWrite([
+  {
+    namespace: 'db.authors',
+    name: 'insertOne',
+    document: { name: 'bob', published: 2 }
+  },
+  {
+    namespace: 'db.authors',
+    name: 'replaceOne',
+    filter: { name: 'bob' },
+    replacement: { name: 'ann', published: 2 }
+  },
+  {
+    namespace: 'db.authors',
+    name: 'updateOne',
+    filter: { name: 'bob', published: 2 },
+    update: {}
+  },
+  {
+    namespace: 'db.authors',
+    name: 'updateMany',
+    filter: { name: 'bob', published: 2 },
+    update: {}
+  },
+  { namespace: 'db.authors', name: 'deleteOne', filter: {} },
+  { namespace: 'db.authors', name: 'deleteMany', filter: {} }
+]);
+
+// No schemas - incorrect use - random namespaces, no type checking
+client.bulkWrite([
+  {
+    namespace: 'db.whatever',
+    name: 'insertOne',
+    document: { name: 'bob', randomKey: 2 }
+  },
+  {
+    namespace: 'db.change',
+    name: 'replaceOne',
+    filter: { name: 'bob' },
+    replacement: { name: 2, published: 2 }
+  },
+  {
+    namespace: 'db.it',
+    name: 'updateOne',
+    filter: { name: 'bob', published: new Date() },
+    update: {}
+  },
+  {
+    namespace: 'db.up',
+    name: 'updateMany',
+    filter: { name: 'bob', published: 2 },
+    update: {}
+  },
+  { namespace: 'db.random', name: 'deleteOne', filter: {} },
+  { namespace: 'db.namespace', name: 'deleteMany', filter: {} }
+]);
+
+// Operation names are still type checked when there is no schema
+expectError<ClientBulkWriteModel>({
+  namespace: 'db.author',
+  name: 'insertLots', // Not an operation we support
+  document: { name: 'bob', published: 2 }
+});
+
+type MongoDBSchemas = {
+  'db.books': Book;
+  'db.authors': Author;
+  'db.stores': Store;
+};
+
+expectError<ClientBulkWriteModel<MongoDBSchemas>>({
+  namespace: 'db.author', // Unknown namespace! a typo!
+  name: 'insertOne',
+  document: { name: 'bob', published: 2 }
+});
+
+expectError<ClientBulkWriteModel<MongoDBSchemas>>({
+  namespace: 'db.authors',
+  name: 'insertOne',
+  document: { name: 'bob', published: '' } // Incorrect type for known field
+});
+
+expectError<ClientBulkWriteModel<MongoDBSchemas>>({
+  namespace: 'db.authors',
+  name: 'insertOne',
+  document: { name: 'bob', publish: 2 } // unknown field! typo!
+});
+
+// Defined schemas - all correct use
+client.bulkWrite<MongoDBSchemas>([
+  {
+    namespace: 'db.authors',
+    name: 'insertOne',
+    document: { name: 'bob', published: 2 }
+  },
+  {
+    namespace: 'db.authors',
+    name: 'replaceOne',
+    filter: { name: 'bob' },
+    replacement: { name: 'ann', published: 2 }
+  },
+  {
+    namespace: 'db.authors',
+    name: 'updateOne',
+    filter: { name: 'bob', published: 2 },
+    update: {}
+  },
+  {
+    namespace: 'db.authors',
+    name: 'updateMany',
+    filter: { name: 'bob', published: 2 },
+    update: {}
+  },
+  { namespace: 'db.authors', name: 'deleteOne', filter: {} },
+  { namespace: 'db.authors', name: 'deleteMany', filter: {} }
+]);
+
+// Defined schemas - incorrect use
+expectError(
+  client.bulkWrite<MongoDBSchemas>([
+    {
+      namespace: 'db.authors',
+      name: 'insertOne',
+      document: { name: 'bob', published: '' } // wrong type
+    },
+    {
+      namespace: 'db.authors',
+      name: 'replaceOne',
+      filter: { name: 'bob' },
+      replacement: { name: 'ann', publish: 2 } // key typo
+    },
+    {
+      namespace: 'db.blah', // unknown namespace
+      name: 'updateOne',
+      filter: { name: 'bob', published: 2 },
+      update: {}
+    },
+    {
+      namespace: 'db.authors',
+      name: 'updateManyy', // unknown operation
+      filter: { name: 'bob', published: 2 },
+      update: {}
+    },
+    { namespace: 'db.authors', name: 'deleteOne', filter: {} },
+    { namespace: 'db.authors', name: 'deleteMany', filter: {} }
+  ])
+);
+
+type MongoDBSchemasWithCalculations = {
+  // River Books uses star ratings
+  [key: `river-books.${string}`]: Book & { fiveStarRatings: number };
+  // Ocean literature uses thumbs up for ratings
+  [key: `ocean-literature.${string}`]: Book & { thumbsUp: number };
+};
+
+// correct use
+client.bulkWrite<MongoDBSchemasWithCalculations>([
+  {
+    namespace: 'river-books.store0',
+    name: 'insertOne',
+    document: { title: 'abc', released: new Date(), fiveStarRatings: 10 }
+  },
+  {
+    namespace: 'ocean-literature.store0',
+    name: 'insertOne',
+    document: { title: 'abc', released: new Date(), thumbsUp: 10 }
+  }
+]);
+
+// prevented from changing each store's rating system!
+expectError(
+  client.bulkWrite<MongoDBSchemasWithCalculations>([
+    {
+      namespace: 'river-books.store0',
+      name: 'insertOne',
+      document: { title: 'abc', released: new Date(), thumbsUp: 10 }
+    },
+    {
+      namespace: 'ocean-literature.store0',
+      name: 'insertOne',
+      document: { title: 'abc', released: new Date(), fiveStarRatings: 10 }
+    }
+  ])
+);
+
+// Example partial use case:
+// I want to make sure I don't mess up any namespaces but I don't want to define schemas:
+
+type MongoDBNamespaces = 'db.books' | 'db.authors' | 'db.stores';
+
+client.bulkWrite<{ [K in MongoDBNamespaces]: Document }>([
+  {
+    namespace: 'db.books',
+    name: 'insertOne',
+    document: { title: 'abc', released: 32n, blah_blah: 10 } // wrong type for released does not error
+  },
+  {
+    namespace: 'db.authors',
+    name: 'insertOne',
+    document: { title: 'abc', released: 'yesterday', fiveStarRatings: 10 }
+  }
+]);
+
+expectError(
+  client.bulkWrite<{ [K in MongoDBNamespaces]: Document }>([
+    {
+      namespace: 'db.wrongNS',
+      name: 'insertOne',
+      document: { title: 'abc', released: new Date(), thumbsUp: 10 }
+    }
+  ])
+);

--- a/test/types/client_bulk_write.test-d.ts
+++ b/test/types/client_bulk_write.test-d.ts
@@ -1,4 +1,4 @@
-import { expectError, expectType } from 'tsd';
+import { expectAssignable, expectError, expectNotAssignable, expectType } from 'tsd';
 
 import {
   type ClientBulkWriteModel,
@@ -23,23 +23,26 @@ type Author = { name: string; published: number };
 type Store = { _id: UUID };
 
 // Baseline check that schema modifies the following fields for each type.
-expectType<ClientInsertOneModel<Book>['document']>(null as unknown as OptionalId<Book>);
+declare const clientInsertOneModel: ClientInsertOneModel<Book>;
+expectType<OptionalId<Book>>(clientInsertOneModel.document);
 
-expectType<ClientReplaceOneModel<Book>['filter']>(null as unknown as Filter<Book>);
-expectType<ClientReplaceOneModel<Book>['replacement']>(null as unknown as WithoutId<Book>);
+declare const clientReplaceOneModel: ClientReplaceOneModel<Book>;
+expectType<Filter<Book>>(clientReplaceOneModel.filter);
+expectType<WithoutId<Book>>(clientReplaceOneModel.replacement);
 
-expectType<ClientUpdateOneModel<Book>['filter']>(null as unknown as Filter<Book>);
-expectType<ClientUpdateOneModel<Book>['update']>(
-  null as unknown as UpdateFilter<Book> | Document[]
-);
+declare const clientUpdateOneModel: ClientUpdateOneModel<Book>;
+expectType<Filter<Book>>(clientUpdateOneModel.filter);
+expectType<UpdateFilter<Book> | Document[]>(clientUpdateOneModel.update);
 
-expectType<ClientUpdateManyModel<Book>['filter']>(null as unknown as Filter<Book>);
-expectType<ClientUpdateManyModel<Book>['update']>(
-  null as unknown as UpdateFilter<Book> | Document[]
-);
+declare const clientUpdateManyModel: ClientUpdateManyModel<Book>;
+expectType<Filter<Book>>(clientUpdateManyModel.filter);
+expectType<UpdateFilter<Book> | Document[]>(clientUpdateManyModel.update);
 
-expectType<ClientDeleteOneModel<Book>['filter']>(null as unknown as Filter<Book>);
-expectType<ClientDeleteManyModel<Book>['filter']>(null as unknown as Filter<Book>);
+declare const clientDeleteOneModel: ClientDeleteOneModel<Book>;
+expectType<Filter<Book>>(clientDeleteOneModel.filter);
+
+declare const clientDeleteManyModel: ClientDeleteManyModel<Book>;
+expectType<Filter<Book>>(clientDeleteManyModel.filter);
 
 client.bulkWrite([]); // empty should always work
 
@@ -72,7 +75,7 @@ client.bulkWrite([
   { namespace: 'db.authors', name: 'deleteMany', filter: {} }
 ]);
 
-// No schemas - incorrect use - random namespaces, no type checking
+// No schemas - random namespaces, no type checking
 client.bulkWrite([
   {
     namespace: 'db.whatever',
@@ -168,27 +171,40 @@ expectError(
       namespace: 'db.authors',
       name: 'insertOne',
       document: { name: 'bob', published: '' } // wrong type
-    },
+    }
+  ])
+);
+
+expectError(
+  client.bulkWrite<MongoDBSchemas>([
     {
       namespace: 'db.authors',
       name: 'replaceOne',
       filter: { name: 'bob' },
       replacement: { name: 'ann', publish: 2 } // key typo
-    },
+    }
+  ])
+);
+
+expectError(
+  client.bulkWrite<MongoDBSchemas>([
     {
       namespace: 'db.blah', // unknown namespace
       name: 'updateOne',
       filter: { name: 'bob', published: 2 },
       update: {}
-    },
+    }
+  ])
+);
+
+expectError(
+  client.bulkWrite<MongoDBSchemas>([
     {
       namespace: 'db.authors',
       name: 'updateManyy', // unknown operation
       filter: { name: 'bob', published: 2 },
       update: {}
-    },
-    { namespace: 'db.authors', name: 'deleteOne', filter: {} },
-    { namespace: 'db.authors', name: 'deleteMany', filter: {} }
+    }
   ])
 );
 

--- a/test/unit/operations/client_bulk_write/results_merger.test.ts
+++ b/test/unit/operations/client_bulk_write/results_merger.test.ts
@@ -45,6 +45,7 @@ describe('ClientBulkWriteResultsMerger', function () {
 
     it('initializes the result', function () {
       expect(resultsMerger.result).to.deep.equal({
+        acknowledged: true,
         insertedCount: 0,
         upsertedCount: 0,
         matchedCount: 0,


### PR DESCRIPTION
### Description

#### What is changing?

- Adds namespace to schema mapping type
- Adds tests/examples to our tsd tests

- Some important choices:
  - We should default only where needed ("near the top"), the Models now require an input schema, Document can be used when none is needed. 
  - `ClientBulkWriteModel` is exported on its own and is _not_ an array type. We can offer this seperate from the client API so annotations can be used to get this string to schema behavior (but I would advocate for putting it directly into the API)

##### Is there new documentation needed for these changes?

Yes, I think the API doc on client.bulkWrite should explain how to use the TS a bit. I started in the TS doc for `ClientBulkWriteModel` 

We mostly use "inline" models to demo the API, however, this TS change does not cause friction in wrapping this API, it does have some considerations though, if you make a helper that returns InsertOneModels you will want the return type to still preserve the type of "namespace" where appropriate to get autocomplete and assertions.  -- we should write a small example of this.

#### What is the motivation for this change?

Users of this method can get thier schema asserted on the various bulkWrite models making sure input data is not adjusted accidentally or that filters aren't written in a way that doees not match the data format at all. 

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### New client bulk write API supported

A new bulk write API on the `MongoClient` is now supported for users on server versions 8.0 and higher.
This API is meant to replace the existing bulk write API on the `Collection` as it supports a bulk
write across multiple databases and collections in a single call.

#### Usage

Users of this API call `MongoClient#bulkWrite` and provide a list of bulk write models and options.
The models have a structure as follows:

#### Insert One

* Note that when no `_id` field is provided in the document, the driver will generate a BSON `ObjectId`
automatically. *

```ts
{
  namespace: '<db>.<collection>',
  name: 'insertOne',
  document: Document
}
```

#### Update One

```ts
{
  namespace: '<db>.<collection>',
  name: 'updateOne',
  filter: Document,
  update: Document | Document[],
  arrayFilters?: Document[],
  hint?: Document | string,
  collation?: Document,
  upsert: boolean
}
```

#### Update Many

* Note that write errors occuring with an update many model present are not retryable. *

```ts
{
  namespace: '<db>.<collection>',
  name: 'updateMany',
  filter: Document,
  update: Document | Document[],
  arrayFilters?: Document[],
  hint?: Document | string,
  collation?: Document,
  upsert: boolean
}
```

#### Replace One

```ts
{
  namespace: '<db>.<collection>',
  name: 'replaceOne',
  filter: Document,
  replacement: Document,
  hint?: Document | string,
  collation?: Document
}
```

#### Delete One

```ts
{
  namespace: '<db>.<collection>',
  name: 'deleteOne',
  filter: Document,
  hint?: Document | string,
  collation?: Document
}
```

#### Delete Many

* Note that write errors occuring with a delete many model present are not retryable. *

```ts
{
  namespace: '<db>.<collection>',
  name: 'deleteMany',
  filter: Document,
  hint?: Document | string,
  collation?: Document
}
```

#### Example

Below is a mixed model example of using the new API:

```ts
const client = new MongoClient(process.env.MONGODB_URI);
const models = [
  {
    name: 'insertOne',
    namespace: 'db.authors',
    document: { name: 'King' }
  },
  {
    name: 'insertOne',
    namespace: 'db.books',
    document: { name: 'It' }
  },
  {
    name: 'updateOne',
    namespace: 'db.books',
    filter: { name: 'it' },
    update: { $set: { year: 1986 } }
  }
];
const result = await client.bulkWrite(models);

```

The bulk write specific options that can be provided to the API are as follows:

- `ordered`: Optional boolean that indicates the bulk write as ordered. Defaults to true.
- `verboseResults`: Optional boolean to indicate to provide verbose results. Defaults to false.
- `bypassDocumentValidation`: Optional boolean to bypass document validation rules. Defaults to false.
- `let`: Optional document of parameter names and values that can be accessed using $$var. No default.

The object returned by the bulk write API is:

```ts
interface ClientBulkWriteResult {
  // Whether the bulk write was acknowledged.
  readonly acknowledged: boolean;
  // The total number of documents inserted across all insert operations.
  readonly insertedCount: number;
  // The total number of documents upserted across all update operations.
  readonly upsertedCount: number;
  // The total number of documents matched across all update operations.
  readonly matchedCount: number;
  // The total number of documents modified across all update operations.
  readonly modifiedCount: number;
  // The total number of documents deleted across all delete operations.
  readonly deletedCount: number;
  // The results of each individual insert operation that was successfully performed.
  // Note the keys in the map are the associated index in the models array.
  readonly insertResults?: ReadonlyMap<number, ClientInsertOneResult>;
  // The results of each individual update operation that was successfully performed.
  // Note the keys in the map are the associated index in the models array.
  readonly updateResults?: ReadonlyMap<number, ClientUpdateResult>;
  // The results of each individual delete operation that was successfully performed.
  // Note the keys in the map are the associated index in the models array.
  readonly deleteResults?: ReadonlyMap<number, ClientDeleteResult>;
}
```

#### Error Handling

Server side errors encountered during a bulk write will throw a `MongoClientBulkWriteError`. This error
has the following properties:

- `writeConcernErrors`: Ann array of documents for each write concern error that occurred.
- `writeErrors`: A map of index pointing at the models provided and the individual write error.
- `partialResult`: The client bulk write result at the point where the error was thrown.

#### Schema assertion support

```ts
interface Book {
  name: string;
  authorName: string;
}

interface Author {
  name: string;
}

type MongoDBSchemas = {
  'db.books': Book;
  'db.authors': Author;
}

const model: ClientBulkWriteModel<MongoDBSchemas> = {
  namespace: 'db.books'
  name: 'insertOne',
  document: { title: 'Practical MongoDB Aggregations', authorName: 3 } 
  // error `authorName` cannot be number
};
```

Notice how authorName is type checked against the `Book` type because namespace is set to `"db.books"`. 

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
