### PR TITLE
fix(NODE-6602): only wrap errors from SOCKS in network errors

### DIFF
--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -19,5 +19,6 @@ fi
 source $DRIVERS_TOOLS/.evergreen/install-node.sh
 
 npm install "${NPM_OPTIONS}"
+npm install mongodb/js-bson#main
 
 source $DRIVERS_TOOLS/.evergreen/init-node-and-npm-env.sh

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -19,6 +19,5 @@ fi
 source $DRIVERS_TOOLS/.evergreen/install-node.sh
 
 npm install "${NPM_OPTIONS}"
-npm install mongodb/js-bson#main
 
 source $DRIVERS_TOOLS/.evergreen/init-node-and-npm-env.sh

--- a/src/cmap/connect.ts
+++ b/src/cmap/connect.ts
@@ -386,16 +386,15 @@ export async function makeSocket(options: MakeConnectionOptions): Promise<Stream
   if (existingSocket) {
     resolve(socket);
   } else {
-    const connectEvent = useTLS ? 'secureConnect' : 'connect';
     const start = performance.now();
+    const connectEvent = useTLS ? 'secureConnect' : 'connect';
     socket
       .once(connectEvent, () => resolve(socket))
       .once('error', error => reject(connectionFailureError('error', error)))
       .once('timeout', () => {
-        const end = performance.now();
-        return reject(
+        reject(
           new MongoNetworkTimeoutError(
-            `socket.connect() timed out! connectTimeoutMS=${connectTimeoutMS}ms, socket.setTimeout fired after ${end - start}ms.`
+            `Socket '${connectEvent}' timed out after ${(performance.now() - start) | 0}ms (connectTimeoutMS: ${connectTimeoutMS})`
           )
         );
       })

--- a/src/cmap/connect.ts
+++ b/src/cmap/connect.ts
@@ -386,35 +386,15 @@ export async function makeSocket(options: MakeConnectionOptions): Promise<Stream
   if (existingSocket) {
     resolve(socket);
   } else {
-    const start = performance.now();
     const connectEvent = useTLS ? 'secureConnect' : 'connect';
     socket
       .once(connectEvent, () => resolve(socket))
-      .once('error', cause =>
-        reject(new MongoNetworkError(MongoError.buildErrorMessage(cause), { cause }))
-      )
-      .once('timeout', () => {
-        reject(
-          new MongoNetworkTimeoutError(
-            `Socket '${connectEvent}' timed out after ${(performance.now() - start) | 0}ms (connectTimeoutMS: ${connectTimeoutMS})`
-          )
-        );
-      })
-      .once('close', () =>
-        reject(
-          new MongoNetworkError(
-            `Socket closed after ${(performance.now() - start) | 0} during connection establishment`
-          )
-        )
-      );
+      .once('error', error => reject(connectionFailureError('error', error)))
+      .once('timeout', () => reject(connectionFailureError('timeout')))
+      .once('close', () => reject(connectionFailureError('close')));
 
     if (options.cancellationToken != null) {
-      cancellationHandler = () =>
-        reject(
-          new MongoNetworkError(
-            `Socket connection establishment was cancelled after ${(performance.now() - start) | 0}`
-          )
-        );
+      cancellationHandler = () => reject(connectionFailureError('cancel'));
       options.cancellationToken.once('cancel', cancellationHandler);
     }
   }
@@ -467,11 +447,9 @@ async function makeSocks5Connection(options: MakeConnectionOptions): Promise<Str
 
   socks ??= loadSocks();
 
-  let existingSocket: Stream;
-
   try {
     // Then, establish the Socks5 proxy connection:
-    const connection = await socks.SocksClient.createConnection({
+    const { socket } = await socks.SocksClient.createConnection({
       existing_socket: rawSocket,
       timeout: options.connectTimeoutMS,
       command: 'connect',
@@ -488,12 +466,35 @@ async function makeSocks5Connection(options: MakeConnectionOptions): Promise<Str
         password: options.proxyPassword || undefined
       }
     });
-    existingSocket = connection.socket;
-  } catch (cause) {
-    throw new MongoNetworkError(MongoError.buildErrorMessage(cause), { cause });
-  }
 
-  // Finally, now treat the resulting duplex stream as the
-  // socket over which we send and receive wire protocol messages:
-  return await makeSocket({ ...options, existingSocket, proxyHost: undefined });
+    // Finally, now treat the resulting duplex stream as the
+    // socket over which we send and receive wire protocol messages:
+    return await makeSocket({
+      ...options,
+      existingSocket: socket,
+      proxyHost: undefined
+    });
+  } catch (error) {
+    throw connectionFailureError('error', error);
+  }
+}
+
+function connectionFailureError(type: 'error', cause: Error): MongoNetworkError;
+function connectionFailureError(type: 'close' | 'timeout' | 'cancel'): MongoNetworkError;
+function connectionFailureError(
+  type: 'error' | 'close' | 'timeout' | 'cancel',
+  cause?: Error
+): MongoNetworkError {
+  switch (type) {
+    case 'error':
+      return new MongoNetworkError(MongoError.buildErrorMessage(cause), { cause });
+    case 'timeout':
+      return new MongoNetworkTimeoutError('connection timed out');
+    case 'close':
+      return new MongoNetworkError('connection closed');
+    case 'cancel':
+      return new MongoNetworkError('connection establishment was cancelled');
+    default:
+      return new MongoNetworkError('unknown network error');
+  }
 }

--- a/src/cmap/connect.ts
+++ b/src/cmap/connect.ts
@@ -387,10 +387,18 @@ export async function makeSocket(options: MakeConnectionOptions): Promise<Stream
     resolve(socket);
   } else {
     const connectEvent = useTLS ? 'secureConnect' : 'connect';
+    const start = performance.now();
     socket
       .once(connectEvent, () => resolve(socket))
       .once('error', error => reject(connectionFailureError('error', error)))
-      .once('timeout', () => reject(connectionFailureError('timeout')))
+      .once('timeout', () => {
+        const end = performance.now();
+        return reject(
+          new MongoNetworkTimeoutError(
+            `socket.connect() timed out! connectTimeoutMS=${connectTimeoutMS}ms, socket.setTimeout fired after ${end - start}ms.`
+          )
+        );
+      })
       .once('close', () => reject(connectionFailureError('close')));
 
     if (options.cancellationToken != null) {

--- a/src/cmap/connect.ts
+++ b/src/cmap/connect.ts
@@ -390,7 +390,9 @@ export async function makeSocket(options: MakeConnectionOptions): Promise<Stream
     const connectEvent = useTLS ? 'secureConnect' : 'connect';
     socket
       .once(connectEvent, () => resolve(socket))
-      .once('error', error => reject(connectionFailureError('error', error)))
+      .once('error', cause =>
+        reject(new MongoNetworkError(MongoError.buildErrorMessage(cause), { cause }))
+      )
       .once('timeout', () => {
         reject(
           new MongoNetworkTimeoutError(
@@ -398,10 +400,21 @@ export async function makeSocket(options: MakeConnectionOptions): Promise<Stream
           )
         );
       })
-      .once('close', () => reject(connectionFailureError('close')));
+      .once('close', () =>
+        reject(
+          new MongoNetworkError(
+            `Socket closed after ${(performance.now() - start) | 0} during connection establishment`
+          )
+        )
+      );
 
     if (options.cancellationToken != null) {
-      cancellationHandler = () => reject(connectionFailureError('cancel'));
+      cancellationHandler = () =>
+        reject(
+          new MongoNetworkError(
+            `Socket connection establishment was cancelled after ${(performance.now() - start) | 0}`
+          )
+        );
       options.cancellationToken.once('cancel', cancellationHandler);
     }
   }
@@ -454,9 +467,11 @@ async function makeSocks5Connection(options: MakeConnectionOptions): Promise<Str
 
   socks ??= loadSocks();
 
+  let existingSocket: Stream;
+
   try {
     // Then, establish the Socks5 proxy connection:
-    const { socket } = await socks.SocksClient.createConnection({
+    const connection = await socks.SocksClient.createConnection({
       existing_socket: rawSocket,
       timeout: options.connectTimeoutMS,
       command: 'connect',
@@ -473,35 +488,12 @@ async function makeSocks5Connection(options: MakeConnectionOptions): Promise<Str
         password: options.proxyPassword || undefined
       }
     });
-
-    // Finally, now treat the resulting duplex stream as the
-    // socket over which we send and receive wire protocol messages:
-    return await makeSocket({
-      ...options,
-      existingSocket: socket,
-      proxyHost: undefined
-    });
-  } catch (error) {
-    throw connectionFailureError('error', error);
+    existingSocket = connection.socket;
+  } catch (cause) {
+    throw new MongoNetworkError(MongoError.buildErrorMessage(cause), { cause });
   }
-}
 
-function connectionFailureError(type: 'error', cause: Error): MongoNetworkError;
-function connectionFailureError(type: 'close' | 'timeout' | 'cancel'): MongoNetworkError;
-function connectionFailureError(
-  type: 'error' | 'close' | 'timeout' | 'cancel',
-  cause?: Error
-): MongoNetworkError {
-  switch (type) {
-    case 'error':
-      return new MongoNetworkError(MongoError.buildErrorMessage(cause), { cause });
-    case 'timeout':
-      return new MongoNetworkTimeoutError('connection timed out');
-    case 'close':
-      return new MongoNetworkError('connection closed');
-    case 'cancel':
-      return new MongoNetworkError('connection establishment was cancelled');
-    default:
-      return new MongoNetworkError('unknown network error');
-  }
+  // Finally, now treat the resulting duplex stream as the
+  // socket over which we send and receive wire protocol messages:
+  return await makeSocket({ ...options, existingSocket, proxyHost: undefined });
 }

--- a/test/benchmarks/driverBench/index.js
+++ b/test/benchmarks/driverBench/index.js
@@ -2,7 +2,6 @@
 
 const MongoBench = require('../mongoBench');
 const os = require('node:os');
-const util = require('node:util');
 const process = require('node:process');
 
 const Runner = MongoBench.Runner;
@@ -33,10 +32,7 @@ const systemInfo = () =>
     `- arch: ${os.arch()}`,
     `- os: ${process.platform} (${os.release()})`,
     `- ram: ${platform.ram}`,
-    `- node: ${process.version}`,
-    `- driver: ${MONGODB_DRIVER_VERSION} (${MONGODB_DRIVER_REVISION}): ${MONGODB_DRIVER_PATH}`,
-    `  - options ${util.inspect(MONGODB_CLIENT_OPTIONS)}`,
-    `- bson: ${MONGODB_BSON_VERSION} (${MONGODB_BSON_REVISION}): (${MONGODB_BSON_PATH})\n`
+    `- node: ${process.version}\n`
   ].join('\n');
 console.log(systemInfo());
 
