### PR TITLE
test(NODE-5722): unpin on endSessions test

### DIFF
--- a/test/spec/load-balancers/transactions.json
+++ b/test/spec/load-balancers/transactions.json
@@ -1,6 +1,6 @@
 {
   "description": "transactions are correctly pinned to connections for load-balanced clusters",
-  "schemaVersion": "1.3",
+  "schemaVersion": "1.4",
   "runOnRequirements": [
     {
       "topologies": [
@@ -1600,6 +1600,50 @@
             }
           ]
         },
+        {
+          "client": "client0",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "pinned connection is released when session ended",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            },
+            "session": "session0"
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "endSession",
+          "object": "session0"
+        }
+      ],
+      "expectEvents": [
         {
           "client": "client0",
           "eventType": "cmap",

--- a/test/spec/load-balancers/transactions.yml
+++ b/test/spec/load-balancers/transactions.yml
@@ -1,6 +1,6 @@
 description: transactions are correctly pinned to connections for load-balanced clusters
 
-schemaVersion: '1.3'
+schemaVersion: '1.4'
 
 runOnRequirements:
   - topologies: [ load-balanced ]
@@ -595,4 +595,22 @@ tests:
           - connectionReadyEvent: {}
           - connectionCheckedOutEvent: {}
           # Events for abortTransaction.
+          - connectionCheckedInEvent: {}
+
+  - description: pinned connection is released when session ended
+    operations:
+      - *startTransaction
+      - *transactionalInsert
+      - *commitTransaction
+      - &endSession
+        name: endSession
+        object: *session0
+    expectEvents:
+      - client: *client0
+        eventType: cmap
+        events:
+          # Events for the insert and commitTransaction.
+          - connectionReadyEvent: {}
+          - connectionCheckedOutEvent: {}
+          # Events for endSession.
           - connectionCheckedInEvent: {}


### PR DESCRIPTION
### Description

Syncs unified tests for the latest unpinning test.

#### What is changing?

Sync of the load balancer unified tests.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-5722

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
