### PR TITLE
fix(NODE-6340): OIDC reauth uses caches speculative auth result

### DIFF
--- a/src/cmap/auth/mongodb_oidc.ts
+++ b/src/cmap/auth/mongodb_oidc.ts
@@ -143,7 +143,7 @@ export class MongoDBOIDC extends AuthProvider {
    */
   override async auth(authContext: AuthContext): Promise<void> {
     const { connection, reauthenticating, response } = authContext;
-    if (response?.speculativeAuthenticate?.done) {
+    if (response?.speculativeAuthenticate?.done && !reauthenticating) {
       return;
     }
     const credentials = getCredentials(authContext);

--- a/test/integration/auth/mongodb_oidc.prose.test.ts
+++ b/test/integration/auth/mongodb_oidc.prose.test.ts
@@ -546,6 +546,96 @@ describe('OIDC Auth Spec Tests', function () {
           expect(callbackSpy).to.have.been.calledTwice;
         });
       });
+
+      describe('4.4 Speculative Authentication should be ignored on Reauthentication', function () {
+        let utilClient: MongoClient;
+        const callbackSpy = sinon.spy(createCallback());
+        const commands = [];
+        // - Create an OIDC configured client.
+        // - Populate the *Client Cache* with a valid access token to enforce Speculative Authentication.
+        // - Perform an `insert` operation that succeeds.
+        // - Assert that the callback was not called.
+        // - Assert there were no `SaslStart` commands executed.
+        // - Set a fail point for `insert` commands of the form:
+        // ```javascript
+        // {
+        //   configureFailPoint: "failCommand",
+        //   mode: {
+        //     times: 1
+        //   },
+        //   data: {
+        //     failCommands: [
+        //       "insert"
+        //     ],
+        //     errorCode: 391 // ReauthenticationRequired
+        //   }
+        // }
+        // ```
+        // - Perform an `insert` operation that succeeds.
+        // - Assert that the callback was called once.
+        // - Assert there were `SaslStart` commands executed.
+        // - Close the client.
+        beforeEach(async function () {
+          client = new MongoClient(uriSingle, {
+            authMechanismProperties: {
+              OIDC_CALLBACK: callbackSpy
+            },
+            retryReads: false,
+            monitorCommands: true
+          });
+          client.on('commandStarted', event => {
+            console.log(event);
+            if (event.commandName === 'saslStart') {
+              commands.push(event);
+            }
+          });
+          const provider = client.s.authProviders.getOrCreateProvider('MONGODB-OIDC', {
+            OIDC_CALLBACK: callbackSpy
+          }) as MongoDBOIDC;
+          const token = await readFile(path.join(process.env.OIDC_TOKEN_DIR, 'test_user1'), {
+            encoding: 'utf8'
+          });
+          provider.workflow.cache.put({ accessToken: token });
+          collection = client.db('test').collection('test');
+          await collection.insertOne({ name: 'test' });
+          expect(callbackSpy).to.not.have.been.called;
+          expect(commands).to.be.empty;
+
+          utilClient = new MongoClient(uriSingle, {
+            authMechanismProperties: {
+              OIDC_CALLBACK: createCallback()
+            },
+            retryReads: false
+          });
+          await utilClient
+            .db()
+            .admin()
+            .command({
+              configureFailPoint: 'failCommand',
+              mode: {
+                times: 1
+              },
+              data: {
+                failCommands: ['insert'],
+                errorCode: 391
+              }
+            });
+        });
+
+        afterEach(async function () {
+          await utilClient.db().admin().command({
+            configureFailPoint: 'failCommand',
+            mode: 'off'
+          });
+          await utilClient.close();
+        });
+
+        it('successfully authenticates', async function () {
+          await collection.insertOne({ name: 'test' });
+          expect(callbackSpy).to.have.been.calledOnce;
+          expect(commands.length).to.equal(1);
+        });
+      });
     });
   });
 


### PR DESCRIPTION
### Description

Changes OIDC not to skip reauthentication when the initial auth happened via speculative authentication.

#### What is changing?

- Fixes the reauth case.
- Adds the new prose test.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

https://jira.mongodb.org/browse/DRIVERS-2960

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### MONGODB-OIDC now properly reauthenticates in speculative auth scenarios

When using MONGODB-OIDC authentication and the initial handshake contained speculative authentication, the driver would not properly reauthenticate when the server would raise 391 errors. This is now fixed.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
