### PR TITLE
fix(NODE-6617): add missing perf_hooks import

### DIFF
--- a/src/cmap/connect.ts
+++ b/src/cmap/connect.ts
@@ -1,7 +1,8 @@
-import type { Socket, SocketConnectOpts } from 'net';
-import * as net from 'net';
-import type { ConnectionOptions as TLSConnectionOpts, TLSSocket } from 'tls';
-import * as tls from 'tls';
+import type { Socket, SocketConnectOpts } from 'node:net';
+import * as net from 'node:net';
+import { performance } from 'node:perf_hooks';
+import type { ConnectionOptions as TLSConnectionOpts, TLSSocket } from 'node:tls';
+import * as tls from 'node:tls';
 
 import type { Document } from '../bson';
 import { LEGACY_HELLO_COMMAND } from '../constants';

--- a/src/timeout.ts
+++ b/src/timeout.ts
@@ -1,4 +1,5 @@
-import { clearTimeout, setTimeout } from 'timers';
+import { performance } from 'node:perf_hooks';
+import { clearTimeout, setTimeout } from 'node:timers';
 
 import { type Document } from './bson';
 import { MongoInvalidArgumentError, MongoOperationTimeoutError, MongoRuntimeError } from './error';

--- a/test/integration/client-side-encryption/driver.test.ts
+++ b/test/integration/client-side-encryption/driver.test.ts
@@ -1,8 +1,10 @@
+import * as crypto from 'node:crypto';
+import { performance } from 'node:perf_hooks';
+import { setTimeout } from 'node:timers/promises';
+
 import { type Binary, EJSON, UUID } from 'bson';
 import { expect } from 'chai';
-import * as crypto from 'crypto';
 import * as sinon from 'sinon';
-import { setTimeout } from 'timers/promises';
 
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { ClientEncryption } from '../../../src/client-side-encryption/client_encryption';

--- a/test/integration/client-side-operations-timeout/client_side_operations_timeout.prose.test.ts
+++ b/test/integration/client-side-operations-timeout/client_side_operations_timeout.prose.test.ts
@@ -1,14 +1,15 @@
 /* Specification prose tests */
 
 import { type ChildProcess, spawn } from 'node:child_process';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { performance } from 'node:perf_hooks';
 import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
 
 import { expect } from 'chai';
-import * as os from 'os';
-import * as path from 'path';
 import * as semver from 'semver';
 import * as sinon from 'sinon';
-import { pipeline } from 'stream/promises';
 
 import { type CommandStartedEvent } from '../../../mongodb';
 import {

--- a/test/integration/node-specific/auto_connect.test.ts
+++ b/test/integration/node-specific/auto_connect.test.ts
@@ -1,5 +1,7 @@
+import { once } from 'node:events';
+import { performance } from 'node:perf_hooks';
+
 import { expect } from 'chai';
-import { once } from 'events';
 import * as sinon from 'sinon';
 
 import {


### PR DESCRIPTION
### Description

#### What is changing?

- Add missing `node: perf_hooks` import to use `performance.now()` safely.

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

There is a bug in `timeout.ts` related to the usage of `performance.now()` without the `node: perf_hooks` import introduced with this commit https://github.com/mongodb/node-mongodb-native/commit/bd8a9f44f37159c494957cbe9d343b08d98bf128 (related Jira : https://jira.mongodb.org/browse/NODE-6090).

I have search for all `performance.now()` usages and fix all of them in this PR.

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
