### PR TITLE
feat(NODE-6419): deprecate explain options API for find and aggregate

### DIFF
--- a/src/operations/aggregate.ts
+++ b/src/operations/aggregate.ts
@@ -1,6 +1,7 @@
 import type { Document } from '../bson';
 import { CursorResponse, ExplainedCursorResponse } from '../cmap/wire_protocol/responses';
 import { MongoInvalidArgumentError } from '../error';
+import { type ExplainOptions } from '../explain';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
 import { maxWireVersion, type MongoDBNamespace } from '../utils';
@@ -14,7 +15,7 @@ export const DB_AGGREGATE_COLLECTION = 1 as const;
 const MIN_WIRE_VERSION_$OUT_READ_CONCERN_SUPPORT = 8;
 
 /** @public */
-export interface AggregateOptions extends CommandOperationOptions {
+export interface AggregateOptions extends Omit<CommandOperationOptions, 'explain'> {
   /** allowDiskUse lets the server know if it can use disk to store temporary results for the aggregation (requires mongodb 2.6 \>). */
   allowDiskUse?: boolean;
   /** The number of documents to return per batch. See [aggregation documentation](https://www.mongodb.com/docs/manual/reference/command/aggregate). */
@@ -35,6 +36,13 @@ export interface AggregateOptions extends CommandOperationOptions {
   let?: Document;
 
   out?: string;
+
+  /**
+   * Specifies the verbosity mode for the explain output.
+   * @deprecated This API is deprecated in favor of `collection.aggregate().explain()`
+   * or `db.aggregate().explain()`.
+   */
+  explain?: ExplainOptions['explain'];
 }
 
 /** @internal */

--- a/src/operations/find.ts
+++ b/src/operations/find.ts
@@ -1,6 +1,7 @@
 import type { Document } from '../bson';
 import { CursorResponse, ExplainedCursorResponse } from '../cmap/wire_protocol/responses';
 import { MongoInvalidArgumentError } from '../error';
+import { type ExplainOptions } from '../explain';
 import { ReadConcern } from '../read_concern';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
@@ -15,7 +16,7 @@ import { Aspect, defineAspects, type Hint } from './operation';
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export interface FindOptions<TSchema extends Document = Document>
-  extends Omit<CommandOperationOptions, 'writeConcern'> {
+  extends Omit<CommandOperationOptions, 'writeConcern' | 'explain'> {
   /** Sets the limit of documents returned in the query. */
   limit?: number;
   /** Set to sort the documents coming back from the query. Array of indexes, `[['a', 1]]` etc. */
@@ -63,6 +64,12 @@ export interface FindOptions<TSchema extends Document = Document>
    * @deprecated Starting from MongoDB 4.4 this flag is not needed and will be ignored.
    */
   oplogReplay?: boolean;
+
+  /**
+   * Specifies the verbosity mode for the explain output.
+   * @deprecated This API is deprecated in favor of `collection.find().explain()`.
+   */
+  explain?: ExplainOptions['explain'];
 }
 
 /** @internal */

--- a/test/types/community/collection/findX.test-d.ts
+++ b/test/types/community/collection/findX.test-d.ts
@@ -388,7 +388,3 @@ expectType<WithId<{ a: number; b: string }> | null>(
     }
   )
 );
-
-{
-  coll.find({}, { explain});
-}

--- a/test/types/community/collection/findX.test-d.ts
+++ b/test/types/community/collection/findX.test-d.ts
@@ -388,3 +388,7 @@ expectType<WithId<{ a: number; b: string }> | null>(
     }
   )
 );
+
+{
+  coll.find({}, { explain});
+}


### PR DESCRIPTION
### Description

#### What is changing?

`collection.find({}, { explain: ... })` and `collection/db.aggregate({}, { explain: ... })` are deprecated.

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Find and Aggregate Explain in Options is Deprecated

Specifying explain for cursors in the operation's options is deprecated in favor of the `.explain()` methods on cursors:

```typescript
collection.find({}, { explain: true })
// -> collection.find({}).explain()

collection.aggregate([], { explain: true })
// -> collection.aggregate([]).explain()

db.find([], { explain: true })
// -> db.find([]).explain()
```

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
