### PR TITLE
test(NODE-4955): sync unacknowledged write spec tests

### DIFF
--- a/test/spec/command-logging-and-monitoring/logging/command.json
+++ b/test/spec/command-logging-and-monitoring/logging/command.json
@@ -93,6 +93,7 @@
               "component": "command",
               "data": {
                 "message": "Command succeeded",
+                "databaseName": "logging-tests",
                 "commandName": "ping",
                 "reply": {
                   "$$type": "string"
@@ -177,6 +178,7 @@
               "component": "command",
               "data": {
                 "message": "Command failed",
+                "databaseName": "logging-tests",
                 "commandName": "find",
                 "failure": {
                   "$$exists": true

--- a/test/spec/command-logging-and-monitoring/logging/command.yml
+++ b/test/spec/command-logging-and-monitoring/logging/command.yml
@@ -52,13 +52,14 @@ tests:
             component: command
             data:
               message: "Command succeeded"
+              databaseName: *databaseName
               commandName: *commandName
               reply: { $$type: string }
               requestId: { $$type: [int, long] }
               serverHost: { $$type: string }
               serverPort: { $$type: [int, long] }
               durationMS: { $$type: [double, int, long] }
-        
+
   - description: "A failed command"
     operations:
       - name: &commandName find
@@ -85,10 +86,10 @@ tests:
             component: command
             data:
               message: "Command failed"
+              databaseName: *databaseName
               commandName: *commandName
               failure: { $$exists: true }
               requestId:  { $$type: [int, long] }
               serverHost: { $$type: string }
               serverPort: { $$type: [int, long] }
               durationMS: { $$type: [double, int, long] }
-

--- a/test/spec/command-logging-and-monitoring/monitoring/find.json
+++ b/test/spec/command-logging-and-monitoring/monitoring/find.json
@@ -1,6 +1,6 @@
 {
   "description": "find",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.15",
   "createEntities": [
     {
       "client": {
@@ -103,7 +103,8 @@
                     ]
                   }
                 },
-                "commandName": "find"
+                "commandName": "find",
+                "databaseName": "command-monitoring-tests"
               }
             }
           ]
@@ -198,7 +199,8 @@
                     ]
                   }
                 },
-                "commandName": "find"
+                "commandName": "find",
+                "databaseName": "command-monitoring-tests"
               }
             }
           ]
@@ -262,7 +264,8 @@
                     ]
                   }
                 },
-                "commandName": "find"
+                "commandName": "find",
+                "databaseName": "command-monitoring-tests"
               }
             }
           ]
@@ -338,7 +341,8 @@
                     ]
                   }
                 },
-                "commandName": "find"
+                "commandName": "find",
+                "databaseName": "command-monitoring-tests"
               }
             },
             {
@@ -376,7 +380,8 @@
                     ]
                   }
                 },
-                "commandName": "getMore"
+                "commandName": "getMore",
+                "databaseName": "command-monitoring-tests"
               }
             }
           ]
@@ -464,7 +469,8 @@
                     ]
                   }
                 },
-                "commandName": "find"
+                "commandName": "find",
+                "databaseName": "command-monitoring-tests"
               }
             },
             {
@@ -498,7 +504,8 @@
                     ]
                   }
                 },
-                "commandName": "getMore"
+                "commandName": "getMore",
+                "databaseName": "command-monitoring-tests"
               }
             }
           ]
@@ -539,7 +546,8 @@
             },
             {
               "commandFailedEvent": {
-                "commandName": "find"
+                "commandName": "find",
+                "databaseName": "command-monitoring-tests"
               }
             }
           ]

--- a/test/spec/command-logging-and-monitoring/monitoring/find.yml
+++ b/test/spec/command-logging-and-monitoring/monitoring/find.yml
@@ -1,6 +1,6 @@
 description: "find"
 
-schemaVersion: "1.1"
+schemaVersion: "1.15"
 
 createEntities:
   - client:
@@ -56,6 +56,7 @@ tests:
                   firstBatch:
                     -  { _id: 1, x: 11 }
               commandName: find
+              databaseName: *databaseName
 
   - description: "A successful find with options"
     operations:
@@ -98,6 +99,7 @@ tests:
                     - { x: 33 }
                     - { x: 22 }
               commandName: find
+              databaseName: *databaseName
 
   - description: "A successful find with showRecordId and returnKey"
     operations:
@@ -131,6 +133,7 @@ tests:
                     - { _id: 4 }
                     - { _id: 5 }
               commandName: find
+              databaseName: *databaseName
 
   - description: "A successful find with a getMore"
     operations:
@@ -162,6 +165,7 @@ tests:
                     - { _id: 2, x: 22 }
                     - { _id: 3, x: 33 }
               commandName: find
+              databaseName: *databaseName
           - commandStartedEvent:
               command:
                 getMore: { $$type: [ int, long ] }
@@ -179,6 +183,7 @@ tests:
                     - { _id: 4, x: 44 }
                     - { _id: 5, x: 55 }
               commandName: getMore
