### PR TITLE
feat(NODE-6069): OIDC k8s machine workflow

### DIFF
--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -1266,7 +1266,7 @@ tasks:
           args:
             - src/.evergreen/run-azure-kms-tests.sh
 
-  - name: "oidc-auth-test-k8s-latest"
+  - name: "oidc-auth-test-k8s-latest-eks"
     commands:
       - func: "install dependencies"
       - command: subprocess.exec
@@ -1280,9 +1280,13 @@ tasks:
             ENVIRONMENT: k8s
             K8S_VARIANT: eks
             SCRIPT: run-oidc-prose-tests.sh
-          include_expansions_in_env: ["DRIVERS_TOOLS", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN"]
+          include_expansions_in_env: ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN"]
           args:
             - .evergreen/run-oidc-tests-k8s.sh
+
+  - name: "oidc-auth-test-k8s-latest-eks"
+    commands:
+      - func: "install dependencies"
       - command: subprocess.exec
         type: test
         params:
@@ -1294,9 +1298,13 @@ tasks:
             ENVIRONMENT: k8s
             K8S_VARIANT: gke
             SCRIPT: run-oidc-prose-tests.sh
-          include_expansions_in_env: ["DRIVERS_TOOLS", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN"]
+          include_expansions_in_env: ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN"]
           args:
             - .evergreen/run-oidc-tests-k8s.sh
+    
+  - name: "oidc-auth-test-k8s-latest-aks"
+    commands:
+      - func: "install dependencies"
       - command: subprocess.exec
         type: test
         params:
@@ -1308,7 +1316,7 @@ tasks:
             ENVIRONMENT: k8s
             K8S_VARIANT: aks
             SCRIPT: run-oidc-prose-tests.sh
-          include_expansions_in_env: ["DRIVERS_TOOLS", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN"]
+          include_expansions_in_env: ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN"]
           args:
             - .evergreen/run-oidc-tests-k8s.sh
 
@@ -1542,7 +1550,9 @@ task_groups:
     setup_group_can_fail_task: true
     setup_group_timeout_secs: 1800
     tasks:
-      - oidc-auth-test-k8s-latest
+      - oidc-auth-test-k8s-latest-eks
+      - oidc-auth-test-k8s-latest-gke
+      - oidc-auth-test-k8s-latest-aks
 
   - name: testtestoidc_task_group
     setup_group:

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -1284,7 +1284,7 @@ tasks:
           args:
             - .evergreen/run-oidc-tests-k8s.sh
 
-  - name: "oidc-auth-test-k8s-latest-eks"
+  - name: "oidc-auth-test-k8s-latest-gke"
     commands:
       - func: "install dependencies"
       - command: subprocess.exec

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -1275,6 +1275,7 @@ tasks:
           working_dir: src
           binary: bash
           env:
+            DRIVERS_TOOLS: ${DRIVERS_TOOLS}
             PROJECT_DIRECTORY: ${PROJECT_DIRECTORY}
             ENVIRONMENT: k8s
             K8S_VARIANT: eks
@@ -1288,6 +1289,7 @@ tasks:
           working_dir: src
           binary: bash
           env:
+            DRIVERS_TOOLS: ${DRIVERS_TOOLS}
             PROJECT_DIRECTORY: ${PROJECT_DIRECTORY}
             ENVIRONMENT: k8s
             K8S_VARIANT: gke
@@ -1301,6 +1303,7 @@ tasks:
           working_dir: src
           binary: bash
           env:
+            DRIVERS_TOOLS: ${DRIVERS_TOOLS}
             PROJECT_DIRECTORY: ${PROJECT_DIRECTORY}
             ENVIRONMENT: k8s
             K8S_VARIANT: aks

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -1530,7 +1530,7 @@ task_groups:
     tasks:
       - test-azurekms-task
 
-  - name: testk8soidc_task_group
+  - name: testk8soidc_task_group_eks
     setup_group:
       - func: fetch source
       - command: ec2.assume_role
@@ -1551,7 +1551,49 @@ task_groups:
     setup_group_timeout_secs: 1800
     tasks:
       - oidc-auth-test-k8s-latest-eks
+
+  - name: testk8soidc_task_group_gke
+    setup_group:
+      - func: fetch source
+      - command: ec2.assume_role
+        params:
+          role_arn: ${OIDC_AWS_ROLE_ARN}
+      - command: subprocess.exec
+        params:
+          binary: bash
+          args:
+            - ${DRIVERS_TOOLS}/.evergreen/auth_oidc/k8s/setup.sh
+    teardown_task:
+      - command: subprocess.exec
+        params:
+          binary: bash
+          args:
+            - ${DRIVERS_TOOLS}/.evergreen/auth_oidc/k8s/teardown.sh
+    setup_group_can_fail_task: true
+    setup_group_timeout_secs: 1800
+    tasks:
       - oidc-auth-test-k8s-latest-gke
+
+  - name: testk8soidc_task_group_aks
+    setup_group:
+      - func: fetch source
+      - command: ec2.assume_role
+        params:
+          role_arn: ${OIDC_AWS_ROLE_ARN}
+      - command: subprocess.exec
+        params:
+          binary: bash
+          args:
+            - ${DRIVERS_TOOLS}/.evergreen/auth_oidc/k8s/setup.sh
+    teardown_task:
+      - command: subprocess.exec
+        params:
+          binary: bash
+          args:
+            - ${DRIVERS_TOOLS}/.evergreen/auth_oidc/k8s/teardown.sh
+    setup_group_can_fail_task: true
+    setup_group_timeout_secs: 1800
+    tasks:
       - oidc-auth-test-k8s-latest-aks
 
   - name: testtestoidc_task_group

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -1266,6 +1266,36 @@ tasks:
           args:
             - src/.evergreen/run-azure-kms-tests.sh
 
+  - name: "oidc-auth-test-k8s-latest"
+    commands:
+      - func: "install dependencies"
+      - command: subprocess.exec
+        type: test
+        params:
+          working_dir: src
+          binary: bash
+          env:
+            PROJECT_DIRECTORY: ${PROJECT_DIRECTORY}
+            ENVIRONMENT: k8s
+            K8S_VARIANT: eks
+            SCRIPT: run-oidc-prose-tests.sh
+          include_expansions_in_env: ["DRIVERS_TOOLS", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN"]
+          args:
+            - .evergreen/run-oidc-tests-k8s.sh
+      - command: subprocess.exec
+        type: test
+        params:
+          working_dir: src
+          binary: bash
+          env:
+            PROJECT_DIRECTORY: ${PROJECT_DIRECTORY}
+            ENVIRONMENT: k8s
+            K8S_VARIANT: gke
+            SCRIPT: run-oidc-prose-tests.sh
+          include_expansions_in_env: ["DRIVERS_TOOLS", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN"]
+          args:
+            - .evergreen/run-oidc-tests-k8s.sh
+
   - name: "oidc-auth-test-azure-latest"
     commands:
       - func: "install dependencies"
@@ -1475,6 +1505,28 @@ task_groups:
             - ${DRIVERS_TOOLS}/.evergreen/csfle/azurekms/teardown.sh
     tasks:
       - test-azurekms-task
+
+  - name: testk8soidc_task_group
+    setup_group:
+      - func: fetch source
+      - command: ec2.assume_role
+        params:
+          role_arn: ${OIDC_AWS_ROLE_ARN}
+      - command: subprocess.exec
+        params:
+          binary: bash
+          args:
+            - ${DRIVERS_TOOLS}/.evergreen/auth_oidc/k8s/setup.sh
+    teardown_task:
+      - command: subprocess.exec
+        params:
+          binary: bash
+          args:
+            - ${DRIVERS_TOOLS}/.evergreen/auth_oidc/k8s/teardown.sh
+    setup_group_can_fail_task: true
+    setup_group_timeout_secs: 1800
+    tasks:
+      - oidc-auth-test-k8s-latest
 
   - name: testtestoidc_task_group
     setup_group:

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -1295,6 +1295,19 @@ tasks:
           include_expansions_in_env: ["DRIVERS_TOOLS", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN"]
           args:
             - .evergreen/run-oidc-tests-k8s.sh
+      - command: subprocess.exec
+        type: test
+        params:
+          working_dir: src
+          binary: bash
+          env:
+            PROJECT_DIRECTORY: ${PROJECT_DIRECTORY}
+            ENVIRONMENT: k8s
+            K8S_VARIANT: aks
+            SCRIPT: run-oidc-prose-tests.sh
+          include_expansions_in_env: ["DRIVERS_TOOLS", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN"]
+          args:
+            - .evergreen/run-oidc-tests-k8s.sh
 
   - name: "oidc-auth-test-azure-latest"
     commands:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1218,6 +1218,43 @@ tasks:
             EXPECTED_AZUREKMS_OUTCOME: failure
           args:
             - src/.evergreen/run-azure-kms-tests.sh
+  - name: oidc-auth-test-k8s-latest
+    commands:
+      - func: install dependencies
+      - command: subprocess.exec
+        type: test
+        params:
+          working_dir: src
+          binary: bash
+          env:
+            PROJECT_DIRECTORY: ${PROJECT_DIRECTORY}
+            ENVIRONMENT: k8s
+            K8S_VARIANT: eks
+            SCRIPT: run-oidc-prose-tests.sh
+          include_expansions_in_env:
+            - DRIVERS_TOOLS
+            - AWS_ACCESS_KEY_ID
+            - AWS_SECRET_ACCESS_KEY
+            - AWS_SESSION_TOKEN
+          args:
+            - .evergreen/run-oidc-tests-k8s.sh
+      - command: subprocess.exec
+        type: test
+        params:
+          working_dir: src
+          binary: bash
+          env:
+            PROJECT_DIRECTORY: ${PROJECT_DIRECTORY}
+            ENVIRONMENT: k8s
+            K8S_VARIANT: gke
+            SCRIPT: run-oidc-prose-tests.sh
+          include_expansions_in_env:
+            - DRIVERS_TOOLS
+            - AWS_ACCESS_KEY_ID
+            - AWS_SECRET_ACCESS_KEY
+            - AWS_SESSION_TOKEN
+          args:
+            - .evergreen/run-oidc-tests-k8s.sh
   - name: oidc-auth-test-azure-latest
     commands:
       - func: install dependencies
@@ -4411,6 +4448,27 @@ task_groups:
             - ${DRIVERS_TOOLS}/.evergreen/csfle/azurekms/teardown.sh
     tasks:
       - test-azurekms-task
+  - name: testk8soidc_task_group
+    setup_group:
+      - func: fetch source
+      - command: ec2.assume_role
+        params:
+          role_arn: ${OIDC_AWS_ROLE_ARN}
+      - command: subprocess.exec
+        params:
+          binary: bash
+          args:
+            - ${DRIVERS_TOOLS}/.evergreen/auth_oidc/k8s/setup.sh
+    teardown_task:
+      - command: subprocess.exec
+        params:
+          binary: bash
+          args:
+            - ${DRIVERS_TOOLS}/.evergreen/auth_oidc/k8s/teardown.sh
+    setup_group_can_fail_task: true
+    setup_group_timeout_secs: 1800
+    tasks:
+      - oidc-auth-test-k8s-latest
   - name: testtestoidc_task_group
     setup_group:
       - func: fetch source
@@ -5094,6 +5152,7 @@ buildvariants:
       - testtestoidc_task_group
       - testazureoidc_task_group
       - testgcpoidc_task_group
+      - testk8soidc_task_group
   - name: rhel8-test-atlas
     display_name: Atlas Cluster Tests
     run_on: rhel80-large

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1255,6 +1255,23 @@ tasks:
             - AWS_SESSION_TOKEN
           args:
             - .evergreen/run-oidc-tests-k8s.sh
+      - command: subprocess.exec
+        type: test
+        params:
+          working_dir: src
+          binary: bash
+          env:
+            PROJECT_DIRECTORY: ${PROJECT_DIRECTORY}
+            ENVIRONMENT: k8s
+            K8S_VARIANT: aks
+            SCRIPT: run-oidc-prose-tests.sh
+          include_expansions_in_env:
+            - DRIVERS_TOOLS
+            - AWS_ACCESS_KEY_ID
+            - AWS_SECRET_ACCESS_KEY
+            - AWS_SESSION_TOKEN
+          args:
+            - .evergreen/run-oidc-tests-k8s.sh
   - name: oidc-auth-test-azure-latest
     commands:
       - func: install dependencies

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1238,7 +1238,7 @@ tasks:
             - AWS_SESSION_TOKEN
           args:
             - .evergreen/run-oidc-tests-k8s.sh
-  - name: oidc-auth-test-k8s-latest-eks
+  - name: oidc-auth-test-k8s-latest-gke
     commands:
       - func: install dependencies
       - command: subprocess.exec

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -4471,7 +4471,7 @@ task_groups:
             - ${DRIVERS_TOOLS}/.evergreen/csfle/azurekms/teardown.sh
     tasks:
       - test-azurekms-task
-  - name: testk8soidc_task_group
+  - name: testk8soidc_task_group_eks
     setup_group:
       - func: fetch source
       - command: ec2.assume_role
@@ -4492,7 +4492,47 @@ task_groups:
     setup_group_timeout_secs: 1800
     tasks:
       - oidc-auth-test-k8s-latest-eks
+  - name: testk8soidc_task_group_gke
+    setup_group:
+      - func: fetch source
+      - command: ec2.assume_role
+        params:
+          role_arn: ${OIDC_AWS_ROLE_ARN}
+      - command: subprocess.exec
+        params:
+          binary: bash
+          args:
+            - ${DRIVERS_TOOLS}/.evergreen/auth_oidc/k8s/setup.sh
+    teardown_task:
+      - command: subprocess.exec
+        params:
+          binary: bash
+          args:
+            - ${DRIVERS_TOOLS}/.evergreen/auth_oidc/k8s/teardown.sh
+    setup_group_can_fail_task: true
+    setup_group_timeout_secs: 1800
+    tasks:
       - oidc-auth-test-k8s-latest-gke
+  - name: testk8soidc_task_group_aks
+    setup_group:
+      - func: fetch source
+      - command: ec2.assume_role
+        params:
+          role_arn: ${OIDC_AWS_ROLE_ARN}
+      - command: subprocess.exec
+        params:
+          binary: bash
+          args:
+            - ${DRIVERS_TOOLS}/.evergreen/auth_oidc/k8s/setup.sh
+    teardown_task:
+      - command: subprocess.exec
+        params:
+          binary: bash
+          args:
+            - ${DRIVERS_TOOLS}/.evergreen/auth_oidc/k8s/teardown.sh
+    setup_group_can_fail_task: true
+    setup_group_timeout_secs: 1800
+    tasks:
       - oidc-auth-test-k8s-latest-aks
   - name: testtestoidc_task_group
     setup_group:
@@ -5177,7 +5217,9 @@ buildvariants:
       - testtestoidc_task_group
       - testazureoidc_task_group
       - testgcpoidc_task_group
-      - testk8soidc_task_group
+      - testk8soidc_task_group_eks
+      - testk8soidc_task_group_gke
+      - testk8soidc_task_group_aks
   - name: rhel8-test-atlas
     display_name: Atlas Cluster Tests
     run_on: rhel80-large

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1218,7 +1218,7 @@ tasks:
             EXPECTED_AZUREKMS_OUTCOME: failure
           args:
             - src/.evergreen/run-azure-kms-tests.sh
-  - name: oidc-auth-test-k8s-latest
+  - name: oidc-auth-test-k8s-latest-eks
     commands:
       - func: install dependencies
       - command: subprocess.exec
@@ -1233,12 +1233,14 @@ tasks:
             K8S_VARIANT: eks
             SCRIPT: run-oidc-prose-tests.sh
           include_expansions_in_env:
-            - DRIVERS_TOOLS
             - AWS_ACCESS_KEY_ID
             - AWS_SECRET_ACCESS_KEY
             - AWS_SESSION_TOKEN
           args:
             - .evergreen/run-oidc-tests-k8s.sh
+  - name: oidc-auth-test-k8s-latest-eks
+    commands:
+      - func: install dependencies
       - command: subprocess.exec
         type: test
         params:
@@ -1251,12 +1253,14 @@ tasks:
             K8S_VARIANT: gke
             SCRIPT: run-oidc-prose-tests.sh
           include_expansions_in_env:
-            - DRIVERS_TOOLS
             - AWS_ACCESS_KEY_ID
             - AWS_SECRET_ACCESS_KEY
             - AWS_SESSION_TOKEN
           args:
             - .evergreen/run-oidc-tests-k8s.sh
+  - name: oidc-auth-test-k8s-latest-aks
+    commands:
+      - func: install dependencies
       - command: subprocess.exec
         type: test
         params:
@@ -1269,7 +1273,6 @@ tasks:
             K8S_VARIANT: aks
             SCRIPT: run-oidc-prose-tests.sh
           include_expansions_in_env:
-            - DRIVERS_TOOLS
             - AWS_ACCESS_KEY_ID
             - AWS_SECRET_ACCESS_KEY
             - AWS_SESSION_TOKEN
@@ -4488,7 +4491,9 @@ task_groups:
     setup_group_can_fail_task: true
     setup_group_timeout_secs: 1800
     tasks:
-      - oidc-auth-test-k8s-latest
+      - oidc-auth-test-k8s-latest-eks
+      - oidc-auth-test-k8s-latest-gke
+      - oidc-auth-test-k8s-latest-aks
   - name: testtestoidc_task_group
     setup_group:
       - func: fetch source

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1227,6 +1227,7 @@ tasks:
           working_dir: src
           binary: bash
           env:
+            DRIVERS_TOOLS: ${DRIVERS_TOOLS}
             PROJECT_DIRECTORY: ${PROJECT_DIRECTORY}
             ENVIRONMENT: k8s
             K8S_VARIANT: eks
@@ -1244,6 +1245,7 @@ tasks:
           working_dir: src
           binary: bash
           env:
+            DRIVERS_TOOLS: ${DRIVERS_TOOLS}
             PROJECT_DIRECTORY: ${PROJECT_DIRECTORY}
             ENVIRONMENT: k8s
             K8S_VARIANT: gke
@@ -1261,6 +1263,7 @@ tasks:
           working_dir: src
           binary: bash
           env:
+            DRIVERS_TOOLS: ${DRIVERS_TOOLS}
             PROJECT_DIRECTORY: ${PROJECT_DIRECTORY}
             ENVIRONMENT: k8s
             K8S_VARIANT: aks

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -722,7 +722,9 @@ BUILD_VARIANTS.push({
     'testtestoidc_task_group',
     'testazureoidc_task_group',
     'testgcpoidc_task_group',
-    'testk8soidc_task_group'
+    'testk8soidc_task_group_eks',
+    'testk8soidc_task_group_gke',
+    'testk8soidc_task_group_aks'
   ]
 });
 

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -721,7 +721,8 @@ BUILD_VARIANTS.push({
   tasks: [
     'testtestoidc_task_group',
     'testazureoidc_task_group',
-    'testgcpoidc_task_group'
+    'testgcpoidc_task_group',
+    'testk8soidc_task_group'
   ]
 });
 

--- a/.evergreen/run-oidc-prose-tests.sh
+++ b/.evergreen/run-oidc-prose-tests.sh
@@ -8,10 +8,7 @@ source ./.evergreen/prepare-shell.sh
 
 ENVIRONMENT=${ENVIRONMENT:-"test"}
 PROJECT_DIRECTORY=${PROJECT_DIRECTORY:-"."}
-
-if [ -n "${K8S_VARIANT}" ]; then
-  source $DRIVERS_TOOLS/.evergreen/init-node-and-npm-env.sh
-fi
+source $DRIVERS_TOOLS/.evergreen/init-node-and-npm-env.sh
 
 if [ -z "${MONGODB_URI_SINGLE}" ]; then
   echo "Must specify MONGODB_URI_SINGLE"
@@ -33,11 +30,5 @@ else
     echo "Must specify K8S_VARIANT"
     exit 1
   fi
-
-  # Since this is running in a pod, we need to ensure Node is installed properly.
-  source $DRIVERS_TOOLS/.evergreen/install-node.sh
-  npm install "${NPM_OPTIONS}"
-  source $DRIVERS_TOOLS/.evergreen/init-node-and-npm-env.sh
-
   npm run check:oidc-k8s
 fi

--- a/.evergreen/run-oidc-prose-tests.sh
+++ b/.evergreen/run-oidc-prose-tests.sh
@@ -19,10 +19,16 @@ if [ "$ENVIRONMENT" = "azure" ]; then
   npm run check:oidc-azure
 elif [ "$ENVIRONMENT" = "gcp" ]; then
   npm run check:oidc-gcp
-else
+elif [ "$ENVIRONMENT" = "test" ]; then
   if [ -z "${OIDC_TOKEN_FILE}" ]; then
     echo "Must specify OIDC_TOKEN_FILE"
     exit 1
   fi
   npm run check:oidc-test
+else
+  if [ -z "${K8S_VARIANT}" ]; then
+    echo "Must specify K8S_VARIANT"
+    exit 1
+  fi
+  npm run check:oidc-k8s
 fi

--- a/.evergreen/run-oidc-prose-tests.sh
+++ b/.evergreen/run-oidc-prose-tests.sh
@@ -8,7 +8,10 @@ source ./.evergreen/prepare-shell.sh
 
 ENVIRONMENT=${ENVIRONMENT:-"test"}
 PROJECT_DIRECTORY=${PROJECT_DIRECTORY:-"."}
-source $DRIVERS_TOOLS/.evergreen/init-node-and-npm-env.sh
+
+if [ -n "${K8S_VARIANT}" ]; then
+  source $DRIVERS_TOOLS/.evergreen/init-node-and-npm-env.sh
+fi
 
 if [ -z "${MONGODB_URI_SINGLE}" ]; then
   echo "Must specify MONGODB_URI_SINGLE"
@@ -30,5 +33,11 @@ else
     echo "Must specify K8S_VARIANT"
     exit 1
   fi
+
+  # Since this is running in a pod, we need to ensure Node is installed properly.
+  source $DRIVERS_TOOLS/.evergreen/install-node.sh
+  npm install "${NPM_OPTIONS}"
+  source $DRIVERS_TOOLS/.evergreen/init-node-and-npm-env.sh
+
   npm run check:oidc-k8s
 fi

--- a/.evergreen/run-oidc-tests-k8s.sh
+++ b/.evergreen/run-oidc-tests-k8s.sh
@@ -8,7 +8,7 @@ tar -czf $K8S_DRIVERS_TAR_FILE src drivers-tools
 cd -
 bash $DRIVERS_TOOLS/.evergreen/auth_oidc/k8s/setup-pod.sh
 bash $DRIVERS_TOOLS/.evergreen/auth_oidc/k8s/run-self-test.sh
-export K8S_TEST_CMD="source ./env.sh && cd src && ENVIRONMENT=k8s ./.evergreen/${SCRIPT}"
+export K8S_TEST_CMD="cd src && DRIVERS_TOOLS=${DRIVERS_TOOLS} ENVIRONMENT=k8s ./.evergreen/${SCRIPT}"
 source $DRIVERS_TOOLS/.evergreen/auth_oidc/k8s/secrets-export.sh
 bash $DRIVERS_TOOLS/.evergreen/auth_oidc/k8s/run-driver-test.sh
 bash $DRIVERS_TOOLS/.evergreen/auth_oidc/k8s/teardown-pod.sh

--- a/.evergreen/run-oidc-tests-k8s.sh
+++ b/.evergreen/run-oidc-tests-k8s.sh
@@ -6,7 +6,7 @@ export K8S_DRIVERS_TAR_FILE=/tmp/node-mongodb-native.tgz
 tar czf $K8S_DRIVERS_TAR_FILE .
 bash $DRIVERS_TOOLS/.evergreen/auth_oidc/k8s/setup-pod.sh
 bash $DRIVERS_TOOLS/.evergreen/auth_oidc/k8s/run-self-test.sh
-export K8S_TEST_CMD="ENVIRONMENT=k8s ./.evergreen/${SCRIPT}"
+export K8S_TEST_CMD="DRIVERS_TOOLS=${DRIVERS_TOOLS} ENVIRONMENT=k8s ./.evergreen/${SCRIPT}"
 source $DRIVERS_TOOLS/.evergreen/auth_oidc/k8s/secrets-export.sh
 bash $DRIVERS_TOOLS/.evergreen/auth_oidc/k8s/run-driver-test.sh
 bash $DRIVERS_TOOLS/.evergreen/auth_oidc/k8s/teardown-pod.sh

--- a/.evergreen/run-oidc-tests-k8s.sh
+++ b/.evergreen/run-oidc-tests-k8s.sh
@@ -3,7 +3,9 @@ set -o xtrace   # Write all commands first to stderr
 set -o errexit  # Exit the script with error if any of the commands fail
 
 export K8S_DRIVERS_TAR_FILE=/tmp/node-mongodb-native.tgz
-tar czf $K8S_DRIVERS_TAR_FILE .
+cd ..
+tar -czf $K8S_DRIVERS_TAR_FILE src drivers-tools
+cd -
 bash $DRIVERS_TOOLS/.evergreen/auth_oidc/k8s/setup-pod.sh
 bash $DRIVERS_TOOLS/.evergreen/auth_oidc/k8s/run-self-test.sh
 export K8S_TEST_CMD="DRIVERS_TOOLS=${DRIVERS_TOOLS} ENVIRONMENT=k8s ./.evergreen/${SCRIPT}"

--- a/.evergreen/run-oidc-tests-k8s.sh
+++ b/.evergreen/run-oidc-tests-k8s.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -o xtrace   # Write all commands first to stderr
+set -o errexit  # Exit the script with error if any of the commands fail
+
+export K8S_DRIVERS_TAR_FILE=/tmp/node-mongodb-native.tgz
+tar czf $K8S_DRIVERS_TAR_FILE .
+bash $DRIVERS_TOOLS/.evergreen/auth_oidc/k8s/setup-pod.sh
+bash $DRIVERS_TOOLS/.evergreen/auth_oidc/k8s/run-self-test.sh
+export K8S_TEST_CMD="ENVIRONMENT=k8s ./.evergreen/${SCRIPT}"
+source $DRIVERS_TOOLS/.evergreen/auth_oidc/k8s/secrets-export.sh
+bash $DRIVERS_TOOLS/.evergreen/auth_oidc/k8s/run-driver-test.sh
+bash $DRIVERS_TOOLS/.evergreen/auth_oidc/k8s/teardown-pod.sh

--- a/.evergreen/run-oidc-tests-k8s.sh
+++ b/.evergreen/run-oidc-tests-k8s.sh
@@ -8,7 +8,7 @@ tar -czf $K8S_DRIVERS_TAR_FILE src drivers-tools
 cd -
 bash $DRIVERS_TOOLS/.evergreen/auth_oidc/k8s/setup-pod.sh
 bash $DRIVERS_TOOLS/.evergreen/auth_oidc/k8s/run-self-test.sh
-export K8S_TEST_CMD="DRIVERS_TOOLS=${DRIVERS_TOOLS} ENVIRONMENT=k8s ./.evergreen/${SCRIPT}"
+export K8S_TEST_CMD="source ./env.sh && cd src && ENVIRONMENT=k8s ./.evergreen/${SCRIPT}"
 source $DRIVERS_TOOLS/.evergreen/auth_oidc/k8s/secrets-export.sh
 bash $DRIVERS_TOOLS/.evergreen/auth_oidc/k8s/run-driver-test.sh
 bash $DRIVERS_TOOLS/.evergreen/auth_oidc/k8s/teardown-pod.sh

--- a/package.json
+++ b/package.json
@@ -151,6 +151,7 @@
     "check:oidc-test": "mocha --config test/mocha_mongodb.json test/integration/auth/mongodb_oidc.prose.test.ts",
     "check:oidc-azure": "mocha --config test/mocha_mongodb.json test/integration/auth/mongodb_oidc_azure.prose.05.test.ts",
     "check:oidc-gcp": "mocha --config test/mocha_mongodb.json test/integration/auth/mongodb_oidc_gcp.prose.06.test.ts",
+    "check:oidc-k8s": "mocha --config test/mocha_mongodb.json test/integration/auth/mongodb_oidc_k8s.prose.07.test.ts",
     "check:ocsp": "mocha --config test/manual/mocharc.json test/manual/ocsp_support.test.js",
     "check:kerberos": "nyc mocha --config test/manual/mocharc.json test/manual/kerberos.test.ts",
     "check:tls": "mocha --config test/manual/mocharc.json test/manual/tls_support.test.ts",

--- a/src/cmap/auth/mongo_credentials.ts
+++ b/src/cmap/auth/mongo_credentials.ts
@@ -31,7 +31,8 @@ function getDefaultAuthMechanism(hello: Document | null): AuthMechanism {
 const ALLOWED_ENVIRONMENT_NAMES: AuthMechanismProperties['ENVIRONMENT'][] = [
   'test',
   'azure',
-  'gcp'
+  'gcp',
+  'k8s'
 ];
 const ALLOWED_HOSTS_ERROR = 'Auth mechanism property ALLOWED_HOSTS must be an array of strings.';
 
@@ -62,7 +63,7 @@ export interface AuthMechanismProperties extends Document {
   /** A user provided OIDC human interacted callback function. */
   OIDC_HUMAN_CALLBACK?: OIDCCallbackFunction;
   /** The OIDC environment. Note that 'test' is for internal use only. */
-  ENVIRONMENT?: 'test' | 'azure' | 'gcp';
+  ENVIRONMENT?: 'test' | 'azure' | 'gcp' | 'k8s';
   /** Allowed hosts that OIDC auth can connect to. */
   ALLOWED_HOSTS?: string[];
   /** The resource token for OIDC auth in Azure and GCP. */

--- a/src/cmap/auth/mongodb_oidc.ts
+++ b/src/cmap/auth/mongodb_oidc.ts
@@ -6,6 +6,7 @@ import { type AuthContext, AuthProvider } from './auth_provider';
 import type { MongoCredentials } from './mongo_credentials';
 import { AzureMachineWorkflow } from './mongodb_oidc/azure_machine_workflow';
 import { GCPMachineWorkflow } from './mongodb_oidc/gcp_machine_workflow';
+import { K8SMachineWorkflow } from './mongodb_oidc/k8s_machine_workflow';
 import { TokenCache } from './mongodb_oidc/token_cache';
 import { TokenMachineWorkflow } from './mongodb_oidc/token_machine_workflow';
 
@@ -88,7 +89,7 @@ export type OIDCCallbackFunction = (params: OIDCCallbackParams) => Promise<OIDCR
 /** The current version of OIDC implementation. */
 export const OIDC_VERSION = 1;
 
-type EnvironmentName = 'test' | 'azure' | 'gcp' | undefined;
+type EnvironmentName = 'test' | 'azure' | 'gcp' | 'k8s' | undefined;
 
 /** @internal */
 export interface Workflow {
@@ -118,6 +119,7 @@ export const OIDC_WORKFLOWS: Map<EnvironmentName, () => Workflow> = new Map();
 OIDC_WORKFLOWS.set('test', () => new TokenMachineWorkflow(new TokenCache()));
 OIDC_WORKFLOWS.set('azure', () => new AzureMachineWorkflow(new TokenCache()));
 OIDC_WORKFLOWS.set('gcp', () => new GCPMachineWorkflow(new TokenCache()));
+OIDC_WORKFLOWS.set('k8s', () => new K8SMachineWorkflow(new TokenCache()));
 
 /**
  * OIDC auth provider.

--- a/src/cmap/auth/mongodb_oidc/k8s_machine_workflow.ts
+++ b/src/cmap/auth/mongodb_oidc/k8s_machine_workflow.ts
@@ -1,0 +1,38 @@
+import { readFile } from 'fs/promises';
+
+import { type AccessToken, MachineWorkflow } from './machine_workflow';
+import { type TokenCache } from './token_cache';
+
+/** The fallback file name */
+const FALLBACK_FILENAME = '/var/run/secrets/kubernetes.io/serviceaccount/token';
+
+/** The azure environment variable for the file name. */
+const AZURE_FILENAME = 'AZURE_FEDERATED_TOKEN_FILE';
+
+/** The AWS environment variable for the file name. */
+const AWS_FILENAME = 'AWS_WEB_IDENTITY_TOKEN_FILE';
+
+export class K8SMachineWorkflow extends MachineWorkflow {
+  /**
+   * Instantiate the machine workflow.
+   */
+  constructor(cache: TokenCache) {
+    super(cache);
+  }
+
+  /**
+   * Get the token from the environment.
+   */
+  async getToken(): Promise<AccessToken> {
+    let filename: string;
+    if (process.env[AZURE_FILENAME]) {
+      filename = process.env[AZURE_FILENAME];
+    } else if (process.env[AWS_FILENAME]) {
+      filename = process.env[AWS_FILENAME];
+    } else {
+      filename = FALLBACK_FILENAME;
+    }
+    const token = await readFile(filename, 'utf8');
+    return { access_token: token };
+  }
+}

--- a/test/integration/auth/mongodb_oidc_k8s.prose.07.test.ts
+++ b/test/integration/auth/mongodb_oidc_k8s.prose.07.test.ts
@@ -5,8 +5,9 @@ import { type Collection, MongoClient } from '../../mongodb';
 const DEFAULT_URI = 'mongodb://127.0.0.1:27017';
 
 describe('OIDC Auth Spec K8s Tests', function () {
-  // Note there is no spec or tests for GCP yet, these are 2 scenarios based on the
-  // drivers tools scripts available.
+  // Note there is no spec or tests for K8s, and it's optional to run the entire
+  // machine prose tests on the additional environments so we do 1 sanity check
+  // here. This same test will run in CI on AKS, EKS, and GKE.
   describe('6. GCP Tests', function () {
     let client: MongoClient;
     let collection: Collection;

--- a/test/integration/auth/mongodb_oidc_k8s.prose.07.test.ts
+++ b/test/integration/auth/mongodb_oidc_k8s.prose.07.test.ts
@@ -8,7 +8,7 @@ describe('OIDC Auth Spec K8s Tests', function () {
   // Note there is no spec or tests for K8s, and it's optional to run the entire
   // machine prose tests on the additional environments so we do 1 sanity check
   // here. This same test will run in CI on AKS, EKS, and GKE.
-  describe('6. GCP Tests', function () {
+  describe('7. K8s Tests', function () {
     let client: MongoClient;
     let collection: Collection;
 

--- a/test/integration/auth/mongodb_oidc_k8s.prose.07.test.ts
+++ b/test/integration/auth/mongodb_oidc_k8s.prose.07.test.ts
@@ -1,0 +1,37 @@
+import { expect } from 'chai';
+
+import { type Collection, MongoClient } from '../../mongodb';
+
+const DEFAULT_URI = 'mongodb://127.0.0.1:27017';
+
+describe('OIDC Auth Spec K8s Tests', function () {
+  // Note there is no spec or tests for GCP yet, these are 2 scenarios based on the
+  // drivers tools scripts available.
+  describe('6. GCP Tests', function () {
+    let client: MongoClient;
+    let collection: Collection;
+
+    beforeEach(function () {
+      if (!this.configuration.isOIDC(process.env.MONGODB_URI_SINGLE, 'k8s')) {
+        this.skipReason = 'K8s OIDC prose tests require a K8s OIDC environment.';
+        this.skip();
+      }
+    });
+
+    afterEach(async function () {
+      await client?.close();
+    });
+
+    describe('7.1 K8s With Environment Set', function () {
+      beforeEach(function () {
+        client = new MongoClient(process.env.MONGODB_URI_SINGLE ?? DEFAULT_URI);
+        collection = client.db('test').collection('test');
+      });
+
+      it('successfully authenticates', async function () {
+        const result = await collection.findOne();
+        expect(result).to.not.be.null;
+      });
+    });
+  });
+});

--- a/test/spec/auth/legacy/connection-string.json
+++ b/test/spec/auth/legacy/connection-string.json
@@ -626,6 +626,26 @@
       "uri": "mongodb://user:pass@localhost/?authMechanism=MONGODB-OIDC&authMechanismProperties=ENVIRONMENT:gcp",
       "valid": false,
       "credential": null
+    },
+    {
+      "description": "should recognise the mechanism with k8s provider (MONGODB-OIDC)",
+      "uri": "mongodb://localhost/?authMechanism=MONGODB-OIDC&authMechanismProperties=ENVIRONMENT:k8s",
+      "valid": true,
+      "credential": {
+        "username": null,
+        "password": null,
+        "source": "$external",
+        "mechanism": "MONGODB-OIDC",
+        "mechanism_properties": {
+          "ENVIRONMENT": "k8s"
+        }
+      }
+    },
+    {
+      "description": "should throw an error for a username and password with k8s provider (MONGODB-OIDC)",
+      "uri": "mongodb://user:pass@localhost/?authMechanism=MONGODB-OIDC&authMechanismProperties=ENVIRONMENT:k8s",
+      "valid": false,
+      "credential": null
     }
   ]
 }

--- a/test/spec/auth/legacy/connection-string.yml
+++ b/test/spec/auth/legacy/connection-string.yml
@@ -454,3 +454,18 @@ tests:
   uri: mongodb://user:pass@localhost/?authMechanism=MONGODB-OIDC&authMechanismProperties=ENVIRONMENT:gcp
   valid: false
   credential: null
+- description: should recognise the mechanism with k8s provider (MONGODB-OIDC)
+  uri: mongodb://localhost/?authMechanism=MONGODB-OIDC&authMechanismProperties=ENVIRONMENT:k8s
+  valid: true
+  credential:
+    username: null
+    password: null
+    source: $external
+    mechanism: MONGODB-OIDC
+    mechanism_properties:
+      ENVIRONMENT: k8s
+- description: should throw an error for a username and password with k8s provider
+    (MONGODB-OIDC)
+  uri: mongodb://user:pass@localhost/?authMechanism=MONGODB-OIDC&authMechanismProperties=ENVIRONMENT:k8s
+  valid: false
+  credential: null


### PR DESCRIPTION
### Description

Implements Kubernetes support for MONGODB-OIDC

#### What is changing?
- Adds support for AKS, EKS, GKE
- Adds evergreen task groups for both environments to run prose tests.
- Creates the new K8s machine workflow.

##### Is there new documentation needed for these changes?

Yes in the manual.

#### What is the motivation for this change?

DRIVERS-2882

https://github.com/mongodb/specifications/pull/1622

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### MONGODB-OIDC Authentication now supports Kubernetes Environments.

For k8s environments running in Amazon's EKS (Elastic Kubernetes Service), Google's GKE (Google Kubernetes Engine), or Azure's AKS (Azure Kubernetes Service) simply provide an `ENVIRONMENT` auth mechanism property in the URI or `MongoClient` options of "k8s".

Example:

```ts
const client = new MongoClient('mongodb://host:port/?authMechanism=MONGODB-OIDC&authMechanismProperties=ENVIRONMENT:k8s');
```

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
