### PR TITLE
fix(NODE-6613): Update error messages when primaries go stale

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -359,10 +359,13 @@ export class MongoStalePrimaryError extends MongoRuntimeError {
     serverDescription: ServerDescription,
     maxSetVersion: number | null,
     maxElectionId: ObjectId | null,
+    message?: string,
     options?: { cause?: Error }
   ) {
+    console.log(message);
     super(
-      `primary marked stale due to electionId/setVersion mismatch: server setVersion: ${serverDescription.setVersion}, server electionId: ${serverDescription.electionId}, topology setVersion: ${maxSetVersion}, topology electionId: ${maxElectionId}`,
+      message ??
+        `primary marked stale due to electionId/setVersion mismatch: server setVersion: ${serverDescription.setVersion}, server electionId: ${serverDescription.electionId}, topology setVersion: ${maxSetVersion}, topology electionId: ${maxElectionId}`,
       options
     );
   }

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,10 +1,10 @@
-import type { Document, ObjectId } from './bson';
+import type { Document } from './bson';
 import {
   type ClientBulkWriteError,
   type ClientBulkWriteResult
 } from './operations/client_bulk_write/common';
 import type { ServerType } from './sdam/common';
-import type { ServerDescription, TopologyVersion } from './sdam/server_description';
+import type { TopologyVersion } from './sdam/server_description';
 import type { TopologyDescription } from './sdam/topology_description';
 
 /** @public */
