### PR TITLE
ci(NODE-6686): deployed Atlas cluster tests use secrets manager

### DIFF
--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -1606,6 +1606,7 @@ task_groups:
             MONGODB_VERSION: "7.0"
             LAMBDA_STACK_NAME: dbx-node-lambda
             CLUSTER_PREFIX: dbx-node-lambda
+            VAULT_NAME: atlas
           args:
             - ${DRIVERS_TOOLS}/.evergreen/atlas/setup-atlas-cluster.sh
       - command: expansions.update

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -1630,9 +1630,9 @@ task_groups:
         params:
           working_dir: src
           binary: bash
-          add_expansions_to_env: true
           env:
             MONGODB_VERSION: "7.0"
+            CLUSTER_PREFIX: dbx-node-search-indexes
           args:
             - ${DRIVERS_TOOLS}/.evergreen/atlas/setup-atlas-cluster.sh
       - command: expansions.update
@@ -1643,7 +1643,6 @@ task_groups:
         params:
           working_dir: src
           binary: bash
-          add_expansions_to_env: true
           args:
             - ${DRIVERS_TOOLS}/.evergreen/atlas/teardown-atlas-cluster.sh
     setup_group_can_fail_task: true

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -1606,9 +1606,9 @@ task_groups:
             MONGODB_VERSION: "7.0"
             LAMBDA_STACK_NAME: dbx-node-lambda
             CLUSTER_PREFIX: dbx-node-lambda
-            VAULT_NAME: atlas
           args:
             - ${DRIVERS_TOOLS}/.evergreen/atlas/setup-atlas-cluster.sh
+            - atlas
       - command: expansions.update
         params:
           file: src/atlas-expansion.yml

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -1602,9 +1602,10 @@ task_groups:
         params:
           working_dir: src
           binary: bash
-          add_expansions_to_env: true
           env:
             MONGODB_VERSION: "7.0"
+            LAMBDA_STACK_NAME: dbx-node-lambda
+            CLUSTER_PREFIX: dbx-node-lambda
           args:
             - ${DRIVERS_TOOLS}/.evergreen/atlas/setup-atlas-cluster.sh
       - command: expansions.update
@@ -1615,7 +1616,6 @@ task_groups:
         params:
           working_dir: src
           binary: bash
-          add_expansions_to_env: true
           args:
             - ${DRIVERS_TOOLS}/.evergreen/atlas/teardown-atlas-cluster.sh
     setup_group_can_fail_task: true

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -4627,9 +4627,9 @@ task_groups:
             MONGODB_VERSION: '7.0'
             LAMBDA_STACK_NAME: dbx-node-lambda
             CLUSTER_PREFIX: dbx-node-lambda
-            VAULT_NAME: atlas
           args:
             - ${DRIVERS_TOOLS}/.evergreen/atlas/setup-atlas-cluster.sh
+            - atlas
       - command: expansions.update
         params:
           file: src/atlas-expansion.yml

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -4650,9 +4650,9 @@ task_groups:
         params:
           working_dir: src
           binary: bash
-          add_expansions_to_env: true
           env:
             MONGODB_VERSION: '7.0'
+            CLUSTER_PREFIX: dbx-node-search-indexes
           args:
             - ${DRIVERS_TOOLS}/.evergreen/atlas/setup-atlas-cluster.sh
       - command: expansions.update
@@ -4663,7 +4663,6 @@ task_groups:
         params:
           working_dir: src
           binary: bash
-          add_expansions_to_env: true
           args:
             - ${DRIVERS_TOOLS}/.evergreen/atlas/teardown-atlas-cluster.sh
     setup_group_can_fail_task: true

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -4623,9 +4623,10 @@ task_groups:
         params:
           working_dir: src
           binary: bash
-          add_expansions_to_env: true
           env:
             MONGODB_VERSION: '7.0'
