### PR TITLE
test(NODE-6527): sync pool-checkout-returned-connection-maxConnecting tests

### DIFF
--- a/test/spec/connection-monitoring-and-pooling/cmap-format/pool-checkout-returned-connection-maxConnecting.json
+++ b/test/spec/connection-monitoring-and-pooling/cmap-format/pool-checkout-returned-connection-maxConnecting.json
@@ -23,6 +23,7 @@
     }
   },
   "poolOptions": {
+    "maxConnecting": 2,
     "maxPoolSize": 10,
     "waitQueueTimeoutMS": 5000
   },
@@ -72,9 +73,8 @@
       "connection": "conn0"
     },
     {
-      "name": "waitForEvent",
-      "event": "ConnectionCheckedOut",
-      "count": 4
+      "name": "wait",
+      "ms": 100
     }
   ],
   "events": [
@@ -103,14 +103,6 @@
     {
       "type": "ConnectionCheckedOut",
       "connectionId": 1,
-      "address": 42
-    },
-    {
-      "type": "ConnectionCheckedOut",
-      "address": 42
-    },
-    {
-      "type": "ConnectionCheckedOut",
       "address": 42
     }
   ],

--- a/test/spec/connection-monitoring-and-pooling/cmap-format/pool-checkout-returned-connection-maxConnecting.yml
+++ b/test/spec/connection-monitoring-and-pooling/cmap-format/pool-checkout-returned-connection-maxConnecting.yml
@@ -15,6 +15,7 @@ failPoint:
     blockConnection: true
     blockTimeMS: 750
 poolOptions:
+  maxConnecting: 2
   maxPoolSize: 10
   waitQueueTimeoutMS: 5000
 operations:
@@ -45,14 +46,13 @@ operations:
     count: 4
   - name: wait
     ms: 100
-  # check original connection back in, so the thread that isn't
-  # currently establishing will become unblocked. Then wait for
-  # all threads to complete.
+  # Check original connection back in, so one of the waiting threads can check
+  # out the idle connection before the two new connections are ready.
   - name: checkIn
     connection: conn0
-  - name: waitForEvent
-    event: ConnectionCheckedOut
-    count: 4
+  # Wait for 100ms to let one of the blocked checkOut operations complete.
+  - name: wait
+    ms: 100
 events:
   # main thread checking out a Connection and holding it
   - type: ConnectionCreated
@@ -69,15 +69,13 @@ events:
   - type: ConnectionCheckedIn
     connectionId: 1
     address: 42
-  # remaining thread checking out the returned Connection
+  # Another thread checks out the returned Connection before the two new
+  # connections are checked out.
   - type: ConnectionCheckedOut
     connectionId: 1
     address: 42
-  # first two threads finishing Connection establishment
-  - type: ConnectionCheckedOut
-    address: 42
-  - type: ConnectionCheckedOut
-    address: 42
+  # Events after this can come in different orders but still be valid.
+  # See DRIVERS-2223 for details.
 ignore:
   - ConnectionPoolReady
   - ConnectionClosed


### PR DESCRIPTION
### Description

#### What is changing?

Small CMAP test sync.

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
