### PR TITLE
chore(NODE-6502) Address two other usages of system python

### DIFF
--- a/.evergreen/run-azure-kms-mock-server.sh
+++ b/.evergreen/run-azure-kms-mock-server.sh
@@ -4,6 +4,9 @@ if [ -z ${DRIVERS_TOOLS+omitted} ]; then echo "DRIVERS_TOOLS is unset" && exit 1
 
 set -o errexit
 
-python3 $DRIVERS_TOOLS/.evergreen/csfle/bottle.py fake_azure:imds &
+pushd $DRIVERS_TOOLS/.evergreen/csfle
+. ./activate-kmstlsvenv.sh
+python bottle.py fake_azure:imds &
+popd
 
 echo "Running Azure KMS idms server on port 8080"

--- a/.evergreen/run-socks5-tests.sh
+++ b/.evergreen/run-socks5-tests.sh
@@ -30,7 +30,7 @@ function setup_fle() {
 
 node -v
 
-PYTHON_BINARY=${PYTHON_BINARY:-python3}
+PYTHON_BINARY=$(bash -c ". $DRIVERS_TOOLS/.evergreen/find-python3.sh && ensure_python3 2>/dev/null")
 
 # ssl setup
 SSL=${SSL:-nossl}


### PR DESCRIPTION
### Description

#### What is changing?
Follow up to #4322

##### Is there new documentation needed for these changes?
No

#### What is the motivation for this change?
Use scripts from drivers-evergreen-tools instead of using the system python package manager.

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
