### PR TITLE
fix(NODE-6436): only force majority write concern on commitTransaction retry

### DIFF
--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -124,6 +124,9 @@ export class ClientSession
   owner?: symbol | AbstractCursor;
   defaultTransactionOptions: TransactionOptions;
   transaction: Transaction;
+  /** @internal
+   * Keeps track of whether or not the current transaction has attempted to be committed. Is
+   * initially undefined. Gets set to false when startTransaction is called. When commitTransaction is sent to server, if the commitTransaction succeeds, it is then set to undefined, otherwise, set to true */
   commitAttempted?: boolean;
   /** @internal */
   [kServerSession]: ServerSession | null;

--- a/test/integration/transactions/transactions.test.ts
+++ b/test/integration/transactions/transactions.test.ts
@@ -272,11 +272,12 @@ describe('Transactions', function () {
       'commitTransaction does not override write concern on initial attempt',
       { requires: { mongodb: '>=4.2.0', topology: '!single' } },
       async function () {
+        const collection = await client.db('test').createCollection('test');
         const session = client.startSession({
           defaultTransactionOptions: { writeConcern: { w: 1 } }
         });
         session.startTransaction();
-        await client.db('test').collection('test').insertOne({ x: 1 }, { session });
+        await collection.insertOne({ x: 1 }, { session });
         await session.commitTransaction();
 
         const commitTransactions = commandsStarted.filter(

--- a/test/integration/transactions/transactions.test.ts
+++ b/test/integration/transactions/transactions.test.ts
@@ -272,6 +272,10 @@ describe('Transactions', function () {
       'commitTransaction does not override write concern on initial attempt',
       { requires: { mongodb: '>=4.2.0', topology: '!single' } },
       async function () {
+        await client
+          .db('test')
+          .dropCollection('test')
+          .catch(() => null);
         const collection = await client.db('test').createCollection('test');
         const session = client.startSession({
           defaultTransactionOptions: { writeConcern: { w: 1 } }

--- a/test/integration/transactions/transactions.test.ts
+++ b/test/integration/transactions/transactions.test.ts
@@ -237,7 +237,6 @@ describe('Transactions', function () {
       client = this.configuration.newClient(undefined, { monitorCommands: true });
       commandsStarted = [];
       client.on('commandStarted', ev => {
-        console.log(ev);
         commandsStarted.push(ev);
       });
     });


### PR DESCRIPTION
### Description

#### What is changing?

Ensure that `commitTransaction` only overrides the write concern when the `commitTransaction` call is retried (both with builtin retry mechanism and user-initiated retry).

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

Needed by NODE-3914

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### `ClientSession.commitTransaction()` no longer unconditionally overrides write concern
Prior to this change, `ClientSession.commitTransaction()` would always override any previously configured `writeConcern` on the initial attempt. This overriding behaviour now only applies to internal and user-initiated retries of `ClientSession.commitTransaction()` for a given transaction.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [X] Ran `npm run check:lint` script
- [X] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [X] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [X] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
