### PR TITLE
docs(NODE-6483): Add documentation for countDocuments $match operator

### DIFF
--- a/src/collection.ts
+++ b/src/collection.ts
@@ -765,6 +765,9 @@ export class Collection<TSchema extends Document = Document> {
   /**
    * Gets the number of documents matching the filter.
    * For a fast count of the total documents in a collection see {@link Collection#estimatedDocumentCount| estimatedDocumentCount}.
+   *
+   * Due to countDocuments using the $match aggregation pipeline stage, certain query operators cannot be used in countDocuments. This includes the $where and $near query operators, among others. Details can be found in the documentation for the $match aggregation pipeline stage.
+   *
    * **Note**: When migrating from {@link Collection#count| count} to {@link Collection#countDocuments| countDocuments}
    * the following query operators must be replaced:
    *


### PR DESCRIPTION
### Description
Add docs in from drivers ticket.

#### What is changing?
See above

##### Is there new documentation needed for these changes?
Only API docs

#### What is the motivation for this change?
DRIVERS-2728

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Document that countDocuments() uses $match and may not support the same filters as find/count commands

The API documentation for `Collection.countDocuments` now documents [restrictions](https://www.mongodb.com/docs/manual/reference/operator/aggregation/match/#restrictions) for filters in the countDocuments API that result from the API using aggregation pipeline.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
