### PR TITLE
chore: fix bson import lint

### DIFF
--- a/src/operations/client_bulk_write/executor.ts
+++ b/src/operations/client_bulk_write/executor.ts
@@ -1,5 +1,4 @@
-import { type Document } from 'bson';
-
+import { type Document } from '../../bson';
 import { ClientBulkWriteCursor } from '../../cursor/client_bulk_write_cursor';
 import {
   MongoClientBulkWriteError,


### PR DESCRIPTION
### Description

#### What is changing?

- fix bson import lint

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

bson importing from the one file in the driver controls all usages of BSON APIs.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
