### PR TITLE
test(NODE-6388): unskip rangev2 compact tests on serverless

### DIFF
--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Rangev2-Compact.json
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Rangev2-Compact.json
@@ -6,8 +6,7 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ],
-      "serverless": "forbid"
+      ]
     }
   ],
   "database_name": "default",

--- a/test/spec/client-side-encryption/tests/legacy/fle2v2-Rangev2-Compact.yml
+++ b/test/spec/client-side-encryption/tests/legacy/fle2v2-Rangev2-Compact.yml
@@ -3,7 +3,6 @@ runOn:
   - minServerVersion: "8.0.0" # Require range v2 support on server.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
-    serverless: forbid # Skip on serverless until CLOUDP-267864 is resolved.
 database_name: "default"
 collection_name: &collection_name "default"
 data: []


### PR DESCRIPTION
### Description

#### What is changing?

Unskip rangev2 compact tests on serverless.

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
