### PR TITLE
feat(NODE-6451): retry SRV and TXT lookup for DNS timeout errors

### DIFF
--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -521,6 +521,10 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> implements
    * This means the time to setup the `MongoClient` does not count against `timeoutMS`.
    * If you are using `timeoutMS` we recommend connecting your client explicitly in advance of any operation to avoid this inconsistent execution time.
    *
+   * @remarks
+   * The driver will look up corresponding SRV and TXT records if the connection string starts with `mongodb+srv://`.
+   * If those look ups throw a DNS Timeout error, the driver will retry the look up once.
+   *
    * @see docs.mongodb.org/manual/reference/connection-string/
    */
   async connect(): Promise<this> {
@@ -726,6 +730,10 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> implements
    *
    * @remarks
    * The programmatically provided options take precedence over the URI options.
+   *
+   * @remarks
+   * The driver will look up corresponding SRV and TXT records if the connection string starts with `mongodb+srv://`.
+   * If those look ups throw a DNS Timeout error, the driver will retry the look up once.
    *
    * @see https://www.mongodb.com/docs/manual/reference/connection-string/
    */

--- a/test/integration/initial-dns-seedlist-discovery/dns_seedlist.test.ts
+++ b/test/integration/initial-dns-seedlist-discovery/dns_seedlist.test.ts
@@ -1,0 +1,162 @@
+import { expect } from 'chai';
+import * as dns from 'dns';
+import * as sinon from 'sinon';
+
+import { MongoClient } from '../../mongodb';
+
+const metadata: MongoDBMetadataUI = { requires: { topology: '!single' } };
+
+// This serves as a placeholder for _whatever_ node.js may throw. We only rely upon `.code`
+class DNSTimeoutError extends Error {
+  code = 'ETIMEOUT';
+}
+// This serves as a placeholder for _whatever_ node.js may throw. We only rely upon `.code`
+class DNSSomethingError extends Error {
+  code = undefined;
+}
+
+const CONNECTION_STRING = `mongodb+srv://test1.test.build.10gen.cc`;
+// 27018 localhost.test.build.10gen.cc.
+// 27017 localhost.test.build.10gen.cc.
+
+describe('DNS timeout errors', () => {
+  let client: MongoClient;
+
+  beforeEach(async function () {
+    client = new MongoClient(CONNECTION_STRING, { serverSelectionTimeoutMS: 2000, tls: false });
+  });
+
+  afterEach(async function () {
+    sinon.restore();
+    await client.close();
+  });
+
+  const restoreDNS =
+    api =>
+    async (...args) => {
+      sinon.restore();
+      return await dns.promises[api](...args);
+    };
+
+  describe('when SRV record look up times out', () => {
+    beforeEach(() => {
+      sinon
+        .stub(dns.promises, 'resolveSrv')
+        .onFirstCall()
+        .rejects(new DNSTimeoutError())
+        .onSecondCall()
+        .callsFake(restoreDNS('resolveSrv'));
+    });
+
+    afterEach(async function () {
+      sinon.restore();
+    });
+
+    it('retries timeout error', metadata, async () => {
+      await client.connect();
+    });
+  });
+
+  describe('when TXT record look up times out', () => {
+    beforeEach(() => {
+      sinon
+        .stub(dns.promises, 'resolveTxt')
+        .onFirstCall()
+        .rejects(new DNSTimeoutError())
+        .onSecondCall()
+        .callsFake(restoreDNS('resolveTxt'));
+    });
+
+    afterEach(async function () {
+      sinon.restore();
+    });
+
+    it('retries timeout error', metadata, async () => {
+      await client.connect();
+    });
+  });
+
+  describe('when SRV record look up times out twice', () => {
+    beforeEach(() => {
+      sinon
+        .stub(dns.promises, 'resolveSrv')
+        .onFirstCall()
+        .rejects(new DNSTimeoutError())
+        .onSecondCall()
+        .rejects(new DNSTimeoutError())
+        .onThirdCall()
+        .callsFake(restoreDNS('resolveSrv'));
+    });
+
+    afterEach(async function () {
+      sinon.restore();
+    });
+
+    it('throws timeout error', metadata, async () => {
+      const error = await client.connect().catch(error => error);
+      expect(error).to.be.instanceOf(DNSTimeoutError);
+    });
+  });
+
+  describe('when TXT record look up times out twice', () => {
+    beforeEach(() => {
+      sinon
+        .stub(dns.promises, 'resolveTxt')
+        .onFirstCall()
+        .rejects(new DNSTimeoutError())
+        .onSecondCall()
+        .rejects(new DNSTimeoutError())
+        .onThirdCall()
+        .callsFake(restoreDNS('resolveTxt'));
+    });
+
+    afterEach(async function () {
+      sinon.restore();
+    });
+
+    it('throws timeout error', metadata, async () => {
+      const error = await client.connect().catch(error => error);
+      expect(error).to.be.instanceOf(DNSTimeoutError);
+    });
+  });
+
+  describe('when SRV record look up throws a non-timeout error', () => {
+    beforeEach(() => {
+      sinon
+        .stub(dns.promises, 'resolveSrv')
+        .onFirstCall()
+        .rejects(new DNSSomethingError())
+        .onSecondCall()
+        .callsFake(restoreDNS('resolveSrv'));
+    });
+
+    afterEach(async function () {
+      sinon.restore();
+    });
+
+    it('throws that error', metadata, async () => {
+      const error = await client.connect().catch(error => error);
+      expect(error).to.be.instanceOf(DNSSomethingError);
+    });
+  });
+
+  describe('when TXT record look up throws a non-timeout error', () => {
+    beforeEach(() => {
+      sinon
+        .stub(dns.promises, 'resolveTxt')
+        .onFirstCall()
+        .rejects(new DNSSomethingError())
+        .onSecondCall()
+        .callsFake(restoreDNS('resolveTxt'));
+    });
+
+    afterEach(async function () {
+      sinon.restore();
+    });
+
+    it('throws that error', metadata, async () => {
+      const error = await client.connect().catch(error => error);
+      expect(error).to.be.instanceOf(DNSSomethingError);
+    });
+  });
+});

--- a/test/integration/initial-dns-seedlist-discovery/dns_seedlist.test.ts
+++ b/test/integration/initial-dns-seedlist-discovery/dns_seedlist.test.ts
@@ -85,9 +85,7 @@ describe('DNS timeout errors', () => {
         .onFirstCall()
         .rejects(new DNSTimeoutError())
         .onSecondCall()
-        .rejects(new DNSTimeoutError())
-        .onThirdCall()
-        .callsFake(restoreDNS('resolveSrv'));
+        .rejects(new DNSTimeoutError());
     });
 
     afterEach(async function () {
@@ -97,6 +95,7 @@ describe('DNS timeout errors', () => {
     it('throws timeout error', metadata, async () => {
       const error = await client.connect().catch(error => error);
       expect(error).to.be.instanceOf(DNSTimeoutError);
+      expect(stub).to.have.been.calledTwice;
     });
   });
 
@@ -107,9 +106,7 @@ describe('DNS timeout errors', () => {
         .onFirstCall()
         .rejects(new DNSTimeoutError())
         .onSecondCall()
-        .rejects(new DNSTimeoutError())
-        .onThirdCall()
-        .callsFake(restoreDNS('resolveTxt'));
+        .rejects(new DNSTimeoutError());
     });
 
     afterEach(async function () {


### PR DESCRIPTION
### Description

#### What is changing?

- When the dns.TIMEOUT error is detected when resolving SRV and TXT the driver will try those look ups again.

##### Is there new documentation needed for these changes?

Yes API updated

#### What is the motivation for this change?

In some environments (possibly FAAS?) it has been observed that DNS look ups can fail transiently. The driver can attempt to mitigate these with a retry.

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### DNS SRV & TXT look up timeouts are retried

To mitigate the potentially transient DNS timeout error, the driver now catches and retries the DNS lookups upon resolving a `mongodb+srv://` style connection string. 

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
