### PR TITLE
perf(NODE-6525): remove setPrototype and defineProperty from hot path

### DIFF
--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -970,9 +970,7 @@ export class ServerSession {
   isDirty: boolean;
 
   /** @internal */
-  constructor(
-    cloned?: { id: ServerSessionId; lastUse: number; txnNumber: number; isDirty: boolean } | null
-  ) {
+  constructor(cloned?: ServerSession | null) {
     if (cloned != null) {
       const idBytes = Buffer.allocUnsafe(16);
       idBytes.set(cloned.id.id.buffer);

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -137,7 +137,7 @@ export class ClientSession
    * initially undefined. Gets set to false when startTransaction is called. When commitTransaction is sent to server, if the commitTransaction succeeds, it is then set to undefined, otherwise, set to true */
   commitAttempted?: boolean;
   /** @internal */
-  [kServerSession]: ServerSession | null;
+  private [kServerSession]: ServerSession | null;
   /** @internal */
   [kSnapshotTime]?: Timestamp;
   /** @internal */

--- a/test/benchmarks/driverBench/index.js
+++ b/test/benchmarks/driverBench/index.js
@@ -90,12 +90,12 @@ benchmarkRunner
         info: {
           test_name: benchmarkName,
           tags: [bsonType],
-          // Args can only be a map of string -> int32. So if its a number coerce it to an int32,
+          // Args can only be a map of string -> int32. So if its a number leave it be,
           // if it is anything else test for truthiness and set to 1 or 0.
           args: Object.fromEntries(
             Object.entries(MONGODB_CLIENT_OPTIONS).map(([key, value]) => [
               key,
-              typeof value === 'number' ? value | 0 : value ? 1 : 0
+              typeof value === 'number' ? value : value ? 1 : 0
             ])
           )
         },

--- a/test/benchmarks/driverBench/index.js
+++ b/test/benchmarks/driverBench/index.js
@@ -90,7 +90,7 @@ benchmarkRunner
         info: {
           test_name: benchmarkName,
           tags: [bsonType],
-          // Args can only be a map of string -> int32. So if its a number leave it be,
+          // Args can only be a map of string -> int32. So if its a number coerce it to an int32,
           // if it is anything else test for truthiness and set to 1 or 0.
           args: Object.fromEntries(
             Object.entries(MONGODB_CLIENT_OPTIONS).map(([key, value]) => [


### PR DESCRIPTION
### Description

#### What is changing?

- Making various performance improvements to the hot paths of the driver

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

Regain performance

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Improved performance

TBD...

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
