### PR TITLE
chore(NODE-6459): compare CSOT performance

### DIFF
--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -1179,8 +1179,7 @@ tasks:
         type: setup
         params:
           updates:
-            - { key: NODE_LTS_VERSION, value: v18.16.0 }
-            - { key: NPM_VERSION, value: "9" }
+            - { key: NODE_LTS_VERSION, value: v22.11.0 }
             - { key: VERSION, value: v6.0-perf }
             - { key: TOPOLOGY, value: server }
             - { key: AUTH, value: noauth }
@@ -1202,8 +1201,7 @@ tasks:
         type: setup
         params:
           updates:
-            - { key: NODE_LTS_VERSION, value: v18.16.0 }
-            - { key: NPM_VERSION, value: "9" }
+            - { key: NODE_LTS_VERSION, value: v22.11.0 }
             - { key: VERSION, value: v6.0-perf }
             - { key: TOPOLOGY, value: server }
             - { key: AUTH, value: noauth }
@@ -1215,6 +1213,28 @@ tasks:
         params:
           file: src/results.json
 
+  - name: run-spec-benchmark-tests-node-server-enableUtf8Validation-false
+    tags:
+      - run-spec-benchmark-tests
+      - performance
+    exec_timeout_secs: 3600
+    commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - { key: NODE_LTS_VERSION, value: v18.16.0 }
+            - { key: NPM_VERSION, value: "9" }
+            - { key: VERSION, value: v6.0-perf }
+            - { key: TOPOLOGY, value: server }
+            - { key: AUTH, value: noauth }
+            - { key: MONGODB_CLIENT_OPTIONS, value: '{"enableUtf8Validation": false}' }
+      - func: install dependencies
+      - func: bootstrap mongo-orchestration
+      - func: run spec driver benchmarks
+      - command: perf.send
+        params:
+          file: src/results.json
 
   - name: "test-gcpkms-task"
     commands:
@@ -1786,3 +1806,4 @@ buildvariants:
       - run-spec-benchmark-tests-node-server
       - run-spec-benchmark-tests-node-server-timeoutMS-120000
       - run-spec-benchmark-tests-node-server-timeoutMS-0
+      - run-spec-benchmark-tests-node-server-enableUtf8Validation-false

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -1223,8 +1223,7 @@ tasks:
         type: setup
         params:
           updates:
-            - { key: NODE_LTS_VERSION, value: v18.16.0 }
-            - { key: NPM_VERSION, value: "9" }
+            - { key: NODE_LTS_VERSION, value: v22.11.0 }
             - { key: VERSION, value: v6.0-perf }
             - { key: TOPOLOGY, value: server }
             - { key: AUTH, value: noauth }

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -1213,28 +1213,6 @@ tasks:
         params:
           file: src/results.json
 
-  - name: run-spec-benchmark-tests-node-server-enableUtf8Validation-false
-    tags:
-      - run-spec-benchmark-tests
-      - performance
-    exec_timeout_secs: 3600
-    commands:
-      - command: expansions.update
-        type: setup
-        params:
-          updates:
-            - { key: NODE_LTS_VERSION, value: v22.11.0 }
-            - { key: VERSION, value: v6.0-perf }
-            - { key: TOPOLOGY, value: server }
-            - { key: AUTH, value: noauth }
-            - { key: MONGODB_CLIENT_OPTIONS, value: '{"enableUtf8Validation": false}' }
-      - func: install dependencies
-      - func: bootstrap mongo-orchestration
-      - func: run spec driver benchmarks
-      - command: perf.send
-        params:
-          file: src/results.json
-
   - name: "test-gcpkms-task"
     commands:
       - command: expansions.update
@@ -1367,7 +1345,7 @@ tasks:
           include_expansions_in_env: ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN"]
           args:
             - .evergreen/run-oidc-tests-k8s.sh
-    
+
   - name: "oidc-auth-test-k8s-latest-aks"
     commands:
       - func: "install dependencies"
@@ -1805,4 +1783,3 @@ buildvariants:
       - run-spec-benchmark-tests-node-server
       - run-spec-benchmark-tests-node-server-timeoutMS-120000
       - run-spec-benchmark-tests-node-server-timeoutMS-0
-      - run-spec-benchmark-tests-node-server-enableUtf8Validation-false

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -1103,6 +1103,7 @@ functions:
           PROJECT_DIRECTORY: ${PROJECT_DIRECTORY}
           MONGODB_URI: ${MONGODB_URI}
           DRIVERS_TOOLS: ${DRIVERS_TOOLS}