@@ -67,18 +63,18 @@ benchmarkRunner
     ]);
 
     const readBench = average([
-      // microBench.singleBench.findOne,
-      // microBench.multiBench.findManyAndEmptyCursor,
-      // microBench.multiBench.gridFsDownload,
+      microBench.singleBench.findOne,
+      microBench.multiBench.findManyAndEmptyCursor,
+      microBench.multiBench.gridFsDownload,
       microBench.parallel.gridfsMultiFileDownload,
       microBench.parallel.ldjsonMultiFileExport
     ]);
     const writeBench = average([
-      // microBench.singleBench.smallDocInsertOne,
-      // microBench.singleBench.largeDocInsertOne,
-      // microBench.multiBench.smallDocBulkInsert,
-      // microBench.multiBench.largeDocBulkInsert,
-      // microBench.multiBench.gridFsUpload,
+      microBench.singleBench.smallDocInsertOne,
+      microBench.singleBench.largeDocInsertOne,
+      microBench.multiBench.smallDocBulkInsert,
+      microBench.multiBench.largeDocBulkInsert,
+      microBench.multiBench.gridFsUpload,
       microBench.parallel.ldjsonMultiFileUpload,
       microBench.parallel.gridfsMultiFileUpload
     ]);
@@ -121,6 +117,6 @@ benchmarkRunner
     return writeFile('results.json', results);
   })
   .catch(err => {
-    console.error('failure: ', err.name, err.message, err.stack);
+    console.error('failure: ', err.name, err.message);
     process.exit(1);
   });

