### PR TITLE
fix(NODE-6412): read stale response from previously timed out connection

### DIFF
--- a/src/cmap/connection.ts
+++ b/src/cmap/connection.ts
@@ -747,9 +747,12 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
       }
     } catch (readError) {
       if (TimeoutError.is(readError)) {
-        throw new MongoOperationTimeoutError(
+        const error = new MongoOperationTimeoutError(
           `Timed out during socket read (${readError.duration}ms)`
         );
+        this.dataEvents = null;
+        this.onError(error);
+        throw error;
       }
       throw readError;
     } finally {

--- a/test/integration/client-side-operations-timeout/client_side_operations_timeout.spec.test.ts
+++ b/test/integration/client-side-operations-timeout/client_side_operations_timeout.spec.test.ts
@@ -49,6 +49,12 @@ describe('CSOT spec tests', function () {
   runUnifiedSuite(specs, (test, configuration) => {
     const sessionCSOTTests = ['timeoutMS applied to withTransaction'];
     if (
+      configuration.topologyType === 'LoadBalanced' &&
+      test.description === 'timeoutMS is refreshed for close'
+    ) {
+      return 'LoadBalanced cannot refresh timeoutMS and run expected killCursors because pinned connection has been closed by the timeout';
+    }
+    if (
       sessionCSOTTests.includes(test.description) &&
       configuration.topologyType === 'ReplicaSetWithPrimary' &&
       semver.satisfies(configuration.version, '<=4.4')


### PR DESCRIPTION
### Description

#### What is changing?

- Close a connection that has been timed out

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

If the connection is not closed it will go back into the pool and a subsequent operation will read the reply to the previous operation

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
