### PR TITLE
test(NODE-6266): Remove serverless proxy incremental rollout tests

### DIFF
--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -1389,14 +1389,8 @@ task_groups:
           script: |
             ${PREPARE_SHELL}
             set +o xtrace
-            if [[ -n "${USE_SERVERLESS_PROXY}" ]];
-            then
-              export SERVERLESS_GROUP="${PROXY_SERVERLESS_DRIVERS_GROUP}"
-            else
-              export SERVERLESS_GROUP="${SERVERLESS_DRIVERS_GROUP}"
-            fi
             LOADBALANCED=ON \
-            SERVERLESS_DRIVERS_GROUP=${SERVERLESS_GROUP} \
+            SERVERLESS_DRIVERS_GROUP=${SERVERLESS_DRIVERS_GROUP} \
             SERVERLESS_API_PUBLIC_KEY=${SERVERLESS_API_PUBLIC_KEY} \
             SERVERLESS_API_PRIVATE_KEY=${SERVERLESS_API_PRIVATE_KEY} \
               bash ${DRIVERS_TOOLS}/.evergreen/serverless/create-instance.sh
@@ -1410,13 +1404,7 @@ task_groups:
           script: |
             ${PREPARE_SHELL}
             set +o xtrace
-            if [[ -n "${USE_SERVERLESS_PROXY}" ]];
-            then
-              export SERVERLESS_GROUP="${PROXY_SERVERLESS_DRIVERS_GROUP}"
-            else
-              export SERVERLESS_GROUP="${SERVERLESS_DRIVERS_GROUP}"
-            fi
-            SERVERLESS_DRIVERS_GROUP=${SERVERLESS_GROUP} \
+            SERVERLESS_DRIVERS_GROUP=${SERVERLESS_DRIVERS_GROUP} \
             SERVERLESS_API_PUBLIC_KEY=${SERVERLESS_API_PUBLIC_KEY} \
             SERVERLESS_API_PRIVATE_KEY=${SERVERLESS_API_PRIVATE_KEY} \
             SERVERLESS_INSTANCE_NAME=${SERVERLESS_INSTANCE_NAME} \

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -4332,14 +4332,8 @@ task_groups:
           script: |
             ${PREPARE_SHELL}
             set +o xtrace
-            if [[ -n "${USE_SERVERLESS_PROXY}" ]];
-            then
-              export SERVERLESS_GROUP="${PROXY_SERVERLESS_DRIVERS_GROUP}"
-            else
-              export SERVERLESS_GROUP="${SERVERLESS_DRIVERS_GROUP}"
-            fi
             LOADBALANCED=ON \
-            SERVERLESS_DRIVERS_GROUP=${SERVERLESS_GROUP} \
+            SERVERLESS_DRIVERS_GROUP=${SERVERLESS_DRIVERS_GROUP} \
             SERVERLESS_API_PUBLIC_KEY=${SERVERLESS_API_PUBLIC_KEY} \
             SERVERLESS_API_PRIVATE_KEY=${SERVERLESS_API_PRIVATE_KEY} \
               bash ${DRIVERS_TOOLS}/.evergreen/serverless/create-instance.sh
@@ -4353,13 +4347,7 @@ task_groups:
           script: |
             ${PREPARE_SHELL}
             set +o xtrace
-            if [[ -n "${USE_SERVERLESS_PROXY}" ]];
-            then
-              export SERVERLESS_GROUP="${PROXY_SERVERLESS_DRIVERS_GROUP}"
-            else
-              export SERVERLESS_GROUP="${SERVERLESS_DRIVERS_GROUP}"
-            fi
-            SERVERLESS_DRIVERS_GROUP=${SERVERLESS_GROUP} \
+            SERVERLESS_DRIVERS_GROUP=${SERVERLESS_DRIVERS_GROUP} \
             SERVERLESS_API_PUBLIC_KEY=${SERVERLESS_API_PUBLIC_KEY} \
             SERVERLESS_API_PRIVATE_KEY=${SERVERLESS_API_PRIVATE_KEY} \
             SERVERLESS_INSTANCE_NAME=${SERVERLESS_INSTANCE_NAME} \
@@ -5080,15 +5068,6 @@ buildvariants:
     expansions:
       NODE_LTS_VERSION: 16
       NPM_VERSION: 9
-    tasks:
-      - serverless_task_group
-  - name: rhel8-test-serverless-proxy
-    display_name: Serverless Proxy Test
-    run_on: rhel80-large
-    expansions:
-      NODE_LTS_VERSION: 16
-      NPM_VERSION: 9
-      USE_SERVERLESS_PROXY: true
     tasks:
       - serverless_task_group
   - name: rhel8-test-gcp-kms

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -696,18 +696,6 @@ BUILD_VARIANTS.push({
 });
 
 BUILD_VARIANTS.push({
-  name: 'rhel8-test-serverless-proxy',
-  display_name: 'Serverless Proxy Test',
-  run_on: DEFAULT_OS,
-  expansions: {
-    NODE_LTS_VERSION: LOWEST_LTS,
-    NPM_VERSION: 9,
-    USE_SERVERLESS_PROXY: true
-  },
-  tasks: ['serverless_task_group']
-});
-
-BUILD_VARIANTS.push({
   name: 'rhel8-test-gcp-kms',
   display_name: 'GCP KMS Test',
   run_on: DEBIAN_OS,


### PR DESCRIPTION
### Description
Remove serverless proxy build variants as Serverless gRPC Proxy is being sunset..

#### What is changing?
Remove serverless proxy build variants. Revert changes from the [NODE-5731 PR](https://github.com/mongodb/node-mongodb-native/pull/4003/files#diff-2bc841e86ce96b7b422ae203fd8315d0b2a461956cecbe0e096420656fc3fb12).

##### Is there new documentation needed for these changes?
No, test only change.

#### What is the motivation for this change?
DRIVERS-2939.

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
