### PR TITLE
ci(NODE-6694): kerberos tests use secrets manager

### DIFF
--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -411,13 +411,7 @@ functions:
         binary: bash
         working_dir: src
         env:
-          PROJECT_DIRECTORY: ${PROJECT_DIRECTORY}
           DRIVERS_TOOLS: ${DRIVERS_TOOLS}
-          KRB5_KEYTAB: ${gssapi_auth_keytab_base64}
-          KRB5_NEW_KEYTAB: ${gssapi_auth_new_keytab_base64}
-          KRB5_PRINCIPAL: ${gssapi_auth_principal}
-          MONGODB_URI: ${gssapi_auth_mongodb_uri}
-          NODE_LTS_VERSION: ${NODE_LTS_VERSION}
         args:
           - .evergreen/run-kerberos-tests.sh
 

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -360,13 +360,7 @@ functions:
         binary: bash
         working_dir: src
         env:
-          PROJECT_DIRECTORY: ${PROJECT_DIRECTORY}
           DRIVERS_TOOLS: ${DRIVERS_TOOLS}
-          KRB5_KEYTAB: ${gssapi_auth_keytab_base64}
-          KRB5_NEW_KEYTAB: ${gssapi_auth_new_keytab_base64}
-          KRB5_PRINCIPAL: ${gssapi_auth_principal}
-          MONGODB_URI: ${gssapi_auth_mongodb_uri}
-          NODE_LTS_VERSION: ${NODE_LTS_VERSION}
         args:
           - .evergreen/run-kerberos-tests.sh
   run ldap tests:

--- a/.evergreen/run-kerberos-tests.sh
+++ b/.evergreen/run-kerberos-tests.sh
@@ -16,7 +16,7 @@ set +o verbose
 if [[ "$OSTYPE" == "darwin"* ]]; then
     echo ${KEYTAB_BASE64_AES} | base64 -D >"$(pwd)/.evergreen/drivers.keytab"
 else
-    echo ${KEYTAB_BASE64_AES} | base64 -D >"$(pwd)/.evergreen/drivers.keytab"
+    echo ${KEYTAB_BASE64_AES} | base64 -d >"$(pwd)/.evergreen/drivers.keytab"
 fi
 echo "Running kdestroy"
 kdestroy -A

--- a/.evergreen/run-kerberos-tests.sh
+++ b/.evergreen/run-kerberos-tests.sh
@@ -14,9 +14,9 @@ echo "Writing keytab"
 # DON'T PRINT KEYTAB TO STDOUT
 set +o verbose
 if [[ "$OSTYPE" == "darwin"* ]]; then
-    echo ${KAYTAB_BASE64_AES} | base64 -D >"$(pwd)/.evergreen/drivers.keytab"
+    echo ${KEYTAB_BASE64_AES} | base64 -D >"$(pwd)/.evergreen/drivers.keytab"
 else
-    echo ${KAYTAB_BASE64_AES} | base64 -d >"$(pwd)/.evergreen/drivers.keytab"
+    echo ${KEYTAB_BASE64_AES} | base64 -D >"$(pwd)/.evergreen/drivers.keytab"
 fi
 echo "Running kdestroy"
 kdestroy -A

--- a/.evergreen/run-kerberos-tests.sh
+++ b/.evergreen/run-kerberos-tests.sh
@@ -27,7 +27,7 @@ USER=$(node -p "encodeURIComponent(process.env.PRINCIPAL)")
 export MONGODB_URI="mongodb://${USER}@${SASL_HOST}/${GSSAPI_DB}?authMechanism=GSSAPI"
 
 set -o xtrace
-# npm install kerberos@2.0.1
+npm install kerberos@2.0.1
 npm run check:kerberos
 
 set +o xtrace

--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,5 @@ expansions.sh
 .drivers-tools/
 
 crypt_shared.sh
+
+*keytab

