### PR TITLE
ci(NODE-6684): serverless tests use AWS secrets manager

### DIFF
--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -238,27 +238,13 @@ functions:
           . ./set-temp-creds.sh
           popd
 
-          MONGODB_URI="${MONGODB_URI}" \
-          AUTH=${AUTH} SSL=${SSL} TEST_CSFLE=true \
-          MONGODB_API_VERSION="${MONGODB_API_VERSION}"
-
           export MONGODB_API_VERSION="${MONGODB_API_VERSION}"
           export AUTH="auth"
           export SSL="ssl"
-          export SERVERLESS="1"
-          export SERVERLESS_ATLAS_USER="${SERVERLESS_ATLAS_USER}"
-          export SERVERLESS_ATLAS_PASSWORD="${SERVERLESS_ATLAS_PASSWORD}"
-          export SERVERLESS_URI="${SERVERLESS_URI}"
+          export TEST_CSFLE=true
 
-          echo "setting SERVERLESS_URI: $SERVERLESS_URI"
-
-          export MONGODB_URI="${SERVERLESS_URI}"
-          export SINGLE_MONGOS_LB_URI="${SERVERLESS_URI}"
-
-          # Setting MULTI_MONGOS to the SERVERLESS_URI is intentional
-          # LB tests pick one host out of the comma separated list
-          # so just passing the one host is equivalent
-          export MULTI_MONGOS_LB_URI="${SERVERLESS_URI}"
+          source secrets-export.sh
+          source serverless.env
 
           bash ${PROJECT_DIRECTORY}/.evergreen/run-serverless-tests.sh
 
@@ -1427,32 +1413,24 @@ task_groups:
     setup_group_timeout_secs: 1800 # 30 minutes
     setup_group:
       - func: "fetch source"
-      - command: shell.exec
+      - command: subprocess.exec
         params:
-          shell: bash
-          script: |
-            ${PREPARE_SHELL}
-            set +o xtrace
-            LOADBALANCED=ON \
-            SERVERLESS_DRIVERS_GROUP=${SERVERLESS_DRIVERS_GROUP} \
-            SERVERLESS_API_PUBLIC_KEY=${SERVERLESS_API_PUBLIC_KEY} \
-            SERVERLESS_API_PRIVATE_KEY=${SERVERLESS_API_PRIVATE_KEY} \
-              bash ${DRIVERS_TOOLS}/.evergreen/serverless/create-instance.sh
-      - command: expansions.update
-        params:
-          file: serverless-expansion.yml
+          working_dir: "src"
+          binary: bash
+          env:
+            DRIVERS_TOOLS: ${DRIVERS_TOOLS}
+          args:
+            - .evergreen/setup-serverless.sh
+
     teardown_group:
       - func: "upload test results"
-      - command: shell.exec
+      - command: subprocess.exec
         params:
-          script: |
-            ${PREPARE_SHELL}
-            set +o xtrace
-            SERVERLESS_DRIVERS_GROUP=${SERVERLESS_DRIVERS_GROUP} \
-            SERVERLESS_API_PUBLIC_KEY=${SERVERLESS_API_PUBLIC_KEY} \
-            SERVERLESS_API_PRIVATE_KEY=${SERVERLESS_API_PRIVATE_KEY} \
-            SERVERLESS_INSTANCE_NAME=${SERVERLESS_INSTANCE_NAME} \
-              bash ${DRIVERS_TOOLS}/.evergreen/serverless/delete-instance.sh
+          working_dir: "src"
+          binary: bash
+          args:
+            - ${DRIVERS_TOOLS}/.evergreen/serverless/delete-instance.sh
+            
     tasks:
       - ".serverless"
 

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -209,27 +209,13 @@ functions:
           . ./set-temp-creds.sh
           popd
 
-          MONGODB_URI="${MONGODB_URI}" \
-          AUTH=${AUTH} SSL=${SSL} TEST_CSFLE=true \
-          MONGODB_API_VERSION="${MONGODB_API_VERSION}"
-
           export MONGODB_API_VERSION="${MONGODB_API_VERSION}"
           export AUTH="auth"
           export SSL="ssl"
-          export SERVERLESS="1"
-          export SERVERLESS_ATLAS_USER="${SERVERLESS_ATLAS_USER}"
-          export SERVERLESS_ATLAS_PASSWORD="${SERVERLESS_ATLAS_PASSWORD}"
-          export SERVERLESS_URI="${SERVERLESS_URI}"
+          export TEST_CSFLE=true
 