+          MONGODB_CLIENT_OPTIONS: ${MONGODB_CLIENT_OPTIONS}
         binary: bash
         args:
           - ${PROJECT_DIRECTORY}/.evergreen/run-benchmarks.sh
@@ -1167,6 +1168,53 @@ tasks:
       - command: perf.send
         params:
           file: src/results.json
+
+  - name: run-spec-benchmark-tests-node-server-timeoutMS-120000
+    tags:
+      - run-spec-benchmark-tests
+      - performance
+    exec_timeout_secs: 3600
+    commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - { key: NODE_LTS_VERSION, value: v18.16.0 }
+            - { key: NPM_VERSION, value: "9" }
+            - { key: VERSION, value: v6.0-perf }
+            - { key: TOPOLOGY, value: server }
+            - { key: AUTH, value: noauth }
+            - { key: MONGODB_CLIENT_OPTIONS, value: '{"timeoutMS": 120000}' }
+      - func: install dependencies
+      - func: bootstrap mongo-orchestration
+      - func: run spec driver benchmarks
+      - command: perf.send
+        params:
+          file: src/results.json
+
+  - name: run-spec-benchmark-tests-node-server-timeoutMS-0
+    tags:
+      - run-spec-benchmark-tests
+      - performance
+    exec_timeout_secs: 3600
+    commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - { key: NODE_LTS_VERSION, value: v18.16.0 }
+            - { key: NPM_VERSION, value: "9" }
+            - { key: VERSION, value: v6.0-perf }
+            - { key: TOPOLOGY, value: server }
+            - { key: AUTH, value: noauth }
+            - { key: MONGODB_CLIENT_OPTIONS, value: '{"timeoutMS": 0}' }
+      - func: install dependencies
+      - func: bootstrap mongo-orchestration
+      - func: run spec driver benchmarks
+      - command: perf.send
+        params:
+          file: src/results.json
+
 
   - name: "test-gcpkms-task"
     commands:
@@ -1736,3 +1784,5 @@ buildvariants:
     run_on: rhel90-dbx-perf-large
     tasks:
       - run-spec-benchmark-tests-node-server
+      - run-spec-benchmark-tests-node-server-timeoutMS-120000
+      - run-spec-benchmark-tests-node-server-timeoutMS-0

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1171,27 +1171,6 @@ tasks:
       - command: perf.send
         params:
           file: src/results.json
-  - name: run-spec-benchmark-tests-node-server-enableUtf8Validation-false
-    tags:
-      - run-spec-benchmark-tests
-      - performance
-    exec_timeout_secs: 3600
-    commands:
-      - command: expansions.update
-        type: setup
-        params:
-          updates:
-            - {key: NODE_LTS_VERSION, value: v22.11.0}
-            - {key: VERSION, value: v6.0-perf}
-            - {key: TOPOLOGY, value: server}
-            - {key: AUTH, value: noauth}
-            - {key: MONGODB_CLIENT_OPTIONS, value: '{"enableUtf8Validation": false}'}
-      - func: install dependencies
-      - func: bootstrap mongo-orchestration
-      - func: run spec driver benchmarks
-      - command: perf.send
-        params:
-          file: src/results.json
   - name: test-gcpkms-task
     commands:
       - command: expansions.update
@@ -4736,7 +4715,6 @@ buildvariants:
       - run-spec-benchmark-tests-node-server
       - run-spec-benchmark-tests-node-server-timeoutMS-120000
       - run-spec-benchmark-tests-node-server-timeoutMS-0
-      - run-spec-benchmark-tests-node-server-enableUtf8Validation-false
   - name: rhel80-large-gallium
     display_name: rhel8 Node16
     run_on: rhel80-large

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1181,8 +1181,7 @@ tasks:
         type: setup
         params:
           updates:
-            - {key: NODE_LTS_VERSION, value: v18.16.0}
-            - {key: NPM_VERSION, value: '9'}
+            - {key: NODE_LTS_VERSION, value: v22.11.0}
             - {key: VERSION, value: v6.0-perf}
             - {key: TOPOLOGY, value: server}
             - {key: AUTH, value: noauth}

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1139,8 +1139,7 @@ tasks:
         type: setup
         params:
           updates:
-            - {key: NODE_LTS_VERSION, value: v18.16.0}
-            - {key: NPM_VERSION, value: '9'}
+            - {key: NODE_LTS_VERSION, value: v22.11.0}
             - {key: VERSION, value: v6.0-perf}
             - {key: TOPOLOGY, value: server}
             - {key: AUTH, value: noauth}
