### PR TITLE
fix(NODE-6407): use conversationId returned by the server instead of hardcoded integer in SASL implementation for MONGODB-AWS.

### DIFF
--- a/src/cmap/auth/mongodb_aws.ts
+++ b/src/cmap/auth/mongodb_aws.ts
@@ -148,7 +148,7 @@ export class MongoDBAWS extends AuthProvider {
 
     const saslContinue = {
       saslContinue: 1,
-      conversationId: 1,
+      conversationId: saslStartResponse.conversationId,
       payload: BSON.serialize(payload, bsonOptions)
     };
 


### PR DESCRIPTION
### Description
`MONGODB-AWS` authentication mechanism should follow SASL [spec](https://github.com/mongodb/specifications/blob/master/source/auth/auth.md#sasl-mechanisms). Current implementation ignores the `conversationId` sent by the server and uses a hardcoded integer for all `saslContinue` messages across all conversations.

#### What is changing?
Changing the hardcoded integer for `conversationId` to utilize the one that gets returned in the `saslStart` response.

##### Is there new documentation needed for these changes?
No. This change brings the implementation to spec.

#### What is the motivation for this change?

This is a bug. MONGODB-AWS authentication failed on database emulating MongoDB.

### Release Highlight

Fixes SASL implementation for MONGODB-AWS to use conversationId returned by the server instead of hardcoded integer.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
