### PR TITLE
feat(NODE-6421): add support for timeoutMS to explain helpers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "mocha": "^10.4.0",
         "mocha-sinon": "^2.1.2",
         "mongodb-client-encryption": "^6.1.0",
-        "mongodb-legacy": "^6.1.2",
+        "mongodb-legacy": "^6.1.3",
         "nyc": "^15.1.0",
         "prettier": "^3.3.3",
         "semver": "^7.6.3",
@@ -6440,11 +6440,10 @@
       }
     },
     "node_modules/mongodb-legacy": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/mongodb-legacy/-/mongodb-legacy-6.1.2.tgz",
-      "integrity": "sha512-oj+LLtvhhi8XuAQ8dll2BVjrnKxOo/7ylyQu0LsKmzyGcbrvzcyvFUOLC6rPhuJPOvnezh3MZ3/Sk9Tl1jpUpg==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/mongodb-legacy/-/mongodb-legacy-6.1.3.tgz",
+      "integrity": "sha512-XJ2PIbVEHUUF4/SyH00dfeprfeLOdWiHcKq8At+JoEZeTue+IAG39G2ixRwClnI7roPb/46K8IF713v9dgQ8rg==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "mongodb": "^6.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "mocha": "^10.4.0",
     "mocha-sinon": "^2.1.2",
     "mongodb-client-encryption": "^6.1.0",
-    "mongodb-legacy": "^6.1.2",
+    "mongodb-legacy": "^6.1.3",
     "nyc": "^15.1.0",
     "prettier": "^3.3.3",
     "semver": "^7.6.3",

--- a/src/cursor/aggregation_cursor.ts
+++ b/src/cursor/aggregation_cursor.ts
@@ -1,6 +1,11 @@
 import type { Document } from '../bson';
 import { MongoAPIError } from '../error';
-import type { ExplainCommandOptions, ExplainVerbosityLike } from '../explain';
+import {
+  Explain,
+  type ExplainCommandOptions,
+  type ExplainVerbosityLike,
+  validateExplainTimeoutOptions
+} from '../explain';
 import type { MongoClient } from '../mongo_client';
 import { AggregateOperation, type AggregateOptions } from '../operations/aggregate';
 import { executeOperation } from '../operations/execute_operation';
