### PR TITLE
fix(NODE-6584): improve typing for files in AutoEncryptionOptions

### DIFF
--- a/src/client-side-encryption/auto_encrypter.ts
+++ b/src/client-side-encryption/auto_encrypter.ts
@@ -57,7 +57,7 @@ export interface AutoEncryptionOptions {
     /** If true, autoEncryption will not attempt to spawn a mongocryptd before connecting  */
     mongocryptdBypassSpawn?: boolean;
     /** The path to the mongocryptd executable on the system */
-    mongocryptdSpawnPath?: string;
+    mongocryptdSpawnPath?: `${string}mongocryptd${'.exe' | ''}`;
     /** Command line arguments to use when auto-spawning a mongocryptd */
     mongocryptdSpawnArgs?: string[];
     /**
@@ -83,7 +83,7 @@ export interface AutoEncryptionOptions {
      *
      * Requires the MongoDB Crypt shared library, available in MongoDB 6.0 or higher.
      */
-    cryptSharedLibPath?: string;
+    cryptSharedLibPath?: `${string}mongo_crypt_v${number}.${'so' | 'dll' | 'dylib'}`;
     /**
      * If specified, never use mongocryptd and instead fail when the MongoDB Crypt
      * shared library could not be loaded.

--- a/test/types/client-side-encryption.test-d.ts
+++ b/test/types/client-side-encryption.test-d.ts
@@ -2,6 +2,7 @@ import { expectAssignable, expectError, expectNotAssignable, expectType } from '
 
 import type {
   AWSEncryptionKeyOptions,
+  AutoEncryptionOptions,
   AzureEncryptionKeyOptions,
   ClientEncryption,
   ClientEncryptionEncryptOptions,
@@ -106,4 +107,53 @@ expectAssignable<RequiredCreateEncryptedCollectionSettings>({
   expectAssignable<ClientEncryptionDataKeyProvider>('kmip:named');
 
   expectNotAssignable<ClientEncryptionDataKeyProvider>('arbitrary string');
+}
+
+{
+  expectAssignable<AutoEncryptionOptions>({
+    extraOptions: {
+      mongocryptdSpawnPath: 'mongocryptd'
+    }
+  });
+  expectAssignable<AutoEncryptionOptions>({
+    extraOptions: {
+      mongocryptdSpawnPath: 'mongocryptd.exe'
+    }
+  });
+  expectAssignable<AutoEncryptionOptions>({
+    extraOptions: {
+      mongocryptdSpawnPath: '/usr/bin/mongocryptd'
+    }
+  });
+  expectNotAssignable<AutoEncryptionOptions>({
+    extraOptions: {
+      mongocryptdSpawnPath: 'mongo_crypt_v1.so'
+    }
+  });
+
+  expectAssignable<AutoEncryptionOptions>({
+    extraOptions: {
+      cryptSharedLibPath: 'mongo_crypt_v1.so'
+    }
+  });
+  expectAssignable<AutoEncryptionOptions>({
+    extraOptions: {
+      cryptSharedLibPath: 'mongo_crypt_v1.dll'
+    }
+  });
+  expectAssignable<AutoEncryptionOptions>({
+    extraOptions: {
+      cryptSharedLibPath: 'mongo_crypt_v1.dylib'
+    }
+  });
+  expectAssignable<AutoEncryptionOptions>({
+    extraOptions: {
+      cryptSharedLibPath: '/usr/lib/mongo_crypt_v1.dylib'
+    }
+  });
+  expectNotAssignable<AutoEncryptionOptions>({
+    extraOptions: {
+      cryptSharedLibPath: 'libmongocrypt.so'
+    }
+  });
 }


### PR DESCRIPTION
### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