@@ -355,18 +355,8 @@ export class MongoStalePrimaryError extends MongoRuntimeError {
    *
    * @public
    **/
-  constructor(
-    serverDescription: ServerDescription,
-    maxSetVersion: number | null,
-    maxElectionId: ObjectId | null,
-    message?: string,
-    options?: { cause?: Error }
-  ) {
-    super(
-      message ??
-        `primary marked stale due to electionId/setVersion mismatch: server setVersion: ${serverDescription.setVersion}, server electionId: ${serverDescription.electionId}, topology setVersion: ${maxSetVersion}, topology electionId: ${maxElectionId}`,
-      options
-    );
+  constructor(message: string, options?: { cause?: Error }) {
+    super(message, options);
   }
 
   override get name(): string {

--- a/src/error.ts
+++ b/src/error.ts
@@ -362,7 +362,6 @@ export class MongoStalePrimaryError extends MongoRuntimeError {
     message?: string,
     options?: { cause?: Error }
   ) {
-    console.log(message);
     super(
       message ??
         `primary marked stale due to electionId/setVersion mismatch: server setVersion: ${serverDescription.setVersion}, server electionId: ${serverDescription.electionId}, topology setVersion: ${maxSetVersion}, topology electionId: ${maxElectionId}`,

--- a/src/sdam/topology_description.ts
+++ b/src/sdam/topology_description.ts
@@ -376,6 +376,19 @@ function updateRsFromPrimary(
   maxSetVersion: number | null = null,
   maxElectionId: ObjectId | null = null
 ): [TopologyType, string | null, number | null, ObjectId | null] {
+  const setVersionElectionIdMismatch = (
+    serverDescription: ServerDescription,
+    maxSetVersion: number | null,
+    maxElectionId: ObjectId | null
+  ) => {
+    return (
+      `primary marked stale due to electionId/setVersion mismatch:` +
+      ` server setVersion: ${serverDescription.setVersion},` +
+      ` server electionId: ${serverDescription.electionId},` +
+      ` topology setVersion: ${maxSetVersion},` +
+      ` topology electionId: ${maxElectionId}`
+    );
+  };
   setName = setName || serverDescription.setName;
   if (setName !== serverDescription.setName) {
     serverDescriptions.delete(serverDescription.address);
@@ -401,7 +414,9 @@ function updateRsFromPrimary(
       serverDescriptions.set(
         serverDescription.address,
         new ServerDescription(serverDescription.address, undefined, {
-          error: new MongoStalePrimaryError(serverDescription, maxSetVersion, maxElectionId)
+          error: new MongoStalePrimaryError(
+            setVersionElectionIdMismatch(serverDescription, maxSetVersion, maxElectionId)
+          )
         })
       );
 
@@ -419,7 +434,9 @@ function updateRsFromPrimary(
           serverDescriptions.set(
             serverDescription.address,
             new ServerDescription(serverDescription.address, undefined, {
-              error: new MongoStalePrimaryError(serverDescription, maxSetVersion, maxElectionId)
+              error: new MongoStalePrimaryError(
+                setVersionElectionIdMismatch(serverDescription, maxSetVersion, maxElectionId)
+              )
             })
           );
 
@@ -446,9 +463,6 @@ function updateRsFromPrimary(
         address,
         new ServerDescription(server.address, undefined, {
           error: new MongoStalePrimaryError(
-            serverDescription,
-            maxSetVersion,
-            maxElectionId,
             'primary marked stale due to discovery of newer primary'
           )
         })

--- a/src/sdam/topology_description.ts
+++ b/src/sdam/topology_description.ts
@@ -398,7 +398,6 @@ function updateRsFromPrimary(
     } else {
       // Stale primary
       // replace serverDescription with a default ServerDescription of type "Unknown"
-      console.log(`marking newly discovered primary: ${serverDescription.address} as stale`);
       serverDescriptions.set(
         serverDescription.address,
         new ServerDescription(serverDescription.address, undefined, {
@@ -417,7 +416,6 @@ function updateRsFromPrimary(
           compareObjectId(maxElectionId, electionId) > 0
         ) {
           // this primary is stale, we must remove it
-          console.log(`marking newly discovered primary: ${serverDescription.address} as stale`);
           serverDescriptions.set(
             serverDescription.address,
             new ServerDescription(serverDescription.address, undefined, {
@@ -443,9 +441,6 @@ function updateRsFromPrimary(
   // We've heard from the primary. Is it the same primary as before?
   for (const [address, server] of serverDescriptions) {
     if (server.type === ServerType.RSPrimary && server.address !== serverDescription.address) {
-      console.log(
-        `server.address: ${server.address}; serverDescription.address: ${serverDescription.address}`
-      );
       // Reset old primary's type to Unknown.
       serverDescriptions.set(
         address,

--- a/src/sdam/topology_description.ts
+++ b/src/sdam/topology_description.ts
@@ -398,6 +398,7 @@ function updateRsFromPrimary(
     } else {
       // Stale primary
       // replace serverDescription with a default ServerDescription of type "Unknown"
+      console.log(`marking newly discovered primary: ${serverDescription.address} as stale`);
       serverDescriptions.set(
         serverDescription.address,
         new ServerDescription(serverDescription.address, undefined, {
@@ -416,6 +417,7 @@ function updateRsFromPrimary(
           compareObjectId(maxElectionId, electionId) > 0
         ) {
           // this primary is stale, we must remove it
+          console.log(`marking newly discovered primary: ${serverDescription.address} as stale`);
           serverDescriptions.set(
             serverDescription.address,
             new ServerDescription(serverDescription.address, undefined, {
@@ -441,11 +443,19 @@ function updateRsFromPrimary(
   // We've heard from the primary. Is it the same primary as before?
   for (const [address, server] of serverDescriptions) {
     if (server.type === ServerType.RSPrimary && server.address !== serverDescription.address) {
+      console.log(
+        `server.address: ${server.address}; serverDescription.address: ${serverDescription.address}`
+      );
       // Reset old primary's type to Unknown.
       serverDescriptions.set(
         address,
         new ServerDescription(server.address, undefined, {
-          error: new MongoStalePrimaryError(serverDescription, maxSetVersion, maxElectionId)
+          error: new MongoStalePrimaryError(
+            serverDescription,
+            maxSetVersion,
+            maxElectionId,
+            'primary marked stale due to discovery of newer primary'
+          )
         })
       );
 

--- a/test/spec/server-discovery-and-monitoring/rs/new_primary.json
+++ b/test/spec/server-discovery-and-monitoring/rs/new_primary.json
@@ -58,7 +58,8 @@
         "servers": {
           "a:27017": {
             "type": "Unknown",
-            "setName": null
+            "setName": null,
+            "error": "primary marked stale due to discovery of newer primary"
           },
           "b:27017": {
             "type": "RSPrimary",

--- a/test/spec/server-discovery-and-monitoring/rs/new_primary.yml
+++ b/test/spec/server-discovery-and-monitoring/rs/new_primary.yml
@@ -63,7 +63,8 @@ phases: [
                 "a:27017": {
 
                     type: "Unknown",
-                    setName:
+                    setName:,
+                    error: "primary marked stale due to discovery of newer primary"
                 },
 
                 "b:27017": {

--- a/test/spec/server-discovery-and-monitoring/rs/new_primary_new_electionid.json
+++ b/test/spec/server-discovery-and-monitoring/rs/new_primary_new_electionid.json
@@ -77,7 +77,7 @@
             "type": "Unknown",
             "setName": null,
             "electionId": null,
-            "error": "primary marked stale due to electionId/setVersion mismatch"
+            "error": "primary marked stale due to discovery of newer primary"
           },
           "b:27017": {
             "type": "RSPrimary",

--- a/test/spec/server-discovery-and-monitoring/rs/new_primary_new_electionid.yml
+++ b/test/spec/server-discovery-and-monitoring/rs/new_primary_new_electionid.yml
@@ -64,7 +64,7 @@ phases: [
                     type: "Unknown",
                     setName: ,
                     electionId: ,
-                    error: "primary marked stale due to electionId/setVersion mismatch"
+                    error: "primary marked stale due to discovery of newer primary"
                 },
                 "b:27017": {
                     type: "RSPrimary",

--- a/test/spec/server-discovery-and-monitoring/rs/new_primary_new_setversion.json
+++ b/test/spec/server-discovery-and-monitoring/rs/new_primary_new_setversion.json
@@ -77,7 +77,7 @@
             "type": "Unknown",
             "setName": null,
             "electionId": null,
-            "error": "primary marked stale due to electionId/setVersion mismatch"
+            "error": "primary marked stale due to discovery of newer primary"
           },
           "b:27017": {
             "type": "RSPrimary",

--- a/test/spec/server-discovery-and-monitoring/rs/new_primary_new_setversion.yml
+++ b/test/spec/server-discovery-and-monitoring/rs/new_primary_new_setversion.yml
@@ -64,7 +64,7 @@ phases: [
                     type: "Unknown",
                     setName: ,
                     electionId:,
-                    error: "primary marked stale due to electionId/setVersion mismatch"
+                    error: "primary marked stale due to discovery of newer primary"
                 },
                 "b:27017": {
                     type: "RSPrimary",

--- a/test/spec/server-discovery-and-monitoring/rs/primary_disconnect_electionid.json
+++ b/test/spec/server-discovery-and-monitoring/rs/primary_disconnect_electionid.json
@@ -49,7 +49,7 @@
             "type": "Unknown",
             "setName": null,
             "electionId": null,
-            "error": "primary marked stale due to electionId/setVersion mismatch"
+            "error": "primary marked stale due to discovery of newer primary"
           },
           "b:27017": {
             "type": "RSPrimary",
@@ -125,6 +125,7 @@
           "a:27017": {
             "type": "Unknown",
             "setName": null,
+            "error": "primary marked stale due to electionId/setVersion mismatch",
             "electionId": null
           },
           "b:27017": {

--- a/test/spec/server-discovery-and-monitoring/rs/primary_disconnect_electionid.yml
+++ b/test/spec/server-discovery-and-monitoring/rs/primary_disconnect_electionid.yml
@@ -37,7 +37,7 @@ phases: [
                     type: "Unknown",
                     setName: ,
                     electionId:,
-                    error: "primary marked stale due to electionId/setVersion mismatch"
+                    error: "primary marked stale due to discovery of newer primary"
                 },
                 "b:27017": {
                     type: "RSPrimary",
@@ -100,6 +100,7 @@ phases: [
                 "a:27017": {
                     type: "Unknown",
                     setName: ,
+                    error: "primary marked stale due to electionId/setVersion mismatch",
                     electionId:
                 },
                 "b:27017": {

--- a/test/spec/server-discovery-and-monitoring/rs/primary_disconnect_setversion.json
+++ b/test/spec/server-discovery-and-monitoring/rs/primary_disconnect_setversion.json
@@ -49,7 +49,7 @@
             "type": "Unknown",
             "setName": null,
             "electionId": null,
-            "error": "primary marked stale due to electionId/setVersion mismatch"
+            "error": "primary marked stale due to discovery of newer primary"
           },
           "b:27017": {
             "type": "RSPrimary",
@@ -125,6 +125,7 @@
           "a:27017": {
             "type": "Unknown",
             "setName": null,
+            "error": "primary marked stale due to electionId/setVersion mismatch",
             "electionId": null
           },
           "b:27017": {

--- a/test/spec/server-discovery-and-monitoring/rs/primary_disconnect_setversion.yml
+++ b/test/spec/server-discovery-and-monitoring/rs/primary_disconnect_setversion.yml
@@ -37,7 +37,7 @@ phases: [
                     type: "Unknown",
                     setName: ,
                     electionId:,
-                    error: "primary marked stale due to electionId/setVersion mismatch"
+                    error: "primary marked stale due to discovery of newer primary"
                 },
                 "b:27017": {
                     type: "RSPrimary",
@@ -100,6 +100,7 @@ phases: [
                 "a:27017": {
                     type: "Unknown",
                     setName: ,
+                    error: "primary marked stale due to electionId/setVersion mismatch",
                     electionId:
                 },
                 "b:27017": {

--- a/test/spec/server-discovery-and-monitoring/rs/setversion_greaterthan_max_without_electionid.json
+++ b/test/spec/server-discovery-and-monitoring/rs/setversion_greaterthan_max_without_electionid.json
@@ -66,7 +66,7 @@
             "type": "Unknown",
             "setName": null,
             "electionId": null,
-            "error": "primary marked stale due to electionId/setVersion mismatch"
+            "error": "primary marked stale due to discovery of newer primary"
           },
           "b:27017": {
             "type": "RSPrimary",

--- a/test/spec/server-discovery-and-monitoring/rs/setversion_greaterthan_max_without_electionid.yml
+++ b/test/spec/server-discovery-and-monitoring/rs/setversion_greaterthan_max_without_electionid.yml
@@ -62,7 +62,7 @@ phases: [
                     type: "Unknown",
                     setName: ,
                     electionId:,
-                    error: "primary marked stale due to electionId/setVersion mismatch"
+                    error: "primary marked stale due to discovery of newer primary"
                 },
                 "b:27017": {
                     type: "RSPrimary",

--- a/test/spec/server-discovery-and-monitoring/rs/setversion_without_electionid-pre-6.0.json
+++ b/test/spec/server-discovery-and-monitoring/rs/setversion_without_electionid-pre-6.0.json
@@ -66,7 +66,7 @@
             "type": "Unknown",
             "setName": null,
             "electionId": null,
-            "error": "primary marked stale due to electionId/setVersion mismatch"
+            "error": "primary marked stale due to discovery of newer primary"
           },
           "b:27017": {
             "type": "RSPrimary",

--- a/test/spec/server-discovery-and-monitoring/rs/setversion_without_electionid-pre-6.0.yml
+++ b/test/spec/server-discovery-and-monitoring/rs/setversion_without_electionid-pre-6.0.yml
@@ -62,7 +62,7 @@ phases: [
                     type: "Unknown",
                     setName: ,
                     electionId:,
-                    error: "primary marked stale due to electionId/setVersion mismatch"
+                    error: "primary marked stale due to discovery of newer primary"
                 },
                 "b:27017": {
                     type: "RSPrimary",

--- a/test/spec/server-discovery-and-monitoring/rs/use_setversion_without_electionid-pre-6.0.json
+++ b/test/spec/server-discovery-and-monitoring/rs/use_setversion_without_electionid-pre-6.0.json
@@ -74,7 +74,7 @@
             "type": "Unknown",
             "setName": null,
             "electionId": null,
-            "error": "primary marked stale due to electionId/setVersion mismatch"
+            "error": "primary marked stale due to discovery of newer primary"
           },
           "b:27017": {
             "type": "RSPrimary",

--- a/test/spec/server-discovery-and-monitoring/rs/use_setversion_without_electionid-pre-6.0.yml
+++ b/test/spec/server-discovery-and-monitoring/rs/use_setversion_without_electionid-pre-6.0.yml
@@ -63,7 +63,7 @@ phases: [
                     type: "Unknown",
                     setName: ,
                     electionId:,
-                    error: "primary marked stale due to electionId/setVersion mismatch"
+                    error: "primary marked stale due to discovery of newer primary"
                 },
                 "b:27017": {
                     type: "RSPrimary",

--- a/test/unit/assorted/server_discovery_and_monitoring.test.ts
+++ b/test/unit/assorted/server_discovery_and_monitoring.test.ts
@@ -116,7 +116,7 @@ describe('Server Discovery and Monitoring', function () {
 
       expect(aOutcome.type).to.equal('Unknown');
       expect(aOutcome.error).to.match(
-        /primary marked stale due to electionId\/setVersion mismatch: server setVersion: \d+, server electionId: \d{24}, topology setVersion: \d, topology electionId: \d{24}/
+        /primary marked stale due to electionId\/setVersion mismatch: server setVersion: \d+, server electionId: \d{24}, topology setVersion: \d+, topology electionId: \d{24}/
       );
     });
   });

--- a/test/unit/assorted/server_discovery_and_monitoring.test.ts
+++ b/test/unit/assorted/server_discovery_and_monitoring.test.ts
@@ -1,0 +1,123 @@
+import { expect } from 'chai';
+import { type TopologyDescription } from 'mongodb-legacy';
+import * as sinon from 'sinon';
+
+import {
+  type MongoClient,
+  ObjectId,
+  Server,
+  ServerDescription,
+  Topology,
+  TOPOLOGY_DESCRIPTION_CHANGED,
+  type TopologyDescriptionChangedEvent
+} from '../../mongodb';
+
+const SDAM_EVENTS = [
+  // Topology events
+  TOPOLOGY_DESCRIPTION_CHANGED
+];
+
+describe('Server Discovery and Monitoring', function () {
+  let serverConnect: sinon.SinonStub;
+  let topologySelectServer: sinon.SinonStub;
+  let client: MongoClient;
+  let events: TopologyDescriptionChangedEvent[] = [];
+
+  function getNewDescription() {
+    const [topologyDescriptionChanged] = events.filter(
+      x => x.name === 'topologyDescriptionChanged'
+    );
+    events = [];
+    return topologyDescriptionChanged.newDescription;
+  }
+
+  before(async function () {
+    serverConnect = sinon.stub(Server.prototype, 'connect').callsFake(function () {
+      this.s.state = 'connected';
+      this.emit('connect');
+    });
+    topologySelectServer = sinon
+      .stub(Topology.prototype, 'selectServer')
+      .callsFake(async function (_selector, _options) {
+        topologySelectServer.restore();
+
+        const fakeServer = { s: { state: 'connected' }, removeListener: () => true };
+        return fakeServer;
+      });
+    const events = [];
+    client.on('topologyDescriptionChanged', event => events.push(event));
+    await client.connect();
+  });
+
+  after(function () {
+    serverConnect.restore();
+  });
+
+  describe('when a newer primary is detected', function () {
+    it('steps down original primary to unknown server description with appropriate error message', async function () {
+      let newDescription: TopologyDescription;
+      // Start with a as primary
+      client.topology.serverUpdateHandler(
+        new ServerDescription('a:27017', {
+          ok: 1,
+          helloOk: true,
+          isWritablePrimary: true,
+          hosts: ['a:27017', 'b:27017'],
+          setName: 'rs',
+          setVersion: 1,
+          electionId: ObjectId.createFromHexString('000000000000000000000001'),
+          minWireVersion: 0,
+          maxWireVersion: 21
+        })
+      );
+
+      newDescription = getNewDescription();
+
+      expect(newDescription.type).to.equal('ReplicaSetWithPrimary');
+
+      // b is elected as primary, a gets marked stale
+      client.topology.serverUpdateHandler(
+        new ServerDescription('b:27017', {
+          ok: 1,
+          helloOk: true,
+          isWritablePrimary: true,
+          hosts: ['a:27017', 'b:27017'],
+          setName: 'rs',
+          setVersion: 2,
+          electionId: ObjectId.createFromHexString('000000000000000000000001'),
+          minWireVersion: 0,
+          maxWireVersion: 21
+        })
+      );
+
+      newDescription = getNewDescription();
+
+      let aOutcome = newDescription.servers.get('a:27017');
+      expect(aOutcome.error).to.match(/primary marked stale due to discovery of newer primary/);
+
+      // a still incorrectly reports as primary
+      client.topology.serverUpdateHandler(
+        new ServerDescription('a:27017', {
+          ok: 1,
+          helloOk: true,
+          isWritablePrimary: true,
+          hosts: ['a:27017', 'b:27017'],
+          setName: 'rs',
+          setVersion: 1,
+          electionId: ObjectId.createFromHexString('000000000000000000000001'),
+          minWireVersion: 0,
+          maxWireVersion: 21
+        })
+      );
+
+      newDescription = getNewDescription();
+
+      aOutcome = newDescription.servers.get('a:27017');
+
+      expect(aOutcome.type).to.equal('Unknown');
+      expect(aOutcome.error).to.match(
+        /primary marked stale due to electionId\/setVersion mismatch: server setVersion: \d+, server electionId: \d{24}, topology setVersion: \d, topology electionId: \d{24}/
+      );
+    });
+  });
+});


### PR DESCRIPTION
### Description

#### What is changing?

Update error messages added to `ServerDescription` objects to more accurately reflect Topology state when Primaries step down.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-6613, DRIVERS-2972
<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [X] Ran `npm run check:lint` script
- [X] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [X] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [X] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
