### PR TITLE
ci(...): use virtualenv and find_python to use the correct python version in CI

### DIFF
--- a/.evergreen/activate-kms-venv.sh
+++ b/.evergreen/activate-kms-venv.sh
@@ -1,11 +1,7 @@
 #!/bin/bash
 set -o errexit  # Exit the script with error if any of the commands fail
 
-cd ${DRIVERS_TOOLS}/.evergreen/csfle
+pushd ${DRIVERS_TOOLS}/.evergreen/csfle
 . ./activate-kmstlsvenv.sh
 
-if [ "Windows_NT" = "$OS" ]; then
-  echo "export PYTHON_EXEC='kmstlsvenv/Scripts/python.exe'" > prepare-kmsvenv.sh
-else
-  echo "export PYTHON_EXEC='./kmstlsvenv/bin/python3'" > prepare-kmsvenv.sh
-fi
+popd

--- a/.evergreen/run-azure-kms-mock-server.sh
+++ b/.evergreen/run-azure-kms-mock-server.sh
@@ -4,6 +4,13 @@ if [ -z ${DRIVERS_TOOLS+omitted} ]; then echo "DRIVERS_TOOLS is unset" && exit 1
 
 set -o errexit
 
-python3 $DRIVERS_TOOLS/.evergreen/csfle/bottle.py fake_azure:imds &
+source ./activate-kms-venv.sh
+
+
+echo "Python version information"
+echo "which python?: ${which python}"
+echo "python -v: ${python -v}"
+
+python $DRIVERS_TOOLS/.evergreen/csfle/bottle.py fake_azure:imds &
 
 echo "Running Azure KMS idms server on port 8080"

--- a/.evergreen/run-kmip-server.sh
+++ b/.evergreen/run-kmip-server.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 set -o errexit  # Exit the script with error if any of the commands fail
 
-cd ${DRIVERS_TOOLS}/.evergreen/csfle
-. ./prepare-kmsvenv.sh
+source ./activate-kms-venv.sh
 
-echo "$PYTHON_EXEC"
 
-$PYTHON_EXEC -u kms_kmip_server.py \
+echo "Python version information"
+echo "which python?: ${which python}"
+echo "python -v: ${python -v}"
+
+python -u kms_kmip_server.py \
   --ca_file ../x509gen/ca.pem \
   --cert_file ../x509gen/server.pem \
   --port 5698

--- a/.evergreen/run-kms-servers.sh
+++ b/.evergreen/run-kms-servers.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 set -o errexit  # Exit the script with error if any of the commands fail
 
-cd ${DRIVERS_TOOLS}/.evergreen/csfle
-. ./prepare-kmsvenv.sh
+source ./activate-kms-venv.sh
 
-echo "$PYTHON_EXEC"
+echo "Python version information"
+echo "which python?: ${which python}"
+echo "python -v: ${python -v}"
 
-$PYTHON_EXEC -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/expired.pem --port 8000 &
-$PYTHON_EXEC -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/wrong-host.pem --port 8001 &
-$PYTHON_EXEC -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/server.pem --port 8002 --require_client_cert &
+python -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/expired.pem --port 8000 &
+python -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/wrong-host.pem --port 8001 &
+python -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/server.pem --port 8002 --require_client_cert &

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -45,7 +45,8 @@ if [[ -z "${CLIENT_ENCRYPTION}" ]]; then
   unset AWS_ACCESS_KEY_ID;
   unset AWS_SECRET_ACCESS_KEY;
 else
-  pip install --upgrade boto3
+  source "$DRIVERS_TOOLS/.evergreen/venv-utils.sh"
+  venvactivate "$DRIVERS_TOOLS/.evergreen/orchestration/venv"  pip install --upgrade boto3
   # Get access to the AWS temporary credentials:
   echo "adding temporary AWS credentials to environment"
   # CSFLE_AWS_TEMP_ACCESS_KEY_ID, CSFLE_AWS_TEMP_SECRET_ACCESS_KEY, CSFLE_AWS_TEMP_SESSION_TOKEN


### PR DESCRIPTION
### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
