### PR TITLE
chore: set DRIVERS_TOOLS for benchmarks

### DIFF
--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -1102,6 +1102,7 @@ functions:
         env:
           PROJECT_DIRECTORY: ${PROJECT_DIRECTORY}
           MONGODB_URI: ${MONGODB_URI}
+          DRIVERS_TOOLS: ${DRIVERS_TOOLS}
         binary: bash
         args:
           - ${PROJECT_DIRECTORY}/.evergreen/run-benchmarks.sh

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1064,6 +1064,7 @@ functions:
         env:
           PROJECT_DIRECTORY: ${PROJECT_DIRECTORY}
           MONGODB_URI: ${MONGODB_URI}
+          DRIVERS_TOOLS: ${DRIVERS_TOOLS}
         binary: bash
         args:
           - ${PROJECT_DIRECTORY}/.evergreen/run-benchmarks.sh

--- a/.evergreen/run-benchmarks.sh
+++ b/.evergreen/run-benchmarks.sh
@@ -1,5 +1,9 @@
 #! /bin/bash
 
+set -o errexit
+set -o xtrace
+set -o nounset
+
 source $DRIVERS_TOOLS/.evergreen/init-node-and-npm-env.sh
 
 export MONGODB_URI=$MONGODB_URI

--- a/test/benchmarks/driverBench/index.js
+++ b/test/benchmarks/driverBench/index.js
@@ -22,7 +22,9 @@ const systemInfo = () =>
     `- cores: ${platform.cores}`,
     `- arch: ${os.arch()}`,
     `- os: ${process.platform} (${os.release()})`,
-    `- ram: ${platform.ram}\n`
+    `- ram: ${platform.ram}`,
+    `- bson: ${require('bson/package.json').version}`,
+    `- node: ${process.version}\n`
   ].join('\n');
 console.log(systemInfo());
 


### PR DESCRIPTION
### Description

#### What is changing?

- DRIVERS_TOOLS was unset for benchmarks changing the node version
- Add a print for node version

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

Test on our pinned node version

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