-          echo "setting SERVERLESS_URI: $SERVERLESS_URI"
-
-          export MONGODB_URI="${SERVERLESS_URI}"
-          export SINGLE_MONGOS_LB_URI="${SERVERLESS_URI}"
-
-          # Setting MULTI_MONGOS to the SERVERLESS_URI is intentional
-          # LB tests pick one host out of the comma separated list
-          # so just passing the one host is equivalent
-          export MULTI_MONGOS_LB_URI="${SERVERLESS_URI}"
+          source secrets-export.sh
+          source serverless.env
 
           bash ${PROJECT_DIRECTORY}/.evergreen/run-serverless-tests.sh
   start-load-balancer:
@@ -4458,32 +4444,22 @@ task_groups:
     setup_group_timeout_secs: 1800
     setup_group:
       - func: fetch source
-      - command: shell.exec
+      - command: subprocess.exec
         params:
-          shell: bash
-          script: |
-            ${PREPARE_SHELL}
-            set +o xtrace
-            LOADBALANCED=ON \
-            SERVERLESS_DRIVERS_GROUP=${SERVERLESS_DRIVERS_GROUP} \
-            SERVERLESS_API_PUBLIC_KEY=${SERVERLESS_API_PUBLIC_KEY} \
-            SERVERLESS_API_PRIVATE_KEY=${SERVERLESS_API_PRIVATE_KEY} \
-              bash ${DRIVERS_TOOLS}/.evergreen/serverless/create-instance.sh
-      - command: expansions.update
-        params:
-          file: serverless-expansion.yml
+          working_dir: src
+          binary: bash
+          env:
+            DRIVERS_TOOLS: ${DRIVERS_TOOLS}
+          args:
+            - .evergreen/setup-serverless.sh
     teardown_group:
       - func: upload test results
-      - command: shell.exec
+      - command: subprocess.exec
         params:
-          script: |
-            ${PREPARE_SHELL}
-            set +o xtrace
-            SERVERLESS_DRIVERS_GROUP=${SERVERLESS_DRIVERS_GROUP} \
-            SERVERLESS_API_PUBLIC_KEY=${SERVERLESS_API_PUBLIC_KEY} \
-            SERVERLESS_API_PRIVATE_KEY=${SERVERLESS_API_PRIVATE_KEY} \
-            SERVERLESS_INSTANCE_NAME=${SERVERLESS_INSTANCE_NAME} \
-              bash ${DRIVERS_TOOLS}/.evergreen/serverless/delete-instance.sh
+          working_dir: src
+          binary: bash
+          args:
+            - ${DRIVERS_TOOLS}/.evergreen/serverless/delete-instance.sh
     tasks:
       - .serverless
   - name: test_gcpkms_task_group

--- a/.evergreen/run-serverless-tests.sh
+++ b/.evergreen/run-serverless-tests.sh
@@ -3,7 +3,6 @@
 source $DRIVERS_TOOLS/.evergreen/init-node-and-npm-env.sh
 
 if [ -z ${SERVERLESS+omitted} ]; then echo "SERVERLESS is unset" && exit 1; fi
-if [ -z ${SERVERLESS_URI+omitted} ]; then echo "SERVERLESS_URI is unset" && exit 1; fi
 if [ -z ${SINGLE_MONGOS_LB_URI+omitted} ]; then echo "SINGLE_MONGOS_LB_URI is unset" && exit 1; fi
 if [ -z ${MULTI_MONGOS_LB_URI+omitted} ]; then echo "MULTI_MONGOS_LB_URI is unset" && exit 1; fi
 if [ -z ${MONGODB_URI+omitted} ]; then echo "MONGODB_URI is unset" && exit 1; fi

--- a/.evergreen/setup-serverless.sh
+++ b/.evergreen/setup-serverless.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+bash ${DRIVERS_TOOLS}/.evergreen/secrets_handling/setup-secrets.sh drivers/serverless
+bash ${DRIVERS_TOOLS}/.evergreen/serverless/create-instance.sh
+
+cp ${DRIVERS_TOOLS}/.evergreen/serverless/secrets-export.sh .
+
+# generate a source-able expansion file
+cat serverless-expansion.yml | sed 's/: /=/g' > serverless.env
+
+echo 'export MONGODB_URI="${SERVERLESS_URI}"' >> serverless.env
+echo 'export SINGLE_MONGOS_LB_URI="${SERVERLESS_URI}"' >> serverless.env
+echo 'export MULTI_MONGOS_LB_URI="${SERVERLESS_URI}"' >> serverless.env
+echo 'export SERVERLESS=1' >> serverless.env

