### PR TITLE
chore(NODE-6622): pin npm version for node 18 to 10

### DIFF
--- a/.evergreen/ci_matrix_constants.js
+++ b/.evergreen/ci_matrix_constants.js
@@ -1,7 +1,7 @@
 const MONGODB_VERSIONS = ['latest', 'rapid', '8.0', '7.0', '6.0', '5.0', '4.4', '4.2', '4.0'];
 const versions = [
   { codeName: 'gallium', versionNumber: 16, npmVersion: 9 },
-  { codeName: 'hydrogen', versionNumber: 18, npmVersion: 'latest' },
+  { codeName: 'hydrogen', versionNumber: 18, npmVersion: 10 },
   { codeName: 'iron', versionNumber: 20, npmVersion: 'latest' },
   { codeName: 'jod', versionNumber: 22, npmVersion: 'latest' },
 ];

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -4842,7 +4842,7 @@ buildvariants:
     run_on: rhel80-large
     expansions:
       NODE_LTS_VERSION: 18
-      NPM_VERSION: latest
+      NPM_VERSION: 10
       CLIENT_ENCRYPTION: true
     tasks:
       - test-latest-server
@@ -5123,7 +5123,7 @@ buildvariants:
     run_on: windows-vsCurrent-large
     expansions:
       NODE_LTS_VERSION: 18
-      NPM_VERSION: latest
+      NPM_VERSION: 10
     tasks:
       - test-latest-server
       - test-latest-replica_set

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -3581,7 +3581,7 @@ tasks:
         params:
           updates:
             - {key: NODE_LTS_VERSION, value: '18'}
-            - {key: NPM_VERSION, value: latest}
+            - {key: NPM_VERSION, value: '10'}
       - func: install dependencies
       - func: run unit tests
   - name: run-unit-tests-node-20

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -416,7 +416,8 @@ for (const {
     const nodeLtsDisplayName = `Node${NODE_LTS_VERSION}`;
     const name = `${osName}-${NODE_LTS_VERSION >= 20 ? nodeLtsDisplayName : nodeLTSCodeName}`;
     const display_name = `${osDisplayName} ${nodeLtsDisplayName}`;
-    const expansions = { NODE_LTS_VERSION, NPM_VERSION: NODE_LTS_VERSION === 16 ? 9 : NODE_LTS_VERSION === 18 ? 10 : 'latest' };
+    const NPM_VERSION = versions.find(({versionNumber}) => versionNumber === NODE_LTS_VERSION).npmVersion;
+    const expansions = { NODE_LTS_VERSION, NPM_VERSION };
     const taskNames = tasks.map(({ name }) => name);
 
     if (clientEncryption) {

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -416,7 +416,7 @@ for (const {
     const nodeLtsDisplayName = `Node${NODE_LTS_VERSION}`;
     const name = `${osName}-${NODE_LTS_VERSION >= 20 ? nodeLtsDisplayName : nodeLTSCodeName}`;
     const display_name = `${osDisplayName} ${nodeLtsDisplayName}`;
-    const expansions = { NODE_LTS_VERSION, NPM_VERSION: NODE_LTS_VERSION === 16 ? 9 : 'latest' };
+    const expansions = { NODE_LTS_VERSION, NPM_VERSION: NODE_LTS_VERSION === 16 ? 9 : NODE_LTS_VERSION === 18 ? 10 : 'latest' };
     const taskNames = tasks.map(({ name }) => name);
 
     if (clientEncryption) {

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -9,9 +9,12 @@ export NODE_LTS_VERSION=${NODE_LTS_VERSION:-16}
 # npm version can be defined in the environment for cases where we need to install
 # a version lower than latest to support EOL Node versions.
 
-# If NODE_LTS_VERSION is numeric and less than 18, default to 9. Do not override if it is already set.
+# If NODE_LTS_VERSION is numeric and less than 18, default to 9, if less than 20, default to 10.
+# Do not override if it is already set.
 if [[ "$NODE_LTS_VERSION" =~ ^[0-9]+$ && "$NODE_LTS_VERSION" -lt 18 ]]; then
     export NPM_VERSION=${NPM_VERSION:-9}
+elif [[ "$NODE_LTS_VERSION" =~ ^[0-9]+$ && "$NODE_LTS_VERSION" -lt 20 ]]; then
+    export NPM_VERSION=${NPM_VERSION:-10}
 else
     export NPM_VERSION=${NPM_VERSION:-latest}
 fi


### PR DESCRIPTION
### Description

#### What is changing?

- Add pins for npm 10 whereever we use node 18

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

NPM 11 drops support for node 18

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