@@ -65,11 +70,20 @@ export class AggregationCursor<TSchema = any> extends AbstractCursor<TSchema> {
 
   /** @internal */
   async _initialize(session: ClientSession): Promise<InitialCursorResponse> {
-    const aggregateOperation = new AggregateOperation(this.namespace, this.pipeline, {
+    const options = {
       ...this.aggregateOptions,
       ...this.cursorOptions,
       session
-    });
+    };
+    try {
+      validateExplainTimeoutOptions(options, Explain.fromOptions(options));
+    } catch {
+      throw new MongoAPIError(
+        'timeoutMS cannot be used with explain when explain is specified in aggregateOptions'
+      );
+    }
+
+    const aggregateOperation = new AggregateOperation(this.namespace, this.pipeline, options);
 
     const response = await executeOperation(this.client, aggregateOperation, this.timeoutContext);
 
@@ -77,14 +91,45 @@ export class AggregationCursor<TSchema = any> extends AbstractCursor<TSchema> {
   }
 
   /** Execute the explain for the cursor */
-  async explain(verbosity?: ExplainVerbosityLike | ExplainCommandOptions): Promise<Document> {
+  async explain(): Promise<Document>;
+  async explain(verbosity: ExplainVerbosityLike | ExplainCommandOptions): Promise<Document>;
+  async explain(options: { timeoutMS?: number }): Promise<Document>;
+  async explain(
+    verbosity: ExplainVerbosityLike | ExplainCommandOptions,
+    options: { timeoutMS?: number }
+  ): Promise<Document>;
+  async explain(
+    verbosity?: ExplainVerbosityLike | ExplainCommandOptions | { timeoutMS?: number },
+    options?: { timeoutMS?: number }
+  ): Promise<Document> {
+    let explain: ExplainVerbosityLike | ExplainCommandOptions | undefined;
+    let timeout: { timeoutMS?: number } | undefined;
+    if (verbosity == null && options == null) {
+      explain = true;
+      timeout = undefined;
+    } else if (verbosity != null && options == null) {
+      explain =
+        typeof verbosity !== 'object'
+          ? verbosity
+          : 'verbosity' in verbosity
+            ? verbosity
+            : undefined;
+
+      timeout = typeof verbosity === 'object' && 'timeoutMS' in verbosity ? verbosity : undefined;
+    } else {
+      // @ts-expect-error TS isn't smart enough to determine that if both options are provided, the first is explain options
+      explain = verbosity;
+      timeout = options;
+    }
+
     return (
       await executeOperation(
         this.client,
         new AggregateOperation(this.namespace, this.pipeline, {
           ...this.aggregateOptions, // NOTE: order matters here, we may need to refine this
           ...this.cursorOptions,
-          explain: verbosity ?? true
+          ...timeout,
+          explain: explain ?? true
         })
       )
     ).shift(this.deserializationOptions);

--- a/src/explain.ts
+++ b/src/explain.ts
@@ -1,5 +1,6 @@
 import { type Document } from 'bson';
 
+import { AbstractCursor } from './cursor/abstract_cursor';
 import { MongoAPIError } from './error';
 
 /** @public */
@@ -122,4 +123,52 @@ export function decorateWithExplain(
   }
 
   return baseCommand;
+}
+
+/**
+ * @public
+ *
+ * A base class for any cursors that have `explain()` methods.
+ */
+export abstract class ExplainableCursor<TSchema> extends AbstractCursor<TSchema> {
+  /** Execute the explain for the cursor */
+  abstract explain(): Promise<Document>;
+  abstract explain(verbosity: ExplainVerbosityLike | ExplainCommandOptions): Promise<Document>;
+  abstract explain(options: { timeoutMS?: number }): Promise<Document>;
+  abstract explain(
+    verbosity: ExplainVerbosityLike | ExplainCommandOptions,
+    options: { timeoutMS?: number }
+  ): Promise<Document>;
+  abstract explain(
+    verbosity?: ExplainVerbosityLike | ExplainCommandOptions | { timeoutMS?: number },
+    options?: { timeoutMS?: number }
+  ): Promise<Document>;
+
+  protected resolveExplainTimeoutOptions(
+    verbosity?: ExplainVerbosityLike | ExplainCommandOptions | { timeoutMS?: number },
+    options?: { timeoutMS?: number }
+  ): { timeout?: { timeoutMS?: number }; explain?: ExplainVerbosityLike | ExplainCommandOptions } {
+    let explain: ExplainVerbosityLike | ExplainCommandOptions | undefined;
+    let timeout: { timeoutMS?: number } | undefined;
+
+    if (verbosity == null && options == null) {
+      explain = undefined;
+      timeout = undefined;
+    } else if (verbosity != null && options == null) {
+      explain =
+        typeof verbosity !== 'object'
+          ? verbosity
+          : 'verbosity' in verbosity
+            ? verbosity
+            : undefined;
+
+      timeout = typeof verbosity === 'object' && 'timeoutMS' in verbosity ? verbosity : undefined;
+    } else {
+      // @ts-expect-error TS isn't smart enough to determine that if both options are provided, the first is explain options
+      explain = verbosity;
+      timeout = options;
+    }
+
+    return { timeout, explain };
+  }
 }

--- a/src/explain.ts
+++ b/src/explain.ts
@@ -1,5 +1,4 @@
-import { type Document } from 'bson';
-
+import { type Document } from './bson';
 import { AbstractCursor } from './cursor/abstract_cursor';
 import { MongoAPIError } from './error';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import { ListCollectionsCursor } from './cursor/list_collections_cursor';
 import { ListIndexesCursor } from './cursor/list_indexes_cursor';
 import type { RunCommandCursor } from './cursor/run_command_cursor';
 import { Db } from './db';
+import { ExplainableCursor } from './explain';
 import { GridFSBucket } from './gridfs';
 import { GridFSBucketReadStream } from './gridfs/download';
 import { GridFSBucketWriteStream } from './gridfs/upload';
@@ -91,6 +92,7 @@ export {
   ClientSession,
   Collection,
   Db,
+  ExplainableCursor,
   FindCursor,
   GridFSBucket,
   GridFSBucketReadStream,

--- a/src/operations/command.ts
+++ b/src/operations/command.ts
@@ -1,19 +1,19 @@
 import type { BSONSerializeOptions, Document } from '../bson';
 import { type MongoDBResponseConstructor } from '../cmap/wire_protocol/responses';
 import { MongoInvalidArgumentError } from '../error';
-import { Explain, type ExplainOptions } from '../explain';
+import {
+  decorateWithExplain,
+  Explain,
+  type ExplainOptions,
+  validateExplainTimeoutOptions
+} from '../explain';
 import { ReadConcern } from '../read_concern';
 import type { ReadPreference } from '../read_preference';
 import type { Server } from '../sdam/server';
 import { MIN_SECONDARY_WRITE_WIRE_VERSION } from '../sdam/server_selection';
 import type { ClientSession } from '../sessions';
 import { type TimeoutContext } from '../timeout';
-import {
-  commandSupportsReadConcern,
-  decorateWithExplain,
-  maxWireVersion,
-  MongoDBNamespace
-} from '../utils';
+import { commandSupportsReadConcern, maxWireVersion, MongoDBNamespace } from '../utils';
 import { WriteConcern, type WriteConcernOptions } from '../write_concern';
 import type { ReadConcernLike } from './../read_concern';
 import { AbstractOperation, Aspect, type OperationOptions } from './operation';
@@ -97,6 +97,7 @@ export abstract class CommandOperation<T> extends AbstractOperation<T> {
 
     if (this.hasAspect(Aspect.EXPLAINABLE)) {
       this.explain = Explain.fromOptions(options);
+      validateExplainTimeoutOptions(this.options, this.explain);
     } else if (options?.explain != null) {
       throw new MongoInvalidArgumentError(`Option "explain" is not supported on this command`);
     }

--- a/src/operations/find.ts
+++ b/src/operations/find.ts
@@ -2,13 +2,17 @@ import type { Document } from '../bson';
 import { CursorResponse, ExplainedCursorResponse } from '../cmap/wire_protocol/responses';
 import { type AbstractCursorOptions, type CursorTimeoutMode } from '../cursor/abstract_cursor';
 import { MongoInvalidArgumentError } from '../error';
-import { type ExplainOptions } from '../explain';
+import {
+  decorateWithExplain,
+  type ExplainOptions,
+  validateExplainTimeoutOptions
+} from '../explain';
 import { ReadConcern } from '../read_concern';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
 import { formatSort, type Sort } from '../sort';
 import { type TimeoutContext } from '../timeout';
-import { decorateWithExplain, type MongoDBNamespace, normalizeHintField } from '../utils';
+import { type MongoDBNamespace, normalizeHintField } from '../utils';
 import { type CollationOptions, CommandOperation, type CommandOperationOptions } from './command';
 import { Aspect, defineAspects, type Hint } from './operation';
 
@@ -119,6 +123,7 @@ export class FindOperation extends CommandOperation<CursorResponse> {
 
     let findCommand = makeFindCommand(this.ns, this.filter, options);
     if (this.explain) {
+      validateExplainTimeoutOptions(this.options, this.explain);
       findCommand = decorateWithExplain(findCommand, this.explain);
     }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -25,7 +25,6 @@ import {
   MongoParseError,
   MongoRuntimeError
 } from './error';
-import type { Explain, ExplainVerbosity } from './explain';
 import type { MongoClient } from './mongo_client';
 import type { CommandOperationOptions, OperationParent } from './operations/command';
 import type { Hint, OperationOptions } from './operations/operation';
@@ -243,32 +242,6 @@ export function decorateWithReadConcern(
   if (Object.keys(readConcern).length > 0) {
     Object.assign(command, { readConcern: readConcern });
   }
-}
-
-/**
- * Applies an explain to a given command.
- * @internal
- *
- * @param command - the command on which to apply the explain
- * @param options - the options containing the explain verbosity
- */
-export function decorateWithExplain(
-  command: Document,
-  explain: Explain
-): {
-  explain: Document;
-  verbosity: ExplainVerbosity;
-  maxTimeMS?: number;
-} {
-  type ExplainCommand = ReturnType<typeof decorateWithExplain>;
-  const { verbosity, maxTimeMS } = explain;
-  const baseCommand: ExplainCommand = { explain: command, verbosity };
-
-  if (typeof maxTimeMS === 'number') {
-    baseCommand.maxTimeMS = maxTimeMS;
-  }
-
-  return baseCommand;
 }
 
 /**

--- a/test/integration/crud/explain.test.ts
+++ b/test/integration/crud/explain.test.ts
@@ -5,9 +5,13 @@ import {
   type Collection,
   type CommandStartedEvent,
   type Db,
+  type Document,
   type MongoClient,
-  MongoServerError
+  MongoOperationTimeoutError,
+  MongoServerError,
+  squashError
 } from '../../mongodb';
+import { clearFailPoint, configureFailPoint, measureDuration } from '../../tools/utils';
 import { filterForCommands } from '../shared';
 
 const explain = [true, false, 'queryPlanner', 'allPlansExecution', 'executionStats', 'invalid'];
@@ -295,6 +299,411 @@ describe('CRUD API explain option', function () {
         expect(explain).not.to.have.property('maxTimeMS');
       };
     }
+  });
+
+  describe('explain with timeoutMS', function () {
+    let client: MongoClient;
+    type ExplainStartedEvent = CommandStartedEvent & {
+      command: { explain: Document & { maxTimeMS?: number }; maxTimeMS?: number };
+    };
+    const commands: ExplainStartedEvent[] = [];
+
+    describe('Explain helpers respect timeoutMS', function () {
+      afterEach(async function () {
+        await clearFailPoint(
+          this.configuration,
+          this.configuration.url({ useMultipleMongoses: false })
+        );
+      });
+
+      beforeEach(async function () {
+        const uri = this.configuration.url({ useMultipleMongoses: false });
+        await configureFailPoint(
+          this.configuration,
+          {
+            configureFailPoint: 'failCommand',
+            mode: 'alwaysOn',
+            data: {
+              failCommands: ['explain'],
+              blockConnection: true,
+              blockTimeMS: 2000
+            }
+          },
+          this.configuration.url({ useMultipleMongoses: false })
+        );
+
+        client = this.configuration.newClient(uri, { monitorCommands: true });
+        client.on('commandStarted', filterForCommands('explain', commands));
+        await client.connect();
+      });
+
+      afterEach(async function () {
+        await client?.close();
+        commands.length = 0;
+      });
+
+      describe('when a cursor api is being explained', function () {
+        describe('when timeoutMS is provided', function () {
+          it(
+            'the explain command times out after timeoutMS',
+            { requires: { mongodb: '>=4.4' } },
+            async function () {
+              const cursor = client.db('foo').collection('bar').find({}, { timeoutMS: 1000 });
+              const { duration, result } = await measureDuration(() =>
+                cursor.explain({ verbosity: 'queryPlanner' }).catch(e => e)
+              );
+
+              expect(result).to.be.instanceOf(MongoOperationTimeoutError);
+              expect(duration).to.be.within(1000 - 100, 1000 + 100);
+            }
+          );
+
+          it(
+            'the explain command has the calculated maxTimeMS value attached',
+            { requires: { mongodb: '>=4.4' } },
+            async function () {
+              const cursor = client.db('foo').collection('bar').find({}, { timeoutMS: 1000 });
+              const timeout = await cursor.explain({ verbosity: 'queryPlanner' }).catch(e => e);
+              expect(timeout).to.be.instanceOf(MongoOperationTimeoutError);
+
+              const [
+                {
+                  command: { maxTimeMS }
+                }
+              ] = commands;
+
+              expect(maxTimeMS).to.be.a('number');
+            }
+          );
+
+          it(
+            'the explained command does not have a maxTimeMS value attached',
+            { requires: { mongodb: '>=4.4' } },
+            async function () {
+              const cursor = client.db('foo').collection('bar').find({}, { timeoutMS: 1000 });
+              const timeout = await cursor.explain({ verbosity: 'queryPlanner' }).catch(e => e);
+              expect(timeout).to.be.instanceOf(MongoOperationTimeoutError);
+
+              const [
+                {
+                  command: {
+                    explain: { maxTimeMS }
+                  }
+                }
+              ] = commands;
+
+              expect(maxTimeMS).not.to.exist;
+            }
+          );
+        });
+
+        describe('when timeoutMS and maxTimeMS are both provided', function () {
+          it(
+            'an error is thrown indicating incompatibility of those options',
+            { requires: { mongodb: '>=4.4' } },
+            async function () {
+              const cursor = client.db('foo').collection('bar').find({}, { timeoutMS: 1000 });
+              const error = await cursor
+                .explain({ verbosity: 'queryPlanner', maxTimeMS: 1000 })
+                .catch(e => e);
+              expect(error).to.match(/Cannot use maxTimeMS with timeoutMS for explain commands/);
+            }
+          );
+        });
+      });
+
+      describe('when a non-cursor api is being explained', function () {
+        describe('when timeoutMS is provided', function () {
+          it(
+            'the explain command times out after timeoutMS',
+            { requires: { mongodb: '>=4.4' } },
+            async function () {
+              const { duration, result } = await measureDuration(() =>
+                client
+                  .db('foo')
+                  .collection('bar')
+                  .deleteMany(
+                    {},
+                    {
+                      timeoutMS: 1000,
+                      explain: { verbosity: 'queryPlanner' }
+                    }
+                  )
+                  .catch(e => e)
+              );
+
+              expect(result).to.be.instanceOf(MongoOperationTimeoutError);
+              expect(duration).to.be.within(1000 - 100, 1000 + 100);
+            }
+          );
+
+          it(
+            'the explain command has the calculated maxTimeMS value attached',
+            { requires: { mongodb: '>=4.4' } },
+            async function () {
+              const timeout = await client
+                .db('foo')
+                .collection('bar')
+                .deleteMany(
+                  {},
+                  {
+                    timeoutMS: 1000,
+                    explain: { verbosity: 'queryPlanner' }
+                  }
+                )
+                .catch(e => e);
+
+              expect(timeout).to.be.instanceOf(MongoOperationTimeoutError);
+
+              const [
+                {
+                  command: { maxTimeMS }
+                }
+              ] = commands;
+
+              expect(maxTimeMS).to.be.a('number');
+            }
+          );
+
+          it(
+            'the explained command does not have a maxTimeMS value attached',
+            { requires: { mongodb: '>=4.4' } },
+            async function () {
+              const timeout = await client
+                .db('foo')
+                .collection('bar')
+                .deleteMany(
+                  {},
+                  {
+                    timeoutMS: 1000,
+                    explain: { verbosity: 'queryPlanner' }
+                  }
+                )
+                .catch(e => e);
+
+              expect(timeout).to.be.instanceOf(MongoOperationTimeoutError);
+
+              const [
+                {
+                  command: {
+                    explain: { maxTimeMS }
+                  }
+                }
+              ] = commands;
+
+              expect(maxTimeMS).not.to.exist;
+            }
+          );
+        });
+
+        describe('when timeoutMS and maxTimeMS are both provided', function () {
+          it(
+            'an error is thrown indicating incompatibility of those options',
+            { requires: { mongodb: '>=4.4' } },
+            async function () {
+              const error = await client
+                .db('foo')
+                .collection('bar')
+                .deleteMany(
+                  {},
+                  {
+                    timeoutMS: 1000,
+                    explain: { verbosity: 'queryPlanner', maxTimeMS: 1000 }
+                  }
+                )
+                .catch(e => e);
+
+              expect(error).to.match(/Cannot use maxTimeMS with timeoutMS for explain commands/);
+            }
+          );
+        });
+      });
+
+      describe('when find({}, { explain: ...}) is used with timeoutMS', function () {
+        it(
+          'an error is thrown indicating that explain is not supported with timeoutMS for this API',
+          { requires: { mongodb: '>=4.4' } },
+          async function () {
+            const error = await client
+              .db('foo')
+              .collection('bar')
+              .find(
+                {},
+                {
+                  timeoutMS: 1000,
+                  explain: { verbosity: 'queryPlanner', maxTimeMS: 1000 }
+                }
+              )
+              .toArray()
+              .catch(e => e);
+
+            expect(error).to.match(
+              /timeoutMS cannot be used with explain when explain is specified in findOptions/
+            );
+          }
+        );
+      });
+
+      describe('when aggregate({}, { explain: ...}) is used with timeoutMS', function () {
+        it(
+          'an error is thrown indicating that explain is not supported with timeoutMS for this API',
+          { requires: { mongodb: '>=4.4' } },
+          async function () {
+            const error = await client
+              .db('foo')
+              .collection('bar')
+              .aggregate([], {
+                timeoutMS: 1000,
+                explain: { verbosity: 'queryPlanner', maxTimeMS: 1000 }
+              })
+              .toArray()
+              .catch(e => e);
+
+            expect(error).to.match(
+              /timeoutMS cannot be used with explain when explain is specified in aggregateOptions/
+            );
+          }
+        );
+      });
+    });
+
+    describe('fluent api timeoutMS precedence and inheritance', function () {
+      beforeEach(async function () {
+        client = this.configuration.newClient({}, { monitorCommands: true });
+        client.on('commandStarted', filterForCommands('explain', commands));
+        await client.connect();
+        await client.db('foo').dropDatabase().catch(squashError);
+        await client.db('foo').createCollection('bar');
+      });
+
+      afterEach(async function () {
+        await client?.close();
+        commands.length = 0;
+      });
+
+      /**
+       * The tests in this section test that timeoutMS is respected by asserting that when specified,
+       * maxTimeMS is set on the explain command.  That should only ever be true when timeoutMS is
+       * set, but if that is true when timeoutMS is not set, that could cause these tests to pass
+       * erroneously.
+       *
+       * These tests assert that maxTimeMS is not present on commands when timeoutMS is not provided.
+       */
+      describe('precondition tests', function () {
+        beforeEach('find does not set maxTimeMS if timeoutMS is not set', async function () {
+          {
+            const cursor = client.db('foo').collection('bar').find();
+            await cursor.explain({ verbosity: 'queryPlanner' });
+
+            const [
+              {
+                command: { maxTimeMS }
+              }
+            ] = commands;
+            expect(maxTimeMS).not.to.exist;
+            commands.length = 0;
+          }
+        });
+
+        beforeEach('aggregate does not set maxTimeMS if timeoutMS is not set', async function () {
+          {
+            const cursor = client.db('foo').collection('bar').aggregate([]);
+            await cursor.explain({ verbosity: 'queryPlanner' });
+
+            const [
+              {
+                command: { maxTimeMS }
+              }
+            ] = commands;
+            expect(maxTimeMS).not.to.exist;
+            commands.length = 0;
+          }
+        });
+      });
+
+      describe('find({}, { timeoutMS }).explain()', function () {
+        it('respects the timeoutMS from the find options', async function () {
+          const cursor = client.db('foo').collection('bar').find({}, { timeoutMS: 800 });
+          await cursor.explain({ verbosity: 'queryPlanner' });
+
+          const [
+            {
+              command: { maxTimeMS }
+            }
+          ] = commands;
+          expect(maxTimeMS).to.exist;
+        });
+      });
+
+      describe('find().explain({}, { timeoutMS })', function () {
+        it('respects the timeoutMS from the explain helper', async function () {
+          const cursor = client.db('foo').collection('bar').find();
+          await cursor.explain({ verbosity: 'queryPlanner' }, { timeoutMS: 800 });
+
+          const [
+            {
+              command: { maxTimeMS }
+            }
+          ] = commands;
+          expect(maxTimeMS).to.exist;
+        });
+      });
+
+      describe('find({}, { timeoutMS} ).explain({}, { timeoutMS })', function () {
+        it('the timeoutMS from the explain helper has precedence', async function () {
+          const cursor = client.db('foo').collection('bar').find({}, { timeoutMS: 100 });
+          await cursor.explain({ verbosity: 'queryPlanner' }, { timeoutMS: 800 });
+          const [
+            {
+              command: { maxTimeMS }
+            }
+          ] = commands;
+          expect(maxTimeMS).to.exist;
+          expect(maxTimeMS).to.be.greaterThan(100);
+        });
+      });
+
+      describe('aggregate([], { timeoutMS }).explain()', function () {
+        it('respects the timeoutMS from the find options', async function () {
+          const cursor = client.db('foo').collection('bar').aggregate([], { timeoutMS: 800 });
+          await cursor.explain({ verbosity: 'queryPlanner' });
+
+          const [
+            {
+              command: { maxTimeMS }
+            }
+          ] = commands;
+          expect(maxTimeMS).to.exist;
+        });
+      });
+
+      describe('aggregate([], { timeoutMS })', function () {
+        it('respects the timeoutMS from the explain helper', async function () {
+          const cursor = client.db('foo').collection('bar').aggregate();
+          await cursor.explain({ verbosity: 'queryPlanner' }, { timeoutMS: 800 });
+          const [
+            {
+              command: { maxTimeMS }
+            }
+          ] = commands;
+          expect(maxTimeMS).to.exist;
+        });
+      });
+
+      describe('aggregate([], { timeoutMS} ).explain({}, { timeoutMS })', function () {
+        it('the timeoutMS from the explain helper has precedence', async function () {
+          const cursor = client.db('foo').collection('bar').aggregate([], { timeoutMS: 100 });
+          await cursor.explain({ verbosity: 'queryPlanner' }, { timeoutMS: 800 });
+          const [
+            {
+              command: { maxTimeMS }
+            }
+          ] = commands;
+          expect(maxTimeMS).to.exist;
+          expect(maxTimeMS).to.be.greaterThan(100);
+        });
+      });
+    });
   });
 });
 