@@ -1161,12 +1160,33 @@ tasks:
         type: setup
         params:
           updates:
+            - {key: NODE_LTS_VERSION, value: v22.11.0}
+            - {key: VERSION, value: v6.0-perf}
+            - {key: TOPOLOGY, value: server}
+            - {key: AUTH, value: noauth}
+            - {key: MONGODB_CLIENT_OPTIONS, value: '{"timeoutMS": 0}'}
+      - func: install dependencies
+      - func: bootstrap mongo-orchestration
+      - func: run spec driver benchmarks
+      - command: perf.send
+        params:
+          file: src/results.json
+  - name: run-spec-benchmark-tests-node-server-enableUtf8Validation-false
+    tags:
+      - run-spec-benchmark-tests
+      - performance
+    exec_timeout_secs: 3600
+    commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
             - {key: NODE_LTS_VERSION, value: v18.16.0}
             - {key: NPM_VERSION, value: '9'}
             - {key: VERSION, value: v6.0-perf}
             - {key: TOPOLOGY, value: server}
             - {key: AUTH, value: noauth}
-            - {key: MONGODB_CLIENT_OPTIONS, value: '{"timeoutMS": 0}'}
+            - {key: MONGODB_CLIENT_OPTIONS, value: '{"enableUtf8Validation": false}'}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run spec driver benchmarks
@@ -4717,6 +4737,7 @@ buildvariants:
       - run-spec-benchmark-tests-node-server
       - run-spec-benchmark-tests-node-server-timeoutMS-120000
       - run-spec-benchmark-tests-node-server-timeoutMS-0
+      - run-spec-benchmark-tests-node-server-enableUtf8Validation-false
   - name: rhel80-large-gallium
     display_name: rhel8 Node16
     run_on: rhel80-large

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1065,6 +1065,7 @@ functions:
           PROJECT_DIRECTORY: ${PROJECT_DIRECTORY}
           MONGODB_URI: ${MONGODB_URI}
           DRIVERS_TOOLS: ${DRIVERS_TOOLS}
+          MONGODB_CLIENT_OPTIONS: ${MONGODB_CLIENT_OPTIONS}
         binary: bash
         args:
           - ${PROJECT_DIRECTORY}/.evergreen/run-benchmarks.sh
@@ -1122,6 +1123,50 @@ tasks:
             - {key: VERSION, value: v6.0-perf}
             - {key: TOPOLOGY, value: server}
             - {key: AUTH, value: noauth}
+      - func: install dependencies
+      - func: bootstrap mongo-orchestration
+      - func: run spec driver benchmarks
+      - command: perf.send
+        params:
+          file: src/results.json
+  - name: run-spec-benchmark-tests-node-server-timeoutMS-120000
+    tags:
+      - run-spec-benchmark-tests
+      - performance
+    exec_timeout_secs: 3600
+    commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NODE_LTS_VERSION, value: v18.16.0}
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: v6.0-perf}
+            - {key: TOPOLOGY, value: server}
+            - {key: AUTH, value: noauth}
+            - {key: MONGODB_CLIENT_OPTIONS, value: '{"timeoutMS": 120000}'}
+      - func: install dependencies
+      - func: bootstrap mongo-orchestration
+      - func: run spec driver benchmarks
+      - command: perf.send
+        params:
+          file: src/results.json
+  - name: run-spec-benchmark-tests-node-server-timeoutMS-0
+    tags:
+      - run-spec-benchmark-tests
+      - performance
+    exec_timeout_secs: 3600
+    commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NODE_LTS_VERSION, value: v18.16.0}
+            - {key: NPM_VERSION, value: '9'}
+            - {key: VERSION, value: v6.0-perf}
+            - {key: TOPOLOGY, value: server}
+            - {key: AUTH, value: noauth}
+            - {key: MONGODB_CLIENT_OPTIONS, value: '{"timeoutMS": 0}'}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run spec driver benchmarks
@@ -4670,6 +4715,8 @@ buildvariants:
     run_on: rhel90-dbx-perf-large
     tasks:
       - run-spec-benchmark-tests-node-server
+      - run-spec-benchmark-tests-node-server-timeoutMS-120000
+      - run-spec-benchmark-tests-node-server-timeoutMS-0
   - name: rhel80-large-gallium
     display_name: rhel8 Node16
     run_on: rhel80-large

