### PR TITLE
test(NODE-6405): stop mongo orchestration in post task

### DIFF
--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -71,6 +71,12 @@ functions:
       params:
         file: mo-expansion.yml
 
+  "stop mongo-orchestration":
+    - command: shell.exec
+      params:
+        script: |
+          bash ${DRIVERS_TOOLS}/.evergreen/stop-orchestration.sh
+
   "bootstrap mongohoused":
     - command: shell.exec
       params:
@@ -1773,6 +1779,7 @@ pre:
 post:
   - func: "reset aws instance profile"
   - func: "upload test results"
+  - func: "stop mongo-orchestration"
   - func: "upload coverage report"
   - func: "cleanup"
 

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -46,6 +46,11 @@ functions:
     - command: expansions.update
       params:
         file: mo-expansion.yml
+  stop mongo-orchestration:
+    - command: shell.exec
+      params:
+        script: |
+          bash ${DRIVERS_TOOLS}/.evergreen/stop-orchestration.sh
   bootstrap mongohoused:
     - command: shell.exec
       params:
@@ -4706,6 +4711,7 @@ pre:
 post:
   - func: reset aws instance profile
   - func: upload test results
+  - func: stop mongo-orchestration
   - func: upload coverage report
   - func: cleanup
 ignore:


### PR DESCRIPTION
### Description

Adds a post task to kill mongo orchestration

#### What is changing?

Updates evergreen config to always attempt to stop mongo-orchestration in a post task.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-6405

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