--- a/test/manual/kerberos.test.ts
+++ b/test/manual/kerberos.test.ts
@@ -218,7 +218,7 @@ describe('Kerberos', function () {
         if (!expectedError) {
           expect.fail('Expected connect with invalid SERVICE_HOST to fail');
         }
-        expect(expectedError.message).to.match(/GSS failure|UNKNOWN_SERVER/);
+        expect(expectedError.message).to.match(/GSS failure|UNKNOWN_SERVER|Server not found in Kerberos database/);
       });
     });
 

--- a/test/manual/kerberos.test.ts
+++ b/test/manual/kerberos.test.ts
@@ -34,7 +34,7 @@ describe('Kerberos', function () {
     client = null;
   });
 
-  let krb5Uri = process.env.MONGODB_URI;
+  const krb5Uri = process.env.MONGODB_URI;
   const host = process.env.SASL_HOST;
 
   if (!process.env.PRINCIPAL) {
@@ -218,7 +218,9 @@ describe('Kerberos', function () {
         if (!expectedError) {
           expect.fail('Expected connect with invalid SERVICE_HOST to fail');
         }
-        expect(expectedError.message).to.match(/GSS failure|UNKNOWN_SERVER|Server not found in Kerberos database/);
+        expect(expectedError.message).to.match(
+          /GSS failure|UNKNOWN_SERVER|Server not found in Kerberos database/
+        );
       });
     });
 

--- a/test/manual/kerberos.test.ts
+++ b/test/manual/kerberos.test.ts
@@ -34,25 +34,12 @@ describe('Kerberos', function () {
     client = null;
   });
 
-  if (process.env.MONGODB_URI == null) {
-    console.error('skipping Kerberos tests, MONGODB_URI environment variable is not defined');
-    return;
-  }
   let krb5Uri = process.env.MONGODB_URI;
-  const parts = krb5Uri.split('@', 2);
-  const host = parts[1].split('/')[0];
+  const host = process.env.SASL_HOST;
 
-  if (!process.env.KRB5_PRINCIPAL) {
-    console.error('skipping Kerberos tests, KRB5_PRINCIPAL environment variable is not defined');
+  if (!process.env.PRINCIPAL) {
+    console.error('skipping Kerberos tests, PRINCIPAL environment variable is not defined');
     return;
-  }
-
-  if (process.platform === 'win32') {
-    console.error('Win32 run detected');
-    if (process.env.LDAPTEST_PASSWORD == null) {
-      throw new Error('The env parameter LDAPTEST_PASSWORD must be set');
-    }
-    krb5Uri = `${parts[0]}:${process.env.LDAPTEST_PASSWORD}@${parts[1]}`;
   }
 
   it('should authenticate with original uri', async function () {
@@ -277,7 +264,7 @@ describe('Kerberos', function () {
 
   it('should fail to authenticate with bad credentials', async function () {
     client = new MongoClient(
-      krb5Uri.replace(encodeURIComponent(process.env.KRB5_PRINCIPAL), 'bad%40creds.cc')
+      krb5Uri.replace(encodeURIComponent(process.env.PRINCIPAL), 'bad%40creds.cc')
     );
     const err = await client.connect().catch(e => e);
     expect(err.message).to.match(/Authentication failed/);

--- a/test/readme.md
+++ b/test/readme.md
@@ -38,6 +38,7 @@ about the types of tests and how to run them.
       - [Launching an Atlas Cluster](#launching-an-atlas-cluster)
       - [Search Indexes](#search-indexes)
       - [Deployed Lambda Tests](#deployed-lambda-tests)
+    - [Kerberos Tests](#kerberos-tests)
     - [TODO Special Env Sections](#todo-special-env-sections)
   - [Testing driver changes with mongosh](#testing-driver-changes-with-mongosh)
     - [Point mongosh to the driver](#point-mongosh-to-the-driver)
@@ -614,9 +615,12 @@ The URI of the cluster is available in the `atlas-expansions.yml` file.
 
 TODO(NODE-6698): Update deployed lambda test section.
 
+### Kerberos Tests
+
+Run `.evergreen/run-kerberos-tests.sh`.
+
 ### TODO Special Env Sections
 
-- Kerberos
 - AWS Authentication
 - OCSP
 - TLS


### PR DESCRIPTION
### Description

#### What is changing?

Kerberos tests use secrets manager.

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
