### PR TITLE
chore: fix runCommand bench hello size

### DIFF
--- a/test/benchmarks/mongoBench/suites/singleBench.js
+++ b/test/benchmarks/mongoBench/suites/singleBench.js
@@ -36,8 +36,8 @@ function makeSingleBench(suite) {
     )
     .benchmark('runCommand', benchmark =>
       benchmark
-        // { hello: true } is 13 bytes. However the legacy hello was 16 bytes, to preserve history comparison data we leave this value as is.
-        .taskSize(0.16)
+        // { hello: true } is 13 bytes of BSON x 10,000 iterations
+        .taskSize(0.13)
         .setup(makeClient)
         .setup(connectClient)
         .setup(initDb)


### PR DESCRIPTION
### Description

#### What is changing?

- Fix the inaccurate command document size

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

When we changed to hello from the legacy hello the size wasn't updated. We left it as is to preserve our performance history but with our recent reset, we should update this now

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
