### PR TITLE
docs(NODE-6223): timeoutMS does not govern auto-connect

### DIFF
--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -47,6 +47,7 @@ import { readPreferenceServerSelector } from './sdam/server_selection';
 import type { SrvPoller } from './sdam/srv_polling';
 import { Topology, type TopologyEvents } from './sdam/topology';
 import { ClientSession, type ClientSessionOptions, ServerSessionPool } from './sessions';
+import { Timeout } from './timeout';
 import {
   COSMOS_DB_CHECK,
   COSMOS_DB_MSG,
@@ -520,13 +521,19 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> implements
       return await this.connectionLock;
     }
 
-    try {
-      this.connectionLock = this._connect();
-      await this.connectionLock;
-    } finally {
-      // release
+    const timeoutMS = this[kOptions].timeoutMS;
+
+    this.connectionLock = this._connect().finally(() => {
+      // Clear the lock only when this promise finishes:
       this.connectionLock = undefined;
-    }
+    });
+
+    await (timeoutMS == null
+      ? this.connectionLock
+      : Promise.race([
+          this.connectionLock,
+          Timeout.expires(timeoutMS).catch(Timeout.convertError)
+        ]));
 
     return this;
   }

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -514,6 +514,13 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> implements
   /**
    * Connect to MongoDB using a url
    *
+   * @remarks
+   * Calling connect is optional as the first operation you preform will call connect if it's needed.
+   * `timeoutMS` specified at the client-level will bound the time any operation can take before throwing a timeout error.
+   * However, when the operation being run is automatically connecting your MongoClient the timeoutMS will only be used for the operation portion of task.
+   * This means the time to setup the MongoClient does not count against timeoutMS.
+   * If you are using timeoutMS we recommend connecting your client explicitly in advance of any operation to avoid this inconsistent execution time.
+   *
    * @see docs.mongodb.org/manual/reference/connection-string/
    */
   async connect(): Promise<this> {
@@ -715,6 +722,13 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> implements
 
   /**
    * Connect to MongoDB using a url
+   *
+   * @remarks
+   * Calling connect is optional as the first operation you preform will call connect if it's needed.
+   * `timeoutMS` specified at the client-level will bound the time any operation can take before throwing a timeout error.
+   * However, when the operation being run is automatically connecting your MongoClient the timeoutMS will only be used for the operation portion of task.
+   * This means the time to setup the MongoClient does not count against timeoutMS.
+   * If you are using timeoutMS we recommend connecting your client explicitly in advance of any operation to avoid this inconsistent execution time.
    *
    * @remarks
    * The programmatically provided options take precedence over the URI options.

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -515,8 +515,8 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> implements
    *
    * @remarks
    * Calling `connect` is optional since the first operation you perform will call `connect` if it's needed.
-   * `timeoutMS` specified at the client-level will bound the time any operation can take before throwing a timeout error.
-   * However, when the operation being run is automatically connecting your `MongoClient` the `timeoutMS` will only be used for the operation portion of task.
+   * `timeoutMS` will bound the time any operation can take before throwing a timeout error.
+   * However, when the operation being run is automatically connecting your `MongoClient` the `timeoutMS` will not apply to the time taken to connect the MongoClient.
    * This means the time to setup the `MongoClient` does not count against `timeoutMS`.
    * If you are using `timeoutMS` we recommend connecting your client explicitly in advance of any operation to avoid this inconsistent execution time.
    *
@@ -718,8 +718,8 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> implements
    *
    * @remarks
    * Calling `connect` is optional since the first operation you perform will call `connect` if it's needed.
-   * `timeoutMS` specified at the client-level will bound the time any operation can take before throwing a timeout error.
-   * However, when the operation being run is automatically connecting your `MongoClient` the `timeoutMS` will only be used for the operation portion of task.
+   * `timeoutMS` will bound the time any operation can take before throwing a timeout error.
+   * However, when the operation being run is automatically connecting your `MongoClient` the `timeoutMS` will not apply to the time taken to connect the MongoClient.
    * This means the time to setup the `MongoClient` does not count against `timeoutMS`.
    * If you are using `timeoutMS` we recommend connecting your client explicitly in advance of any operation to avoid this inconsistent execution time.
    *

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -516,7 +516,7 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> implements
    * @remarks
    * Calling `connect` is optional since the first operation you perform will call `connect` if it's needed.
    * `timeoutMS` specified at the client-level will bound the time any operation can take before throwing a timeout error.
-   * However, when the operation being run is automatically connecting your `MongoClient` the timeoutMS will only be used for the operation portion of task.
+   * However, when the operation being run is automatically connecting your `MongoClient` the `timeoutMS` will only be used for the operation portion of task.
    * This means the time to setup the `MongoClient` does not count against `timeoutMS`.
    * If you are using `timeoutMS` we recommend connecting your client explicitly in advance of any operation to avoid this inconsistent execution time.
    *
@@ -719,7 +719,7 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> implements
    * @remarks
    * Calling `connect` is optional since the first operation you perform will call `connect` if it's needed.
    * `timeoutMS` specified at the client-level will bound the time any operation can take before throwing a timeout error.
-   * However, when the operation being run is automatically connecting your `MongoClient` the timeoutMS will only be used for the operation portion of task.
+   * However, when the operation being run is automatically connecting your `MongoClient` the `timeoutMS` will only be used for the operation portion of task.
    * This means the time to setup the `MongoClient` does not count against `timeoutMS`.
    * If you are using `timeoutMS` we recommend connecting your client explicitly in advance of any operation to avoid this inconsistent execution time.
    *

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -514,11 +514,11 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> implements
    * Connect to MongoDB using a url
    *
    * @remarks
-   * Calling connect is optional as the first operation you preform will call connect if it's needed.
+   * Calling `connect` is optional since the first operation you perform will call `connect` if it's needed.
    * `timeoutMS` specified at the client-level will bound the time any operation can take before throwing a timeout error.
-   * However, when the operation being run is automatically connecting your MongoClient the timeoutMS will only be used for the operation portion of task.
-   * This means the time to setup the MongoClient does not count against timeoutMS.
-   * If you are using timeoutMS we recommend connecting your client explicitly in advance of any operation to avoid this inconsistent execution time.
+   * However, when the operation being run is automatically connecting your `MongoClient` the timeoutMS will only be used for the operation portion of task.
+   * This means the time to setup the `MongoClient` does not count against `timeoutMS`.
+   * If you are using `timeoutMS` we recommend connecting your client explicitly in advance of any operation to avoid this inconsistent execution time.
    *
    * @see docs.mongodb.org/manual/reference/connection-string/
    */
@@ -717,11 +717,11 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> implements
    * Connect to MongoDB using a url
    *
    * @remarks
-   * Calling connect is optional as the first operation you preform will call connect if it's needed.
+   * Calling `connect` is optional since the first operation you perform will call `connect` if it's needed.
    * `timeoutMS` specified at the client-level will bound the time any operation can take before throwing a timeout error.
-   * However, when the operation being run is automatically connecting your MongoClient the timeoutMS will only be used for the operation portion of task.
-   * This means the time to setup the MongoClient does not count against timeoutMS.
-   * If you are using timeoutMS we recommend connecting your client explicitly in advance of any operation to avoid this inconsistent execution time.
+   * However, when the operation being run is automatically connecting your `MongoClient` the timeoutMS will only be used for the operation portion of task.
+   * This means the time to setup the `MongoClient` does not count against `timeoutMS`.
+   * If you are using `timeoutMS` we recommend connecting your client explicitly in advance of any operation to avoid this inconsistent execution time.
    *
    * @remarks
    * The programmatically provided options take precedence over the URI options.

--- a/src/timeout.ts
+++ b/src/timeout.ts
@@ -126,6 +126,12 @@ export class Timeout extends Promise<never> {
   static override reject(rejection?: Error): Timeout {
     return new Timeout(undefined, { duration: 0, unref: true, rejection });
   }
+
+  static convertError(this: void, cause: unknown): never {
+    if (TimeoutError.is(cause)) throw new MongoOperationTimeoutError('Timed out');
+    if (cause instanceof Error) throw cause;
+    throw new MongoRuntimeError('Unknown error', { cause: cause as any });
+  }
 }
 
 /** @internal */

--- a/src/timeout.ts
+++ b/src/timeout.ts
@@ -126,12 +126,6 @@ export class Timeout extends Promise<never> {
   static override reject(rejection?: Error): Timeout {
     return new Timeout(undefined, { duration: 0, unref: true, rejection });
   }
-
-  static convertError(this: void, cause: unknown): never {
-    if (TimeoutError.is(cause)) throw new MongoOperationTimeoutError('Timed out');
-    if (cause instanceof Error) throw cause;
-    throw new MongoRuntimeError('Unknown error', { cause: cause as any });
-  }
 }
 
 /** @internal */

--- a/test/integration/node-specific/auto_connect.test.ts
+++ b/test/integration/node-specific/auto_connect.test.ts
@@ -886,7 +886,7 @@ describe('When executing an operation for the first time', () => {
       });
 
       it(
-        'client.connect() 'takes as long as selectServer is delayed for and does not throw a timeout error',
+        'client.connect() takes as long as selectServer is delayed for and does not throw a timeout error',
         { requires: { auth: 'enabled' } },
         async function () {
           const start = performance.now();

--- a/test/integration/node-specific/auto_connect.test.ts
+++ b/test/integration/node-specific/auto_connect.test.ts
@@ -858,7 +858,7 @@ describe('When executing an operation for the first time', () => {
           await utilClient.close();
         });
 
-        it('client.connect() takes as long as ping is delayed for and does not throw a timeout error', async function () {
+        it('timeoutMS from the client is not used for the internal `ping`', async function () {
           const start = performance.now();
           const returnedClient = await client.connect();
           const end = performance.now();

--- a/test/integration/node-specific/auto_connect.test.ts
+++ b/test/integration/node-specific/auto_connect.test.ts
@@ -824,7 +824,7 @@ describe('When executing an operation for the first time', () => {
     });
   });
 
-  describe('and CSOT is enabled', function () {
+  describe('when CSOT is enabled', function () {
     let client: MongoClient;
 
     beforeEach(async function () {
@@ -835,14 +835,14 @@ describe('When executing an operation for the first time', () => {
       await client.close();
     });
 
-    describe('and nothing is wrong', function () {
+    describe('when nothing is wrong', function () {
       it('connects the client', async function () {
         await client.connect();
         expect(client).to.have.property('topology').that.is.instanceOf(Topology);
       });
     });
 
-    describe('and the server requires auth and ping is delayed', function () {
+    describe('when the server requires auth and ping is delayed', function () {
       beforeEach(async function () {
         // set failpoint to delay ping
         // create new util client to avoid affecting the test client
@@ -856,7 +856,7 @@ describe('When executing an operation for the first time', () => {
       });
 
       it(
-        'takes as long as ping is delayed for and does not throw a timeout error',
+        'client.connect() takes as long as ping is delayed for and does not throw a timeout error',
         { requires: { auth: 'enabled' } },
         async function () {
           const start = performance.now();
@@ -886,7 +886,7 @@ describe('When executing an operation for the first time', () => {
       });
 
       it(
-        'takes as long as selectServer is delayed for and does not throw a timeout error',
+        'client.connect() 'takes as long as selectServer is delayed for and does not throw a timeout error',
         { requires: { auth: 'enabled' } },
         async function () {
           const start = performance.now();


### PR DESCRIPTION
### Description

#### What is changing?

Added docs

##### Is there new documentation needed for these changes?

New docs for docs? interesting idea

#### What is the motivation for this change?

Auto connect or plain connect performs file system access, DNS lookup, monitor creation, mongocryptd launching, and more! each one of these steps has its own mechanism for cancellation that is not considered by the CSOT spec. Alternatively we considered ignoring cancelling those operations and simply racing with a timeout, however, the impact could be squashing important errors. 

Auto connect needs a future rework to better align with the drivers "always connected" perspective, for now, its best to explicitly connect if there's concern that the connecting operation won't complete in a globally set timeoutMS value.

### Q&A

#### Is there anything that the user can set that will bound the execution time of autoconnect in this case?

Nothing specific to auto-connect, any client options: `socketTimeoutMS`, `waitQueueTimeoutMS`, `serverSelectionTimeoutMS`, `connectTimeoutMS` are all general options that control those components of the driver for all operations. Auto-connect or just connect itself has its own set of operations that cannot be timed out at all, reading TLS files, SRV/TXT DNS lookup, monitoring start-up, server selection, and a ping. Also, auto-encryption can have an internal client that repeats the aforementioned as well.

Generally, folks observe a `MongoServerSelectionError` when the ping forces a server selection that the monitors fail to service in time. That cannot be set for only connect and only covers a common case.

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