--- a/.evergreen/run-benchmarks.sh
+++ b/.evergreen/run-benchmarks.sh
@@ -7,6 +7,7 @@ set -o nounset
 source $DRIVERS_TOOLS/.evergreen/init-node-and-npm-env.sh
 
 export MONGODB_URI=$MONGODB_URI
+export MONGODB_CLIENT_OPTIONS=$MONGODB_CLIENT_OPTIONS
 
 npm run build:ts
 npm run check:bench

--- a/test/benchmarks/driverBench/common.js
+++ b/test/benchmarks/driverBench/common.js
@@ -23,8 +23,22 @@ function loadSpecString(filePath) {
   return loadSpecFile(filePath, 'utf8');
 }
 
+const MONGODB_CLIENT_OPTIONS = (() => {
+  const optionsString = process.env.MONGODB_CLIENT_OPTIONS;
+  let options = undefined;
+  if (optionsString?.length) {
+    options = JSON.parse(optionsString);
+  }
+  return { ...options };
+})();
+
+const MONGODB_URI = (() => {
+  if (process.env.MONGODB_URI?.length) return process.env.MONGODB_URI;
+  return 'mongodb://127.0.0.1:27017';
+})();
+
 function makeClient() {
-  this.client = new MongoClient(process.env.MONGODB_URI || 'mongodb://127.0.0.1:27017');
+  this.client = new MongoClient(MONGODB_URI, MONGODB_CLIENT_OPTIONS);
 }
 
 function connectClient() {
@@ -101,6 +115,8 @@ async function writeSingleByteFileToBucket() {
 }
 
 module.exports = {
+  MONGODB_URI,
+  MONGODB_CLIENT_OPTIONS,
   makeClient,
   connectClient,
   disconnectClient,

--- a/test/benchmarks/driverBench/index.js
+++ b/test/benchmarks/driverBench/index.js
@@ -106,12 +106,6 @@ benchmarkRunner
   })
   .then(data => {
     const results = JSON.stringify(data, undefined, 2);
-    const print_results = data.map(({ info: { test_name, args }, metrics: [{ value }] }) => ({
-      test_name,
-      args,
-      value
-    }));
-    console.log(inspect(print_results, { depth: Infinity, colors: true }));
     return writeFile('results.json', results);
   })
   .catch(err => console.error(err));

--- a/test/benchmarks/driverBench/index.js
+++ b/test/benchmarks/driverBench/index.js
@@ -11,7 +11,7 @@ let bsonType = 'js-bson';
 const { inspect } = require('util');
 const { writeFile } = require('fs/promises');
 const { makeParallelBenchmarks, makeSingleBench, makeMultiBench } = require('../mongoBench/suites');
-const { MONGODB_URI, MONGODB_CLIENT_OPTIONS } = require('./common');
+const { MONGODB_CLIENT_OPTIONS } = require('./common');
 
 const hw = os.cpus();
 const ram = os.totalmem() / 1024 ** 3;
@@ -91,7 +91,12 @@ benchmarkRunner
         info: {
           test_name: benchmarkName,
           tags: [bsonType],
-          args: { MONGODB_URI, MONGODB_CLIENT_OPTIONS }
+          args: {
+            // Sadly args can only be int32
+            ...(typeof MONGODB_CLIENT_OPTIONS.timeoutMS === 'number'
+              ? { timeoutMS: MONGODB_CLIENT_OPTIONS.timeoutMS }
+              : {})
+          }
         },
         metrics: [{ name: 'megabytes_per_second', value: result }]
       };

--- a/test/benchmarks/driverBench/index.js
+++ b/test/benchmarks/driverBench/index.js
@@ -11,6 +11,7 @@ let bsonType = 'js-bson';
 const { inspect } = require('util');
 const { writeFile } = require('fs/promises');
 const { makeParallelBenchmarks, makeSingleBench, makeMultiBench } = require('../mongoBench/suites');
+const { MONGODB_URI, MONGODB_CLIENT_OPTIONS } = require('./common');
 
 const hw = os.cpus();
 const ram = os.totalmem() / 1024 ** 3;
@@ -89,7 +90,8 @@ benchmarkRunner
       return {
         info: {
           test_name: benchmarkName,
-          tags: [bsonType]
+          tags: [bsonType],
+          args: { MONGODB_URI, MONGODB_CLIENT_OPTIONS }
         },
         metrics: [{ name: 'megabytes_per_second', value: result }]
       };

