### PR TITLE
chore(NODE-6493): CSOT clean ups and sync runCursorCommand test

### DIFF
--- a/etc/notes/errors.md
+++ b/etc/notes/errors.md
@@ -111,7 +111,7 @@ This class should **never** be directly instantiated.
 
 ### `MongoOperationTimeoutError`
 
-- TODO(NODE-5688): Add MongoOperationTimeoutError documentation
+- TODO(NODE-6491): Add MongoOperationTimeoutError documentation
 
 ### MongoUnexpectedServerResponseError
 

--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -543,6 +543,8 @@ export type ChangeStreamEvents<
   /**
    * @remarks Note that the `close` event is currently emitted whenever the internal `ChangeStreamCursor`
    * instance is closed, which can occur multiple times for a given `ChangeStream` instance.
+   *
+   * TODO(NODE-6434): address this issue in NODE-6434
    */
   close(): void;
 };

--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -1092,7 +1092,7 @@ export const OPTIONS = {
     type: 'string'
   },
   socketTimeoutMS: {
-    deprecated: 'Please use timeoutMS instead',
+    // TODO(NODE-6491): deprecated: 'Please use timeoutMS instead',
     default: 0,
     type: 'uint'
   },
@@ -1163,7 +1163,7 @@ export const OPTIONS = {
     }
   },
   waitQueueTimeoutMS: {
-    deprecated: 'Please use timeoutMS instead',
+    // TODO(NODE-6491): deprecated: 'Please use timeoutMS instead',
     default: 0,
     type: 'uint'
   },

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -113,7 +113,6 @@ export interface AbstractCursorOptions extends BSONSerializeOptions {
   /**
    * When applicable `maxTimeMS` controls the amount of time the initial command
    * that constructs a cursor should take. (ex. find, aggregate, listCollections)
-   * @deprecated Will be removed in the next major version. Please use timeoutMS instead.
    */
   maxTimeMS?: number;
   /**
@@ -775,7 +774,6 @@ export abstract class AbstractCursor<
    * Set a maxTimeMS on the cursor query, allowing for hard timeout limits on queries (Only supported on MongoDB 2.6 or higher)
    *
    * @param value - Number of milliseconds to wait before aborting the query.
-   * @deprecated Will be removed in the next major version. Please use the timeoutMS option instead.
    */
   maxTimeMS(value: number): this {
     this.throwIfInitialized();

--- a/src/cursor/run_command_cursor.ts
+++ b/src/cursor/run_command_cursor.ts
@@ -81,7 +81,6 @@ export class RunCommandCursor extends AbstractCursor {
   /**
    * Controls the `getMore.maxTimeMS` field. Only valid when cursor is tailable await
    * @param maxTimeMS - the number of milliseconds to wait for new data
-   * @deprecated Will be removed in the next major version. Please use timeoutMS instead.
    */
   public setMaxTimeMS(maxTimeMS: number): this {
     this.getMoreOptions.maxAwaitTimeMS = maxTimeMS;
@@ -118,7 +117,6 @@ export class RunCommandCursor extends AbstractCursor {
 
   /**
    * Unsupported for RunCommandCursor: maxTimeMS must be configured directly on command document
-   * @deprecated Will be removed in the next major version.
    */
   public override maxTimeMS(_: number): never {
     throw new MongoAPIError(

--- a/src/error.ts
+++ b/src/error.ts
@@ -128,9 +128,6 @@ function isAggregateError(e: unknown): e is Error & { errors: Error[] } {
  * mongodb-client-encryption has a dependency on this error, it uses the constructor with a string argument
  */
 export class MongoError extends Error {
-  get [Symbol.toStringTag]() {
-    return this.name;
-  }
   /** @internal */
   [kErrorLabels]: Set<string>;
   /**

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -155,10 +155,7 @@ export interface MongoClientOptions extends BSONSerializeOptions, SupportedNodeC
   tlsInsecure?: boolean;
   /** The time in milliseconds to attempt a connection before timing out. */
   connectTimeoutMS?: number;
-  /**
-   * The time in milliseconds to attempt a send or receive on a socket before the attempt times out.
-   * @deprecated Will be removed in the next major version. Please use timeoutMS instead
-   */
+  /** The time in milliseconds to attempt a send or receive on a socket before the attempt times out. */
   socketTimeoutMS?: number;
   /** An array or comma-delimited string of compressors to enable network compression for communication between this client and a mongod/mongos instance. */
   compressors?: CompressorName[] | string;
@@ -182,10 +179,7 @@ export interface MongoClientOptions extends BSONSerializeOptions, SupportedNodeC
   maxConnecting?: number;
   /** The maximum number of milliseconds that a connection can remain idle in the pool before being removed and closed. */
   maxIdleTimeMS?: number;
-  /**
-   * The maximum time in milliseconds that a thread can wait for a connection to become available.
-   * @deprecated Will be removed in the next major version. Please use timeoutMS instead
-   */
+  /** The maximum time in milliseconds that a thread can wait for a connection to become available. */
   waitQueueTimeoutMS?: number;
   /** Specify a read concern for the collection (only MongoDB 3.2 or higher supported) */
   readConcern?: ReadConcernLike;

--- a/src/operations/aggregate.ts
+++ b/src/operations/aggregate.ts
@@ -28,7 +28,6 @@ export interface AggregateOptions extends Omit<CommandOperationOptions, 'explain
   cursor?: Document;
   /**
    * Specifies a cumulative time limit in milliseconds for processing operations on the cursor. MongoDB interrupts the operation at the earliest following interrupt point.
-   * @deprecated Will be removed in the next major version. Please use timeoutMS instead.
    */
   maxTimeMS?: number;
   /** The maximum amount of time for the server to wait on new documents to satisfy a tailable cursor query. */

--- a/src/operations/command.ts
+++ b/src/operations/command.ts
@@ -42,7 +42,6 @@ export interface CommandOperationOptions
   collation?: CollationOptions;
   /**
    * maxTimeMS is a server-side time limit in milliseconds for processing an operation.
-   * @deprecated Will be removed in the next major version. Please use timeoutMS instead.
    */
   maxTimeMS?: number;
   /**

--- a/src/operations/count.ts
+++ b/src/operations/count.ts
@@ -15,7 +15,6 @@ export interface CountOptions extends CommandOperationOptions {
   limit?: number;
   /**
    * Number of milliseconds to wait before aborting the query.
-   * @deprecated Will be removed in the next major version. Please use timeoutMS instead.
    */
   maxTimeMS?: number;
   /** An index name hint for the query. */

--- a/src/operations/estimated_document_count.ts
+++ b/src/operations/estimated_document_count.ts
@@ -12,7 +12,6 @@ export interface EstimatedDocumentCountOptions extends CommandOperationOptions {
    * The maximum amount of time to allow the operation to run.
    *
    * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
-   * @deprecated Will be removed in the next major version. Please use timeoutMS instead.
    */
   maxTimeMS?: number;
 }

--- a/src/sdam/server.ts
+++ b/src/sdam/server.ts
@@ -346,7 +346,6 @@ export class Server extends TypedEventEmitter<ServerEvents> {
         operationError.code === MONGODB_ERROR_CODES.Reauthenticate
       ) {
         await this.pool.reauthenticate(conn);
-        // TODO(NODE-5682): Implement CSOT support for socket read/write at the connection layer
         try {
           const res = await conn.command(ns, cmd, finalOptions, responseType);
           throwIfWriteConcernError(res);

--- a/src/sdam/topology.ts
+++ b/src/sdam/topology.ts
@@ -180,7 +180,7 @@ export interface SelectServerOptions {
   previousServer?: ServerDescription;
   /**
    * @internal
-   * TODO(NODE-5685): Make this required
+   * TODO(NODE-6496): Make this required by making ChangeStream use LegacyTimeoutContext
    * */
   timeoutContext?: TimeoutContext;
 }

--- a/src/timeout.ts
+++ b/src/timeout.ts
@@ -32,10 +32,6 @@ type Reject = Parameters<ConstructorParameters<typeof Promise<never>>[0]>[1];
  * if interacted with exclusively through its public API
  * */
 export class Timeout extends Promise<never> {
-  get [Symbol.toStringTag](): 'MongoDBTimeout' {
-    return 'MongoDBTimeout';
-  }
-
   private id?: NodeJS.Timeout;
 
   public readonly start: number;
@@ -110,17 +106,6 @@ export class Timeout extends Promise<never> {
 
   public static expires(duration: number, unref?: true): Timeout {
     return new Timeout(undefined, { duration, unref });
-  }
-
-  static is(timeout: unknown): timeout is Timeout {
-    return (
-      typeof timeout === 'object' &&
-      timeout != null &&
-      Symbol.toStringTag in timeout &&
-      timeout[Symbol.toStringTag] === 'MongoDBTimeout' &&
-      'then' in timeout &&
-      typeof timeout.then === 'function'
-    );
   }
 
   static override reject(rejection?: Error): Timeout {

--- a/src/transactions.ts
+++ b/src/transactions.ts
@@ -68,10 +68,7 @@ export interface TransactionOptions extends Omit<CommandOperationOptions, 'timeo
   writeConcern?: WriteConcern;
   /** A default read preference for commands in this transaction */
   readPreference?: ReadPreferenceLike;
-  /**
-   * Specifies the maximum amount of time to allow a commit action on a transaction to run in milliseconds
-   * @deprecated This option is deprecated in favor of `timeoutMS` or `defaultTimeoutMS`.
-   */
+  /** Specifies the maximum amount of time to allow a commit action on a transaction to run in milliseconds */
   maxCommitTimeMS?: number;
 }
 

--- a/src/write_concern.ts
+++ b/src/write_concern.ts
@@ -15,8 +15,9 @@ export interface WriteConcernOptions {
 export interface WriteConcernSettings {
   /** The write concern */
   w?: W;
-  /** The write concern timeout
-   * @deprecated Will be removed in the next major version. Please use timeoutMS */
+  /**
+   * The write concern timeout.
+   */
   wtimeoutMS?: number;
   /** The journal write concern */
   journal?: boolean;
@@ -29,8 +30,6 @@ export interface WriteConcernSettings {
   j?: boolean;
   /**
    * The write concern timeout.
-   * @deprecated
-   * Will be removed in the next major version. Please use the wtimeoutMS option.
    */
   wtimeout?: number;
   /**
@@ -69,7 +68,6 @@ export class WriteConcern {
   readonly journal?: boolean;
   /**
    * Specify a time limit to prevent write operations from blocking indefinitely.
-   * @deprecated Will be removed in the next major version. Please use timeoutMS
    */
   readonly wtimeoutMS?: number;
   /**

--- a/test/benchmarks/driverBench/common.js
+++ b/test/benchmarks/driverBench/common.js
@@ -24,9 +24,7 @@ function loadSpecString(filePath) {
 }
 
 function makeClient() {
-  this.client = new MongoClient(process.env.MONGODB_URI || 'mongodb://127.0.0.1:27017', {
-    timeoutMS: 0
-  });
+  this.client = new MongoClient(process.env.MONGODB_URI || 'mongodb://127.0.0.1:27017');
 }
 
 function connectClient() {

--- a/test/integration/client-side-operations-timeout/client_side_operations_timeout.prose.test.ts
+++ b/test/integration/client-side-operations-timeout/client_side_operations_timeout.prose.test.ts
@@ -403,6 +403,7 @@ describe('CSOT spec prose tests', function () {
     });
   });
 
+  /** TODO(DRIVERS-2884): Drivers should not interrupt creating connections with a client-side timeout */
   context.skip('4. Background Connection Pooling', () => {
     /**
      * The tests in this section MUST only be run if the server version is 4.4 or higher and the URI has authentication

--- a/test/integration/client-side-operations-timeout/client_side_operations_timeout.spec.test.ts
+++ b/test/integration/client-side-operations-timeout/client_side_operations_timeout.spec.test.ts
@@ -7,12 +7,9 @@ import { runUnifiedSuite } from '../../tools/unified-spec-runner/runner';
 const skippedSpecs = {};
 
 const skippedTests = {
-  'timeoutMS can be configured on a MongoClient - createChangeStream on client': 'TODO(NODE-6305)',
-  'timeoutMS applies to whole operation, not individual attempts - createChangeStream on client':
-    'TODO(NODE-6305)',
-  'Tailable cursor iteration timeoutMS is refreshed for getMore - failure': 'TODO(NODE-6305)',
+  'Tailable cursor iteration timeoutMS is refreshed for getMore - failure': 'TODO(NODE-6493)',
   'Tailable cursor awaitData iteration timeoutMS is refreshed for getMore - failure':
-    'TODO(NODE-6305)',
+    'TODO(NODE-6493)',
   'command is not sent if RTT is greater than timeoutMS': 'TODO(DRIVERS-2965)',
   'Non=tailable cursor iteration timeoutMS is refreshed for getMore if timeoutMode is iteration - failure':
     'TODO(DRIVERS-2965)',

--- a/test/integration/client-side-operations-timeout/client_side_operations_timeout.spec.test.ts
+++ b/test/integration/client-side-operations-timeout/client_side_operations_timeout.spec.test.ts
@@ -7,13 +7,8 @@ import { runUnifiedSuite } from '../../tools/unified-spec-runner/runner';
 const skippedSpecs = {};
 
 const skippedTests = {
-  'Tailable cursor iteration timeoutMS is refreshed for getMore - failure': 'TODO(NODE-6493)',
-  'Tailable cursor awaitData iteration timeoutMS is refreshed for getMore - failure':
-    'TODO(NODE-6493)',
   'command is not sent if RTT is greater than timeoutMS': 'TODO(DRIVERS-2965)',
-  'Non=tailable cursor iteration timeoutMS is refreshed for getMore if timeoutMode is iteration - failure':
-    'TODO(DRIVERS-2965)',
-  'Non-tailable cursor lifetime remaining timeoutMS applied to getMore if timeoutMode is unset':
+  'Non-tailable cursor iteration timeoutMS is refreshed for getMore if timeoutMode is iteration - failure':
     'TODO(DRIVERS-2965)',
   'maxTimeMS value in the command is less than timeoutMS':
     'TODO(DRIVERS-2970): see modified test in unified-csot-node-specs',

--- a/test/spec/client-side-operations-timeout/runCursorCommand.json
+++ b/test/spec/client-side-operations-timeout/runCursorCommand.json
@@ -200,7 +200,7 @@
                   },
                   "collection": "collection",
                   "maxTimeMS": {
-                    "$$exists": true
+                    "$$exists": false
                   }
                 }
               }
@@ -210,7 +210,7 @@
       ]
     },
     {
-      "description": "Non=tailable cursor iteration timeoutMS is refreshed for getMore if timeoutMode is iteration - failure",
+      "description": "Non-tailable cursor iteration timeoutMS is refreshed for getMore if timeoutMode is iteration - failure",
       "runOnRequirements": [
         {
           "serverless": "forbid"

--- a/test/spec/client-side-operations-timeout/runCursorCommand.yml
+++ b/test/spec/client-side-operations-timeout/runCursorCommand.yml
@@ -70,7 +70,7 @@ tests:
     runOnRequirements:
       - serverless: forbid
     operations:
-      # Block find/getMore for 15ms.
+      # Block find/getMore for 60ms.
       - name: failPoint
         object: testRunner
         arguments:
@@ -83,8 +83,9 @@ tests:
               blockConnection: true
               blockTimeMS: 60
       # Run a find with timeoutMS less than double our failPoint blockTimeMS and
-      # batchSize less than the total document count will cause a find and a getMore to be sent.
-      # Both will block for 60ms so together they will go over the timeout.
+      # batchSize less than the total document count will cause a find and a 
+      # getMore to be sent. Both will block for 60ms so together they will go 
+      # over the timeout.
       - name: runCursorCommand
         object: *db
         arguments:
@@ -106,12 +107,12 @@ tests:
               command:
                 getMore: { $$type: [int, long] }
                 collection: *collection
-                maxTimeMS: { $$exists: true }
+                maxTimeMS: { $$exists: false }
 
   # If timeoutMode=ITERATION, timeoutMS applies separately to the initial find and the getMore on the cursor. Neither
   # command should have a maxTimeMS field. This is a failure test. The "find" inherits timeoutMS=100 and "getMore"
   # commands are blocked for 60ms, causing iteration to fail with a timeout error.
-  - description: Non=tailable cursor iteration timeoutMS is refreshed for getMore if timeoutMode is iteration - failure
+  - description: Non-tailable cursor iteration timeoutMS is refreshed for getMore if timeoutMode is iteration - failure
     runOnRequirements:
       - serverless: forbid
     operations:

--- a/test/types/mongodb.test-d.ts
+++ b/test/types/mongodb.test-d.ts
@@ -20,8 +20,8 @@ declare const options: MongoDBDriver.MongoClientOptions;
 expectDeprecated(options.w);
 expectDeprecated(options.journal);
 expectDeprecated(options.wtimeoutMS);
-expectDeprecated(options.socketTimeoutMS);
-expectDeprecated(options.waitQueueTimeoutMS);
+// TODO(NODE-6491): expectDeprecated(options.socketTimeoutMS);
+// TODO(NODE-6491): expectDeprecated(options.waitQueueTimeoutMS);
 expectNotDeprecated(options.writeConcern);
 expectNotDeprecated(options.serverSelectionTimeoutMS);
 expectNotDeprecated(options.connectTimeoutMS);
@@ -29,29 +29,29 @@ expectNotDeprecated(options.connectTimeoutMS);
 expectType<WriteConcernSettings | WriteConcern | undefined>(options.writeConcern);
 
 declare const estimatedDocumentCountOptions: MongoDBDriver.EstimatedDocumentCountOptions;
-expectDeprecated(estimatedDocumentCountOptions.maxTimeMS);
+// TODO(NODE-6491): expectDeprecated(estimatedDocumentCountOptions.maxTimeMS);
 
 declare const countOptions: MongoDBDriver.CountOptions;
-expectDeprecated(countOptions.maxTimeMS);
+// TODO(NODE-6491): expectDeprecated(countOptions.maxTimeMS);
 
 declare const commandOptions: MongoDBDriver.CommandOperationOptions;
-expectDeprecated(commandOptions.maxTimeMS);
+// TODO(NODE-6491): expectDeprecated(commandOptions.maxTimeMS);
 
 declare const aggregateOptions: MongoDBDriver.AggregateOptions;
-expectDeprecated(aggregateOptions.maxTimeMS);
+// TODO(NODE-6491): expectDeprecated(aggregateOptions.maxTimeMS);
 
 declare const runCommandCursor: MongoDBDriver.RunCommandCursor;
-expectDeprecated(runCommandCursor.setMaxTimeMS);
-expectDeprecated(runCommandCursor.maxTimeMS);
+// TODO(NODE-6491): expectDeprecated(runCommandCursor.setMaxTimeMS);
+// TODO(NODE-6491): expectDeprecated(runCommandCursor.maxTimeMS);
 
 declare const cursorOptions: MongoDBDriver.AbstractCursorOptions;
-expectDeprecated(cursorOptions.maxTimeMS);
+// TODO(NODE-6491): expectDeprecated(cursorOptions.maxTimeMS);
 
 declare const abstractCursor: MongoDBDriver.AbstractCursor;
-expectDeprecated(abstractCursor.maxTimeMS);
+// TODO(NODE-6491): expectDeprecated(abstractCursor.maxTimeMS);
 
 declare const txnOptions: MongoDBDriver.TransactionOptions;
-expectDeprecated(txnOptions.maxCommitTimeMS);
+// TODO(NODE-6491): expectDeprecated(txnOptions.maxCommitTimeMS);
 
 interface TSchema extends Document {
   name: string;

--- a/test/types/write_concern.test-d.ts
+++ b/test/types/write_concern.test-d.ts
@@ -14,5 +14,5 @@ expectNotAssignable<ListIndexesOptions>({ writeConcern: { w: 0 } });
 expectNotAssignable<ChangeStreamOptions>({ writeConcern: { w: 0 } });
 
 declare const wc: WriteConcern;
-expectDeprecated(wc.wtimeoutMS);
+// TODO(NODE-6491): expectDeprecated(wc.wtimeoutMS);
 expectDeprecated(wc.wtimeout);

--- a/test/unit/explain.test.ts
+++ b/test/unit/explain.test.ts
@@ -59,19 +59,19 @@ describe('class Explain {}', function () {
       {}
     );
 
-    it('resolveExplainTimeoutOptions(no arguments)', function () {
+    it('when called with no arguments returns neither timeout nor explain', function () {
       const { timeout, explain } = cursor.resolveExplainTimeoutOptions();
       expect(timeout).to.be.undefined;
       expect(explain).to.be.undefined;
     });
 
-    it('resolveExplainTimeoutOptions(<timeout options>)', function () {
+    it('when called with a timeoutMS option returns only timeout options', function () {
       const { timeout, explain } = cursor.resolveExplainTimeoutOptions({ timeoutMS: 1_000 });
       expect(timeout).to.deep.equal({ timeoutMS: 1_000 });
       expect(explain).to.be.undefined;
     });
 
-    it('resolveExplainTimeoutOptions(<explain options>)', function () {
+    it('when called with explain settings returns only explain options', function () {
       const { timeout, explain } = cursor.resolveExplainTimeoutOptions({
         verbosity: 'queryPlanner'
       });
@@ -79,7 +79,7 @@ describe('class Explain {}', function () {
       expect(explain).to.deep.equal({ verbosity: 'queryPlanner' });
     });
 
-    it('resolveExplainTimeoutOptions(<explain options, timeout options>)', function () {
+    it('when called with explain settings and timeout options returns both explain and timeout options', function () {
       const { timeout, explain } = cursor.resolveExplainTimeoutOptions(
         { verbosity: 'queryPlanner' },
         { timeoutMS: 1_000 }

--- a/test/unit/explain.test.ts
+++ b/test/unit/explain.test.ts
@@ -51,7 +51,7 @@ describe('class Explain {}', function () {
     });
   });
 
-  describe('parseTimeoutOptions()', function () {
+  describe('resolveExplainTimeoutOptions()', function () {
     const cursor = new FindCursor(
       new MongoClient('mongodb://localhost:27027'),
       MongoDBNamespace.fromString('foo.bar'),
@@ -59,19 +59,19 @@ describe('class Explain {}', function () {
       {}
     );
 
-    it('parseTimeoutOptions()', function () {
+    it('resolveExplainTimeoutOptions(no arguments)', function () {
       const { timeout, explain } = cursor.resolveExplainTimeoutOptions();
       expect(timeout).to.be.undefined;
       expect(explain).to.be.undefined;
     });
 
-    it('parseTimeoutOptions(<timeout options>)', function () {
+    it('resolveExplainTimeoutOptions(<timeout options>)', function () {
       const { timeout, explain } = cursor.resolveExplainTimeoutOptions({ timeoutMS: 1_000 });
       expect(timeout).to.deep.equal({ timeoutMS: 1_000 });
       expect(explain).to.be.undefined;
     });
 
-    it('parseTimeoutOptions(<explain options>)', function () {
+    it('resolveExplainTimeoutOptions(<explain options>)', function () {
       const { timeout, explain } = cursor.resolveExplainTimeoutOptions({
         verbosity: 'queryPlanner'
       });
@@ -79,7 +79,7 @@ describe('class Explain {}', function () {
       expect(explain).to.deep.equal({ verbosity: 'queryPlanner' });
     });
 
-    it('parseTimeoutOptions(<explain options, timeout options>)', function () {
+    it('resolveExplainTimeoutOptions(<explain options, timeout options>)', function () {
       const { timeout, explain } = cursor.resolveExplainTimeoutOptions(
         { verbosity: 'queryPlanner' },
         { timeoutMS: 1_000 }

--- a/test/unit/timeout.test.ts
+++ b/test/unit/timeout.test.ts
@@ -14,9 +14,12 @@ describe('Timeout', function () {
   let timeout: Timeout;
 
   beforeEach(() => {
-    if (Timeout.is(timeout)) {
-      timeout.clear();
-    }
+    timeout = null;
+  });
+
+  beforeEach(() => {
+    timeout?.clear();
+    timeout = null;
   });
 
   describe('expires()', function () {
@@ -68,57 +71,6 @@ describe('Timeout', function () {
       it('clears the underlying NodeJS.Timeout instance', function () {
         timeout.clear();
         expect(timeout).to.have.property('id').that.is.undefined;
-      });
-    });
-  });
-
-  describe('is()', function () {
-    context('when called on a Timeout instance', function () {
-      it('returns true', function () {
-        expect(Timeout.is(Timeout.expires(0))).to.be.true;
-      });
-    });
-
-    context('when called on a nullish object ', function () {
-      it('returns false', function () {
-        expect(Timeout.is(undefined)).to.be.false;
-        expect(Timeout.is(null)).to.be.false;
-      });
-    });
-
-    context('when called on a primitive type', function () {
-      it('returns false', function () {
-        expect(Timeout.is(1)).to.be.false;
-        expect(Timeout.is('hello')).to.be.false;
-        expect(Timeout.is(true)).to.be.false;
-        expect(Timeout.is(1n)).to.be.false;
-        expect(Timeout.is(Symbol.for('test'))).to.be.false;
-      });
-    });
-
-    context('when called on a Promise-like object with a matching toStringTag', function () {
-      it('returns true', function () {
-        const timeoutLike = {
-          [Symbol.toStringTag]: 'MongoDBTimeout',
-          then() {
-            return 0;
-          }
-        };
-
-        expect(Timeout.is(timeoutLike)).to.be.true;
-      });
-    });
-
-    context('when called on a Promise-like object without a matching toStringTag', function () {
-      it('returns false', function () {
-        const timeoutLike = {
-          [Symbol.toStringTag]: 'lol',
-          then() {
-            return 0;
-          }
-        };
-
-        expect(Timeout.is(timeoutLike)).to.be.false;
       });
     });
   });


### PR DESCRIPTION
### Description

#### What is changing?

- Includes test sync from: https://jira.mongodb.org/browse/NODE-6493

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

Remaining cleanups for CSOT branch

### Release Highlight


### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