--- a/test/readme.md
+++ b/test/readme.md
@@ -345,13 +345,6 @@ The following steps will walk you through how to create and test a MongoDB Serve
 
 This script uses aws secrets manager to fetch credentials.  Make sure you are logged into AWS and have your profile set correctly.
 
-
-Use AWS secrets manager to fetch credentials that enable usage of the Atlas API:
-
-```bash
-bash ${DRIVERS_TOOLS}/.evergreen/secrets_handling/setup-secrets.sh drivers/serverless
-```
-
 1. Run the setup-serverless script:
 
 ```bash
@@ -365,11 +358,9 @@ source secrets-export.sh
 source serverless.env
 ```
 
-3. Comment out the line in `.evergreen/run-serverless-tests.sh` that sources `install-dependencies.sh`.
+3. Comment out the line in `.evergreen/run-serverless-tests.sh` that sources `install-dependencies.sh` (this downloads node and npm and is only used in CI).
 
 4. Run the `.evergreen/run-serverless-tests.sh` script directly to test serverless instances from your local machine.
-
-> Hint: If the test script fails with an error along the lines of `Uncaught TypeError: Cannot read properties of undefined (reading 'processId')`, ensure you do **not** have the `FAKE_MONGODB_SERVICE_ID` environment variable set.
 
 ### Load Balanced
 

--- a/test/readme.md
+++ b/test/readme.md
@@ -23,16 +23,16 @@ tests will be skipped.
 
 Below is a summary of the types of test automation in this repo.
 
