### PR TITLE
fix(NODE-6418): change stream resumes infinitely after failed aggregates

### DIFF
--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -946,7 +946,7 @@ export class ChangeStream<
     // If the change stream has been closed explicitly, do not process error.
     if (this[kClosed]) return;
 
-    if (isResumableError(changeStreamError, this.cursor.maxWireVersion)) {
+    if (this.cursor.id != null && isResumableError(changeStreamError, this.cursor.maxWireVersion)) {
       this._endStream();
 
       this.cursor.close().then(undefined, squashError);
@@ -975,7 +975,10 @@ export class ChangeStream<
       throw new MongoAPIError(CHANGESTREAM_CLOSED_ERROR);
     }
 
-    if (!isResumableError(changeStreamError, this.cursor.maxWireVersion)) {
+    if (
+      this.cursor.id == null ||
+      !isResumableError(changeStreamError, this.cursor.maxWireVersion)
+    ) {
       try {
         await this.close();
       } catch (error) {

--- a/test/integration/change-streams/change_stream.test.ts
+++ b/test/integration/change-streams/change_stream.test.ts
@@ -2661,6 +2661,7 @@ describe('ChangeStream resumability', function () {
               for await (const change of changeStream) {
                 expect.fail('Change stream produced events on an unresumable error');
               }
+              expect.fail('Change stream did not iterate and did not throw an error');
             } catch (error) {
               expect(error).to.be.instanceOf(MongoServerError);
               expect(aggregateEvents).to.have.lengthOf(2);

--- a/test/integration/change-streams/change_streams.prose.test.ts
+++ b/test/integration/change-streams/change_streams.prose.test.ts
@@ -1,5 +1,3 @@
-import { promisify } from 'node:util';
-
 import { expect } from 'chai';
 import { once } from 'events';
 import * as sinon from 'sinon';


### PR DESCRIPTION
### Description

#### What is changing?
* `changeStream` iteration methods now throw when the `aggregate` command that establishes the change stream on the server side fails

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Change stream infinite resume bug fixed
Before this fix, when change streams would fail to establish a cursor on the server, the driver would infinitely attempt to resume the change stream. Now, when the aggregate to establish the change stream fails, the driver will throw an error and clos the change stream.


<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [X] Ran `npm run check:lint` script
- [X] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [X] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [X] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
