### PR TITLE
perf(NODE-6452): Optimize CommandStartedEvent and CommandSucceededEvent constructors

### DIFF
--- a/src/cmap/command_monitoring_events.ts
+++ b/src/cmap/command_monitoring_events.ts
@@ -6,7 +6,7 @@ import {
   LEGACY_HELLO_COMMAND,
   LEGACY_HELLO_COMMAND_CAMEL_CASE
 } from '../constants';
-import { calculateDurationInMs, deepCopy } from '../utils';
+import { calculateDurationInMs } from '../utils';
 import {
   DocumentSequence,
   OpMsgRequest,
@@ -276,7 +276,7 @@ function extractCommand(command: WriteProtocolMessageType): Document {
       result = { find: collectionName(command) };
       Object.keys(LEGACY_FIND_QUERY_MAP).forEach(key => {
         if (command.query[key] != null) {
-          result[LEGACY_FIND_QUERY_MAP[key]] = deepCopy(command.query[key]);
+          result[LEGACY_FIND_QUERY_MAP[key]] = { ...command.query[key] };
         }
       });
     }
@@ -284,7 +284,7 @@ function extractCommand(command: WriteProtocolMessageType): Document {
     Object.keys(LEGACY_FIND_OPTIONS_MAP).forEach(key => {
       const legacyKey = key as keyof typeof LEGACY_FIND_OPTIONS_MAP;
       if (command[legacyKey] != null) {
-        result[LEGACY_FIND_OPTIONS_MAP[legacyKey]] = deepCopy(command[legacyKey]);
+        result[LEGACY_FIND_OPTIONS_MAP[legacyKey]] = command[legacyKey];
       }
     });
 
@@ -304,19 +304,13 @@ function extractCommand(command: WriteProtocolMessageType): Document {
     return result;
   }
 
-  const clonedQuery: Record<string, unknown> = {};
-  const clonedCommand: Record<string, unknown> = {};
+  let clonedQuery: Record<string, unknown> = {};
+  const clonedCommand: Record<string, unknown> = { ...command };
   if (command.query) {
-    for (const k in command.query) {
-      clonedQuery[k] = deepCopy(command.query[k]);
-    }
+    clonedQuery = { ...command.query };
     clonedCommand.query = clonedQuery;
   }
 
-  for (const k in command) {
-    if (k === 'query') continue;
-    clonedCommand[k] = deepCopy((command as unknown as Record<string, unknown>)[k]);
-  }
   return command.query ? clonedQuery : clonedCommand;
 }
 

--- a/src/cmap/command_monitoring_events.ts
+++ b/src/cmap/command_monitoring_events.ts
@@ -288,19 +288,6 @@ function extractCommand(command: WriteProtocolMessageType): Document {
       }
     });
 
-    OP_QUERY_KEYS.forEach(key => {
-      if (command[key]) {
-        result[key] = command[key];
-      }
-    });
-
-    if (command.pre32Limit != null) {
-      result.limit = command.pre32Limit;
-    }
-
-    if (command.query.$explain) {
-      return { explain: result };
-    }
     return result;
   }
 

