### PR TITLE
chore: add lint rule to prevent import from `bson` in driver src

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -266,6 +266,12 @@
             "patterns": [
               "**/../lib/**",
               "mongodb-mock-server"
+            ],
+            "paths": [
+              {
+                "name": "bson",
+                "message": "Import from the driver's bson.ts file instead."
+              }
             ]
           }
         ]

--- a/src/beta.ts
+++ b/src/beta.ts
@@ -1,4 +1,4 @@
-import { type Document } from 'bson';
+import { type Document } from './bson';
 
 export * from './index';
 

--- a/src/bson.ts
+++ b/src/bson.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-imports */
 import { BSON, type DeserializeOptions, type SerializeOptions } from 'bson';
 
 export {
@@ -12,6 +13,7 @@ export {
   DBRef,
   Decimal128,
   deserialize,
+  type DeserializeOptions,
   Document,
   Double,
   EJSON,
@@ -21,6 +23,7 @@ export {
   MaxKey,
   MinKey,
   ObjectId,
+  type ObjectIdLike,
   serialize,
   Timestamp,
   UUID

--- a/src/cmap/auth/mongodb_oidc.ts
+++ b/src/cmap/auth/mongodb_oidc.ts
@@ -1,5 +1,4 @@
-import type { Document } from 'bson';
-
+import type { Document } from '../../bson';
 import { MongoInvalidArgumentError, MongoMissingCredentialsError } from '../../error';
 import type { HandshakeDocument } from '../connect';
 import type { Connection } from '../connection';

--- a/src/cmap/auth/mongodb_oidc/callback_workflow.ts
+++ b/src/cmap/auth/mongodb_oidc/callback_workflow.ts
@@ -1,6 +1,6 @@
-import { type Document } from 'bson';
 import { setTimeout } from 'timers/promises';
 
+import { type Document } from '../../../bson';
 import { MongoMissingCredentialsError } from '../../../error';
 import { ns } from '../../../utils';
 import type { Connection } from '../../connection';

--- a/src/cmap/auth/mongodb_oidc/command_builders.ts
+++ b/src/cmap/auth/mongodb_oidc/command_builders.ts
@@ -1,5 +1,4 @@
-import { Binary, BSON, type Document } from 'bson';
-
+import { Binary, BSON, type Document } from '../../../bson';
 import { type MongoCredentials } from '../mongo_credentials';
 import { AuthMechanism } from '../providers';
 

--- a/src/cmap/auth/mongodb_oidc/human_callback_workflow.ts
+++ b/src/cmap/auth/mongodb_oidc/human_callback_workflow.ts
@@ -1,5 +1,4 @@
-import { BSON } from 'bson';
-
+import { BSON } from '../../../bson';
 import { MONGODB_ERROR_CODES, MongoError, MongoOIDCError } from '../../../error';
 import { Timeout, TimeoutError } from '../../../timeout';
 import { type Connection } from '../../connection';

--- a/src/cmap/auth/mongodb_oidc/machine_workflow.ts
+++ b/src/cmap/auth/mongodb_oidc/machine_workflow.ts
@@ -1,6 +1,6 @@
-import { type Document } from 'bson';
 import { setTimeout } from 'timers/promises';
 
+import { type Document } from '../../../bson';
 import { ns } from '../../../utils';
 import type { Connection } from '../../connection';
 import type { MongoCredentials } from '../mongo_credentials';

--- a/src/cmap/connection.ts
+++ b/src/cmap/connection.ts
@@ -1,8 +1,13 @@
-import { type DeserializeOptions } from 'bson';
 import { type Readable, Transform, type TransformCallback } from 'stream';
 import { clearTimeout, setTimeout } from 'timers';
 
-import { type BSONSerializeOptions, deserialize, type Document, type ObjectId } from '../bson';
+import {
+  type BSONSerializeOptions,
+  deserialize,
+  type DeserializeOptions,
+  type Document,
+  type ObjectId
+} from '../bson';
 import { type AutoEncrypter } from '../client-side-encryption/auto_encrypter';
 import {
   CLOSE,

--- a/src/cmap/wire_protocol/on_demand/document.ts
+++ b/src/cmap/wire_protocol/on_demand/document.ts
@@ -1,11 +1,10 @@
-import { type DeserializeOptions } from 'bson';
-
 import {
   Binary,
   type BSONElement,
   BSONError,
   BSONType,
   deserialize,
+  type DeserializeOptions,
   getBigInt64LE,
   getFloat64LE,
   getInt32LE,

--- a/src/cmap/wire_protocol/responses.ts
+++ b/src/cmap/wire_protocol/responses.ts
@@ -1,9 +1,8 @@
-import { type DeserializeOptions } from 'bson';
-
 import {
   type BSONElement,
   type BSONSerializeOptions,
   BSONType,
+  type DeserializeOptions,
   type Document,
   Long,
   parseToElementsToArray,

--- a/src/cursor/client_bulk_write_cursor.ts
+++ b/src/cursor/client_bulk_write_cursor.ts
@@ -1,5 +1,4 @@
-import { type Document } from 'bson';
-
+import { type Document } from '../bson';
 import { type ClientBulkWriteCursorResponse } from '../cmap/wire_protocol/responses';
 import { MongoClientBulkWriteCursorError } from '../error';
 import type { MongoClient } from '../mongo_client';

--- a/src/mongo_types.ts
+++ b/src/mongo_types.ts
@@ -1,15 +1,16 @@
-import type { BSONType, ObjectIdLike } from 'bson';
 import { EventEmitter } from 'events';
 
 import type {
   Binary,
   BSONRegExp,
+  BSONType,
   Decimal128,
   Document,
   Double,
   Int32,
   Long,
   ObjectId,
+  ObjectIdLike,
   Timestamp
 } from './bson';
 import { type CommandStartedEvent } from './cmap/command_monitoring_events';

--- a/src/operations/search_indexes/create.ts
+++ b/src/operations/search_indexes/create.ts
@@ -1,5 +1,4 @@
-import type { Document } from 'bson';
-
+import type { Document } from '../../bson';
 import type { Collection } from '../../collection';
 import type { Server } from '../../sdam/server';
 import type { ClientSession } from '../../sessions';

--- a/src/operations/search_indexes/drop.ts
+++ b/src/operations/search_indexes/drop.ts
@@ -1,5 +1,4 @@
-import type { Document } from 'bson';
-
+import type { Document } from '../../bson';
 import type { Collection } from '../../collection';
 import { MONGODB_ERROR_CODES, MongoServerError } from '../../error';
 import type { Server } from '../../sdam/server';

--- a/src/operations/search_indexes/update.ts
+++ b/src/operations/search_indexes/update.ts
@@ -1,5 +1,4 @@
-import type { Document } from 'bson';
-
+import type { Document } from '../../bson';
 import type { Collection } from '../../collection';
 import type { Server } from '../../sdam/server';
 import type { ClientSession } from '../../sessions';


### PR DESCRIPTION
### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
