### PR TITLE
test(NODE-6184): sync CRUD spec tests

### DIFF
--- a/test/spec/crud/unified/aggregate-write-readPreference.json
+++ b/test/spec/crud/unified/aggregate-write-readPreference.json
@@ -78,11 +78,6 @@
           "x": 33
         }
       ]
-    },
-    {
-      "collectionName": "coll1",
-      "databaseName": "db0",
-      "documents": []
     }
   ],
   "tests": [
@@ -159,22 +154,6 @@
             }
           ]
         }
-      ],
-      "outcome": [
-        {
-          "collectionName": "coll1",
-          "databaseName": "db0",
-          "documents": [
-            {
-              "_id": 2,
-              "x": 22
-            },
-            {
-              "_id": 3,
-              "x": 33
-            }
-          ]
-        }
       ]
     },
     {
@@ -247,22 +226,6 @@
                   }
                 }
               }
-            }
-          ]
-        }
-      ],
-      "outcome": [
-        {
-          "collectionName": "coll1",
-          "databaseName": "db0",
-          "documents": [
-            {
-              "_id": 2,
-              "x": 22
-            },
-            {
-              "_id": 3,
-              "x": 33
             }
           ]
         }
@@ -344,22 +307,6 @@
             }
           ]
         }
-      ],
-      "outcome": [
-        {
-          "collectionName": "coll1",
-          "databaseName": "db0",
-          "documents": [
-            {
-              "_id": 2,
-              "x": 22
-            },
-            {
-              "_id": 3,
-              "x": 33
-            }
-          ]
-        }
       ]
     },
     {
@@ -435,22 +382,6 @@
                   }
                 }
               }
-            }
-          ]
-        }
-      ],
-      "outcome": [
-        {
-          "collectionName": "coll1",
-          "databaseName": "db0",
-          "documents": [
-            {
-              "_id": 2,
-              "x": 22
-            },
-            {
-              "_id": 3,
-              "x": 33
             }
           ]
         }

--- a/test/spec/crud/unified/aggregate-write-readPreference.yml
+++ b/test/spec/crud/unified/aggregate-write-readPreference.yml
@@ -51,9 +51,6 @@ initialData:
       - { _id: 1, x: 11 }
       - { _id: 2, x: 22 }
       - { _id: 3, x: 33 }
-  - collectionName: *collection1Name
-    databaseName: *database0Name
-    documents: []
 
 tests:
   - description: "Aggregate with $out includes read preference for 5.0+ server"
@@ -78,12 +75,6 @@ tests:
                 $readPreference: *readPreference
                 readConcern: *readConcern
                 writeConcern: *writeConcern
-    outcome: &outcome
-      - collectionName: *collection1Name
-        databaseName: *database0Name
-        documents:
-          - { _id: 2, x: 22 }
-          - { _id: 3, x: 33 }
 
   - description: "Aggregate with $out omits read preference for pre-5.0 server"
     runOnRequirements:
@@ -108,7 +99,6 @@ tests:
                 $readPreference: { $$exists: false }
                 readConcern: *readConcern
                 writeConcern: *writeConcern
-    outcome: *outcome
 
   - description: "Aggregate with $merge includes read preference for 5.0+ server"
     runOnRequirements:
@@ -131,7 +121,6 @@ tests:
                 $readPreference: *readPreference
                 readConcern: *readConcern
                 writeConcern: *writeConcern
-    outcome: *outcome
 
   - description: "Aggregate with $merge omits read preference for pre-5.0 server"
     runOnRequirements:
@@ -152,4 +141,3 @@ tests:
                 $readPreference: { $$exists: false }
                 readConcern: *readConcern
                 writeConcern: *writeConcern
-    outcome: *outcome

--- a/test/spec/crud/unified/db-aggregate-write-readPreference.json
+++ b/test/spec/crud/unified/db-aggregate-write-readPreference.json
@@ -52,13 +52,6 @@
       }
     }
   ],
-  "initialData": [
-    {
-      "collectionName": "coll0",
-      "databaseName": "db0",
-      "documents": []
-    }
-  ],
   "tests": [
     {
       "description": "Database-level aggregate with $out includes read preference for 5.0+ server",
@@ -138,17 +131,6 @@
                   }
                 }
               }
-            }
-          ]
-        }
-      ],
-      "outcome": [
-        {
-          "collectionName": "coll0",
-          "databaseName": "db0",
-          "documents": [
-            {
-              "_id": 1
             }
           ]
         }
@@ -232,17 +214,6 @@
                   }
                 }
               }
-            }
-          ]
-        }
-      ],
-      "outcome": [
-        {
-          "collectionName": "coll0",
-          "databaseName": "db0",
-          "documents": [
-            {
-              "_id": 1
             }
           ]
         }
@@ -332,17 +303,6 @@
             }
           ]
         }
-      ],
-      "outcome": [
-        {
-          "collectionName": "coll0",
-          "databaseName": "db0",
-          "documents": [
-            {
-              "_id": 1
-            }
-          ]
-        }
       ]
     },
     {
@@ -426,17 +386,6 @@
                   }
                 }
               }
-            }
-          ]
-        }
-      ],
-      "outcome": [
-        {
-          "collectionName": "coll0",
-          "databaseName": "db0",
-          "documents": [
-            {
-              "_id": 1
             }
           ]
         }

--- a/test/spec/crud/unified/db-aggregate-write-readPreference.yml
+++ b/test/spec/crud/unified/db-aggregate-write-readPreference.yml
@@ -43,11 +43,6 @@ createEntities:
       database: *database0
       collectionName: &collection0Name coll0
 
-initialData:
-  - collectionName: *collection0Name
-    databaseName: *database0Name
-    documents: []
-
 tests:
   - description: "Database-level aggregate with $out includes read preference for 5.0+ server"
     runOnRequirements:
@@ -73,11 +68,6 @@ tests:
                 $readPreference: *readPreference
                 readConcern: *readConcern
                 writeConcern: *writeConcern
-    outcome: &outcome
-      - collectionName: *collection0Name
-        databaseName: *database0Name
-        documents:
-          - { _id: 1 }
 
   - description: "Database-level aggregate with $out omits read preference for pre-5.0 server"
     runOnRequirements:
@@ -102,7 +92,6 @@ tests:
                 $readPreference: { $$exists: false }
                 readConcern: *readConcern
                 writeConcern: *writeConcern
-    outcome: *outcome
 
   - description: "Database-level aggregate with $merge includes read preference for 5.0+ server"
     runOnRequirements:
@@ -127,7 +116,6 @@ tests:
                 $readPreference: *readPreference
                 readConcern: *readConcern
                 writeConcern: *writeConcern
-    outcome: *outcome
 
   - description: "Database-level aggregate with $merge omits read preference for pre-5.0 server"
     runOnRequirements:
@@ -148,4 +136,3 @@ tests:
                 $readPreference: { $$exists: false }
                 readConcern: *readConcern
                 writeConcern: *writeConcern
-    outcome: *outcome


### PR DESCRIPTION
### Description
NODE-6184 / DRIVERS-2914

#### What is changing?
Syncing crud/db-aggregate-write-readPreference and crud/aggregate-write-readPreference spec tests to latest spec (DRIVERS-2914).

##### Is there new documentation needed for these changes?
N/A

#### What is the motivation for this change?
Keeping up with spec test changes, avoiding potential race condition.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