-| Type of Test            | Test Location       | About the Tests                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | How to Run Tests                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| ----------------------- | ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Unit                    | `/test/unit`        | The unit tests test individual pieces of code, typically functions. These tests do **not** interact with a real database, so mocks are used instead. <br><br>The unit test directory mirrors the `/src` directory structure with test file names matching the source file names of the code they test.                                                                                                                                                                                          | `npm run check:unit`                                                                                                                                                                                                                                                                                                                                                                                                                                              |
-| Integration             | `/test/integration` | The integration tests test that a given feature or piece of a feature is working as expected. These tests do **not** use mocks; instead, they interact with a real database. <br><br> The integration test directory follows the `test/spec` directory structure representing the different functional areas of the driver. <br><br> **Note:** The `.gitkeep` files are intentionally left to ensure that this directory structure is preserved even as the actual test files are moved around. | `npm run check:test`                                                                                                                                                                                                                                                                                                                                                                                                                                              |
-| Benchmark               | `/test/benchmarks`  | The benchmark tests report how long a designated set of tests take to run. They are used to measure performance.                                                                                                                                                                                                                                                                                                                                                                                | `npm run check:bench`                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| Specialized Environment | `/test/manual`      | The specalized environment tests are functional tests that require specialized environment setups in Evergreen. <br><br>**Note**: "manual" in the directory path does not refer to tests that should be run manually. These tests are automated. These tests have a special Evergreen configuration and run in isolation from the other tests.                                                                                                                                                  | There is no single script for running all of the specialized environment tests. Instead, you can run the appropriate script based on the specialized environment you want to use: <br>- `npm run check:atlas` to test Atlas <br>- `npm run check:adl` to test Atlas Data Lake <br>- `npm run check:ocsp` to test OCSP <br>- `npm run check:kerberos` to test Kerberos <br>- `npm run check:tls` to test TLS <br>- `npm run check:ldap` to test LDAP authorization |
-| TypeScript Definition   | `/test/types`       | The TypeScript definition tests verify the type definitions are correct.                                                                                                                                                                                                                                                                                                                                                                                                                        | `npm run check:tsd`                                                                                                                                                                                                                                                                                                                                                                                                                                               |
-| GitHub Actions          | `/test/action`      | Tests that run as GitHub Actions such as dependency checking.                                                                                                                                                                                                                                                                                                                                                                                                                                   | Currently, only `npm run check:dependencies` but could be expanded to more in the future.                                                                                                                                                                                                                                                                                                                                                                          |
-| Code Examples           | `/test/integration/node-specific/examples`    | Code examples that are also paired with tests that show they are working examples.                                                                                                                                                                                                                                                                                                                                                                                                              | Currently, `npm run check:lambda` to test the AWS Lambda example with default auth and `npm run check:lambda:aws` to test the AWS Lambda example with AWS auth.                                                                                                                                                                                                                                                                                                    |
-| Explicit Resource Management           | `/test/explicit-resource-management`    | Tests that use explicit resource management with the driver's disposable resources.                                                                                                                                                                                                                                                                                                                                                                                                             | `bash .evergreen/run-resource-management-feature-integration.sh`                                                                                                                                                                                                                                                                                      |
+| Type of Test                 | Test Location                              | About the Tests                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | How to Run Tests                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| ---------------------------- | ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Unit                         | `/test/unit`                               | The unit tests test individual pieces of code, typically functions. These tests do **not** interact with a real database, so mocks are used instead. <br><br>The unit test directory mirrors the `/src` directory structure with test file names matching the source file names of the code they test.                                                                                                                                                                                          | `npm run check:unit`                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| Integration                  | `/test/integration`                        | The integration tests test that a given feature or piece of a feature is working as expected. These tests do **not** use mocks; instead, they interact with a real database. <br><br> The integration test directory follows the `test/spec` directory structure representing the different functional areas of the driver. <br><br> **Note:** The `.gitkeep` files are intentionally left to ensure that this directory structure is preserved even as the actual test files are moved around. | `npm run check:test`                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| Benchmark                    | `/test/benchmarks`                         | The benchmark tests report how long a designated set of tests take to run. They are used to measure performance.                                                                                                                                                                                                                                                                                                                                                                                | `npm run check:bench`                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| Specialized Environment      | `/test/manual`                             | The specalized environment tests are functional tests that require specialized environment setups in Evergreen. <br><br>**Note**: "manual" in the directory path does not refer to tests that should be run manually. These tests are automated. These tests have a special Evergreen configuration and run in isolation from the other tests.                                                                                                                                                  | There is no single script for running all of the specialized environment tests. Instead, you can run the appropriate script based on the specialized environment you want to use: <br>- `npm run check:atlas` to test Atlas <br>- `npm run check:adl` to test Atlas Data Lake <br>- `npm run check:ocsp` to test OCSP <br>- `npm run check:kerberos` to test Kerberos <br>- `npm run check:tls` to test TLS <br>- `npm run check:ldap` to test LDAP authorization |
+| TypeScript Definition        | `/test/types`                              | The TypeScript definition tests verify the type definitions are correct.                                                                                                                                                                                                                                                                                                                                                                                                                        | `npm run check:tsd`                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| GitHub Actions               | `/test/action`                             | Tests that run as GitHub Actions such as dependency checking.                                                                                                                                                                                                                                                                                                                                                                                                                                   | Currently, only `npm run check:dependencies` but could be expanded to more in the future.                                                                                                                                                                                                                                                                                                                                                                         |
+| Code Examples                | `/test/integration/node-specific/examples` | Code examples that are also paired with tests that show they are working examples.                                                                                                                                                                                                                                                                                                                                                                                                              | Currently, `npm run check:lambda` to test the AWS Lambda example with default auth and `npm run check:lambda:aws` to test the AWS Lambda example with AWS auth.                                                                                                                                                                                                                                                                                                   |
+| Explicit Resource Management | `/test/explicit-resource-management`       | Tests that use explicit resource management with the driver's disposable resources.                                                                                                                                                                                                                                                                                                                                                                                                             | `bash .evergreen/run-resource-management-feature-integration.sh`                                                                                                                                                                                                                                                                                                                                                                                                  |
 
 ### Spec Tests
 