--- a/src/cmap/command_monitoring_events.ts
+++ b/src/cmap/command_monitoring_events.ts
@@ -254,7 +254,7 @@ const OP_QUERY_KEYS = [
 /** Extract the actual command from the query, possibly up-converting if it's a legacy format */
 function extractCommand(command: WriteProtocolMessageType): Document {
   if (command instanceof OpMsgRequest) {
-    const cmd = deepCopy(command.command);
+    const cmd = { ...command.command };
     // For OP_MSG with payload type 1 we need to pull the documents
     // array out of the document sequence for monitoring.
     if (cmd.ops instanceof DocumentSequence) {
@@ -326,7 +326,7 @@ function extractReply(command: WriteProtocolMessageType, reply?: Document) {
   }
 
   if (command instanceof OpMsgRequest) {
-    return deepCopy(reply.result ? reply.result : reply);
+    return reply.result ? reply.result : reply;
   }
 
   // is this a legacy find command?
@@ -334,14 +334,14 @@ function extractReply(command: WriteProtocolMessageType, reply?: Document) {
     return {
       ok: 1,
       cursor: {
-        id: deepCopy(reply.cursorId),
+        id: reply.cursorId,
         ns: namespace(command),
-        firstBatch: deepCopy(reply.documents)
+        firstBatch: reply.documents
       }
     };
   }
 
-  return deepCopy(reply.result ? reply.result : reply);
+  return reply.result ? reply.result : reply;
 }
 
 function extractConnectionDetails(connection: Connection) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -620,43 +620,6 @@ export function isRecord(
   return true;
 }
 
-/**
- * Make a deep copy of an object
- *
- * NOTE: This is not meant to be the perfect implementation of a deep copy,
- * but instead something that is good enough for the purposes of
- * command monitoring.
- */
-export function deepCopy<T>(value: T): T {
-  if (value == null) {
-    return value;
-  } else if (Array.isArray(value)) {
-    return value.map(item => deepCopy(item)) as unknown as T;
-  } else if (isRecord(value)) {
-    const res = {} as any;
-    for (const key in value) {
-      res[key] = deepCopy(value[key]);
-    }
-    return res;
-  }
-
-  const ctor = (value as any).constructor;
-  if (ctor) {
-    switch (ctor.name.toLowerCase()) {
-      case 'date':
-        return new ctor(Number(value));
-      case 'map':
-        return new Map(value as any) as unknown as T;
-      case 'set':
-        return new Set(value as any) as unknown as T;
-      case 'buffer':
-        return Buffer.from(value as unknown as Buffer) as unknown as T;
-    }
-  }
-
-  return value;
-}
-
 type ListNode<T> = {
   value: T;
   next: ListNode<T> | HeadNode<T>;

--- a/test/integration/command-logging-and-monitoring/command_monitoring.test.ts
+++ b/test/integration/command-logging-and-monitoring/command_monitoring.test.ts
@@ -603,19 +603,4 @@ describe('Command Monitoring', function () {
         });
     }
   });
-
-  describe('Internal state references', function () {
-    let client;
-
-    beforeEach(function () {
-      client = this.configuration.newClient(
-        { writeConcern: { w: 1 } },
-        { maxPoolSize: 1, monitorCommands: true }
-      );
-    });
-
-    afterEach(function (done) {
-      client.close(done);
-    });
-  });
 });

--- a/test/integration/command-logging-and-monitoring/command_monitoring.test.ts
+++ b/test/integration/command-logging-and-monitoring/command_monitoring.test.ts
@@ -617,35 +617,5 @@ describe('Command Monitoring', function () {
     afterEach(function (done) {
       client.close(done);
     });
-
-    // NODE-1502
-    it('should not allow mutation of internal state from commands returned by event monitoring', function () {
-      const started = [];
-      const succeeded = [];
-      client.on('commandStarted', filterForCommands('insert', started));
-      client.on('commandSucceeded', filterForCommands('insert', succeeded));
-      const documentToInsert = { a: { b: 1 } };
-      const db = client.db(this.configuration.db);
-      return db
-        .collection('apm_test')
-        .insertOne(documentToInsert)
-        .then(r => {
-          expect(r).to.have.property('insertedId').that.is.an('object');
-          expect(started).to.have.lengthOf(1);
-          // Check if contents of returned document are equal to document inserted (by value)
-          expect(documentToInsert).to.deep.equal(started[0].command.documents[0]);
-          // Check if the returned document is a clone of the original. This confirms that the
-          // reference is not the same.
-          expect(documentToInsert !== started[0].command.documents[0]).to.equal(true);
-          expect(documentToInsert.a !== started[0].command.documents[0].a).to.equal(true);
-
-          started[0].command.documents[0].a.b = 2;
-          expect(documentToInsert.a.b).to.equal(1);
-
-          expect(started[0].commandName).to.equal('insert');
-          expect(started[0].command.insert).to.equal('apm_test');
-          expect(succeeded).to.have.lengthOf(1);
-        });
-    });
   });
 });


### PR DESCRIPTION
### Description

#### What is changing?
* Remove deep copy from `extractCommand` and `extractReply` helpers

##### Is there new documentation needed for these changes?
No

#### What is the motivation for this change?

Improving performance of command monitoring

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Improve command monitoring performance
Eliminated unnecessary deep copies of command and reply objects when command monitoring is enabled, leading to up to 

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [X] Ran `npm run check:lint` script
- [X] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [X] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