--- a/test/benchmarks/driverBench/index.js
+++ b/test/benchmarks/driverBench/index.js
@@ -67,18 +67,18 @@ benchmarkRunner
     ]);
 
     const readBench = average([
-      microBench.singleBench.findOne,
-      microBench.multiBench.findManyAndEmptyCursor,
-      microBench.multiBench.gridFsDownload,
+      // microBench.singleBench.findOne,
+      // microBench.multiBench.findManyAndEmptyCursor,
+      // microBench.multiBench.gridFsDownload,
       microBench.parallel.gridfsMultiFileDownload,
       microBench.parallel.ldjsonMultiFileExport
     ]);
     const writeBench = average([
-      microBench.singleBench.smallDocInsertOne,
-      microBench.singleBench.largeDocInsertOne,
-      microBench.multiBench.smallDocBulkInsert,
-      microBench.multiBench.largeDocBulkInsert,
-      microBench.multiBench.gridFsUpload,
+      // microBench.singleBench.smallDocInsertOne,
+      // microBench.singleBench.largeDocInsertOne,
+      // microBench.multiBench.smallDocBulkInsert,
+      // microBench.multiBench.largeDocBulkInsert,
+      // microBench.multiBench.gridFsUpload,
       microBench.parallel.ldjsonMultiFileUpload,
       microBench.parallel.gridfsMultiFileUpload
     ]);