--- a/test/benchmarks/driverBench/index.js
+++ b/test/benchmarks/driverBench/index.js
@@ -8,7 +8,6 @@ const Runner = MongoBench.Runner;
 let bsonType = 'js-bson';
 // TODO(NODE-4606): test against different driver configurations in CI
 
-const { inspect } = require('util');
 const { writeFile } = require('fs/promises');
 const { makeParallelBenchmarks, makeSingleBench, makeMultiBench } = require('../mongoBench/suites');
 const { MONGODB_CLIENT_OPTIONS } = require('./common');

--- a/test/benchmarks/driverBench/index.js
+++ b/test/benchmarks/driverBench/index.js
@@ -11,7 +11,6 @@ let bsonType = 'js-bson';
 const { inspect } = require('util');
 const { writeFile } = require('fs/promises');
 const { makeParallelBenchmarks, makeSingleBench, makeMultiBench } = require('../mongoBench/suites');
-const { MONGODB_CLIENT_OPTIONS } = require('./common');
 
 const hw = os.cpus();
 const ram = os.totalmem() / 1024 ** 3;
@@ -91,12 +90,7 @@ benchmarkRunner
         info: {
           test_name: benchmarkName,
           tags: [bsonType],
-          args: {
-            // Sadly args can only be int32
-            ...(typeof MONGODB_CLIENT_OPTIONS.timeoutMS === 'number'
-              ? { timeoutMS: MONGODB_CLIENT_OPTIONS.timeoutMS }
-              : {})
-          }
+          args: process.env.MONGODB_CLIENT_OPTIONS ?? ''
         },
         metrics: [{ name: 'megabytes_per_second', value: result }]
       };

--- a/test/benchmarks/driverBench/index.js
+++ b/test/benchmarks/driverBench/index.js
@@ -106,7 +106,12 @@ benchmarkRunner
   })
   .then(data => {
     const results = JSON.stringify(data, undefined, 2);
-    console.log(inspect(data, { depth: Infinity, colors: true }));
+    const print_results = data.map(({ info: { test_name, args }, metrics: [{ value }] }) => ({
+      test_name,
+      args,
+      value
+    }));
+    console.log(inspect(print_results, { depth: Infinity, colors: true }));
     return writeFile('results.json', results);
   })
   .catch(err => console.error(err));

--- a/test/benchmarks/driverBench/index.js
+++ b/test/benchmarks/driverBench/index.js
@@ -11,6 +11,7 @@ let bsonType = 'js-bson';
 const { inspect } = require('util');
 const { writeFile } = require('fs/promises');
 const { makeParallelBenchmarks, makeSingleBench, makeMultiBench } = require('../mongoBench/suites');
+const { MONGODB_CLIENT_OPTIONS } = require('./common');
 
 const hw = os.cpus();
 const ram = os.totalmem() / 1024 ** 3;
@@ -90,7 +91,14 @@ benchmarkRunner
         info: {
           test_name: benchmarkName,
           tags: [bsonType],
-          args: process.env.MONGODB_CLIENT_OPTIONS ?? ''
+          // Args can only be a map of string -> int32. So if its a number leave it be,
+          // if it is anything else test for truthiness and set to 1 or 0.
+          args: Object.fromEntries(
+            Object.entries(MONGODB_CLIENT_OPTIONS).map(([key, value]) => [
+              key,
+              typeof value === 'number' ? value | 0 : value ? 1 : 0
+            ])
+          )
         },
         metrics: [{ name: 'megabytes_per_second', value: result }]
       };

--- a/test/benchmarks/mongoBench/runner.js
+++ b/test/benchmarks/mongoBench/runner.js
@@ -190,8 +190,8 @@ class Runner {
 
   _errorHandler(error) {
     this.reporter(`Error: ${error.name} - ${error.message} - ${error.stack}`);
-    for (let error = error.cause; error != null; error = error.cause) {
-      this.reporter(`Caused by: ${error.name} - ${error.message} - ${error.stack}`);
+    for (let cause = error.cause; cause != null; cause = cause.cause) {
+      this.reporter(`Caused by: ${cause.name} - ${cause.message} - ${cause.stack}`);
     }
     throw error;
   }


### PR DESCRIPTION
### Description

#### What is changing?

- Add new benchmark tasks for CSOT
  - set to 0, which means no timeouts are made
  - set to 120,000 ms so nothing actually times out but we are making timers


##### Is there new documentation needed for these changes?
No
#### What is the motivation for this change?

More perf data!


### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