+            LAMBDA_STACK_NAME: dbx-node-lambda
+            CLUSTER_PREFIX: dbx-node-lambda
           args:
             - ${DRIVERS_TOOLS}/.evergreen/atlas/setup-atlas-cluster.sh
       - command: expansions.update
@@ -4636,7 +4637,6 @@ task_groups:
         params:
           working_dir: src
           binary: bash
-          add_expansions_to_env: true
           args:
             - ${DRIVERS_TOOLS}/.evergreen/atlas/teardown-atlas-cluster.sh
     setup_group_can_fail_task: true

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -4627,6 +4627,7 @@ task_groups:
             MONGODB_VERSION: '7.0'
             LAMBDA_STACK_NAME: dbx-node-lambda
             CLUSTER_PREFIX: dbx-node-lambda
+            VAULT_NAME: atlas
           args:
             - ${DRIVERS_TOOLS}/.evergreen/atlas/setup-atlas-cluster.sh
       - command: expansions.update

--- a/test/readme.md
+++ b/test/readme.md
@@ -26,18 +26,23 @@ about the types of tests and how to run them.
     - [Skipping Tests](#skipping-tests)
   - [Running Benchmarks](#running-benchmarks)
     - [Configuration](#configuration)
+  - [Secrets](#secrets)
   - [Testing with Special Environments](#testing-with-special-environments)
     - [Serverless](#serverless)
     - [Load Balanced](#load-balanced)
     - [Client-Side Field-Level Encryption (CSFLE)](#client-side-field-level-encryption-csfle)
-      - [Testing driver changes with mongosh](#testing-driver-changes-with-mongosh)
-        - [Point mongosh to the driver](#point-mongosh-to-the-driver)
-        - [Run specific package tests](#run-specific-package-tests)
       - [KMIP FLE support tests](#kmip-fle-support-tests)
     - [Deployed KMS Tests](#deployed-kms-tests)
       - [Azure KMS](#azure-kms)
       - [GCP KMS](#gcp-kms)
+    - [Deployed Atlas Tests](#deployed-atlas-tests)
+      - [Launching an Atlas Cluster](#launching-an-atlas-cluster)
+      - [Search Indexes](#search-indexes)
+      - [Deployed Lambda Tests](#deployed-lambda-tests)
     - [TODO Special Env Sections](#todo-special-env-sections)
+  - [Testing driver changes with mongosh](#testing-driver-changes-with-mongosh)
+    - [Point mongosh to the driver](#point-mongosh-to-the-driver)
+    - [Run specific package tests](#run-specific-package-tests)
 
 ## About the Tests
 
@@ -594,44 +599,6 @@ The following steps will walk you through how to run the tests for CSFLE.
 
    To run the functional tests using the crypt shared library instead of `mongocryptd`, download the appropriate version of the crypt shared library for the enterprise server version [here](https://www.mongodb.com/download-center/enterprise/releases) and then set the location of it in the environment variable `CRYPT_SHARED_LIB_PATH`.
 
-#### Testing driver changes with mongosh
-
-These steps require `mongosh` to be available locally. Clone it from GitHub.
-
-`mongosh` uses a `lerna` monorepo. As a result, `mongosh` contains multiple references to the `mongodb` package
-in their `package.json`s.
-
-Set up `mongosh` by following the steps in the `mongosh` readme.
-
-##### Point mongosh to the driver
-
-mongosh contains a script that does this. To use the script, create an environment
- variable `REPLACE_PACKAGE` that contains a string in the form
-`mongodb:<path to your local instance of the driver>`. The package replacement script will replace
-all occurrences of `mongodb` with the local path of your driver.
-
-An alternative, which can be useful for
-testing a release, is to first run `npm pack` on the driver. This generates a tarball containing all the code
-that would be uploaded to `npm` if it were released. Then, set the environment variable `REPLACE_PACKAGE`
-with the full path to the file.
-
-Once the environment variable is set, run replace package in `mongosh` with:
-```sh
-npm run replace:package
-```
-
-##### Run specific package tests
-
-`mongosh`'s readme documents how to run its tests. Most likely, it isn't necessary to run all of mongosh's
-tests. The `mongosh` readme also documents how to run tests for a particular scope. The scopes are
-listed in the `generate_mongosh_tasks.js` evergreen generation script.
-
-For example, to run the `service-provider-server` package, run the following command in `mongosh`:
-
-```shell
-lerna run test --scope @mongosh/service-provider-server
-```
-
 #### KMIP FLE support tests
 
 1. Install `virtualenv`:
@@ -729,6 +696,29 @@ source $DRIVERS_TOOLS/.evergreen/init-node-and-npm-env.sh
 bash .evergreen/run-deployed-gcp-kms-tests.sh
 ```
 
+
+### Deployed Atlas Tests
+
+#### Launching an Atlas Cluster
+
+Using drivers evergreen tools, run the `setup-atlas-cluster` script.  You must also set the CLUSTER_PREFIX environment variable.
+
+```bash
+CLUSTER_PREFIX=dbx-node-lambda bash ${DRIVERS_TOOLS}/.evergreen/atlas/setup-atlas-cluster.sh
+```
+
+The URI of the cluster is available in the `atlas-expansions.yml` file.
+
+#### Search Indexes
+
+1. Set up an Atlas cluster, as outlined in the "Launching an Atlas Cluster" section.
+2. Add the URI of the cluster to the environment as the MONGODB_URI environment variable.
+3. Run the tests with `npm run check:search-indexes`.
+
+#### Deployed Lambda Tests
+
+TODO
+
 ### TODO Special Env Sections
 
 - Kerberos
@@ -755,3 +745,41 @@ bash .evergreen/run-deployed-gcp-kms-tests.sh
 [npm-csfle]: https://www.npmjs.com/package/mongodb-client-encryption
 [atlas-api-key]: https://docs.atlas.mongodb.com/tutorial/configure-api-access/organization/create-one-api-key
 [scram-auth]: https://docs.atlas.mongodb.com/security-add-mongodb-users/#database-user-authentication
+
+## Testing driver changes with mongosh
+
+These steps require `mongosh` to be available locally. Clone it from GitHub.
+
+`mongosh` uses a `lerna` monorepo. As a result, `mongosh` contains multiple references to the `mongodb` package
+in their `package.json`s.
+
+Set up `mongosh` by following the steps in the `mongosh` readme.
+
+### Point mongosh to the driver
+
+mongosh contains a script that does this. To use the script, create an environment
+ variable `REPLACE_PACKAGE` that contains a string in the form
+`mongodb:<path to your local instance of the driver>`. The package replacement script will replace
+all occurrences of `mongodb` with the local path of your driver.
+
+An alternative, which can be useful for
+testing a release, is to first run `npm pack` on the driver. This generates a tarball containing all the code
+that would be uploaded to `npm` if it were released. Then, set the environment variable `REPLACE_PACKAGE`
+with the full path to the file.
+
+Once the environment variable is set, run replace package in `mongosh` with:
+```sh
+npm run replace:package
+```
+
+### Run specific package tests
+
+`mongosh`'s readme documents how to run its tests. Most likely, it isn't necessary to run all of mongosh's
+tests. The `mongosh` readme also documents how to run tests for a particular scope. The scopes are
+listed in the `generate_mongosh_tasks.js` evergreen generation script.
+
+For example, to run the `service-provider-server` package, run the following command in `mongosh`:
+
+```shell
+lerna run test --scope @mongosh/service-provider-server
+```

--- a/test/readme.md
+++ b/test/readme.md
@@ -717,7 +717,7 @@ The URI of the cluster is available in the `atlas-expansions.yml` file.
 
 #### Deployed Lambda Tests
 
-TODO
+TODO(NODE-6698): Update deployed lambda test section.
 
 ### TODO Special Env Sections
 


### PR DESCRIPTION
### Description

#### What is changing?

Deployed atlas clusters now use Secrets Manager.

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