@@ -121,6 +121,6 @@ benchmarkRunner
     return writeFile('results.json', results);
   })
   .catch(err => {
-    console.error('failure: ', err.name, err.message);
+    console.error('failure: ', err.name, err.message, err.stack);
     process.exit(1);
   });

--- a/test/benchmarks/driverBench/index.js
+++ b/test/benchmarks/driverBench/index.js
@@ -2,6 +2,7 @@
 
 const MongoBench = require('../mongoBench');
 const os = require('node:os');
+const util = require('node:util');
 const process = require('node:process');
 
 const Runner = MongoBench.Runner;
@@ -32,7 +33,10 @@ const systemInfo = () =>
     `- arch: ${os.arch()}`,
     `- os: ${process.platform} (${os.release()})`,
     `- ram: ${platform.ram}`,
-    `- node: ${process.version}\n`
+    `- node: ${process.version}`,
+    `- driver: ${MONGODB_DRIVER_VERSION} (${MONGODB_DRIVER_REVISION}): ${MONGODB_DRIVER_PATH}`,
+    `  - options ${util.inspect(MONGODB_CLIENT_OPTIONS)}`,
+    `- bson: ${MONGODB_BSON_VERSION} (${MONGODB_BSON_REVISION}): (${MONGODB_BSON_PATH})\n`
   ].join('\n');
 console.log(systemInfo());
 

--- a/test/benchmarks/driverBench/index.js
+++ b/test/benchmarks/driverBench/index.js
@@ -59,10 +59,6 @@ benchmarkRunner
     ]);
     const multiBench = average(Object.values(microBench.multiBench));
 
-    // ldjsonMultiFileUpload and ldjsonMultiFileExport cause connection errors.
-    // While we investigate, we will use the last known good values:
-    // https://spruce.mongodb.com/task/mongo_node_driver_next_performance_tests_run_spec_benchmark_tests_node_server_4bc3e500b6f0e8ab01f052c4a1bfb782d6a29b4e_f168e1328f821bbda265e024cc91ae54_24_11_18_15_37_24/logs?execution=0
-
     const parallelBench = average([
       microBench.parallel.ldjsonMultiFileUpload,
       microBench.parallel.ldjsonMultiFileExport,


### PR DESCRIPTION
### Description

#### What is changing?

- SOCKS errors should be wrapped in our network error type
- Improve error messages for socket errors

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

While fixing NODE-6552 the error message changes helped with debugging and caught the error convert bug in a driveby

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### SOCKS5: MongoNetworkError wrap fix

If the driver encounters an error while connecting to a socks5 proxy, the driver wraps the socks5 error in a MongoNetworkError.  In some circumstances, this resulted in the driver wrapping MongoNetworkErrors inside MongoNetworkErrors. 

The driver no longer double wraps errors in MongoNetworkErrors.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