--- a/test/tools/runner/config.ts
+++ b/test/tools/runner/config.ts
@@ -199,7 +199,7 @@ export class TestConfiguration {
   }
 
   newClient(urlOrQueryOptions?: string | Record<string, any>, serverOptions?: MongoClientOptions) {
-    serverOptions = Object.assign(<MongoClientOptions>{}, getEnvironmentalOptions(), serverOptions);
+    serverOptions = Object.assign({}, getEnvironmentalOptions(), serverOptions);
 
     // Support MongoClient constructor form (url, options) for `newClient`.
     if (typeof urlOrQueryOptions === 'string') {
@@ -294,7 +294,23 @@ export class TestConfiguration {
    *
    * @param options - overrides and settings for URI generation
    */
-  url(options?: UrlOptions) {
+  url(
+    options?: UrlOptions & {
+      useMultipleMongoses?: boolean;
+      db?: string;
+      replicaSet?: string;
+      proxyURIParams?: ProxyParams;
+      username?: string;
+      password?: string;
+      auth?: {
+        username?: string;
+        password?: string;
+      };
+      authSource?: string;
+      authMechanism?: string;
+      authMechanismProperties?: Record<string, any>;
+    }
+  ) {
     options = {
       db: this.options.db,
       replicaSet: this.options.replicaSet,

--- a/test/tools/utils.ts
+++ b/test/tools/utils.ts
@@ -15,6 +15,7 @@ import {
   type Document,
   type HostAddress,
   MongoClient,
+  now,
   OP_MSG,
   Topology,
   type TopologyOptions
@@ -616,8 +617,8 @@ export async function configureFailPoint(
   }
 }
 
-export async function clearFailPoint(configuration: TestConfiguration, uri = configuration.url()) {
-  const utilClient = configuration.newClient(uri);
+export async function clearFailPoint(configuration: TestConfiguration, url = configuration.url()) {
+  const utilClient = configuration.newClient(url);
   await utilClient.connect();
 
   try {
@@ -668,4 +669,22 @@ export async function makeMultiResponseBatchModelArray(
   ];
 
   return models;
+}
+
+/**
+ * A utility to measure the duration of an async function.  This is intended to be used for CSOT
+ * testing, where we expect to timeout within a certain threshold and want to measure the duration
+ * of that operation.
+ */
+export async function measureDuration<T>(f: () => Promise<T>): Promise<{
+  duration: number;
+  result: T | Error;
+}> {
+  const start = now();
+  const result = await f().catch(e => e);
+  const end = now();
+  return {
+    duration: end - start,
+    result
+  };
 }

--- a/test/unit/index.test.ts
+++ b/test/unit/index.test.ts
@@ -54,6 +54,7 @@ const EXPECTED_EXPORTS = [
   'Decimal128',
   'Double',
   'ExplainVerbosity',
+  'ExplainableCursor',
   'FindCursor',
   'GridFSBucket',
   'GridFSBucketReadStream',


### PR DESCRIPTION
### Description

#### What is changing?

Explain helpers now support timeoutMS.

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Explain helpers support `timeoutMS`

Explain helpers support timeoutMS:

```typescript
await collection.deleteMany({}, { timeoutMS: 1_000, explain: true });
await collection.find().explain(
  { verbosity: 'queryPlanner' },
  { timeoutMS: 1_000 }
)
```

> [!NOTE] 
> Providing a `maxTimeMS` value with a `timeoutMS` value will throw errors.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
