### PR TITLE
fix(NODE-6454): use timeoutcontext for state machine execute() cursor options

### DIFF
--- a/src/operations/list_collections.ts
+++ b/src/operations/list_collections.ts
@@ -1,6 +1,6 @@
 import type { Binary, Document } from '../bson';
 import { CursorResponse } from '../cmap/wire_protocol/responses';
-import { type CursorTimeoutMode } from '../cursor/abstract_cursor';
+import { type CursorTimeoutContext, type CursorTimeoutMode } from '../cursor/abstract_cursor';
 import type { Db } from '../db';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
@@ -19,6 +19,9 @@ export interface ListCollectionsOptions extends Omit<CommandOperationOptions, 'w
   batchSize?: number;
   /** @internal */
   timeoutMode?: CursorTimeoutMode;
+
+  /** @internal */
+  timeoutContext?: CursorTimeoutContext;
 }
 
 /** @internal */

--- a/test/integration/client-side-encryption/driver.test.ts
+++ b/test/integration/client-side-encryption/driver.test.ts
@@ -2,6 +2,7 @@ import { type Binary, EJSON, UUID } from 'bson';
 import { expect } from 'chai';
 import * as crypto from 'crypto';
 import * as sinon from 'sinon';
+import { setTimeout } from 'timers/promises';
 
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { ClientEncryption } from '../../../src/client-side-encryption/client_encryption';
@@ -13,7 +14,9 @@ import {
   CSOTTimeoutContext,
   type MongoClient,
   MongoOperationTimeoutError,
-  StateMachine
+  resolveTimeoutOptions,
+  StateMachine,
+  TimeoutContext
 } from '../../mongodb';
 import {
   clearFailPoint,
@@ -23,6 +26,7 @@ import {
   measureDuration,
   sleep
 } from '../../tools/utils';
+import { filterForCommands } from '../shared';
 
 const metadata: MongoDBMetadataUI = {
   requires: {
@@ -947,6 +951,68 @@ describe('CSOT', function () {
           });
         }
       );
+
+      context('when the cursor times out and a killCursors is executed', function () {
+        let client: MongoClient;
+        let commands: (CommandStartedEvent & { command: { maxTimeMS?: number } })[] = [];
+
+        beforeEach(async function () {
+          client = this.configuration.newClient({}, { monitorCommands: true });
+          commands = [];
+          client.on('commandStarted', filterForCommands('killCursors', commands));
+
+          await client.connect();
+          const docs = Array.from({ length: 1200 }, (_, i) => ({ i }));
+
+          await client.db('test').collection('test').insertMany(docs);
+
+          await configureFailPoint(this.configuration, {
+            configureFailPoint: 'failCommand',
+            mode: 'alwaysOn',
+            data: {
+              failCommands: ['getMore'],
+              blockConnection: true,
+              blockTimeMS: 2000
+            }
+          });
+        });
+
+        afterEach(async function () {
+          await clearFailPoint(this.configuration);
+          await client.close();
+        });
+
+        it(
+          'refreshes timeoutMS to the full timeout',
+          {
+            requires: {
+              ...metadata.requires,
+              topology: '!load-balanced'
+            }
+          },
+          async function () {
+            const timeoutContext = TimeoutContext.create(
+              resolveTimeoutOptions(client, { timeoutMS: 1900 })
+            );
+
+            await setTimeout(1500);
+
+            const { result: error } = await measureDuration(() =>
+              stateMachine
+                .fetchKeys(client, 'test.test', BSON.serialize({}), timeoutContext)
+                .catch(e => e)
+            );
+            expect(error).to.be.instanceOf(MongoOperationTimeoutError);
+
+            const [
+              {
+                command: { maxTimeMS }
+              }
+            ] = commands;
+            expect(maxTimeMS).to.be.greaterThan(1800);
+          }
+        );
+      });
 
       context('when csot is not enabled and fetchKeys() is delayed', function () {
         let encryptedClient;

--- a/test/tools/utils.ts
+++ b/test/tools/utils.ts
@@ -689,3 +689,19 @@ export async function measureDuration<T>(f: () => Promise<T>): Promise<{
     result
   };
 }
+
+export function mergeTestMetadata(
+  metadata: MongoDBMetadataUI,
+  newMetadata: MongoDBMetadataUI
+): MongoDBMetadataUI {
+  return {
+    requires: {
+      ...metadata.requires,
+      ...newMetadata.requires
+    },
+    sessions: {
+      ...metadata.sessions,
+      ...newMetadata.sessions
+    }
+  };
+}


### PR DESCRIPTION
### Description

#### What is changing?

Instead of using the remainingTimeMS as the value for `timeoutMS` when running cursor operations in the state machine, we provide a CursorTimeoutContext that wraps the original timeout.

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
