### PR TITLE
chore(NODE-6502) Use a python venv wherever we use Python in driver CI 

### DIFF
--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -228,7 +228,10 @@ functions:
           # Get access to the AWS temporary credentials:
           echo "adding temporary AWS credentials to environment"
           # CSFLE_AWS_TEMP_ACCESS_KEY_ID, CSFLE_AWS_TEMP_SECRET_ACCESS_KEY, CSFLE_AWS_TEMP_SESSION_TOKEN
-          . "$DRIVERS_TOOLS"/.evergreen/csfle/set-temp-creds.sh
+          pushd "$DRIVERS_TOOLS"/.evergreen/csfle
+          . ./activate-kmstlsvenv.sh
+          . ./set-temp-creds.sh
+          popd
 
           MONGODB_URI="${MONGODB_URI}" \
           AUTH=${AUTH} SSL=${SSL} TEST_CSFLE=true \

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -199,7 +199,10 @@ functions:
           # Get access to the AWS temporary credentials:
           echo "adding temporary AWS credentials to environment"
           # CSFLE_AWS_TEMP_ACCESS_KEY_ID, CSFLE_AWS_TEMP_SECRET_ACCESS_KEY, CSFLE_AWS_TEMP_SESSION_TOKEN
-          . "$DRIVERS_TOOLS"/.evergreen/csfle/set-temp-creds.sh
+          pushd "$DRIVERS_TOOLS"/.evergreen/csfle
+          . ./activate-kmstlsvenv.sh
+          . ./set-temp-creds.sh
+          popd
 
           MONGODB_URI="${MONGODB_URI}" \
           AUTH=${AUTH} SSL=${SSL} TEST_CSFLE=true \

--- a/.evergreen/run-azure-kms-mock-server.sh
+++ b/.evergreen/run-azure-kms-mock-server.sh
@@ -4,6 +4,9 @@ if [ -z ${DRIVERS_TOOLS+omitted} ]; then echo "DRIVERS_TOOLS is unset" && exit 1
 
 set -o errexit
 
-python3 $DRIVERS_TOOLS/.evergreen/csfle/bottle.py fake_azure:imds &
+pushd $DRIVERS_TOOLS/.evergreen/csfle
+. ./activate-kmstlsvenv.sh
+python bottle.py fake_azure:imds &
+popd
 
 echo "Running Azure KMS idms server on port 8080"

--- a/.evergreen/run-custom-csfle-tests.sh
+++ b/.evergreen/run-custom-csfle-tests.sh
@@ -20,7 +20,10 @@ set -o errexit  # Exit the script with error if any of the commands fail
 # Get access to the AWS temporary credentials:
 echo "adding temporary AWS credentials to environment"
 # CSFLE_AWS_TEMP_ACCESS_KEY_ID, CSFLE_AWS_TEMP_SECRET_ACCESS_KEY, CSFLE_AWS_TEMP_SESSION_TOKEN
-. "$DRIVERS_TOOLS"/.evergreen/csfle/set-temp-creds.sh
+pushd "$DRIVERS_TOOLS"/.evergreen/csfle
+. ./activate-kmstlsvenv.sh
+. ./set-temp-creds.sh
+popd
 
 ABS_PATH_TO_PATCH=$(pwd)
 

--- a/.evergreen/run-socks5-tests.sh
+++ b/.evergreen/run-socks5-tests.sh
@@ -7,7 +7,7 @@ set -o xtrace  # For debuggability, no external credentials are used here
 
 node -v
 
-PYTHON_BINARY=${PYTHON_BINARY:-python3}
+PYTHON_BINARY=$(bash -c ". $DRIVERS_TOOLS/.evergreen/find-python3.sh && ensure_python3 2>/dev/null")
 
 # ssl setup
 SSL=${SSL:-nossl}

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -45,11 +45,13 @@ if [[ -z "${CLIENT_ENCRYPTION}" ]]; then
   unset AWS_ACCESS_KEY_ID;
   unset AWS_SECRET_ACCESS_KEY;
 else
-  pip install --upgrade boto3
+  pushd "$DRIVERS_TOOLS/.evergreen/csfle"
+  . ./activate-kmstlsvenv.sh
   # Get access to the AWS temporary credentials:
   echo "adding temporary AWS credentials to environment"
   # CSFLE_AWS_TEMP_ACCESS_KEY_ID, CSFLE_AWS_TEMP_SECRET_ACCESS_KEY, CSFLE_AWS_TEMP_SESSION_TOKEN
-  source "$DRIVERS_TOOLS"/.evergreen/csfle/set-temp-creds.sh
+  source set-temp-creds.sh
+  popd
 fi
 
 npm install mongodb-client-encryption

--- a/test/readme.md
+++ b/test/readme.md
@@ -384,10 +384,10 @@ The following steps will walk you through how to run the tests for CSFLE.
 
 1. Set temporary AWS credentials
 
-  ```
-  pip3 install boto3
-  PYTHON="python3" source /path/to/mongodb-labs/drivers-evergreen-tools/.evergreen/csfle/set-temp-creds.sh
-  ```
+   ```
+   source /path/to/mongodb-labs/drivers-evergreen-tools/.evergreen/csfle/activate-kmstlsvenv.sh
+   source /path/to/mongodb-labs/drivers-evergreen-tools/.evergreen/csfle/set-temp-creds.sh
+   ```
 
   Alternatively for fish users the following script can be substituted for set-temp-creds.sh:
 


### PR DESCRIPTION
(cherry picked from commits db4eff5 and 247284e)

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
