### PR TITLE
ci(NODE-6641): disable Node latest tasks

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -3662,7 +3662,7 @@ tasks:
         type: setup
         params:
           updates:
-            - {key: NODE_LTS_VERSION, value: latest}
+            - {key: NODE_LTS_VERSION, value: '22'}
             - {key: NPM_VERSION, value: '9'}
       - func: install dependencies
       - func: check resource management
@@ -3676,7 +3676,7 @@ tasks:
           updates:
             - {key: VERSION, value: latest}
             - {key: TOPOLOGY, value: replica_set}
-            - {key: NODE_LTS_VERSION, value: latest}
+            - {key: NODE_LTS_VERSION, value: '22'}
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: check resource management feature integration

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -5085,6 +5085,7 @@ buildvariants:
       - test-tls-support-5.0
       - test-tls-support-4.4
       - test-tls-support-4.2
+    disable: true
   - name: windows-vsCurrent-large-gallium
     display_name: Windows Node16
     run_on: windows-vsCurrent-large

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -550,7 +550,7 @@ SINGLETON_TASKS.push(
       tags: ['resource-management'],
       commands: [
         updateExpansions({
-          NODE_LTS_VERSION: 'latest',
+          NODE_LTS_VERSION: LATEST_LTS,
           NPM_VERSION: 9
         }),
         { func: 'install dependencies' },
@@ -564,7 +564,7 @@ SINGLETON_TASKS.push(
         updateExpansions({
           VERSION: 'latest',
           TOPOLOGY: 'replica_set',
-          NODE_LTS_VERSION: 'latest'
+          NODE_LTS_VERSION: LATEST_LTS 
         }),
         { func: 'install dependencies' },
         { func: 'bootstrap mongo-orchestration' },

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -436,12 +436,13 @@ for (const {
       display_name: `${osDisplayName} Node Latest`,
       run_on,
       expansions: { NODE_LTS_VERSION: 'latest' },
-      tasks: tasks.map(({ name }) => name)
+      tasks: tasks.map(({ name }) => name),
+      // TODO(NODE-6641): Unskip the smoke tests
+      disable: true
     };
     if (clientEncryption) {
       buildVariantData.expansions.CLIENT_ENCRYPTION = true;
     }
-
     BUILD_VARIANTS.push(buildVariantData);
   }
 }


### PR DESCRIPTION
### Description

#### What is changing?
* We are temporarily disabling variants that run on Node latest (currently v23.6.0) due to an issue with installing C++ addons.
* Move resource management tests to run on Node 22


#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->
<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [X] Ran `npm run check:lint` script
- [X] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [X] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [X] Changes are covered by tests
- [X] New TODOs have a related JIRA ticket
