### PR TITLE
fix(NODE-5225): concurrent MongoClient.close() calls each attempt to close the client

### DIFF
--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -367,7 +367,7 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> implements
   /** @internal */
   private connectionLock?: Promise<this>;
   /** @internal */
-  private closeLock?: Promise<void>
+  private closeLock?: Promise<void>;
 
   /**
    * The consolidate, parsed, transformed and merged options.
@@ -642,14 +642,14 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> implements
   async close(force = false): Promise<void> {
     if (this.closeLock) {
       return await this.closeLock;
-    } 
+    }
 
     try {
       this.closeLock = this._close(force);
       await this.closeLock;
     } finally {
       // release
-      this.connectionLock = undefined;
+      this.closeLock = undefined;
     }
   }
 

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -366,6 +366,8 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> implements
   override readonly mongoLogger: MongoLogger | undefined;
   /** @internal */
   private connectionLock?: Promise<this>;
+  /** @internal */
+  private closeLock?: Promise<void>
 
   /**
    * The consolidate, parsed, transformed and merged options.
@@ -638,6 +640,20 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> implements
    * @param force - Force close, emitting no events
    */
   async close(force = false): Promise<void> {
+    if (this.closeLock) {
+      return await this.closeLock;
+    } 
+
+    try {
+      this.closeLock = this._close(force);
+      await this.closeLock;
+    } finally {
+      // release
+      this.connectionLock = undefined;
+    }
+  }
+
+  async _close(force = false): Promise<void> {
     // There's no way to set hasBeenClosed back to false
     Object.defineProperty(this.s, 'hasBeenClosed', {
       value: true,

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -657,7 +657,8 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> implements
     }
   }
 
-  async _close(force = false): Promise<void> {
+  /* @internal */
+  private async _close(force = false): Promise<void> {
     // There's no way to set hasBeenClosed back to false
     Object.defineProperty(this.s, 'hasBeenClosed', {
       value: true,

--- a/test/integration/node-specific/mongo_client.test.ts
+++ b/test/integration/node-specific/mongo_client.test.ts
@@ -820,6 +820,8 @@ describe('class MongoClient', function () {
         await client.close();
 
         expect(client.topology).to.be.undefined;
+      });
+    });
 
     describe('active cursors', function () {
       let collection: Collection<{ _id: number }>;

--- a/test/integration/node-specific/mongo_client.test.ts
+++ b/test/integration/node-specific/mongo_client.test.ts
@@ -722,6 +722,22 @@ describe('class MongoClient', function () {
         expect(client.s.sessionPool.sessions).to.have.lengthOf(1);
       });
     });
+
+    context('concurrent calls', () => {
+      context('when two concurrent calls to close() occur', () => {
+        it('no error is thrown', async function () {
+          expect(() => Promise.all([client.close(), client.close()])).to.not.throw;
+        });
+      });
+
+      context('when more than two concurrent calls to close() occur', () => {
+        it('no error is thrown', async function () {
+          expect(() =>
+            Promise.all([client.close(), client.close(), client.close(), client.close()])
+          ).to.not.throw;
+        });
+      });
+    });
   });
 
   context('when connecting', function () {

--- a/test/unit/mongo_client.test.ts
+++ b/test/unit/mongo_client.test.ts
@@ -1223,4 +1223,22 @@ describe('MongoClient', function () {
       });
     });
   });
+
+  describe('closeLock', function () {
+    let client;
+
+    beforeEach(async function () {
+      client = new MongoClient('mongodb://blah');
+    });
+
+    it('when client.close is pending, client.closeLock is set', () => {
+      client.close();
+      expect(client.closeLock).to.be.instanceOf(Promise);
+    });
+
+    it('when client.close is not pending, client.closeLock is not set', async () => {
+      await client.close();
+      expect(client.closeLock).to.be.undefined;
+    });
+  });
 });


### PR DESCRIPTION
### Description
Previously, concurrent calls to `client.close()` would throw an error. 

#### What is changing?
 This PR introduces a locking mechanism on `client.close()`. The 

##### Is there new documentation needed for these changes?
No.

#### What is the motivation for this change?
User submitted bug: NODE-5225
 
<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### MongoClient.close() can be called concurrently

In the past, concurrent calls to `MongoClient.close()` had poorly defined behavior depending on the exact timing of the second (or more) calls to close().  In some cases, this could also throw errors.

With these changes, MongoClient.close() can be called concurrently safely and always return the same promise.

> [!NOTE]
> This is intended as a correctness fix - we don't recommend calling MongoClient.close() concurrently if it can be avoided.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
