### PR TITLE
feat(NODE-6605):  add error message when invalidating primary

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -342,8 +342,6 @@ export class MongoRuntimeError extends MongoDriverError {
 
 /**
  * An error generated when a primary server is marked stale, never directly thrown
- * @privateRemarks
- * Should **never** be directly instantiated.
  *
  * @public
  * @category Error

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,10 +1,10 @@
-import type { Document } from './bson';
+import type { Document, ObjectId } from './bson';
 import {
   type ClientBulkWriteError,
   type ClientBulkWriteResult
 } from './operations/client_bulk_write/common';
 import type { ServerType } from './sdam/common';
-import type { TopologyVersion } from './sdam/server_description';
+import type { ServerDescription, TopologyVersion } from './sdam/server_description';
 import type { TopologyDescription } from './sdam/topology_description';
 
 /** @public */
@@ -337,6 +337,43 @@ export class MongoRuntimeError extends MongoDriverError {
 
   override get name(): string {
     return 'MongoRuntimeError';
+  }
+}
+
+/**
+ * An error generated when a primary server is marked stale, never directly thrown
+ * @privateRemarks
+ * Should **never** be directly instantiated.
+ *
+ * @public
+ * @category Error
+ */
+export class MongoStalePrimaryError extends MongoRuntimeError {
+  /**
+   * **Do not use this constructor!**
+   *
+   * Meant for internal use only.
+   *
+   * @remarks
+   * This class is only meant to be constructed within the driver. This constructor is
+   * not subject to semantic versioning compatibility guarantees and may change at any time.
+   *
+   * @public
+   **/
+  constructor(
+    serverDescription: ServerDescription,
+    maxSetVersion: number | null,
+    maxElectionId: ObjectId | null,
+    options?: { cause?: Error }
+  ) {
+    super(
+      `primary marked stale due to electionId/setVersion mismatch: server setVersion: ${serverDescription.setVersion}, server electionId: ${serverDescription.electionId}, topology setVersion: ${maxSetVersion}, topology electionId: ${maxElectionId}`,
+      options
+    );
+  }
+
+  override get name(): string {
+    return 'MongoStalePrimaryError';
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,6 +77,7 @@ export {
   MongoServerClosedError,
   MongoServerError,
   MongoServerSelectionError,
+  MongoStalePrimaryError,
   MongoSystemError,
   MongoTailableCursorError,
   MongoTopologyClosedError,

--- a/src/sdam/server_description.ts
+++ b/src/sdam/server_description.ts
@@ -126,6 +126,10 @@ export class ServerDescription {
     this.me = hello?.me?.toLowerCase() ?? null;
     this.$clusterTime = hello?.$clusterTime ?? null;
     this.iscryptd = Boolean(hello?.iscryptd);
+
+    // NOTE: This actually builds the stack string instead of holding onto the getter and all its
+    // associated references. This is done to prevent a memory leak.
+    if (options.error) options.error.stack;
   }
 
   get hostAddress(): HostAddress {

--- a/src/sdam/server_description.ts
+++ b/src/sdam/server_description.ts
@@ -112,7 +112,10 @@ export class ServerDescription {
     this.minRoundTripTime = options?.minRoundTripTime ?? 0;
     this.lastUpdateTime = now();
     this.lastWriteDate = hello?.lastWrite?.lastWriteDate ?? 0;
+    // NOTE: This actually builds the stack string instead of holding onto the getter and all its
+    // associated references. This is done to prevent a memory leak.
     this.error = options.error ?? null;
+    this.error?.stack;
     // TODO(NODE-2674): Preserve int64 sent from MongoDB
     this.topologyVersion = this.error?.topologyVersion ?? hello?.topologyVersion ?? null;
     this.setName = hello?.setName ?? null;
@@ -126,10 +129,6 @@ export class ServerDescription {
     this.me = hello?.me?.toLowerCase() ?? null;
     this.$clusterTime = hello?.$clusterTime ?? null;
     this.iscryptd = Boolean(hello?.iscryptd);
-
-    // NOTE: This actually builds the stack string instead of holding onto the getter and all its
-    // associated references. This is done to prevent a memory leak.
-    if (options.error) options.error.stack;
   }
 
   get hostAddress(): HostAddress {

--- a/src/sdam/topology_description.ts
+++ b/src/sdam/topology_description.ts
@@ -401,7 +401,9 @@ function updateRsFromPrimary(
       serverDescriptions.set(
         serverDescription.address,
         new ServerDescription(serverDescription.address, undefined, {
-          error: new MongoError('stale')
+          error: new MongoError(
+            `primary marked stale due to electionId/setVersion mismatch: server setVersion: ${serverDescription.setVersion}, server electionId: ${serverDescription.electionId}, topology setVersion: ${maxSetVersion}, topology electionId: ${maxElectionId}`
+          )
         })
       );
 
@@ -419,7 +421,9 @@ function updateRsFromPrimary(
           serverDescriptions.set(
             serverDescription.address,
             new ServerDescription(serverDescription.address, undefined, {
-              error: new MongoError('stale')
+              error: new MongoError(
+                `primary marked stale due to electionId/setVersion mismatch: server setVersion: ${serverDescription.setVersion}, server electionId: ${serverDescription.electionId}, topology setVersion: ${maxSetVersion}, topology electionId: ${maxElectionId}`
+              )
             })
           );
 
@@ -444,7 +448,11 @@ function updateRsFromPrimary(
       // Reset old primary's type to Unknown.
       serverDescriptions.set(
         address,
-        new ServerDescription(server.address, undefined, { error: new MongoError('stale') })
+        new ServerDescription(server.address, undefined, {
+          error: new MongoError(
+            `primary marked stale due to electionId/setVersion mismatch: server setVersion: ${server.setVersion}, server electionId: ${server.electionId}, topology setVersion: ${maxSetVersion}, topology electionId: ${maxElectionId}`
+          )
+        })
       );
 
       // There can only be one primary

--- a/src/sdam/topology_description.ts
+++ b/src/sdam/topology_description.ts
@@ -1,6 +1,6 @@
 import { EJSON, type ObjectId } from '../bson';
 import * as WIRE_CONSTANTS from '../cmap/wire_protocol/constants';
-import { type MongoError, MongoRuntimeError } from '../error';
+import { MongoError, MongoRuntimeError } from '../error';
 import { compareObjectId, shuffle } from '../utils';
 import { ServerType, TopologyType } from './common';
 import { ServerDescription } from './server_description';
@@ -400,7 +400,9 @@ function updateRsFromPrimary(
       // replace serverDescription with a default ServerDescription of type "Unknown"
       serverDescriptions.set(
         serverDescription.address,
-        new ServerDescription(serverDescription.address)
+        new ServerDescription(serverDescription.address, undefined, {
+          error: new MongoError('stale')
+        })
       );
 
       return [checkHasPrimary(serverDescriptions), setName, maxSetVersion, maxElectionId];
@@ -416,7 +418,9 @@ function updateRsFromPrimary(
           // this primary is stale, we must remove it
           serverDescriptions.set(
             serverDescription.address,
-            new ServerDescription(serverDescription.address)
+            new ServerDescription(serverDescription.address, undefined, {
+              error: new MongoError('stale')
+            })
           );
 
           return [checkHasPrimary(serverDescriptions), setName, maxSetVersion, maxElectionId];
@@ -438,7 +442,10 @@ function updateRsFromPrimary(
   for (const [address, server] of serverDescriptions) {
     if (server.type === ServerType.RSPrimary && server.address !== serverDescription.address) {
       // Reset old primary's type to Unknown.
-      serverDescriptions.set(address, new ServerDescription(server.address));
+      serverDescriptions.set(
+        address,
+        new ServerDescription(server.address, undefined, { error: new MongoError('stale') })
+      );
 
       // There can only be one primary
       break;

--- a/src/sdam/topology_description.ts
+++ b/src/sdam/topology_description.ts
@@ -1,6 +1,6 @@
 import { EJSON, type ObjectId } from '../bson';
 import * as WIRE_CONSTANTS from '../cmap/wire_protocol/constants';
-import { MongoError, MongoRuntimeError } from '../error';
+import { type MongoError, MongoRuntimeError, MongoStalePrimaryError } from '../error';
 import { compareObjectId, shuffle } from '../utils';
 import { ServerType, TopologyType } from './common';
 import { ServerDescription } from './server_description';
@@ -401,9 +401,7 @@ function updateRsFromPrimary(
       serverDescriptions.set(
         serverDescription.address,
         new ServerDescription(serverDescription.address, undefined, {
-          error: new MongoError(
-            `primary marked stale due to electionId/setVersion mismatch: server setVersion: ${serverDescription.setVersion}, server electionId: ${serverDescription.electionId}, topology setVersion: ${maxSetVersion}, topology electionId: ${maxElectionId}`
-          )
+          error: new MongoStalePrimaryError(serverDescription, maxSetVersion, maxElectionId)
         })
       );
 
@@ -421,9 +419,7 @@ function updateRsFromPrimary(
           serverDescriptions.set(
             serverDescription.address,
             new ServerDescription(serverDescription.address, undefined, {
-              error: new MongoError(
-                `primary marked stale due to electionId/setVersion mismatch: server setVersion: ${serverDescription.setVersion}, server electionId: ${serverDescription.electionId}, topology setVersion: ${maxSetVersion}, topology electionId: ${maxElectionId}`
-              )
+              error: new MongoStalePrimaryError(serverDescription, maxSetVersion, maxElectionId)
             })
           );
 
@@ -449,9 +445,7 @@ function updateRsFromPrimary(
       serverDescriptions.set(
         address,
         new ServerDescription(server.address, undefined, {
-          error: new MongoError(
-            `primary marked stale due to electionId/setVersion mismatch: server setVersion: ${server.setVersion}, server electionId: ${server.electionId}, topology setVersion: ${maxSetVersion}, topology electionId: ${maxElectionId}`
-          )
+          error: new MongoStalePrimaryError(serverDescription, maxSetVersion, maxElectionId)
         })
       );
 

--- a/test/spec/server-discovery-and-monitoring/rs/new_primary.json
+++ b/test/spec/server-discovery-and-monitoring/rs/new_primary.json
@@ -58,6 +58,7 @@
         "servers": {
           "a:27017": {
             "type": "Unknown",
+            "error": "stale",
             "setName": null
           },
           "b:27017": {

--- a/test/spec/server-discovery-and-monitoring/rs/new_primary.json
+++ b/test/spec/server-discovery-and-monitoring/rs/new_primary.json
@@ -58,7 +58,6 @@
         "servers": {
           "a:27017": {
             "type": "Unknown",
-            "error": "stale",
             "setName": null
           },
           "b:27017": {

--- a/test/spec/server-discovery-and-monitoring/rs/new_primary_new_electionid.json
+++ b/test/spec/server-discovery-and-monitoring/rs/new_primary_new_electionid.json
@@ -76,7 +76,8 @@
           "a:27017": {
             "type": "Unknown",
             "setName": null,
-            "electionId": null
+            "electionId": null,
+            "error": "primary marked stale due to electionId/setVersion mismatch"
           },
           "b:27017": {
             "type": "RSPrimary",
@@ -123,7 +124,8 @@
           "a:27017": {
             "type": "Unknown",
             "setName": null,
-            "electionId": null
+            "electionId": null,
+            "error": "primary marked stale due to electionId/setVersion mismatch"
           },
           "b:27017": {
             "type": "RSPrimary",

--- a/test/spec/server-discovery-and-monitoring/rs/new_primary_new_electionid.yml
+++ b/test/spec/server-discovery-and-monitoring/rs/new_primary_new_electionid.yml
@@ -63,7 +63,8 @@ phases: [
                 "a:27017": {
                     type: "Unknown",
                     setName: ,
-                    electionId:
+                    electionId: ,
+                    error: "primary marked stale due to electionId/setVersion mismatch"
                 },
                 "b:27017": {
                     type: "RSPrimary",
@@ -100,7 +101,8 @@ phases: [
                 "a:27017": {
                     type: "Unknown",
                     setName: ,
-                    electionId:
+                    electionId:,
+                    error: "primary marked stale due to electionId/setVersion mismatch"
                 },
                 "b:27017": {
                     type: "RSPrimary",

--- a/test/spec/server-discovery-and-monitoring/rs/new_primary_new_setversion.json
+++ b/test/spec/server-discovery-and-monitoring/rs/new_primary_new_setversion.json
@@ -76,7 +76,8 @@
           "a:27017": {
             "type": "Unknown",
             "setName": null,
-            "electionId": null
+            "electionId": null,
+            "error": "primary marked stale due to electionId/setVersion mismatch"
           },
           "b:27017": {
             "type": "RSPrimary",
@@ -123,7 +124,8 @@
           "a:27017": {
             "type": "Unknown",
             "setName": null,
-            "electionId": null
+            "electionId": null,
+            "error": "primary marked stale due to electionId/setVersion mismatch"
           },
           "b:27017": {
             "type": "RSPrimary",

--- a/test/spec/server-discovery-and-monitoring/rs/new_primary_new_setversion.yml
+++ b/test/spec/server-discovery-and-monitoring/rs/new_primary_new_setversion.yml
@@ -63,7 +63,8 @@ phases: [
                 "a:27017": {
                     type: "Unknown",
                     setName: ,
-                    electionId:
+                    electionId:,
+                    error: "primary marked stale due to electionId/setVersion mismatch"
                 },
                 "b:27017": {
                     type: "RSPrimary",
@@ -100,7 +101,8 @@ phases: [
                 "a:27017": {
                     type: "Unknown",
                     setName: ,
-                    electionId:
+                    electionId:,
+                    error: "primary marked stale due to electionId/setVersion mismatch"
                 },
                 "b:27017": {
                     type: "RSPrimary",

--- a/test/spec/server-discovery-and-monitoring/rs/null_election_id-pre-6.0.json
+++ b/test/spec/server-discovery-and-monitoring/rs/null_election_id-pre-6.0.json
@@ -66,7 +66,7 @@
               "$oid": "000000000000000000000002"
             },
             "minWireVersion": 0,
-            "maxWireVersion": 21
+            "maxWireVersion": 7
           }
         ]
       ],

--- a/test/spec/server-discovery-and-monitoring/rs/primary_disconnect_electionid.json
+++ b/test/spec/server-discovery-and-monitoring/rs/primary_disconnect_electionid.json
@@ -47,9 +47,9 @@
         "servers": {
           "a:27017": {
             "type": "Unknown",
-            "error": {"message": "stale"},
             "setName": null,
-            "electionId": null
+            "electionId": null,
+            "error": "primary marked stale due to electionId/setVersion mismatch"
           },
           "b:27017": {
             "type": "RSPrimary",

--- a/test/spec/server-discovery-and-monitoring/rs/primary_disconnect_electionid.json
+++ b/test/spec/server-discovery-and-monitoring/rs/primary_disconnect_electionid.json
@@ -47,6 +47,7 @@
         "servers": {
           "a:27017": {
             "type": "Unknown",
+            "error": {"message": "stale"},
             "setName": null,
             "electionId": null
           },

--- a/test/spec/server-discovery-and-monitoring/rs/primary_disconnect_electionid.yml
+++ b/test/spec/server-discovery-and-monitoring/rs/primary_disconnect_electionid.yml
@@ -36,7 +36,8 @@ phases: [
                 "a:27017": {
                     type: "Unknown",
                     setName: ,
-                    electionId:
+                    electionId:,
+                    error: "primary marked stale due to electionId/setVersion mismatch"
                 },
                 "b:27017": {
                     type: "RSPrimary",

--- a/test/spec/server-discovery-and-monitoring/rs/primary_disconnect_setversion.json
+++ b/test/spec/server-discovery-and-monitoring/rs/primary_disconnect_setversion.json
@@ -47,6 +47,7 @@
         "servers": {
           "a:27017": {
             "type": "Unknown",
+            "error": { "message": "stale" },
             "setName": null,
             "electionId": null
           },

--- a/test/spec/server-discovery-and-monitoring/rs/primary_disconnect_setversion.json
+++ b/test/spec/server-discovery-and-monitoring/rs/primary_disconnect_setversion.json
@@ -47,9 +47,9 @@
         "servers": {
           "a:27017": {
             "type": "Unknown",
-            "error": { "message": "stale" },
             "setName": null,
-            "electionId": null
+            "electionId": null,
+            "error": "primary marked stale due to electionId/setVersion mismatch"
           },
           "b:27017": {
             "type": "RSPrimary",

--- a/test/spec/server-discovery-and-monitoring/rs/primary_disconnect_setversion.yml
+++ b/test/spec/server-discovery-and-monitoring/rs/primary_disconnect_setversion.yml
@@ -35,6 +35,7 @@ phases: [
             servers: {
                 "a:27017": {
                     type: "Unknown",
+                    error: "stale",
                     setName: ,
                     electionId:
                 },

--- a/test/spec/server-discovery-and-monitoring/rs/primary_disconnect_setversion.yml
+++ b/test/spec/server-discovery-and-monitoring/rs/primary_disconnect_setversion.yml
@@ -35,9 +35,9 @@ phases: [
             servers: {
                 "a:27017": {
                     type: "Unknown",
-                    error: "stale",
                     setName: ,
-                    electionId:
+                    electionId:,
+                    error: "primary marked stale due to electionId/setVersion mismatch"
                 },
                 "b:27017": {
                     type: "RSPrimary",

--- a/test/spec/server-discovery-and-monitoring/rs/setversion_greaterthan_max_without_electionid.json
+++ b/test/spec/server-discovery-and-monitoring/rs/setversion_greaterthan_max_without_electionid.json
@@ -64,6 +64,9 @@
         "servers": {
           "a:27017": {
             "type": "Unknown",
+            "error": {
+              "message": "stale"
+            },
             "setName": null,
             "electionId": null
           },

--- a/test/spec/server-discovery-and-monitoring/rs/setversion_greaterthan_max_without_electionid.json
+++ b/test/spec/server-discovery-and-monitoring/rs/setversion_greaterthan_max_without_electionid.json
@@ -64,11 +64,9 @@
         "servers": {
           "a:27017": {
             "type": "Unknown",
-            "error": {
-              "message": "stale"
-            },
             "setName": null,
-            "electionId": null
+            "electionId": null,
+            "error": "primary marked stale due to electionId/setVersion mismatch"
           },
           "b:27017": {
             "type": "RSPrimary",

--- a/test/spec/server-discovery-and-monitoring/rs/setversion_greaterthan_max_without_electionid.yml
+++ b/test/spec/server-discovery-and-monitoring/rs/setversion_greaterthan_max_without_electionid.yml
@@ -61,7 +61,8 @@ phases: [
                 "a:27017": {
                     type: "Unknown",
                     setName: ,
-                    electionId:
+                    electionId:,
+                    error: "primary marked stale due to electionId/setVersion mismatch"
                 },
                 "b:27017": {
                     type: "RSPrimary",

--- a/test/spec/server-discovery-and-monitoring/rs/setversion_without_electionid-pre-6.0.json
+++ b/test/spec/server-discovery-and-monitoring/rs/setversion_without_electionid-pre-6.0.json
@@ -65,7 +65,8 @@
           "a:27017": {
             "type": "Unknown",
             "setName": null,
-            "electionId": null
+            "electionId": null,
+            "error": "primary marked stale due to electionId/setVersion mismatch"
           },
           "b:27017": {
             "type": "RSPrimary",

--- a/test/spec/server-discovery-and-monitoring/rs/setversion_without_electionid-pre-6.0.yml
+++ b/test/spec/server-discovery-and-monitoring/rs/setversion_without_electionid-pre-6.0.yml
@@ -61,7 +61,8 @@ phases: [
                 "a:27017": {
                     type: "Unknown",
                     setName: ,
-                    electionId:
+                    electionId:,
+                    error: "primary marked stale due to electionId/setVersion mismatch"
                 },
                 "b:27017": {
                     type: "RSPrimary",

--- a/test/spec/server-discovery-and-monitoring/rs/use_setversion_without_electionid-pre-6.0.json
+++ b/test/spec/server-discovery-and-monitoring/rs/use_setversion_without_electionid-pre-6.0.json
@@ -73,7 +73,8 @@
           "a:27017": {
             "type": "Unknown",
             "setName": null,
-            "electionId": null
+            "electionId": null,
+            "error": "primary marked stale due to electionId/setVersion mismatch"
           },
           "b:27017": {
             "type": "RSPrimary",
@@ -117,7 +118,8 @@
           "a:27017": {
             "type": "Unknown",
             "setName": null,
-            "electionId": null
+            "electionId": null,
+            "error": "primary marked stale due to electionId/setVersion mismatch"
           },
           "b:27017": {
             "type": "RSPrimary",

--- a/test/spec/server-discovery-and-monitoring/rs/use_setversion_without_electionid-pre-6.0.yml
+++ b/test/spec/server-discovery-and-monitoring/rs/use_setversion_without_electionid-pre-6.0.yml
@@ -62,7 +62,8 @@ phases: [
                 "a:27017": {
                     type: "Unknown",
                     setName: ,
-                    electionId:
+                    electionId:,
+                    error: "primary marked stale due to electionId/setVersion mismatch"
                 },
                 "b:27017": {
                     type: "RSPrimary",
@@ -99,7 +100,8 @@ phases: [
                 "a:27017": {
                     type: "Unknown",
                     setName: ,
-                    electionId:
+                    electionId:,
+                    error: "primary marked stale due to electionId/setVersion mismatch"
                 },
                 "b:27017": {
                     type: "RSPrimary",

--- a/test/spec/server-discovery-and-monitoring/rs/use_setversion_without_electionid.json
+++ b/test/spec/server-discovery-and-monitoring/rs/use_setversion_without_electionid.json
@@ -81,7 +81,8 @@
           "b:27017": {
             "type": "Unknown",
             "setName": null,
-            "electionId": null
+            "electionId": null,
+            "error": "primary marked stale due to electionId/setVersion mismatch"
           }
         },
         "topologyType": "ReplicaSetWithPrimary",
@@ -128,7 +129,8 @@
           "b:27017": {
             "type": "Unknown",
             "setName": null,
-            "electionId": null
+            "electionId": null,
+            "error": "primary marked stale due to electionId/setVersion mismatch"
           }
         },
         "topologyType": "ReplicaSetWithPrimary",

--- a/test/spec/server-discovery-and-monitoring/rs/use_setversion_without_electionid.yml
+++ b/test/spec/server-discovery-and-monitoring/rs/use_setversion_without_electionid.yml
@@ -68,7 +68,8 @@ phases: [
                 "b:27017": {
                     type: "Unknown",
                     setName: ,
-                    electionId:
+                    electionId:,
+                    error: "primary marked stale due to electionId/setVersion mismatch"
                 }
             },
             topologyType: "ReplicaSetWithPrimary",
@@ -106,7 +107,8 @@ phases: [
                 "b:27017":{
                     type: "Unknown",
                     setName: ,
-                    electionId:
+                    electionId:,
+                    error: "primary marked stale due to electionId/setVersion mismatch"
                 }
             },
             topologyType: "ReplicaSetWithPrimary",

--- a/test/unit/assorted/server_discovery_and_monitoring.spec.test.ts
+++ b/test/unit/assorted/server_discovery_and_monitoring.spec.test.ts
@@ -476,7 +476,7 @@ function assertTopologyDescriptionOutcomeExpectations(
         expect(actualServer).to.have.deep.property(expectedKey, expectedValue);
       } else {
         // pull the message off the error if it is present
-        expect(actualServer).to.have.deep.property(expectedKey).instanceof(MongoError);
+        expect(actualServer).to.have.property(expectedKey).instanceof(MongoError);
         expect(actualServer).property(expectedKey).property('message').includes(expectedValue);
       }
     }

--- a/test/unit/assorted/server_discovery_and_monitoring.spec.test.ts
+++ b/test/unit/assorted/server_discovery_and_monitoring.spec.test.ts
@@ -10,6 +10,7 @@ import {
   isRecord,
   MongoClient,
   MongoCompatibilityError,
+  MongoError,
   MongoNetworkError,
   MongoNetworkTimeoutError,
   MongoServerError,
@@ -25,6 +26,7 @@ import {
   ServerHeartbeatStartedEvent,
   ServerHeartbeatSucceededEvent,
   ServerOpeningEvent,
+  squashError,
   Topology,
   TOPOLOGY_CLOSED,
   TOPOLOGY_DESCRIPTION_CHANGED,
@@ -108,6 +110,7 @@ interface MonitoringOutcome {
 interface OutcomeServerDescription {
   type?: string;
   setName?: string;
+  error?: { message: string };
   setVersion?: number;
   electionId?: ObjectId | null;
   logicalSessionTimeoutMinutes?: number;
@@ -268,6 +271,7 @@ function normalizeServerDescription(serverDescription) {
     // it as `Unknown`.
     serverDescription.type = 'Unknown';
   }
+  serverDescription.error == serverDescription?.error?.message;
 
   return serverDescription;
 }
@@ -322,84 +326,88 @@ async function executeSDAMTest(testData: SDAMTest) {
   // connect the topology
   await client.connect();
 
-  for (const phase of testData.phases) {
-    // Determine which of the two kinds of phases we're running
-    if ('responses' in phase && phase.responses != null) {
-      // phase with responses for hello simulations
-      for (const [address, hello] of phase.responses) {
-        client.topology.serverUpdateHandler(new ServerDescription(address, hello));
-      }
-    } else if ('applicationErrors' in phase && phase.applicationErrors) {
-      // phase with applicationErrors simulating error's from network, timeouts, server
-      for (const appError of phase.applicationErrors) {
-        // Stub will return appError to SDAM machinery
-        const checkOutStub = sinon
-          .stub(ConnectionPool.prototype, 'checkOut')
-          .callsFake(checkoutStubImpl(appError));
-
-        const server = client.topology.s.servers.get(appError.address);
-
-        // Run a dummy command to encounter the error
-        const res = server.command.bind(server)(ns('admin.$cmd'), { ping: 1 }, {});
-        const thrownError = await res.catch(error => error);
-
-        // Restore the stub before asserting anything in case of errors
-        checkOutStub.restore();
-
-        const isApplicationError = error => {
-          // These errors all come from the withConnection stub
-          return (
-            error instanceof MongoNetworkError ||
-            error instanceof MongoNetworkTimeoutError ||
-            error instanceof MongoServerError
-          );
-        };
-        expect(
-          thrownError,
-          `expected the error thrown to be one of MongoNetworkError, MongoNetworkTimeoutError or MongoServerError (referred to in the spec as an "Application Error") got ${thrownError.name} ${thrownError.stack}`
-        ).to.satisfy(isApplicationError);
-      }
-    } else if (phase.outcome != null && Object.keys(phase).length === 1) {
-      // Load Balancer SDAM tests have no "work" to be done for the phase
-    } else {
-      expect.fail(ejson`Unknown phase shape - ${phase}`);
-    }
-
-    if ('outcome' in phase && phase.outcome != null) {
-      if (isMonitoringOutcome(phase.outcome)) {
-        // Test for monitoring events
-        const expectedEvents = convertOutcomeEvents(phase.outcome.events);
-
-        expect(events).to.have.length(expectedEvents.length);
-        for (const [i, actualEvent] of Object.entries(events)) {
-          const actualEventClone = cloneForCompare(actualEvent);
-          expect(actualEventClone).to.matchMongoSpec(expectedEvents[i]);
+  try {
+    for (const phase of testData.phases) {
+      // Determine which of the two kinds of phases we're running
+      if ('responses' in phase && phase.responses != null) {
+        // phase with responses for hello simulations
+        for (const [address, hello] of phase.responses) {
+          client.topology.serverUpdateHandler(new ServerDescription(address, hello));
         }
-      } else if (isTopologyDescriptionOutcome(phase.outcome)) {
-        // Test for SDAM machinery correctly changing the topology type among other properties
-        assertTopologyDescriptionOutcomeExpectations(client.topology, phase.outcome);
-        if (phase.outcome.compatible === false) {
-          // driver specific error throwing
-          if (testData.description === 'Multiple mongoses with large minWireVersion') {
-            // TODO(DRIVERS-2250): There is test bug that causes two errors
-            // this will start failing when the test is synced and fixed
-            expect(errorsThrown).to.have.lengthOf(2);
-          } else {
-            expect(errorsThrown).to.have.lengthOf(1);
-          }
-          expect(errorsThrown[0]).to.be.instanceOf(MongoCompatibilityError);
-          expect(errorsThrown[0].message).to.match(/but this version of the driver/);
-        } else {
-          // unset or true means no errors should be thrown
-          expect(errorsThrown).to.be.empty;
+      } else if ('applicationErrors' in phase && phase.applicationErrors) {
+        // phase with applicationErrors simulating error's from network, timeouts, server
+        for (const appError of phase.applicationErrors) {
+          // Stub will return appError to SDAM machinery
+          const checkOutStub = sinon
+            .stub(ConnectionPool.prototype, 'checkOut')
+            .callsFake(checkoutStubImpl(appError));
+
+          const server = client.topology.s.servers.get(appError.address);
+
+          // Run a dummy command to encounter the error
+          const res = server.command.bind(server)(ns('admin.$cmd'), { ping: 1 }, {});
+          const thrownError = await res.catch(error => error);
+
+          // Restore the stub before asserting anything in case of errors
+          checkOutStub.restore();
+
+          const isApplicationError = error => {
+            // These errors all come from the withConnection stub
+            return (
+              error instanceof MongoNetworkError ||
+              error instanceof MongoNetworkTimeoutError ||
+              error instanceof MongoServerError
+            );
+          };
+          expect(
+            thrownError,
+            `expected the error thrown to be one of MongoNetworkError, MongoNetworkTimeoutError or MongoServerError (referred to in the spec as an "Application Error") got ${thrownError.name} ${thrownError.stack}`
+          ).to.satisfy(isApplicationError);
         }
+      } else if (phase.outcome != null && Object.keys(phase).length === 1) {
+        // Load Balancer SDAM tests have no "work" to be done for the phase
       } else {
-        expect.fail(ejson`Unknown outcome shape - ${phase.outcome}`);
+        expect.fail(ejson`Unknown phase shape - ${phase}`);
       }
 
-      events = [];
-      errorsThrown = [];
+      if ('outcome' in phase && phase.outcome != null) {
+        if (isMonitoringOutcome(phase.outcome)) {
+          // Test for monitoring events
+          const expectedEvents = convertOutcomeEvents(phase.outcome.events);
+
+          expect(events).to.have.length(expectedEvents.length);
+          for (const [i, actualEvent] of Object.entries(events)) {
+            const actualEventClone = cloneForCompare(actualEvent);
+            expect(actualEventClone).to.matchMongoSpec(expectedEvents[i]);
+          }
+        } else if (isTopologyDescriptionOutcome(phase.outcome)) {
+          // Test for SDAM machinery correctly changing the topology type among other properties
+          assertTopologyDescriptionOutcomeExpectations(client.topology, phase.outcome);
+          if (phase.outcome.compatible === false) {
+            // driver specific error throwing
+            if (testData.description === 'Multiple mongoses with large minWireVersion') {
+              // TODO(DRIVERS-2250): There is test bug that causes two errors
+              // this will start failing when the test is synced and fixed
+              expect(errorsThrown).to.have.lengthOf(2);
+            } else {
+              expect(errorsThrown).to.have.lengthOf(1);
+            }
+            expect(errorsThrown[0]).to.be.instanceOf(MongoCompatibilityError);
+            expect(errorsThrown[0].message).to.match(/but this version of the driver/);
+          } else {
+            // unset or true means no errors should be thrown
+            expect(errorsThrown).to.be.empty;
+          }
+        } else {
+          expect.fail(ejson`Unknown outcome shape - ${phase.outcome}`);
+        }
+
+        events = [];
+        errorsThrown = [];
+      }
     }
+  } finally {
+    await client.close().catch(squashError);
   }
 }
 
@@ -464,8 +472,12 @@ function assertTopologyDescriptionOutcomeExpectations(
       if (WIRE_VERSION_KEYS.has(expectedKey) && expectedValue === null) {
         // For wireVersion keys we default to zero instead of null
         expect(actualServer).to.have.property(expectedKey, 0);
-      } else {
+      } else if (expectedKey !== 'error') {
         expect(actualServer).to.have.deep.property(expectedKey, expectedValue);
+      } else {
+        // Check that if we have
+        expect(actualServer).to.have.deep.property(expectedKey).instanceof(MongoError);
+        expect(actualServer).property(expectedKey).property('message').includes(expectedValue);
       }
     }
   }

--- a/test/unit/assorted/server_discovery_and_monitoring.spec.test.ts
+++ b/test/unit/assorted/server_discovery_and_monitoring.spec.test.ts
@@ -271,7 +271,7 @@ function normalizeServerDescription(serverDescription) {
     // it as `Unknown`.
     serverDescription.type = 'Unknown';
   }
-  serverDescription.error == serverDescription?.error?.message;
+  //serverDescription.error = serverDescription?.error?.message;
 
   return serverDescription;
 }
@@ -475,7 +475,7 @@ function assertTopologyDescriptionOutcomeExpectations(
       } else if (expectedKey !== 'error') {
         expect(actualServer).to.have.deep.property(expectedKey, expectedValue);
       } else {
-        // Check that if we have
+        // pull the message off the error if it is present
         expect(actualServer).to.have.deep.property(expectedKey).instanceof(MongoError);
         expect(actualServer).property(expectedKey).property('message').includes(expectedValue);
       }

--- a/test/unit/assorted/server_discovery_and_monitoring.spec.test.ts
+++ b/test/unit/assorted/server_discovery_and_monitoring.spec.test.ts
@@ -271,7 +271,6 @@ function normalizeServerDescription(serverDescription) {
     // it as `Unknown`.
     serverDescription.type = 'Unknown';
   }
-  //serverDescription.error = serverDescription?.error?.message;
 
   return serverDescription;
 }
@@ -475,9 +474,11 @@ function assertTopologyDescriptionOutcomeExpectations(
       } else if (expectedKey !== 'error') {
         expect(actualServer).to.have.deep.property(expectedKey, expectedValue);
       } else {
-        // pull the message off the error if it is present
-        expect(actualServer).to.have.property(expectedKey).instanceof(MongoError);
-        expect(actualServer).property(expectedKey).property('message').includes(expectedValue);
+        expect(typeof expectedValue).to.equal('string');
+        expect(actualServer)
+          .to.have.property(expectedKey)
+          .instanceof(MongoError)
+          .to.match(new RegExp(expectedValue as string));
       }
     }
   }

--- a/test/unit/index.test.ts
+++ b/test/unit/index.test.ts
@@ -106,6 +106,7 @@ const EXPECTED_EXPORTS = [
   'MongoTailableCursorError',
   'MongoTopologyClosedError',
   'MongoTransactionError',
+  'MongoStalePrimaryError',
   'MongoUnexpectedServerResponseError',
   'MongoWriteConcernError',
   'ObjectId',


### PR DESCRIPTION
### Description

#### What is changing?
* Added `MongoStalePrimaryError`
* Updated sdam unit test runner
* Updated spec tests from draft changes in DRIVERS-2972

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Populate `ServerDescription.error` field when primary marked stale
We now attach an error to the newly created ServerDescription object when marking a primary as stale. This helps with debugging SDAM issues when monitoring SDAM events.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [X] Ran `npm run check:lint` script
- [X] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [X] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [X] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