+              databaseName: *databaseName
 
   - description: "A successful find event with a getmore and the server kills the cursor (<= 4.4)"
     runOnRequirements:
@@ -216,6 +221,7 @@ tests:
                     - { _id: 2, x: 22 }
                     - { _id: 3, x: 33 }
               commandName: find
+              databaseName: *databaseName
           - commandStartedEvent:
               command:
                 getMore: { $$type: [ int, long ] }
@@ -232,6 +238,7 @@ tests:
                   nextBatch:
                     - { _id: 4, x: 44 }
               commandName: getMore
+              databaseName: *databaseName
 
   - description: "A failed find event"
     operations:
@@ -252,3 +259,4 @@ tests:
               databaseName: *databaseName
           - commandFailedEvent:
               commandName: find
+              databaseName: *databaseName

--- a/test/spec/command-logging-and-monitoring/monitoring/unacknowledgedBulkWrite.json
+++ b/test/spec/command-logging-and-monitoring/monitoring/unacknowledgedBulkWrite.json
@@ -71,17 +71,7 @@
           "object": "collection",
           "arguments": {
             "filter": {}
-          },
-          "expectResult": [
-            {
-              "_id": 1,
-              "x": 11
-            },
-            {
-              "_id": "unorderedBulkWriteInsertW0",
-              "x": 44
-            }
-          ]
+          }
         }
       ],
       "expectEvents": [

--- a/test/spec/command-logging-and-monitoring/monitoring/unacknowledgedBulkWrite.yml
+++ b/test/spec/command-logging-and-monitoring/monitoring/unacknowledgedBulkWrite.yml
@@ -42,10 +42,6 @@ tests:
         object: *collection
         arguments:
           filter: { }
-        expectResult: [
-          { _id: 1, x: 11 },
-          { _id: "unorderedBulkWriteInsertW0", x: 44 }
-        ]
     expectEvents:
       - client: *client
         ignoreExtraEvents: true

--- a/test/spec/command-logging-and-monitoring/monitoring/writeConcernError.json
+++ b/test/spec/command-logging-and-monitoring/monitoring/writeConcernError.json
@@ -1,9 +1,9 @@
 {
   "description": "writeConcernError",
-  "schemaVersion": "1.13",
+  "schemaVersion": "1.4",
   "runOnRequirements": [
     {
-      "minServerVersion": "4.1.0",
+      "minServerVersion": "4.3.1",
       "topologies": [
         "replicaset"
       ],
@@ -66,11 +66,11 @@
                 "failCommands": [
                   "insert"
                 ],
+                "errorLabels": [
+                  "RetryableWriteError"
+                ],
                 "writeConcernError": {
-                  "code": 91,
-                  "errorLabels": [
-                    "RetryableWriteError"
-                  ]
+                  "code": 91
                 }
               }
             }
@@ -112,11 +112,11 @@
                 "reply": {
                   "ok": 1,
                   "n": 1,
+                  "errorLabels": [
+                    "RetryableWriteError"
+                  ],
                   "writeConcernError": {
-                    "code": 91,
-                    "errorLabels": [
-                      "RetryableWriteError"
-                    ]
+                    "code": 91
                   }
                 },
                 "commandName": "insert"

--- a/test/spec/command-logging-and-monitoring/monitoring/writeConcernError.yml
+++ b/test/spec/command-logging-and-monitoring/monitoring/writeConcernError.yml
@@ -1,8 +1,8 @@
 description: "writeConcernError"
-schemaVersion: "1.13"
+schemaVersion: "1.4"
 runOnRequirements:
   -
-    minServerVersion: 4.1.0
+    minServerVersion: "4.3.1" # failCommand errorLabels option
     topologies:
       - replicaset
     serverless: "forbid"
@@ -41,9 +41,9 @@ tests:
             mode: { times: 1 }
             data:
               failCommands: [ insert ]
+              errorLabels: [ RetryableWriteError ]
               writeConcernError:
                 code: 91 # ShutdownInProgress
-                errorLabels: [RetryableWriteError]
       - name: insertOne
         object: *collection
         arguments:
@@ -63,7 +63,8 @@ tests:
               reply:
                 ok: 1
                 n: 1
-                writeConcernError: { code: 91, errorLabels: [ "RetryableWriteError" ] }
+                errorLabels: [ "RetryableWriteError" ]
+                writeConcernError: { code: 91 }
               commandName: insert
           - commandStartedEvent:
               command:


### PR DESCRIPTION
### Description

#### What is changing?
Sync new spec tests

##### Is there new documentation needed for these changes?
No

#### What is the motivation for this change?
NODE-4955/DRIVERS-2525

Additionally syncs:
- https://jira.mongodb.org/browse/NODE-5808
- https://jira.mongodb.org/browse/NODE-5055
- https://jira.mongodb.org/browse/DRIVERS-2644 (just a schema version fix, no lang ticket)
- 

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [X] Ran `npm run check:lint` script
- [X] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [X] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [X] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
