### PR TITLE
chore(NODE-6488): specify target=es2021 for ts compilation tests

### DIFF
--- a/.evergreen/run-typescript.sh
+++ b/.evergreen/run-typescript.sh
@@ -44,8 +44,12 @@ if [ "$TS_CHECK" == "COMPILE_DRIVER" ]; then
     npm run build:ts
 elif [ "$TS_CHECK" == "CHECK_TYPES" ]; then
     echo "checking driver types"
+    if [ "$TS_VERSION" == "4.4" ]; then
     # check compilation
+        node $TSC mongodb.d.ts --module commonjs --target es2021
+    else
     node $TSC mongodb.d.ts --module node16 --target es2021
+    fi
 else
     "Invalid value $TS_CHECK for TS_CHECK environment variable."
     exit 1

--- a/.evergreen/run-typescript.sh
+++ b/.evergreen/run-typescript.sh
@@ -45,7 +45,7 @@ if [ "$TS_CHECK" == "COMPILE_DRIVER" ]; then
 elif [ "$TS_CHECK" == "CHECK_TYPES" ]; then
     echo "checking driver types"
     # check compilation
-    node $TSC mongodb.d.ts
+    node $TSC mongodb.d.ts --module node16 --target es2021
 else
     "Invalid value $TS_CHECK for TS_CHECK environment variable."
     exit 1

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ This is the lowest typescript version guaranteed to work with our driver: older 
 Since typescript [does not restrict breaking changes to major versions](https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes), we consider this support best effort.
 If you run into any unexpected compiler failures against our supported TypeScript versions, please let us know by filing an issue on our [JIRA](https://jira.mongodb.org/browse/NODE).
 
+Additionally, our Typescript types are compatible with the ECMAScript standard for our minimum supported Node version.  Currently, our Typescript targets es2021.
+
 ## Installation
 
 The recommended way to get started using the Node.js 5.x driver is by using the `npm` (Node Package Manager) to install the dependency in your project.


### PR DESCRIPTION
### Description

#### What is changing?

Set target to es2021 to avoid errors related to supporting JS syntax below our lowest supported node version.

##### Is there new documentation needed for these changes?

Yes, added to the readme

#### What is the motivation for this change?



### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