@@ -295,6 +295,33 @@ When you run the benchmarks verify that the BSON version has been picked by the 
 - bson: 6.10.1 (installed from npm): (.../mongodb/node_modules/bson)
 ```
 
+## Secrets
+
+Secrets needed for testing in special environments are managed in a drivers-wide AWS secrets manager vault.
+
+drivers-evergreen-tools contains scripts that can fetch secrets from secrets manager for local use and use in CI in the [.evergreen/secrets_handling folder](https://github.com/mongodb-labs/drivers-evergreen-tools/blob/master/.evergreen/secrets_handling/README.md).
+
+Local use of secrets manager requires:
+
+- the AWS SDK installed
+- an AWS profile with access to the AWS vault has been configured
+
+(see instructions in the secrets handling readme).
+
+Here's an example usage of the tooling in drivers-evergreen-tools that configures credentials for CSFLE:
+
+```bash
+bash ${DRIVERS_TOOLS}/.evergreen/secrets_handling/setup-secrets.sh drivers/csfle
+source secrets-export.sh
+```
+
+1. The `setup-secrets` script authenticates with AWS, fetches credentials and writes them to a bash file called `secrets-export.sh`.
+2. The setup-secrets accepts a space separated list of all the vaults from which to fetch credentials.  in this case, we fetch credentials from the `drivers/csfle` vault.
+3. Source `secrets-export.sh` to load the credentials into the environment.
+
+> [!IMPORTANT]
+> Make sure `secrets-export.sh` is in the .gitignore of any Github repo you might be using these tools in to avoid leaking credentials.  This is already done for this repo.
+
 ## Testing with Special Environments
 
 In order to test some features, you will need to generate and set a specialized group of environment variables. The subsections below will walk you through how to generate and set the environment variables for these features.
@@ -303,7 +330,7 @@ We recommend using a different terminal for each specialized environment to avoi
 
 Before you begin any of the subsections below, clone the [drivers-evergreen-tools repo](https://github.com/mongodb-labs/drivers-evergreen-tools.git).
 
-We recommend creating an environment variable named `DRIVERS_TOOLS` that stores the path to your local copy of the `driver-evergreen-tools` repo:
+We recommend creating an environment variable named `DRIVERS_TOOLS` that stores the path to your local copy of the `driver-evergreen-tools` repo (code examples in this section will assume this has been done):
 
 ```sh
 export DRIVERS_TOOLS="/path/to/your/copy/of/drivers-evergreen-tools"
@@ -313,69 +340,34 @@ export DRIVERS_TOOLS="/path/to/your/copy/of/drivers-evergreen-tools"
 
 The following steps will walk you through how to create and test a MongoDB Serverless instance.
 
