### PR TITLE
chore(NODE-6664): use correct script_name and replacement substring

### DIFF
--- a/test/integration/node-specific/resource_clean_up.test.ts
+++ b/test/integration/node-specific/resource_clean_up.test.ts
@@ -37,31 +37,22 @@ describe('Driver Resources', () => {
       if (globalThis.AbortController == null || typeof this.configuration.serverApi === 'string') {
         return;
       }
-      try {
-        const res = await runScriptAndReturnHeapInfo(
-          'no_resource_leak_connect_close',
-          this.configuration,
-          async function run({ MongoClient, uri }) {
-            const mongoClient = new MongoClient(uri, { minPoolSize: 100 });
-            await mongoClient.connect();
-            // Any operations will reproduce the issue found in v5.0.0/v4.13.0
-            // it would seem the MessageStream has to be used?
-            await mongoClient.db().command({ ping: 1 });
-            await mongoClient.close();
-          }
-        );
-        startingMemoryUsed = res.startingMemoryUsed;
-        endingMemoryUsed = res.endingMemoryUsed;
-        heap = res.heap;
-      } catch (error) {
-        // We don't expect the process execution to ever fail,
-        // leaving helpful debugging if we see this in CI
-        console.log(`runScript error message: ${error.message}`);
-        console.log(`runScript error stack: ${error.stack}`);
-        console.log(`runScript error cause: ${error.cause}`);
-        // Fail the test
-        this.test?.error(error);
-      }
+      const res = await runScriptAndReturnHeapInfo(
+        'no_resource_leak_connect_close',
+        this.configuration,
+        async function run({ MongoClient, uri }) {
+          const mongoClient = new MongoClient(uri, { minPoolSize: 100 });
+          await mongoClient.connect();
+          // Any operations will reproduce the issue found in v5.0.0/v4.13.0
+          // it would seem the MessageStream has to be used?
+          await mongoClient.db().command({ ping: 1 });
+          await mongoClient.close();
+        }
+      );
+
+      startingMemoryUsed = res.startingMemoryUsed;
+      endingMemoryUsed = res.endingMemoryUsed;
+      heap = res.heap;
     });
 
     describe('ending memory usage', () => {

--- a/test/integration/node-specific/resource_tracking_script_builder.ts
+++ b/test/integration/node-specific/resource_tracking_script_builder.ts
@@ -28,7 +28,7 @@ export type ProcessResourceTestFunction = (options: {
 
 const HEAP_RESOURCE_SCRIPT_PATH = path.resolve(
   __dirname,
-  '../../tools/fixtures/resource_script.in.js'
+  '../../tools/fixtures/heap_resource_script.in.js'
 );
 const REPORT_RESOURCE_SCRIPT_PATH = path.resolve(
   __dirname,

--- a/test/tools/fixtures/heap_resource_script.in.js
+++ b/test/tools/fixtures/heap_resource_script.in.js
@@ -4,7 +4,7 @@
 
 const driverPath = DRIVER_SOURCE_PATH;
 const func = FUNCTION_STRING;
-const name = NAME_STRING;
+const name = SCRIPT_NAME_STRING;
 const uri = URI_STRING;
 const iterations = ITERATIONS_STRING;
 


### PR DESCRIPTION
### Description

#### What is changing?

- Throws the error to the before hook if an error occurs
- use the correct script name
- use SCRIPT_NAME_STRING instead of NAME_STRING

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

Calling the this.test.error(error) function was ending the test run early without error.   Running all the tests would be a nice-to-have. 🙂

Fixing issue introduced in #4355.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
