### PR TITLE
refactor(NODE-4144): remove all symbol properties

### DIFF
--- a/src/bulk/common.ts
+++ b/src/bulk/common.ts
@@ -30,9 +30,6 @@ import {
 } from '../utils';
 import { WriteConcern } from '../write_concern';
 
-/** @internal */
-const kServerError = Symbol('serverError');
-
 /** @public */
 export const BatchType = Object.freeze({
   INSERT: 1,
@@ -315,29 +312,29 @@ export interface WriteConcernErrorData {
  */
 export class WriteConcernError {
   /** @internal */
-  [kServerError]: WriteConcernErrorData;
+  private serverError: WriteConcernErrorData;
 
   constructor(error: WriteConcernErrorData) {
-    this[kServerError] = error;
+    this.serverError = error;
   }
 
   /** Write concern error code. */
   get code(): number | undefined {
-    return this[kServerError].code;
+    return this.serverError.code;
   }
 
   /** Write concern error message. */
   get errmsg(): string | undefined {
-    return this[kServerError].errmsg;
+    return this.serverError.errmsg;
   }
 
   /** Write concern error info. */
   get errInfo(): Document | undefined {
-    return this[kServerError].errInfo;
+    return this.serverError.errInfo;
   }
 
   toJSON(): WriteConcernErrorData {
-    return this[kServerError];
+    return this.serverError;
   }
 
   toString(): string {

--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -794,7 +794,7 @@ export class ChangeStream<
   }
 
   async *[Symbol.asyncIterator](): AsyncGenerator<TChange, void, void> {
-    if (this.isClosed) {
+    if (this.closed) {
       return;
     }
 
@@ -843,7 +843,7 @@ export class ChangeStream<
    * @throws MongoChangeStreamError if the underlying cursor or the change stream is closed
    */
   stream(options?: CursorStreamOptions): Readable & AsyncIterable<TChange> {
-    if (this.isClosed) {
+    if (this.closed) {
       throw new MongoChangeStreamError(CHANGESTREAM_CLOSED_ERROR);
     }
 

--- a/src/cmap/connection_pool.ts
+++ b/src/cmap/connection_pool.ts
@@ -117,7 +117,9 @@ export type ConnectionPoolEvents = {
  */
 export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
   public options: Readonly<ConnectionPoolOptions>;
+  /**  An integer representing the SDAM generation of the pool */
   public generation: number;
+  /** A map of generations to service ids */
   public serviceGenerations: Map<string, number>;
 
   private poolState: PoolState;

--- a/src/encrypter.ts
+++ b/src/encrypter.ts
@@ -8,9 +8,6 @@ import { MongoClient, type MongoClientOptions } from './mongo_client';
 import { type Callback } from './utils';
 
 /** @internal */
-const kInternalClient = Symbol('internalClient');
-
-/** @internal */
 export interface EncrypterOptions {
   autoEncryption: AutoEncryptionOptions;
   maxPoolSize?: number;
@@ -18,7 +15,7 @@ export interface EncrypterOptions {
 
 /** @internal */
 export class Encrypter {
-  [kInternalClient]: MongoClient | null;
+  private internalClient: MongoClient | null;
   bypassAutoEncryption: boolean;
   needsConnecting: boolean;
   autoEncrypter: AutoEncrypter;
@@ -28,7 +25,7 @@ export class Encrypter {
       throw new MongoInvalidArgumentError('Option "autoEncryption" must be specified');
     }
     // initialize to null, if we call getInternalClient, we may set this it is important to not overwrite those function calls.
-    this[kInternalClient] = null;
+    this.internalClient = null;
 
     this.bypassAutoEncryption = !!options.autoEncryption.bypassAutoEncryption;
     this.needsConnecting = false;
@@ -61,7 +58,7 @@ export class Encrypter {
 
   getInternalClient(client: MongoClient, uri: string, options: MongoClientOptions): MongoClient {
     // TODO(NODE-4144): Remove new variable for type narrowing
-    let internalClient = this[kInternalClient];
+    let internalClient = this.internalClient;
     if (internalClient == null) {
       const clonedOptions: MongoClientOptions = {};
 
@@ -77,7 +74,7 @@ export class Encrypter {
       clonedOptions.minPoolSize = 0;
 
       internalClient = new MongoClient(uri, clonedOptions);
-      this[kInternalClient] = internalClient;
+      this.internalClient = internalClient;
 
       for (const eventName of MONGO_CLIENT_EVENTS) {
         for (const listener of client.listeners(eventName)) {
@@ -96,7 +93,7 @@ export class Encrypter {
 
   async connectInternalClient(): Promise<void> {
     // TODO(NODE-4144): Remove new variable for type narrowing
-    const internalClient = this[kInternalClient];
+    const internalClient = this.internalClient;
     if (this.needsConnecting && internalClient != null) {
       this.needsConnecting = false;
       await internalClient.connect();
@@ -114,7 +111,7 @@ export class Encrypter {
     } catch (autoEncrypterError) {
       error = autoEncrypterError;
     }
-    const internalClient = this[kInternalClient];
+    const internalClient = this.internalClient;
     if (internalClient != null && client !== internalClient) {
       return await internalClient.close(force);
     }

--- a/src/encrypter.ts
+++ b/src/encrypter.ts
@@ -57,7 +57,6 @@ export class Encrypter {
   }
 
   getInternalClient(client: MongoClient, uri: string, options: MongoClientOptions): MongoClient {
-    // TODO(NODE-4144): Remove new variable for type narrowing
     let internalClient = this.internalClient;
     if (internalClient == null) {
       const clonedOptions: MongoClientOptions = {};
@@ -92,7 +91,6 @@ export class Encrypter {
   }
 
   async connectInternalClient(): Promise<void> {
-    // TODO(NODE-4144): Remove new variable for type narrowing
     const internalClient = this.internalClient;
     if (this.needsConnecting && internalClient != null) {
       this.needsConnecting = false;

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -333,9 +333,6 @@ export type MongoClientEvents = Pick<TopologyEvents, (typeof MONGO_CLIENT_EVENTS
   open(mongoClient: MongoClient): void;
 };
 
-/** @internal */
-const kOptions = Symbol('options');
-
 /**
  * The **MongoClient** class is a class that allows for making Connections to MongoDB.
  * @public
@@ -367,20 +364,22 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> implements
 
   /**
    * The consolidate, parsed, transformed and merged options.
-   * @internal
    */
-  [kOptions]: MongoOptions;
+  public readonly options: Readonly<
+    Omit<MongoOptions, 'monitorCommands' | 'ca' | 'crl' | 'key' | 'cert'>
+  > &
+    Pick<MongoOptions, 'monitorCommands' | 'ca' | 'crl' | 'key' | 'cert'>;
 
   constructor(url: string, options?: MongoClientOptions) {
     super();
 
-    this[kOptions] = parseOptions(url, this, options);
+    this.options = parseOptions(url, this, options);
 
-    const shouldSetLogger = Object.values(
-      this[kOptions].mongoLoggerOptions.componentSeverities
-    ).some(value => value !== SeverityLevel.OFF);
+    const shouldSetLogger = Object.values(this.options.mongoLoggerOptions.componentSeverities).some(
+      value => value !== SeverityLevel.OFF
+    );
     this.mongoLogger = shouldSetLogger
-      ? new MongoLogger(this[kOptions].mongoLoggerOptions)
+      ? new MongoLogger(this.options.mongoLoggerOptions)
       : undefined;
 
     // eslint-disable-next-line @typescript-eslint/no-this-alias
@@ -389,7 +388,7 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> implements
     // The internal state
     this.s = {
       url,
-      bsonOptions: resolveBSONOptions(this[kOptions]),
+      bsonOptions: resolveBSONOptions(this.options),
       namespace: ns('admin'),
       hasBeenClosed: false,
       sessionPool: new ServerSessionPool(this),
@@ -397,16 +396,16 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> implements
       authProviders: new MongoClientAuthProviders(),
 
       get options() {
-        return client[kOptions];
+        return client.options;
       },
       get readConcern() {
-        return client[kOptions].readConcern;
+        return client.options.readConcern;
       },
       get writeConcern() {
-        return client[kOptions].writeConcern;
+        return client.options.writeConcern;
       },
       get readPreference() {
-        return client[kOptions].readPreference;
+        return client.options.readPreference;
       },
       get isMongoClient(): true {
         return true;
@@ -428,15 +427,15 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> implements
 
   /** @internal */
   private checkForNonGenuineHosts() {
-    const documentDBHostnames = this[kOptions].hosts.filter((hostAddress: HostAddress) =>
+    const documentDBHostnames = this.options.hosts.filter((hostAddress: HostAddress) =>
       isHostMatch(DOCUMENT_DB_CHECK, hostAddress.host)
     );
-    const srvHostIsDocumentDB = isHostMatch(DOCUMENT_DB_CHECK, this[kOptions].srvHost);
+    const srvHostIsDocumentDB = isHostMatch(DOCUMENT_DB_CHECK, this.options.srvHost);
 
-    const cosmosDBHostnames = this[kOptions].hosts.filter((hostAddress: HostAddress) =>
+    const cosmosDBHostnames = this.options.hosts.filter((hostAddress: HostAddress) =>
       isHostMatch(COSMOS_DB_CHECK, hostAddress.host)
     );
-    const srvHostIsCosmosDB = isHostMatch(COSMOS_DB_CHECK, this[kOptions].srvHost);
+    const srvHostIsCosmosDB = isHostMatch(COSMOS_DB_CHECK, this.options.srvHost);
 
     if (documentDBHostnames.length !== 0 || srvHostIsDocumentDB) {
       this.mongoLogger?.info('client', DOCUMENT_DB_MSG);
@@ -445,28 +444,23 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> implements
     }
   }
 
-  /** @see MongoOptions */
-  get options(): Readonly<MongoOptions> {
-    return Object.freeze({ ...this[kOptions] });
-  }
-
   get serverApi(): Readonly<ServerApi | undefined> {
-    return this[kOptions].serverApi && Object.freeze({ ...this[kOptions].serverApi });
+    return this.options.serverApi && Object.freeze({ ...this.options.serverApi });
   }
   /**
    * Intended for APM use only
    * @internal
    */
   get monitorCommands(): boolean {
-    return this[kOptions].monitorCommands;
+    return this.options.monitorCommands;
   }
   set monitorCommands(value: boolean) {
-    this[kOptions].monitorCommands = value;
+    this.options.monitorCommands = value;
   }
 
   /** @internal */
   get autoEncrypter(): AutoEncrypter | undefined {
-    return this[kOptions].autoEncrypter;
+    return this.options.autoEncrypter;
   }
 
   get readConcern(): ReadConcern | undefined {
@@ -551,7 +545,7 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> implements
       return this;
     }
 
-    const options = this[kOptions];
+    const options = this.options;
 
     if (options.tls) {
       if (typeof options.tlsCAFile === 'string') {
@@ -685,7 +679,7 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> implements
 
     topology.close();
 
-    const { encrypter } = this[kOptions];
+    const { encrypter } = this.options;
     if (encrypter) {
       await encrypter.close(this, force);
     }
@@ -706,7 +700,7 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> implements
     }
 
     // Copy the options and add out internal override of the not shared flag
-    const finalOptions = Object.assign({}, this[kOptions], options);
+    const finalOptions = Object.assign({}, this.options, options);
 
     // Return the db object
     const db = new Db(this, dbName, finalOptions);
@@ -748,7 +742,7 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> implements
       this,
       this.s.sessionPool,
       { explicit: true, ...options },
-      this[kOptions]
+      this.options
     );
     this.s.activeSessions.add(session);
     session.once('ended', () => {

--- a/src/sdam/server.ts
+++ b/src/sdam/server.ts
@@ -22,7 +22,6 @@ import {
 } from '../constants';
 import {
   type AnyError,
-  isNetworkErrorBeforeHandshake,
   isNodeShuttingDownError,
   isSDAMUnrecoverableError,
   MONGODB_ERROR_CODES,
@@ -381,7 +380,7 @@ export class Server extends TypedEventEmitter<ServerEvents> {
 
     const isNetworkNonTimeoutError =
       error instanceof MongoNetworkError && !(error instanceof MongoNetworkTimeoutError);
-    const isNetworkTimeoutBeforeHandshakeError = isNetworkErrorBeforeHandshake(error);
+    const isNetworkTimeoutBeforeHandshakeError = MongoNetworkError.isBeforeHandshake(error);
     const isAuthHandshakeError = error.hasErrorLabel(MongoErrorLabel.HandshakeError);
     if (isNetworkNonTimeoutError || isNetworkTimeoutBeforeHandshakeError || isAuthHandshakeError) {
       // In load balanced mode we never mark the server as unknown and always

--- a/src/sdam/server.ts
+++ b/src/sdam/server.ts
@@ -380,7 +380,8 @@ export class Server extends TypedEventEmitter<ServerEvents> {
 
     const isNetworkNonTimeoutError =
       error instanceof MongoNetworkError && !(error instanceof MongoNetworkTimeoutError);
-    const isNetworkTimeoutBeforeHandshakeError = MongoNetworkError.isBeforeHandshake(error);
+    const isNetworkTimeoutBeforeHandshakeError =
+      error instanceof MongoNetworkError && error.beforeHandshake;
     const isAuthHandshakeError = error.hasErrorLabel(MongoErrorLabel.HandshakeError);
     if (isNetworkNonTimeoutError || isNetworkTimeoutBeforeHandshakeError || isAuthHandshakeError) {
       // In load balanced mode we never mark the server as unknown and always

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -174,15 +174,11 @@ export class ClientSession
 
     options = options ?? {};
 
-    if (options.snapshot === true) {
-      this.snapshotEnabled = true;
-      if (options.causalConsistency === true) {
-        throw new MongoInvalidArgumentError(
-          'Properties "causalConsistency" and "snapshot" are mutually exclusive'
-        );
-      }
-    } else {
-      this.snapshotEnabled = false;
+    this.snapshotEnabled = options.snapshot === true;
+    if (options.causalConsistency === true && this.snapshotEnabled) {
+      throw new MongoInvalidArgumentError(
+        'Properties "causalConsistency" and "snapshot" are mutually exclusive'
+      );
     }
 
     this.client = client;

--- a/test/integration/change-streams/change_stream.test.ts
+++ b/test/integration/change-streams/change_stream.test.ts
@@ -22,13 +22,7 @@ import {
   type ResumeToken
 } from '../../mongodb';
 import * as mock from '../../tools/mongodb-mock/index';
-import {
-  type FailPoint,
-  getSymbolFrom,
-  sleep,
-  TestBuilder,
-  UnifiedTestSuiteBuilder
-} from '../../tools/utils';
+import { type FailPoint, sleep, TestBuilder, UnifiedTestSuiteBuilder } from '../../tools/utils';
 import { delay, filterForCommands } from '../shared';
 
 const initIteratorMode = async (cs: ChangeStream) => {
@@ -719,7 +713,7 @@ describe('Change Streams', function () {
   });
 
   describe('should error when used as iterator and emitter concurrently', function () {
-    let client, coll, changeStream, kMode;
+    let client, coll, changeStream;
 
     beforeEach(async function () {
       client = this.configuration.newClient();
@@ -727,7 +721,6 @@ describe('Change Streams', function () {
 
       coll = client.db(this.configuration.db).collection('tester');
       changeStream = coll.watch();
-      kMode = getSymbolFrom(changeStream, 'mode');
     });
 
     afterEach(async function () {
@@ -738,14 +731,14 @@ describe('Change Streams', function () {
     it('should throw when mixing event listeners with iterator methods', {
       metadata: { requires: { topology: 'replicaset' } },
       async test() {
-        expect(changeStream).to.have.property(kMode, false);
+        expect(changeStream).to.have.property('mode', false);
         changeStream.on('change', () => {
           // ChangeStream detects emitter usage via 'newListener' event
           // so this covers all emitter methods
         });
 
         await once(changeStream.cursor, 'init');
-        expect(changeStream).to.have.property(kMode, 'emitter');
+        expect(changeStream).to.have.property('mode', 'emitter');
 
         const errRegex = /ChangeStream cannot be used as an iterator/;
 
@@ -764,10 +757,10 @@ describe('Change Streams', function () {
       metadata: { requires: { topology: 'replicaset' } },
       async test() {
         await initIteratorMode(changeStream);
-        expect(changeStream).to.have.property(kMode, false);
+        expect(changeStream).to.have.property('mode', false);
         const res = await changeStream.tryNext();
         expect(res).to.not.exist;
-        expect(changeStream).to.have.property(kMode, 'iterator');
+        expect(changeStream).to.have.property('mode', 'iterator');
 
         expect(() => {
           changeStream.on('change', () => {

--- a/test/integration/connection-monitoring-and-pooling/connection.test.ts
+++ b/test/integration/connection-monitoring-and-pooling/connection.test.ts
@@ -22,7 +22,7 @@ import {
 } from '../../mongodb';
 import * as mock from '../../tools/mongodb-mock/index';
 import { skipBrokenAuthTestBeforeEachHook } from '../../tools/runner/hooks/configuration';
-import { getSymbolFrom, sleep } from '../../tools/utils';
+import { sleep } from '../../tools/utils';
 import { assert as test, setupDatabase } from '../shared';
 
 const commonConnectOptions = {
@@ -291,10 +291,9 @@ describe('Connection', function () {
           // Get the only connection
           const pool = [...client.topology.s.servers.values()][0].pool;
 
-          const connections = pool[getSymbolFrom(pool, 'connections')];
-          expect(connections).to.have.lengthOf(1);
+          expect(pool.connections).to.have.lengthOf(1);
 
-          const connection = connections.first();
+          const connection = pool.connections.first();
           const socket: EventEmitter = connection.socket;
 
           // Spy on the socket event listeners

--- a/test/integration/crud/misc_cursors.test.js
+++ b/test/integration/crud/misc_cursors.test.js
@@ -13,7 +13,6 @@ const { setTimeout } = require('timers');
 const { ReadPreference, MongoExpiredSessionError } = require('../../mongodb');
 const { ServerType } = require('../../mongodb');
 const { formatSort } = require('../../mongodb');
-const { getSymbolFrom } = require('../../tools/utils');
 
 describe('Cursor', function () {
   before(function () {
@@ -3643,8 +3642,7 @@ describe('Cursor', function () {
               expect(doc).to.exist;
               const clonedCursor = cursor.clone();
               expect(clonedCursor.cursorOptions.session).to.not.exist;
-              const kServerSession = getSymbolFrom(clonedCursor.session, 'serverSession');
-              expect(clonedCursor.session).to.have.property(kServerSession, null); // session is brand new and has not been used
+              expect(clonedCursor.session).to.have.property('_serverSession', null); // session is brand new and has not been used
             })
             .finally(() => {
               return cursor.close();
@@ -3664,8 +3662,7 @@ describe('Cursor', function () {
               expect(doc).to.exist;
               const clonedCursor = cursor.clone();
               expect(clonedCursor.cursorOptions.session).to.not.exist;
-              const kServerSession = getSymbolFrom(clonedCursor.session, 'serverSession');
-              expect(clonedCursor.session).to.have.property(kServerSession, null); // session is brand new and has not been used
+              expect(clonedCursor.session).to.have.property('_serverSession', null); // session is brand new and has not been used
             })
             .finally(() => {
               return cursor.close();

--- a/test/tools/utils.ts
+++ b/test/tools/utils.ts
@@ -120,18 +120,6 @@ export function getEncryptExtraOptions(): {
   return {};
 }
 
-export function getSymbolFrom(target: any, symbolName: any, assertExists = true) {
-  const symbol = Object.getOwnPropertySymbols(target).filter(
-    s => s.toString() === `Symbol(${symbolName})`
-  )[0];
-
-  if (assertExists && !symbol) {
-    throw new Error(`Did not find Symbol(${symbolName}) on ${target}`);
-  }
-
-  return symbol;
-}
-
 export function getEnvironmentalOptions() {
   const options = {};
   if (process.env.MONGODB_API_VERSION) {

--- a/test/unit/cmap/connection.test.ts
+++ b/test/unit/cmap/connection.test.ts
@@ -15,7 +15,6 @@ import {
   SizedMessageTransform
 } from '../../mongodb';
 import * as mock from '../../tools/mongodb-mock/index';
-import { getSymbolFrom } from '../../tools/utils';
 
 const connectionOptionsDefaults = {
   id: 0,
@@ -102,9 +101,7 @@ describe('new Connection()', function () {
       .command(ns('$admin.cmd'), { ping: 1 }, { socketTimeoutMS: 50 })
       .catch(error => error);
 
-    const beforeHandshakeSymbol = getSymbolFrom(error, 'beforeHandshake', false);
-    expect(beforeHandshakeSymbol).to.be.a('symbol');
-    expect(error).to.have.property(beforeHandshakeSymbol, false);
+    expect(error).to.have.property('beforeHandshake', false);
   });
 
   it('calls the command function through command', async function () {
@@ -143,9 +140,7 @@ describe('new Connection()', function () {
 
     const error = await connect(options).catch(error => error);
 
-    const beforeHandshakeSymbol = getSymbolFrom(error, 'beforeHandshake', false);
-    expect(beforeHandshakeSymbol).to.be.a('symbol');
-    expect(error).to.have.property(beforeHandshakeSymbol, true);
+    expect(error).to.have.property('beforeHandshake', true);
   });
 
   describe('NODE-6370: regression test', function () {

--- a/test/unit/error.test.ts
+++ b/test/unit/error.test.ts
@@ -306,7 +306,7 @@ describe('MongoErrors', () => {
 
       it('sets beforeHandshake to true if it is set', () => {
         const error = new MongoNetworkError('error', { beforeHandshake: true });
-        expect(error.beforeHandshake).to.be.false;
+        expect(error.beforeHandshake).to.be.true;
       });
     });
   });

--- a/test/unit/error.test.ts
+++ b/test/unit/error.test.ts
@@ -289,21 +289,25 @@ describe('MongoErrors', () => {
   });
 
   describe('when MongoNetworkError is constructed', () => {
-    it('should only define beforeHandshake symbol if boolean option passed in', function () {
-      const errorWithOptionTrue = new MongoNetworkError('', { beforeHandshake: true });
-      expect(errorWithOptionTrue).to.have.property('beforeHandshake', true);
-
-      const errorWithOptionFalse = new MongoNetworkError('', { beforeHandshake: false });
-      expect(errorWithOptionFalse).to.have.property('beforeHandshake', false);
-
-      const errorWithBadOption = new MongoNetworkError('', {
-        // @ts-expect-error: beforeHandshake must be a boolean value
-        beforeHandshake: 'not boolean'
+    describe('without options', () => {
+      it('sets beforeHandshake to false', () => {
+        const error = new MongoNetworkError('error');
+        expect(error.beforeHandshake).to.be.false;
       });
-      expect(errorWithBadOption).to.not.have.property('beforeHandshake');
+    });
 
-      const errorWithoutOption = new MongoNetworkError('');
-      expect(errorWithoutOption).to.not.have.property('beforeHandshake');
+    describe('with options', () => {
+      it('sets beforeHandshake to false if it is nullish or false', () => {
+        const error = new MongoNetworkError('error', {});
+        expect(error.beforeHandshake).to.be.false;
+        const error2 = new MongoNetworkError('error', { beforeHandshake: false });
+        expect(error2.beforeHandshake).to.be.false;
+      });
+
+      it('sets beforeHandshake to true if it is set', () => {
+        const error = new MongoNetworkError('error', { beforeHandshake: true });
+        expect(error.beforeHandshake).to.be.false;
+      });
     });
   });
 

--- a/test/unit/error.test.ts
+++ b/test/unit/error.test.ts
@@ -38,7 +38,7 @@ import {
 } from '../mongodb';
 import { ReplSetFixture } from '../tools/common';
 import { cleanup } from '../tools/mongodb-mock/index';
-import { getSymbolFrom, topologyWithPlaceholderClient } from '../tools/utils';
+import { topologyWithPlaceholderClient } from '../tools/utils';
 
 describe('MongoErrors', () => {
   let errorClassesFromEntryPoint = Object.fromEntries(
@@ -291,19 +291,19 @@ describe('MongoErrors', () => {
   describe('when MongoNetworkError is constructed', () => {
     it('should only define beforeHandshake symbol if boolean option passed in', function () {
       const errorWithOptionTrue = new MongoNetworkError('', { beforeHandshake: true });
-      expect(getSymbolFrom(errorWithOptionTrue, 'beforeHandshake', false)).to.be.a('symbol');
+      expect(errorWithOptionTrue).to.have.property('beforeHandshake', true);
 
       const errorWithOptionFalse = new MongoNetworkError('', { beforeHandshake: false });
-      expect(getSymbolFrom(errorWithOptionFalse, 'beforeHandshake', false)).to.be.a('symbol');
+      expect(errorWithOptionFalse).to.have.property('beforeHandshake', false);
 
       const errorWithBadOption = new MongoNetworkError('', {
         // @ts-expect-error: beforeHandshake must be a boolean value
         beforeHandshake: 'not boolean'
       });
-      expect(getSymbolFrom(errorWithBadOption, 'beforeHandshake', false)).to.be.an('undefined');
+      expect(errorWithBadOption).to.not.have.property('beforeHandshake');
 
       const errorWithoutOption = new MongoNetworkError('');
-      expect(getSymbolFrom(errorWithoutOption, 'beforeHandshake', false)).to.be.an('undefined');
+      expect(errorWithoutOption).to.not.have.property('beforeHandshake');
     });
   });
 

--- a/test/unit/mongo_client.test.ts
+++ b/test/unit/mongo_client.test.ts
@@ -22,14 +22,8 @@ import {
   SeverityLevel,
   WriteConcern
 } from '../mongodb';
-import { getSymbolFrom } from '../tools/utils';
 
 describe('MongoClient', function () {
-  it('MongoClient should always freeze public options', function () {
-    const client = new MongoClient('mongodb://localhost:27017');
-    expect(client.options).to.be.frozen;
-  });
-
   it('programmatic options should override URI options', function () {
     const options = parseOptions('mongodb://localhost:27017/test?directConnection=true', {
       directConnection: false
@@ -620,8 +614,8 @@ describe('MongoClient', function () {
       expect(clientOptions).to.have.property('monitorCommands', false);
       expect(client.s.options).to.have.property('monitorCommands', false);
       expect(client).to.have.property('monitorCommands', false);
-      const optionsSym = getSymbolFrom(client, 'options');
-      expect(client[optionsSym]).to.have.property('monitorCommands', false);
+
+      expect(client.options).to.have.property('monitorCommands', false);
     });
 
     it('respects monitorCommands option passed in', function () {
@@ -631,14 +625,13 @@ describe('MongoClient', function () {
       const testTable = [
         [clientViaOpt, clientViaOpt.options],
         [clientViaUri, clientViaUri.options]
-      ];
+      ] as const;
 
       for (const [client, clientOptions] of testTable) {
         expect(clientOptions).to.have.property('monitorCommands', true);
         expect(client.s.options).to.have.property('monitorCommands', true);
         expect(client).to.have.property('monitorCommands', true);
-        const optionsSym = getSymbolFrom(client, 'options');
-        expect(client[optionsSym]).to.have.property('monitorCommands', true);
+        expect(client.options).to.have.property('monitorCommands', true);
       }
     });
   });

--- a/test/unit/sdam/topology.test.ts
+++ b/test/unit/sdam/topology.test.ts
@@ -24,7 +24,7 @@ import {
   TopologyType
 } from '../../mongodb';
 import * as mock from '../../tools/mongodb-mock/index';
-import { getSymbolFrom, topologyWithPlaceholderClient } from '../../tools/utils';
+import { topologyWithPlaceholderClient } from '../../tools/utils';
 
 describe('Topology (unit)', function () {
   let client, topology;
@@ -354,8 +354,7 @@ describe('Topology (unit)', function () {
       afterEach(() => {
         // The srv event starts a monitor that we need to clean up
         for (const [, server] of topology.s.servers) {
-          const kMonitorId = getSymbolFrom(server.monitor, 'monitorId');
-          server.monitor[kMonitorId].stop();
+          server.monitor.monitorId.stop();
         }
       });
 


### PR DESCRIPTION
### Description

Similar to: https://github.com/mongodb/node-mongodb-native/pull/4133

#### What is changing?

- Remove all symbol class properties in favor of private and internal marked string properties

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

Symbol class properties were introduced to the driver before we adopted typescript and API-extractor to clearly indicate the accessibility of driver APIs. The symbol properties provided implied privacy, making properties non-trivial to access. Today we have the power of typescript private/protected and API-extractor's type deletion feature for APIs marked internal. With these tools, we can remove symbol properties in favor of appropriately marked string properties. This makes debugging internals easier by making inspection and assertion far more simple.

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
