### PR TITLE
feat(NODE-6403): Add CSOT support to client bulk write

### DIFF
--- a/src/cmap/connection.ts
+++ b/src/cmap/connection.ts
@@ -716,6 +716,8 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
           throw new MongoOperationTimeoutError('Timed out at socket write');
         }
         throw error;
+      } finally {
+        timeout.clear();
       }
     }
     return await drainEvent;

--- a/src/cmap/wire_protocol/on_data.ts
+++ b/src/cmap/wire_protocol/on_data.ts
@@ -116,6 +116,7 @@ export function onData(
     emitter.off('data', eventHandler);
     emitter.off('error', errorHandler);
     finished = true;
+    timeoutForSocketRead?.clear();
     const doneResult = { value: undefined, done: finished } as const;
 
     for (const promise of unconsumedPromises) {

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -243,7 +243,7 @@ export abstract class AbstractCursor<
         options.timeoutMode ??
         (options.tailable ? CursorTimeoutMode.ITERATION : CursorTimeoutMode.LIFETIME);
     } else {
-      if (options.timeoutMode != null)
+      if (options.timeoutMode != null && options.timeoutContext == null)
         throw new MongoInvalidArgumentError('Cannot set timeoutMode without setting timeoutMS');
     }
 

--- a/src/cursor/client_bulk_write_cursor.ts
+++ b/src/cursor/client_bulk_write_cursor.ts
@@ -35,7 +35,7 @@ export class ClientBulkWriteCursor extends AbstractCursor {
   constructor(
     client: MongoClient,
     commandBuilder: ClientBulkWriteCommandBuilder,
-    options: ClientBulkWriteOptions = {}
+    options: ClientBulkWriteCursorOptions = {}
   ) {
     super(client, new MongoDBNamespace('admin', '$cmd'), options);
 
@@ -72,7 +72,11 @@ export class ClientBulkWriteCursor extends AbstractCursor {
       session
     });
 
-    const response = await executeOperation(this.client, clientBulkWriteOperation);
+    const response = await executeOperation(
+      this.client,
+      clientBulkWriteOperation,
+      this.timeoutContext
+    );
     this.cursorResponse = response;
 
     return { server: clientBulkWriteOperation.server, session, response };

--- a/src/operations/client_bulk_write/executor.ts
+++ b/src/operations/client_bulk_write/executor.ts
@@ -1,3 +1,4 @@
+import { CursorTimeoutContext, CursorTimeoutMode } from '../../cursor/abstract_cursor';
 import { ClientBulkWriteCursor } from '../../cursor/client_bulk_write_cursor';
 import {
   MongoClientBulkWriteError,
@@ -5,6 +6,8 @@ import {
   MongoServerError
 } from '../../error';
 import { type MongoClient } from '../../mongo_client';
+import { TimeoutContext } from '../../timeout';
+import { resolveTimeoutOptions } from '../../utils';
 import { WriteConcern } from '../../write_concern';
 import { executeOperation } from '../execute_operation';
 import { ClientBulkWriteOperation } from './client_bulk_write';
@@ -70,17 +73,26 @@ export class ClientBulkWriteExecutor {
       pkFactory
     );
     // Unacknowledged writes need to execute all batches and return { ok: 1}
+    const resolvedOptions = resolveTimeoutOptions(this.client, this.options);
+    const context = TimeoutContext.create(resolvedOptions);
+
     if (this.options.writeConcern?.w === 0) {
       while (commandBuilder.hasNextBatch()) {
         const operation = new ClientBulkWriteOperation(commandBuilder, this.options);
-        await executeOperation(this.client, operation);
+        await executeOperation(this.client, operation, context);
       }
       return { ok: 1 };
     } else {
       const resultsMerger = new ClientBulkWriteResultsMerger(this.options);
       // For each command will will create and exhaust a cursor for the results.
       while (commandBuilder.hasNextBatch()) {
-        const cursor = new ClientBulkWriteCursor(this.client, commandBuilder, this.options);
+        const cursorContext = new CursorTimeoutContext(context, Symbol());
+        const options = {
+          ...this.options,
+          timeoutContext: cursorContext,
+          ...(resolvedOptions.timeoutMS != null && { timeoutMode: CursorTimeoutMode.LIFETIME })
+        };
+        const cursor = new ClientBulkWriteCursor(this.client, commandBuilder, options);
         try {
           await resultsMerger.merge(cursor);
         } catch (error) {

--- a/src/sdam/server.ts
+++ b/src/sdam/server.ts
@@ -106,7 +106,7 @@ export type ServerEvents = {
   EventEmitterWithState;
 
 /** @internal */
-export type ServerCommandOptions = Omit<CommandOptions, 'timeoutContext'> & {
+export type ServerCommandOptions = Omit<CommandOptions, 'timeoutContext' | 'socketTimeoutMS'> & {
   timeoutContext: TimeoutContext;
 };
 

--- a/src/timeout.ts
+++ b/src/timeout.ts
@@ -171,7 +171,7 @@ function isCSOTTimeoutContextOptions(v: unknown): v is CSOTTimeoutContextOptions
 
 /** @internal */
 export abstract class TimeoutContext {
-  static create(options: Partial<TimeoutContextOptions>): TimeoutContext {
+  static create(options: TimeoutContextOptions): TimeoutContext {
     if (options.session?.timeoutContext != null) return options.session?.timeoutContext;
     if (isCSOTTimeoutContextOptions(options)) return new CSOTTimeoutContext(options);
     else if (isLegacyTimeoutContextOptions(options)) return new LegacyTimeoutContext(options);

--- a/src/timeout.ts
+++ b/src/timeout.ts
@@ -171,7 +171,7 @@ function isCSOTTimeoutContextOptions(v: unknown): v is CSOTTimeoutContextOptions
 
 /** @internal */
 export abstract class TimeoutContext {
-  static create(options: TimeoutContextOptions): TimeoutContext {
+  static create(options: Partial<TimeoutContextOptions>): TimeoutContext {
     if (options.session?.timeoutContext != null) return options.session?.timeoutContext;
     if (isCSOTTimeoutContextOptions(options)) return new CSOTTimeoutContext(options);
     else if (isLegacyTimeoutContextOptions(options)) return new LegacyTimeoutContext(options);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -35,6 +35,7 @@ import { ServerType } from './sdam/common';
 import type { Server } from './sdam/server';
 import type { Topology } from './sdam/topology';
 import type { ClientSession } from './sessions';
+import { type TimeoutContextOptions } from './timeout';
 import { WriteConcern } from './write_concern';
 
 /**
@@ -514,6 +515,18 @@ export function hasAtomicOperators(doc: Document | Document[]): boolean {
   return keys.length > 0 && keys[0][0] === '$';
 }
 
+export function resolveTimeoutOptions<T extends Partial<TimeoutContextOptions>>(
+  client: MongoClient,
+  options: T
+): T &
+  Pick<
+    MongoClient['s']['options'],
+    'timeoutMS' | 'serverSelectionTimeoutMS' | 'waitQueueTimeoutMS' | 'socketTimeoutMS'
+  > {
+  const { socketTimeoutMS, serverSelectionTimeoutMS, waitQueueTimeoutMS, timeoutMS } =
+    client.s.options;
+  return { socketTimeoutMS, serverSelectionTimeoutMS, waitQueueTimeoutMS, timeoutMS, ...options };
+}
 /**
  * Merge inherited properties from parent into options, prioritizing values from options,
  * then values from parent.

--- a/test/integration/client-side-operations-timeout/client_side_operations_timeout.prose.test.ts
+++ b/test/integration/client-side-operations-timeout/client_side_operations_timeout.prose.test.ts
@@ -21,7 +21,8 @@ import {
   promiseWithResolvers,
   squashError
 } from '../../mongodb';
-import { type FailPoint } from '../../tools/utils';
+import { type FailPoint, makeMultiBatchWrite } from '../../tools/utils';
+import { filterForCommands } from '../shared';
 
 // TODO(NODE-5824): Implement CSOT prose tests
 describe('CSOT spec prose tests', function () {
@@ -1183,9 +1184,9 @@ describe('CSOT spec prose tests', function () {
     });
   });
 
-  describe.skip(
+  describe(
     '11. Multi-batch bulkWrites',
-    { requires: { mongodb: '>=8.0', serverless: 'forbid' } },
+    { requires: { mongodb: '>=8.0', serverless: 'forbid', topology: 'single' } },
     function () {
       /**
        * ### 11. Multi-batch bulkWrites
@@ -1245,9 +1246,6 @@ describe('CSOT spec prose tests', function () {
         }
       };
 
-      let maxBsonObjectSize: number;
-      let maxMessageSizeBytes: number;
-
       beforeEach(async function () {
         await internalClient
           .db('db')
@@ -1256,29 +1254,20 @@ describe('CSOT spec prose tests', function () {
           .catch(() => null);
         await internalClient.db('admin').command(failpoint);
 
-        const hello = await internalClient.db('admin').command({ hello: 1 });
-        maxBsonObjectSize = hello.maxBsonObjectSize;
-        maxMessageSizeBytes = hello.maxMessageSizeBytes;
-
         client = this.configuration.newClient({ timeoutMS: 2000, monitorCommands: true });
       });
 
-      it.skip('performs two bulkWrites which fail to complete before 2000 ms', async function () {
+      it('performs two bulkWrites which fail to complete before 2000 ms', async function () {
         const writes = [];
-        client.on('commandStarted', ev => writes.push(ev));
+        client.on('commandStarted', filterForCommands('bulkWrite', writes));
 
-        const length = maxMessageSizeBytes / maxBsonObjectSize + 1;
-        const models = Array.from({ length }, () => ({
-          namespace: 'db.coll',
-          name: 'insertOne' as const,
-          document: { a: 'b'.repeat(maxBsonObjectSize - 500) }
-        }));
+        const models = await makeMultiBatchWrite(this.configuration);
 
         const error = await client.bulkWrite(models).catch(error => error);
 
         expect(error, error.stack).to.be.instanceOf(MongoOperationTimeoutError);
-        expect(writes.map(ev => ev.commandName)).to.deep.equal(['bulkWrite', 'bulkWrite']);
-      }).skipReason = 'TODO(NODE-6403): client.bulkWrite is implemented in a follow up';
+        expect(writes).to.have.lengthOf(2);
+      });
     }
   );
 });

--- a/test/integration/client-side-operations-timeout/node_csot.test.ts
+++ b/test/integration/client-side-operations-timeout/node_csot.test.ts
@@ -279,12 +279,16 @@ describe('CSOT driver tests', metadata, () => {
           .stub(Connection.prototype, 'readMany')
           .callsFake(async function* (...args) {
             const realIterator = readManyStub.wrappedMethod.call(this, ...args);
-            const cmd = commandSpy.lastCall.args.at(1);
-            if ('giveMeWriteErrors' in cmd) {
-              await realIterator.next().catch(() => null); // dismiss response
-              yield { parse: () => writeErrorsReply };
-            } else {
-              yield (await realIterator.next()).value;
+            try {
+              const cmd = commandSpy.lastCall.args.at(1);
+              if ('giveMeWriteErrors' in cmd) {
+                await realIterator.next().catch(() => null); // dismiss response
+                yield { parse: () => writeErrorsReply };
+              } else {
+                yield (await realIterator.next()).value;
+              }
+            } finally {
+              realIterator.return();
             }
           });
       });

--- a/test/integration/collection-management/collection_db_management.test.ts
+++ b/test/integration/collection-management/collection_db_management.test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 
-import { Collection, type Db, type MongoClient } from '../../mongodb';
+import { Collection, type Db, type MongoClient, ObjectId } from '../../mongodb';
 
 describe('Collection Management and Db Management', function () {
   let client: MongoClient;
@@ -16,7 +16,7 @@ describe('Collection Management and Db Management', function () {
   });
 
   it('returns a collection object after calling createCollection', async function () {
-    const collection = await db.createCollection('collection');
+    const collection = await db.createCollection(new ObjectId().toHexString());
     expect(collection).to.be.instanceOf(Collection);
   });
 

--- a/test/integration/crud/client_bulk_write.test.ts
+++ b/test/integration/crud/client_bulk_write.test.ts
@@ -1,0 +1,383 @@
+import { expect } from 'chai';
+import { setTimeout } from 'timers/promises';
+
+import {
+  type CommandStartedEvent,
+  type Connection,
+  type ConnectionPool,
+  type MongoClient,
+  MongoError,
+  MongoOperationTimeoutError,
+  now,
+  TimeoutContext
+} from '../../mongodb';
+import {
+  clearFailPoint,
+  configureFailPoint,
+  makeMultiBatchWrite,
+  makeMultiResponseBatchModelArray
+} from '../../tools/utils';
+import { filterForCommands } from '../shared';
+
+const metadata: MongoDBMetadataUI = {
+  requires: {
+    mongodb: '>=8.0',
+    serverless: 'forbid'
+  }
+};
+
+describe('Client Bulk Write', function () {
+  let client: MongoClient;
+
+  afterEach(async function () {
+    await client?.close();
+    await clearFailPoint(this.configuration);
+  });
+
+  describe('CSOT enabled', function () {
+    describe('when timeoutMS is set on the client', function () {
+      beforeEach(async function () {
+        client = this.configuration.newClient({}, { timeoutMS: 300 });
+        await client.connect();
+        await configureFailPoint(this.configuration, {
+          configureFailPoint: 'failCommand',
+          mode: { times: 1 },
+          data: { blockConnection: true, blockTimeMS: 1000, failCommands: ['bulkWrite'] }
+        });
+      });
+
+      it('timeoutMS is used as the timeout for the bulk write', metadata, async function () {
+        const start = now();
+        const timeoutError = await client
+          .bulkWrite([
+            {
+              name: 'insertOne',
+              namespace: 'foo.bar',
+              document: { age: 10 }
+            }
+          ])
+          .catch(e => e);
+        const end = now();
+        expect(timeoutError).to.be.instanceOf(MongoError);
+        expect(end - start).to.be.within(300 - 100, 300 + 100);
+      });
+    });
+
+    describe('when timeoutMS is set on the bulkWrite operation', function () {
+      beforeEach(async function () {
+        client = this.configuration.newClient({});
+
+        await client.connect();
+
+        await configureFailPoint(this.configuration, {
+          configureFailPoint: 'failCommand',
+          mode: { times: 1 },
+          data: { blockConnection: true, blockTimeMS: 1000, failCommands: ['bulkWrite'] }
+        });
+      });
+
+      it('timeoutMS is used as the timeout for the bulk write', metadata, async function () {
+        const start = now();
+        const timeoutError = await client
+          .bulkWrite(
+            [
+              {
+                name: 'insertOne',
+                namespace: 'foo.bar',
+                document: { age: 10 }
+              }
+            ],
+            { timeoutMS: 300 }
+          )
+          .catch(e => e);
+        const end = now();
+        expect(timeoutError).to.be.instanceOf(MongoError);
+        expect(end - start).to.be.within(300 - 100, 300 + 100);
+      });
+    });
+
+    describe('when timeoutMS is set on both the client and operation options', function () {
+      beforeEach(async function () {
+        client = this.configuration.newClient({}, { timeoutMS: 1500 });
+
+        await client.connect();
+
+        await configureFailPoint(this.configuration, {
+          configureFailPoint: 'failCommand',
+          mode: { times: 1 },
+          data: { blockConnection: true, blockTimeMS: 1000, failCommands: ['bulkWrite'] }
+        });
+      });
+
+      it('bulk write options take precedence over the client options', metadata, async function () {
+        const start = now();
+        const timeoutError = await client
+          .bulkWrite(
+            [
+              {
+                name: 'insertOne',
+                namespace: 'foo.bar',
+                document: { age: 10 }
+              }
+            ],
+            { timeoutMS: 300 }
+          )
+          .catch(e => e);
+        const end = now();
+        expect(timeoutError).to.be.instanceOf(MongoError);
+        expect(end - start).to.be.within(300 - 100, 300 + 100);
+      });
+    });
+
+    describe(
+      'unacknowledged writes',
+      {
+        requires: {
+          mongodb: '>=8.0',
+          topology: 'single'
+        }
+      },
+      function () {
+        let connection: Connection;
+        let pool: ConnectionPool;
+
+        beforeEach(async function () {
+          client = this.configuration.newClient({}, { maxPoolSize: 1, waitQueueTimeoutMS: 2000 });
+
+          await client.connect();
+
+          pool = Array.from(client.topology.s.servers.values())[0].pool;
+          connection = await pool.checkOut({
+            timeoutContext: TimeoutContext.create({
+              serverSelectionTimeoutMS: 30000,
+              waitQueueTimeoutMS: 1000
+            })
+          });
+        });
+
+        afterEach(async function () {
+          pool = Array.from(client.topology.s.servers.values())[0].pool;
+          pool.checkIn(connection);
+          await client.close();
+        });
+
+        it('a single batch bulk write does not take longer than timeoutMS', async function () {
+          const start = now();
+          let end;
+          const timeoutError = client
+            .bulkWrite(
+              [
+                {
+                  name: 'insertOne',
+                  namespace: 'foo.bar',
+                  document: { age: 10 }
+                }
+              ],
+              { timeoutMS: 200, writeConcern: { w: 0 } }
+            )
+            .catch(e => e)
+            .then(e => {
+              end = now();
+              return e;
+            });
+
+          await setTimeout(250);
+
+          expect(await timeoutError).to.be.instanceOf(MongoError);
+          expect(end - start).to.be.within(200 - 100, 200 + 100);
+        });
+
+        it(
+          'timeoutMS applies to all batches',
+          {
+            requires: {
+              mongodb: '>=8.0',
+              topology: 'single'
+            }
+          },
+          async function () {
+            const models = await makeMultiBatchWrite(this.configuration);
+            const start = now();
+            let end;
+            const timeoutError = client
+              .bulkWrite(models, {
+                timeoutMS: 400,
+                writeConcern: { w: 0 }
+              })
+              .catch(e => e)
+              .then(r => {
+                end = now();
+                return r;
+              });
+
+            await setTimeout(210);
+
+            pool.checkIn(connection);
+            connection = await pool.checkOut({
+              timeoutContext: TimeoutContext.create({
+                serverSelectionTimeoutMS: 30000,
+                waitQueueTimeoutMS: 1000
+              })
+            });
+
+            await setTimeout(210);
+
+            expect(await timeoutError).to.be.instanceOf(MongoError);
+            expect(end - start).to.be.within(400 - 100, 400 + 100);
+          }
+        );
+      }
+    );
+
+    describe('acknowledged writes', metadata, function () {
+      describe('when a bulk write command times out', function () {
+        beforeEach(async function () {
+          client = this.configuration.newClient({}, { timeoutMS: 1500 });
+
+          await client.connect();
+
+          await configureFailPoint(this.configuration, {
+            configureFailPoint: 'failCommand',
+            mode: { times: 1 },
+            data: { blockConnection: true, blockTimeMS: 1000, failCommands: ['bulkWrite'] }
+          });
+        });
+
+        it('the operation times out', metadata, async function () {
+          const start = now();
+          const timeoutError = await client
+            .bulkWrite(
+              [
+                {
+                  name: 'insertOne',
+                  namespace: 'foo.bar',
+                  document: { age: 10 }
+                }
+              ],
+              { timeoutMS: 300 }
+            )
+            .catch(e => e);
+          const end = now();
+          expect(timeoutError).to.be.instanceOf(MongoError);
+          expect(end - start).to.be.within(300 - 100, 300 + 100);
+        });
+      });
+
+      describe('when the timeout is reached while iterating the result cursor', function () {
+        const commands: CommandStartedEvent[] = [];
+
+        beforeEach(async function () {
+          client = this.configuration.newClient({}, { monitorCommands: true });
+          client.on('commandStarted', filterForCommands(['getMore'], commands));
+          await client.connect();
+
+          await configureFailPoint(this.configuration, {
+            configureFailPoint: 'failCommand',
+            mode: { times: 1 },
+            data: { blockConnection: true, blockTimeMS: 1400, failCommands: ['getMore'] }
+          });
+        });
+
+        it('the bulk write operation times out', metadata, async function () {
+          const models = await makeMultiResponseBatchModelArray(this.configuration);
+          const start = now();
+          const timeoutError = await client
+            .bulkWrite(models, {
+              verboseResults: true,
+              timeoutMS: 1500
+            })
+            .catch(e => e);
+
+          const end = now();
+          expect(timeoutError).to.be.instanceOf(MongoError);
+
+          // DRIVERS-3005 - killCursors causes cursor cleanup to extend past timeoutMS.
+          expect(end - start).to.be.within(2000 - 100, 2000 + 100);
+          expect(commands).to.have.lengthOf(1);
+        });
+      });
+
+      describe('if the cursor encounters and error and a killCursors is sent', function () {
+        const commands: CommandStartedEvent[] = [];
+
+        beforeEach(async function () {
+          client = this.configuration.newClient({}, { monitorCommands: true });
+
+          client.on('commandStarted', filterForCommands(['killCursors'], commands));
+          await client.connect();
+
+          await configureFailPoint(this.configuration, {
+            configureFailPoint: 'failCommand',
+            mode: { times: 2 },
+            data: {
+              blockConnection: true,
+              blockTimeMS: 3000,
+              failCommands: ['getMore', 'killCursors']
+            }
+          });
+        });
+
+        it(
+          'timeoutMS is refreshed to the timeoutMS passed to the bulk write for the killCursors command',
+          metadata,
+          async function () {
+            const models = await makeMultiResponseBatchModelArray(this.configuration);
+            const timeoutError = await client
+              .bulkWrite(models, { ordered: true, timeoutMS: 2800, verboseResults: true })
+              .catch(e => e);
+
+            expect(timeoutError).to.be.instanceOf(MongoOperationTimeoutError);
+
+            const [
+              {
+                command: { maxTimeMS }
+              }
+            ] = commands;
+            expect(maxTimeMS).to.be.greaterThan(1000);
+          }
+        );
+      });
+
+      describe('when the bulk write is executed in multiple batches', function () {
+        const commands: CommandStartedEvent[] = [];
+
+        beforeEach(async function () {
+          client = this.configuration.newClient({}, { monitorCommands: true });
+
+          client.on('commandStarted', filterForCommands('bulkWrite', commands));
+          await client.connect();
+
+          await configureFailPoint(this.configuration, {
+            configureFailPoint: 'failCommand',
+            mode: { times: 2 },
+            data: { blockConnection: true, blockTimeMS: 1010, failCommands: ['bulkWrite'] }
+          });
+        });
+
+        it(
+          'timeoutMS applies to the duration of all batches',
+          {
+            requires: {
+              ...metadata.requires,
+              topology: 'single'
+            }
+          },
+          async function () {
+            const models = await makeMultiBatchWrite(this.configuration);
+            const start = now();
+            const timeoutError = await client
+              .bulkWrite(models, {
+                timeoutMS: 2000
+              })
+              .catch(e => e);
+
+            const end = now();
+            expect(timeoutError).to.be.instanceOf(MongoError);
+            expect(end - start).to.be.within(2000 - 100, 2000 + 100);
+            expect(commands.length, 'Test must execute two batches.').to.equal(2);
+          }
+        );
+      });
+    });
+  });
+});

--- a/test/integration/crud/client_bulk_write.test.ts
+++ b/test/integration/crud/client_bulk_write.test.ts
@@ -14,8 +14,7 @@ import {
   clearFailPoint,
   configureFailPoint,
   makeMultiBatchWrite,
-  makeMultiResponseBatchModelArray,
-  waitUntilPoolsFilled
+  makeMultiResponseBatchModelArray
 } from '../../tools/utils';
 import { filterForCommands } from '../shared';
 

--- a/test/integration/crud/client_bulk_write.test.ts
+++ b/test/integration/crud/client_bulk_write.test.ts
@@ -6,7 +6,6 @@ import {
   type Connection,
   type ConnectionPool,
   type MongoClient,
-  MongoError,
   MongoOperationTimeoutError,
   now,
   TimeoutContext
@@ -58,7 +57,7 @@ describe('Client Bulk Write', function () {
           ])
           .catch(e => e);
         const end = now();
-        expect(timeoutError).to.be.instanceOf(MongoError);
+        expect(timeoutError).to.be.instanceOf(MongoOperationTimeoutError);
         expect(end - start).to.be.within(300 - 100, 300 + 100);
       });
     });
@@ -91,7 +90,7 @@ describe('Client Bulk Write', function () {
           )
           .catch(e => e);
         const end = now();
-        expect(timeoutError).to.be.instanceOf(MongoError);
+        expect(timeoutError).to.be.instanceOf(MongoOperationTimeoutError);
         expect(end - start).to.be.within(300 - 100, 300 + 100);
       });
     });
@@ -124,7 +123,7 @@ describe('Client Bulk Write', function () {
           )
           .catch(e => e);
         const end = now();
-        expect(timeoutError).to.be.instanceOf(MongoError);
+        expect(timeoutError).to.be.instanceOf(MongoOperationTimeoutError);
         expect(end - start).to.be.within(300 - 100, 300 + 100);
       });
     });
@@ -183,7 +182,7 @@ describe('Client Bulk Write', function () {
 
           await setTimeout(250);
 
-          expect(await timeoutError).to.be.instanceOf(MongoError);
+          expect(await timeoutError).to.be.instanceOf(MongoOperationTimeoutError);
           expect(end - start).to.be.within(200 - 100, 200 + 100);
         });
 
@@ -222,7 +221,7 @@ describe('Client Bulk Write', function () {
 
             await setTimeout(210);
 
-            expect(await timeoutError).to.be.instanceOf(MongoError);
+            expect(await timeoutError).to.be.instanceOf(MongoOperationTimeoutError);
             expect(end - start).to.be.within(400 - 100, 400 + 100);
           }
         );
@@ -258,7 +257,7 @@ describe('Client Bulk Write', function () {
             )
             .catch(e => e);
           const end = now();
-          expect(timeoutError).to.be.instanceOf(MongoError);
+          expect(timeoutError).to.be.instanceOf(MongoOperationTimeoutError);
           expect(end - start).to.be.within(300 - 100, 300 + 100);
         });
       });
@@ -289,7 +288,7 @@ describe('Client Bulk Write', function () {
             .catch(e => e);
 
           const end = now();
-          expect(timeoutError).to.be.instanceOf(MongoError);
+          expect(timeoutError).to.be.instanceOf(MongoOperationTimeoutError);
 
           // DRIVERS-3005 - killCursors causes cursor cleanup to extend past timeoutMS.
           expect(end - start).to.be.within(2000 - 100, 2000 + 100);
@@ -372,7 +371,7 @@ describe('Client Bulk Write', function () {
               .catch(e => e);
 
             const end = now();
-            expect(timeoutError).to.be.instanceOf(MongoError);
+            expect(timeoutError).to.be.instanceOf(MongoOperationTimeoutError);
             expect(end - start).to.be.within(2000 - 100, 2000 + 100);
             expect(commands.length, 'Test must execute two batches.').to.equal(2);
           }

--- a/test/integration/crud/client_bulk_write.test.ts
+++ b/test/integration/crud/client_bulk_write.test.ts
@@ -292,8 +292,8 @@ describe('Client Bulk Write', function () {
 
           // DRIVERS-3005 - killCursors causes cursor cleanup to extend past timeoutMS.
           // The amount of time killCursors takes is wildly variable and can take up to almost
-          // 500ms sometimes.
-          expect(end - start).to.be.within(1500, 1500 + 600);
+          // 600-700ms sometimes.
+          expect(end - start).to.be.within(1500, 1500 + 800);
           expect(commands).to.have.lengthOf(1);
         });
       });

--- a/test/integration/crud/client_bulk_write.test.ts
+++ b/test/integration/crud/client_bulk_write.test.ts
@@ -298,7 +298,7 @@ describe('Client Bulk Write', function () {
         });
       });
 
-      describe('if the cursor encounters and error and a killCursors is sent', function () {
+      describe('if the cursor encounters an error and a killCursors is sent', function () {
         const commands: CommandStartedEvent[] = [];
 
         beforeEach(async function () {

--- a/test/tools/runner/config.ts
+++ b/test/tools/runner/config.ts
@@ -7,6 +7,7 @@ import {
   type AuthMechanism,
   HostAddress,
   MongoClient,
+  type MongoClientOptions,
   type ServerApi,
   TopologyType,
   type WriteConcernSettings
@@ -82,7 +83,7 @@ export class TestConfiguration {
     auth?: { username: string; password: string; authSource?: string };
     proxyURIParams?: ProxyParams;
   };
-  serverApi: ServerApi;
+  serverApi?: ServerApi;
   activeResources: number;
   isSrv: boolean;
   serverlessCredentials: { username: string | undefined; password: string | undefined };
@@ -171,13 +172,34 @@ export class TestConfiguration {
     return this.options.replicaSet;
   }
 
+  /**
+   * Returns a `hello`, executed against `uri`.
+   */
+  async hello(uri = this.uri) {
+    const client = this.newClient(uri);
+    try {
+      await client.connect();
+      const { maxBsonObjectSize, maxMessageSizeBytes, maxWriteBatchSize, ...rest } = await client
+        .db('admin')
+        .command({ hello: 1 });
+      return {
+        maxBsonObjectSize,
+        maxMessageSizeBytes,
+        maxWriteBatchSize,
+        ...rest
+      };
+    } finally {
+      await client.close();
+    }
+  }
+
   isOIDC(uri: string, env: string): boolean {
     if (!uri) return false;
     return uri.indexOf('MONGODB-OIDC') > -1 && uri.indexOf(`ENVIRONMENT:${env}`) > -1;
   }
 
-  newClient(urlOrQueryOptions?: string | Record<string, any>, serverOptions?: Record<string, any>) {
-    serverOptions = Object.assign({}, getEnvironmentalOptions(), serverOptions);
+  newClient(urlOrQueryOptions?: string | Record<string, any>, serverOptions?: MongoClientOptions) {
+    serverOptions = Object.assign(<MongoClientOptions>{}, getEnvironmentalOptions(), serverOptions);
 
     // Support MongoClient constructor form (url, options) for `newClient`.
     if (typeof urlOrQueryOptions === 'string') {


### PR DESCRIPTION
### Description

#### What is changing?

This PR adds support for CSOT to the client bulk write API.

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