-1. Create the following environment variables using a command like:
+> [!IMPORTANT]
+> If you set up an Atlas cluster for local use, you MUST delete it when you are finished with it using the [delete-instance script](https://github.com/mongodb-labs/drivers-evergreen-tools/blob/master/.evergreen/serverless/delete-instance.sh).
 
-   ```sh
-   export PROJECT="node-driver"
-   ```
+This script uses aws secrets manager to fetch credentials.  Make sure you are logged into AWS and have your profile set correctly.
 
-   > **Note:** MongoDB employees can pull these values from the Evergreen project's configuration.
 
-   | Variable Name                | Description                                                                                                      |
-   | ---------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-   | `Project`                    | The name of the Evergreen project where the tests will be run (e.g., `mongo-node-driver-next`)                   |
-   | `SERVERLESS_DRIVERS_GROUP`   | The Atlas organization where you will be creating the serverless instance                                        |
-   | `SERVERLESS_API_PUBLIC_KEY`  | The [Atlas API Public Key][atlas-api-key] for the organization where you will be creating a serverless instance  |
-   | `SERVERLESS_API_PRIVATE_KEY` | The [Atlas API Private Key][atlas-api-key] for the organization where you will be creating a serverless instance |
-   | `SERVERLESS_ATLAS_USER`      | The [SCRAM username][scram-auth] for the Atlas user who has permission to create a serverless instance           |
-   | `SERVERLESS_ATLAS_PASSWORD`  | The [SCRAM password][scram-auth] for the Atlas user who has permission to create a serverless instance           |
+Use AWS secrets manager to fetch credentials that enable usage of the Atlas API:
 
-   _**Remember**_ some of these are sensitive credentials, so keep them safe and only put them in your environment when you need them.
+```bash
+bash ${DRIVERS_TOOLS}/.evergreen/secrets_handling/setup-secrets.sh drivers/serverless
+```
 
-1. Run the [create-instance][create-instance-script] script:
+1. Run the setup-serverless script:
 
-   ```sh
-   $DRIVERS_TOOLS/.evergreen/serverless/create-instance.sh
-   ```
+```bash
+bash .evergreen/setup-serverless.sh
+```
 
-   The script will take a few minutes to run. When it is finished, a new file named `serverless-expansion.yml` will be created in the current working directory. The file will contain information about an Evergreen expansion:
+2. Source the expansions and secrets:
 
-   ```yml
-   MONGODB_URI: xxx
-   MONGODB_SRV_URI: xxx
-   SERVERLESS_INSTANCE_NAME: xxx
-   SSL: xxx
-   AUTH: xxx
-   TOPOLOGY: xxx
-   SERVERLESS: xxx
-   SERVERLESS_URI: xxx
-   ```
+```bash
+source secrets-export.sh
+source serverless.env
+```
 
-1. Generate a sourceable environment file from `serverless-expansion.yml` by running the following command:
+3. Comment out the line in `.evergreen/run-serverless-tests.sh` that sources `install-dependencies.sh`.
 
-   ```sh
-   cat serverless-expansion.yml | sed 's/: /=/g' > serverless.env
-   ```
-
-   A new file named `serverless.env` is automatically created.
-
-1. Update the following variables in `serverless.env`, so that they are equivalent to what our Evergreen builds do:
-
-   - Change `MONGODB_URI` to have the same value as `SERVERLESS_URI`.
-   - Add `SINGLE_MONGOS_LB_URI` and set it to the value of `SERVERLESS_URI`.
-   - Add `MULTI_MONGOS_LB_URI` and set it to the value of `SERVERLESS_URI`.
-
-1. Source the environment variables using a command like `source serverless.env`.
-
-1. Export **each** of the environment variables that were created in `serverless.env`. For example:
-
-   ```sh
-   export SINGLE_MONGOS_LB_URI
-   ```
-
-1. Comment out the line in `.evergreen/run-serverless-tests.sh` that sources `install-dependencies.sh`.
-
-1. Run the `.evergreen/run-serverless-tests.sh` script directly to test serverless instances from your local machine.
+4. Run the `.evergreen/run-serverless-tests.sh` script directly to test serverless instances from your local machine.
 
 > Hint: If the test script fails with an error along the lines of `Uncaught TypeError: Cannot read properties of undefined (reading 'processId')`, ensure you do **not** have the `FAKE_MONGODB_SERVICE_ID` environment variable set.
 
@@ -499,15 +491,15 @@ The following steps will walk you through how to run the tests for CSFLE.
    ```
    > **Note:** MongoDB employees can pull these values from the Evergreen project's configuration.
 
-   | Variable Name          |Description                                                      |
-   | -----------------------|---------------------------------------------------------------- |
-   | `AWS_ACCESS_KEY_ID`    | The AWS access key ID used to generate KMS messages             |
-   | `AWS_SECRET_ACCESS_KEY`| The AWS secret access key used to generate KMS messages         |
-   | `AWS_REGION`           | The AWS region where the KMS resides (e.g., `us-east-1`)        |
-   | `AWS_CMK_ID`           | The Customer Master Key for the KMS                             |
-   | `CSFLE_KMS_PROVIDERS`  | The raw EJSON description of the KMS providers. An example of the format is provided below.                                                                          |
-   | `KMIP_TLS_CA_FILE`     | /path/to/mongodb-labs/drivers-evergreen-tools/.evergreen/x509gen/ca.pem|
-   | `KMIP_TLS_CERT_FILE`   | /path/to/mongodb-labs/drivers-evergreen-tools/.evergreen/x509gen/client.pem |
+   | Variable Name           | Description                                                                                 |
+   | ----------------------- | ------------------------------------------------------------------------------------------- |
+   | `AWS_ACCESS_KEY_ID`     | The AWS access key ID used to generate KMS messages                                         |
+   | `AWS_SECRET_ACCESS_KEY` | The AWS secret access key used to generate KMS messages                                     |
+   | `AWS_REGION`            | The AWS region where the KMS resides (e.g., `us-east-1`)                                    |
+   | `AWS_CMK_ID`            | The Customer Master Key for the KMS                                                         |
+   | `CSFLE_KMS_PROVIDERS`   | The raw EJSON description of the KMS providers. An example of the format is provided below. |
+   | `KMIP_TLS_CA_FILE`      | /path/to/mongodb-labs/drivers-evergreen-tools/.evergreen/x509gen/ca.pem                     |
+   | `KMIP_TLS_CERT_FILE`    | /path/to/mongodb-labs/drivers-evergreen-tools/.evergreen/x509gen/client.pem                 |
 
    The value of the `CSFLE_KMS_PROVIDERS` variable will have the following format:
 

--- a/test/tools/runner/config.ts
+++ b/test/tools/runner/config.ts
@@ -117,11 +117,11 @@ export class TestConfiguration {
       replicaSet: url.searchParams.get('replicaSet'),
       proxyURIParams: url.searchParams.get('proxyHost')
         ? {
-          proxyHost: url.searchParams.get('proxyHost'),
-          proxyPort: Number(url.searchParams.get('proxyPort')),
-          proxyUsername: url.searchParams.get('proxyUsername'),
-          proxyPassword: url.searchParams.get('proxyPassword')
-        }
+            proxyHost: url.searchParams.get('proxyHost'),
+            proxyPort: Number(url.searchParams.get('proxyPort')),
+            proxyUsername: url.searchParams.get('proxyUsername'),
+            proxyPassword: url.searchParams.get('proxyPassword')
+          }
         : undefined
     };
     if (url.username) {

--- a/test/tools/runner/config.ts
+++ b/test/tools/runner/config.ts
@@ -13,7 +13,6 @@ import {
   type WriteConcernSettings
 } from '../../mongodb';
 import { getEnvironmentalOptions } from '../utils';
-import { ServerlessFilter } from './filters/serverless_filter';
 
 interface ProxyParams {
   proxyHost?: string;
@@ -100,7 +99,7 @@ export class TestConfiguration {
     this.parameters = { ...context.parameters };
     this.singleMongosLoadBalancerUri = context.singleMongosLoadBalancerUri;
     this.multiMongosLoadBalancerUri = context.multiMongosLoadBalancerUri;
-    this.isServerless = !!ServerlessFilter.isServerless;
+    this.isServerless = !!process.env.SERVERLESS;
     this.topologyType = this.isLoadBalanced ? TopologyType.LoadBalanced : context.topologyType;
     this.buildInfo = context.buildInfo;
     this.serverApi = context.serverApi;
@@ -118,11 +117,11 @@ export class TestConfiguration {
       replicaSet: url.searchParams.get('replicaSet'),
       proxyURIParams: url.searchParams.get('proxyHost')
         ? {
-            proxyHost: url.searchParams.get('proxyHost'),
-            proxyPort: Number(url.searchParams.get('proxyPort')),
-            proxyUsername: url.searchParams.get('proxyUsername'),
-            proxyPassword: url.searchParams.get('proxyPassword')
-          }
+          proxyHost: url.searchParams.get('proxyHost'),
+          proxyPort: Number(url.searchParams.get('proxyPort')),
+          proxyUsername: url.searchParams.get('proxyUsername'),
+          proxyPassword: url.searchParams.get('proxyPassword')
+        }
         : undefined
     };
     if (url.username) {

--- a/test/tools/runner/config.ts
+++ b/test/tools/runner/config.ts
@@ -13,6 +13,7 @@ import {
   type WriteConcernSettings
 } from '../../mongodb';
 import { getEnvironmentalOptions } from '../utils';
+import { ServerlessFilter } from './filters/serverless_filter';
 
 interface ProxyParams {
   proxyHost?: string;
@@ -86,7 +87,6 @@ export class TestConfiguration {
   serverApi?: ServerApi;
   activeResources: number;
   isSrv: boolean;
-  serverlessCredentials: { username: string | undefined; password: string | undefined };
 
   constructor(
     private uri: string,
@@ -100,7 +100,7 @@ export class TestConfiguration {
     this.parameters = { ...context.parameters };
     this.singleMongosLoadBalancerUri = context.singleMongosLoadBalancerUri;
     this.multiMongosLoadBalancerUri = context.multiMongosLoadBalancerUri;
-    this.isServerless = !!process.env.SERVERLESS;
+    this.isServerless = !!ServerlessFilter.isServerless;
     this.topologyType = this.isLoadBalanced ? TopologyType.LoadBalanced : context.topologyType;
     this.buildInfo = context.buildInfo;
     this.serverApi = context.serverApi;


### PR DESCRIPTION
### Description

#### What is changing?

Serverless tests use AWS secrets manager to fetch credentials to set up the cluster.  These tests don't use secretes manager to fetch FLE credentials (https://jira.mongodb.org/browse/NODE-6685).

I also updated the testing readme with instructions on how to use secrets manager and how to setup serverless tests locally.

##### Is there new documentation needed for these changes?

No.

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
