### PR TITLE
feat(NODE-6633): MongoClient.close closes active cursors

### DIFF
--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -871,6 +871,7 @@ export abstract class AbstractCursor<
     this.isClosed = false;
     this.isKilled = false;
     this.initialized = false;
+    this.hasEmittedClose = false;
     this.trackCursor();
 
     // We only want to end this session if we created it, and it hasn't ended yet

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -327,7 +327,7 @@ export interface MongoClientPrivate {
   /**
    * We keep a reference to the cursors that are created from this client.
    * - used to track and close all cursors in client.close().
-   *   Cursor's in this set are ones that still need to have their close method invoked (no other conditions are considered)
+   *   Cursors in this set are ones that still need to have their close method invoked (no other conditions are considered)
    */
   readonly activeCursors: Set<AbstractCursor>;
   readonly sessionPool: ServerSessionPool;

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -324,6 +324,11 @@ export interface MongoClientPrivate {
    * - used to notify the leak checker in our tests if test author forgot to clean up explicit sessions
    */
   readonly activeSessions: Set<ClientSession>;
+  /**
+   * We keep a reference to the cursors that are created from this client.
+   * - used to track and close all cursors in client.close().
+   *   Cursor's in this set are ones that still need to have their close method invoked (no other conditions are considered)
+   */
   readonly activeCursors: Set<AbstractCursor>;
   readonly sessionPool: ServerSessionPool;
   readonly options: MongoOptions;

--- a/test/integration/crud/find_cursor_methods.test.js
+++ b/test/integration/crud/find_cursor_methods.test.js
@@ -251,7 +251,7 @@ describe('Find Cursor', function () {
     });
   });
 
-  context('#rewind', function () {
+  describe('#rewind', function () {
     it('should rewind a cursor', async function () {
       const coll = client.db().collection('abstract_cursor');
       const cursor = coll.find({});
@@ -333,6 +333,25 @@ describe('Find Cursor', function () {
 
           session.endSession(done);
         });
+      }
+    });
+
+    it('emits close after rewind', async () => {
+      let cursor;
+      try {
+        const coll = client.db().collection('abstract_cursor');
+        cursor = coll.find({}, { batchSize: 1 });
+        const closes = [];
+        cursor.on('close', () => closes.push('close'));
+        const doc0 = await cursor.next();
+        await cursor.close();
+        cursor.rewind();
+        const doc1 = await cursor.next();
+        await cursor.close();
+        expect(doc0).to.deep.equal(doc1); // make sure rewind happened
+        expect(closes).to.have.lengthOf(2);
+      } finally {
+        await cursor.close();
       }
     });
   });

--- a/test/integration/crud/misc_cursors.test.js
+++ b/test/integration/crud/misc_cursors.test.js
@@ -1872,7 +1872,7 @@ describe('Cursor', function () {
     expect(cursor).to.have.property('closed', true);
 
     const error = await rejectedEarlyBecauseClientClosed;
-    expect(error).to.be.null; // TODO: is this API or just "how it behaved at the time"
+    expect(error).to.be.null; // TODO(NODE-6632): This should throw again after the client signal aborts the in-progress next call
   });
 
   it('shouldAwaitData', {

--- a/test/integration/crud/misc_cursors.test.js
+++ b/test/integration/crud/misc_cursors.test.js
@@ -10,7 +10,7 @@ const sinon = require('sinon');
 const { Writable } = require('stream');
 const { once, on } = require('events');
 const { setTimeout } = require('timers');
-const { ReadPreference, MongoExpiredSessionError } = require('../../mongodb');
+const { ReadPreference } = require('../../mongodb');
 const { ServerType } = require('../../mongodb');
 const { formatSort } = require('../../mongodb');
 
@@ -1872,7 +1872,7 @@ describe('Cursor', function () {
     expect(cursor).to.have.property('closed', true);
 
     const error = await rejectedEarlyBecauseClientClosed;
-    expect(error).to.be.instanceOf(MongoExpiredSessionError);
+    expect(error).to.be.null; // TODO: is this API or just "how it behaved at the time"
   });
 
   it('shouldAwaitData', {

--- a/test/integration/node-specific/abort_signal.test.ts
+++ b/test/integration/node-specific/abort_signal.test.ts
@@ -603,7 +603,7 @@ describe('AbortSignal support', () => {
       const start = performance.now();
       const result = await cursor.toArray().catch(error => error);
       const end = performance.now();
-      expect(end - start).to.be.lessThan(15);
+      expect(end - start).to.be.lessThan(50);
 
       expect(result).to.be.instanceOf(DOMException);
     });

--- a/test/integration/node-specific/mongo_client.test.ts
+++ b/test/integration/node-specific/mongo_client.test.ts
@@ -783,6 +783,24 @@ describe('class MongoClient', function () {
         expect(client.s.activeCursors).to.have.lengthOf(0);
         expect(kills).to.have.lengthOf(30);
       });
+
+      it('creating cursors after close adds to activeCursors', async () => {
+        expect(client.s.activeCursors).to.have.lengthOf(0);
+        await client.close();
+        collection.find({});
+        expect(client.s.activeCursors).to.have.lengthOf(1);
+      });
+
+      it('rewinding cursors after close adds to activeCursors', async () => {
+        expect(client.s.activeCursors).to.have.lengthOf(0);
+        const cursor = collection.find({}, { batchSize: 1 });
+        await cursor.next();
+        expect(client.s.activeCursors).to.have.lengthOf(1);
+        await client.close();
+        expect(client.s.activeCursors).to.have.lengthOf(0);
+        cursor.rewind();
+        expect(client.s.activeCursors).to.have.lengthOf(1);
+      });
     });
   });
 


### PR DESCRIPTION
### Description

#### What is changing?

- MongoClient's close cursors created from them upon close

##### Is there new documentation needed for these changes?

- Yes. will do.

#### What is the motivation for this change?

In an effort to make MongoClient.close more effective and align with other existing close semantics in the ecosystem our close method is being improved to ensure the client when closed cleans up any resources it was responsible for creating. This allows users to rely on the paradigm that a closed client is no longer performing operations, which is currently not true and is likely surprising.

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### MongoClient.close now closes any outstanding cursors

Previously, cursors could somewhat live beyond the client they came from. What this meant was depending on timing you would learn of the client's (and by proxy, the cursor's) demise via an assertion that the associated session had expired. This only occurred if your cursor needed to use the session, which only happens when it is attempting to run a `getMore` operation to obtain another batch of documents. 

Practically speaking a cursor that lives beyond a client is an exception waiting to happen, the connection pools are closed, the sessions are ended, last call has been served :beers:, it is only a matter of timing and event firing until the cursor learns of its fate and informs you by throwing an error via whatever API is being used (`.toArray()`, `for-await`, `.next()`). 

To make the expected state of cursors clearer in this scenario `MongoClient's` will now close any associated cursor upon its `close()`-ing reducing the risk of leaving behind server-side resources. 

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
