### PR TITLE
test(NODE-6532): unskip transactions tests on serverless

### DIFF
--- a/test/spec/transactions-convenient-api/unified/commit-retry.json
+++ b/test/spec/transactions-convenient-api/unified/commit-retry.json
@@ -422,11 +422,6 @@
     },
     {
       "description": "commit is not retried after MaxTimeMSExpired error",
-      "runOnRequirements": [
-        {
-          "serverless": "forbid"
-        }
-      ],
       "operations": [
         {
           "name": "failPoint",

--- a/test/spec/transactions-convenient-api/unified/commit-retry.yml
+++ b/test/spec/transactions-convenient-api/unified/commit-retry.yml
@@ -212,9 +212,6 @@ tests:
           - { _id: 1 }
   -
     description: commit is not retried after MaxTimeMSExpired error
-    runOnRequirements:
-      # Serverless sets empty `codeName` on failpoint errors. Remove once CLOUDP-280424 is fixed.
-      - serverless: forbid
     operations:
       - name: failPoint
         object: testRunner

--- a/test/spec/transactions-convenient-api/unified/commit-writeconcernerror.json
+++ b/test/spec/transactions-convenient-api/unified/commit-writeconcernerror.json
@@ -1,6 +1,6 @@
 {
   "description": "commit-writeconcernerror",
-  "schemaVersion": "1.4",
+  "schemaVersion": "1.3",
   "runOnRequirements": [
     {
       "minServerVersion": "4.0",
@@ -414,11 +414,6 @@
     },
     {
       "description": "commitTransaction is not retried after UnknownReplWriteConcern error",
-      "runOnRequirements": [
-        {
-          "serverless": "forbid"
-        }
-      ],
       "operations": [
         {
           "name": "failPoint",
@@ -551,11 +546,6 @@
     },
     {
       "description": "commitTransaction is not retried after UnsatisfiableWriteConcern error",
-      "runOnRequirements": [
-        {
-          "serverless": "forbid"
-        }
-      ],
       "operations": [
         {
           "name": "failPoint",
@@ -688,11 +678,6 @@
     },
     {
       "description": "commitTransaction is not retried after MaxTimeMSExpired error",
-      "runOnRequirements": [
-        {
-          "serverless": "forbid"
-        }
-      ],
       "operations": [
         {
           "name": "failPoint",

--- a/test/spec/transactions-convenient-api/unified/commit-writeconcernerror.yml
+++ b/test/spec/transactions-convenient-api/unified/commit-writeconcernerror.yml
@@ -1,6 +1,6 @@
 description: commit-writeconcernerror
 
-schemaVersion: '1.4' # For `serverless` in `runOnRequirements`
+schemaVersion: '1.3'
 
 runOnRequirements:
   - minServerVersion: '4.0'
@@ -151,9 +151,6 @@ tests:
     outcome: *outcome
   -
     description: commitTransaction is not retried after UnknownReplWriteConcern error
-    runOnRequirements:
-      # Serverless sets empty `codeName` on failpoint errors. Remove once CLOUDP-280424 is fixed.
-      - serverless: forbid
     operations:
       - name: failPoint
         object: testRunner
@@ -206,9 +203,6 @@ tests:
     outcome: *outcome
   -
     description: commitTransaction is not retried after UnsatisfiableWriteConcern error
-    runOnRequirements:
-      # Serverless sets empty `codeName` on failpoint errors. Remove once CLOUDP-280424 is fixed.
-      - serverless: forbid
     operations:
       - name: failPoint
         object: testRunner
@@ -232,9 +226,6 @@ tests:
     outcome: *outcome
   -
     description: commitTransaction is not retried after MaxTimeMSExpired error
-    runOnRequirements:
-      # Serverless sets empty `codeName` on failpoint errors. Remove once CLOUDP-280424 is fixed.
-      - serverless: forbid
     operations:
       - name: failPoint
         object: testRunner

--- a/test/spec/transactions/unified/retryable-commit.json
+++ b/test/spec/transactions/unified/retryable-commit.json
@@ -89,11 +89,6 @@
   "tests": [
     {
       "description": "commitTransaction fails after Interrupted",
-      "runOnRequirements": [
-        {
-          "serverless": "forbid"
-        }
-      ],
       "operations": [
         {
           "object": "testRunner",

--- a/test/spec/transactions/unified/retryable-commit.yml
+++ b/test/spec/transactions/unified/retryable-commit.yml
@@ -67,9 +67,6 @@ initialData:
 tests:
   -
     description: 'commitTransaction fails after Interrupted'
-    runOnRequirements:
-      # Serverless sets empty `codeName` on failpoint errors. Remove once CLOUDP-280424 is fixed.
-      - serverless: forbid
     operations:
       -
         object: testRunner


### PR DESCRIPTION
### Description

#### What is changing?

Syncs tests from https://jira.mongodb.org/browse/DRIVERS-3022.

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
