### PR TITLE
chore(NODE-6721): migrate singlebench tests

### DIFF
--- a/test/benchmarks/driver_bench/src/driver.mts
+++ b/test/benchmarks/driver_bench/src/driver.mts
@@ -146,16 +146,8 @@ export class DriverTester {
     this.client = new MongoClient(MONGODB_URI, MONGODB_CLIENT_OPTIONS);
   }
 
-  public get db() {
-    return this.client.db(DB_NAME);
-  }
-
-  public get collection() {
-    return this.client.db(DB_NAME).collection(COLLECTION_NAME);
-  }
-
-  public get bucket(): mongodb.GridFSBucket {
-    return new GridFSBucket(this.db);
+  bucket(db: mongodb.Db) {
+    return new GridFSBucket(db);
   }
 
   async drop() {

--- a/test/benchmarks/driver_bench/src/driver.mts
+++ b/test/benchmarks/driver_bench/src/driver.mts
@@ -138,6 +138,9 @@ export function metrics(test_name: string, result: number, count: number) {
  * For use in setup/teardown mostly.
  */
 export class DriverTester {
+  readonly DB_NAME = DB_NAME;
+  readonly COLLECTION_NAME = COLLECTION_NAME;
+
   public client: mongodb.MongoClient;
   constructor() {
     this.client = new MongoClient(MONGODB_URI, MONGODB_CLIENT_OPTIONS);

--- a/test/benchmarks/driver_bench/src/runner.mts
+++ b/test/benchmarks/driver_bench/src/runner.mts
@@ -95,6 +95,7 @@ console.log(
   ...['total time:', totalDuration, 'sec,'],
   ...['ran:', count, 'times,'],
   ...['median time per run:', medianExecution, 'sec,'],
+  ...['taskSize:', benchmark.taskSize, 'mb,'],
   ...['throughput:', megabytesPerSecond, 'mb/sec']
 );
 

--- a/test/benchmarks/driver_bench/src/suites/multi_bench/aggregate_a_million_documents_and_to_array.mts
+++ b/test/benchmarks/driver_bench/src/suites/multi_bench/aggregate_a_million_documents_and_to_array.mts
@@ -8,7 +8,7 @@ export async function before() {
   await driver.drop();
   await driver.create();
 
-  db = driver.db;
+  db = driver.client.db(driver.DB_NAME);
 }
 
 export async function run() {

--- a/test/benchmarks/driver_bench/src/suites/multi_bench/aggregate_a_million_tweets_and_to_array.mts
+++ b/test/benchmarks/driver_bench/src/suites/multi_bench/aggregate_a_million_tweets_and_to_array.mts
@@ -11,7 +11,7 @@ export async function before() {
 
   tweet = await driver.load('single_and_multi_document/tweet.json', 'json');
 
-  db = driver.db;
+  db = driver.client.db(driver.DB_NAME);
 }
 
 export async function run() {

--- a/test/benchmarks/driver_bench/src/suites/multi_bench/find_many_and_empty_cursor.mts
+++ b/test/benchmarks/driver_bench/src/suites/multi_bench/find_many_and_empty_cursor.mts
@@ -12,7 +12,7 @@ export async function before() {
   const tweet = await driver.load('single_and_multi_document/tweet.json', 'json');
   await driver.insertManyOf(tweet, 10000);
 
-  collection = driver.collection;
+  collection = driver.client.db(driver.DB_NAME).collection(driver.COLLECTION_NAME);
 }
 
 export async function run() {

--- a/test/benchmarks/driver_bench/src/suites/multi_bench/find_many_and_to_array.mts
+++ b/test/benchmarks/driver_bench/src/suites/multi_bench/find_many_and_to_array.mts
@@ -11,7 +11,7 @@ export async function before() {
   const tweet = await driver.load('single_and_multi_document/tweet.json', 'json');
   await driver.insertManyOf(tweet, 10000);
 
-  collection = driver.collection;
+  collection = driver.client.db(driver.DB_NAME).collection(driver.COLLECTION_NAME);
 }
 
 export async function run() {

--- a/test/benchmarks/driver_bench/src/suites/multi_bench/grid_fs_download.mts
+++ b/test/benchmarks/driver_bench/src/suites/multi_bench/grid_fs_download.mts
@@ -16,7 +16,7 @@ export async function before() {
   await driver.drop();
   await driver.create();
 
-  bucket = driver.bucket;
+  bucket = driver.bucket(driver.client.db(driver.DB_NAME));
 
   await bucket.drop().catch(() => null);
 

--- a/test/benchmarks/driver_bench/src/suites/multi_bench/grid_fs_upload.mts
+++ b/test/benchmarks/driver_bench/src/suites/multi_bench/grid_fs_upload.mts
@@ -15,7 +15,7 @@ export async function before() {
   await driver.drop();
   await driver.create();
 
-  bucket = driver.bucket;
+  bucket = driver.bucket(driver.client.db(driver.DB_NAME));
 
   await bucket.drop().catch(() => null);
 }

--- a/test/benchmarks/driver_bench/src/suites/multi_bench/large_doc_bulk_insert.mts
+++ b/test/benchmarks/driver_bench/src/suites/multi_bench/large_doc_bulk_insert.mts
@@ -17,7 +17,7 @@ export async function beforeEach() {
   // Make new "documents" so the _id field is not carried over from the last run
   documents = Array.from({ length: 10 }, () => ({ ...largeDoc })) as any[];
 
-  collection = driver.collection;
+  collection = driver.client.db(driver.DB_NAME).collection(driver.COLLECTION_NAME);
 }
 
 export async function run() {

--- a/test/benchmarks/driver_bench/src/suites/multi_bench/small_doc_bulk_insert.mts
+++ b/test/benchmarks/driver_bench/src/suites/multi_bench/small_doc_bulk_insert.mts
@@ -17,7 +17,7 @@ export async function beforeEach() {
   // Make new "documents" so the _id field is not carried over from the last run
   documents = Array.from({ length: 10000 }, () => ({ ...smallDoc })) as any[];
 
-  collection = driver.collection;
+  collection = driver.client.db(driver.DB_NAME).collection(driver.COLLECTION_NAME);
 }
 
 export async function run() {

--- a/test/benchmarks/driver_bench/src/suites/single_bench/find_one.mts
+++ b/test/benchmarks/driver_bench/src/suites/single_bench/find_one.mts
@@ -1,0 +1,26 @@
+import { driver, type mongodb } from '../../driver.mjs';
+
+export const taskSize = 16.22;
+
+let collection: mongodb.Collection<{ _id: number }>;
+
+export async function before() {
+  await driver.drop();
+  await driver.create();
+
+  const tweet = await driver.load('single_and_multi_document/tweet.json', 'json');
+  await driver.insertManyOf(tweet, 10000, true);
+
+  collection = driver.client.db(driver.DB_NAME).collection(driver.COLLECTION_NAME);
+}
+
+export async function run() {
+  for (let _id = 0; _id < 10000; ++_id) {
+    await collection.findOne({ _id });
+  }
+}
+
+export async function after() {
+  await driver.drop();
+  await driver.close();
+}

--- a/test/benchmarks/driver_bench/src/suites/single_bench/large_doc_insert_one.mts
+++ b/test/benchmarks/driver_bench/src/suites/single_bench/large_doc_insert_one.mts
@@ -1,0 +1,32 @@
+import { driver, type mongodb } from '../../driver.mjs';
+
+export const taskSize = 27.31;
+
+let collection: mongodb.Collection;
+let documents: Record<string, any>[];
+let largeDoc: Record<string, any>;
+
+export async function before() {
+  largeDoc = await driver.load('single_and_multi_document/large_doc.json', 'json');
+}
+
+export async function beforeEach() {
+  await driver.drop();
+  await driver.create();
+
+  // Make new "documents" so the _id field is not carried over from the last run
+  documents = Array.from({ length: 10 }, () => ({ ...largeDoc }));
+
+  collection = driver.collection;
+}
+
+export async function run() {
+  for (const doc of documents) {
+    await collection.insertOne(doc);
+  }
+}
+
+export async function after() {
+  await driver.drop();
+  await driver.close();
+}

--- a/test/benchmarks/driver_bench/src/suites/single_bench/large_doc_insert_one.mts
+++ b/test/benchmarks/driver_bench/src/suites/single_bench/large_doc_insert_one.mts
@@ -17,7 +17,7 @@ export async function beforeEach() {
   // Make new "documents" so the _id field is not carried over from the last run
   documents = Array.from({ length: 10 }, () => ({ ...largeDoc }));
 
-  collection = driver.collection;
+  collection = driver.client.db(driver.DB_NAME).collection(driver.COLLECTION_NAME);
 }
 
 export async function run() {

--- a/test/benchmarks/driver_bench/src/suites/single_bench/ping.mts
+++ b/test/benchmarks/driver_bench/src/suites/single_bench/ping.mts
@@ -1,0 +1,24 @@
+import { driver, type mongodb } from '../../driver.mjs';
+
+// { ping: 1 } is 15 bytes of BSON x 10,000 iterations
+export const taskSize = 0.15;
+
+let db: mongodb.Db;
+
+export async function before() {
+  await driver.drop();
+  await driver.create();
+
+  db = driver.db;
+}
+
+export async function run() {
+  for (let i = 0; i < 10000; ++i) {
+    await db.command({ ping: 1 });
+  }
+}
+
+export async function after() {
+  await driver.drop();
+  await driver.close();
+}

--- a/test/benchmarks/driver_bench/src/suites/single_bench/ping.mts
+++ b/test/benchmarks/driver_bench/src/suites/single_bench/ping.mts
@@ -9,7 +9,7 @@ export async function before() {
   await driver.drop();
   await driver.create();
 
-  db = driver.db;
+  db = driver.client.db(driver.DB_NAME);
 }
 
 export async function run() {

--- a/test/benchmarks/driver_bench/src/suites/single_bench/run_command.mts
+++ b/test/benchmarks/driver_bench/src/suites/single_bench/run_command.mts
@@ -9,7 +9,7 @@ export async function before() {
   await driver.drop();
   await driver.create();
 
-  db = driver.db;
+  db = driver.client.db(driver.DB_NAME);
 }
 
 export async function run() {

--- a/test/benchmarks/driver_bench/src/suites/single_bench/run_command.mts
+++ b/test/benchmarks/driver_bench/src/suites/single_bench/run_command.mts
@@ -1,0 +1,24 @@
+import { driver, type mongodb } from '../../driver.mjs';
+
+// { hello: true } is 13 bytes of BSON x 10,000 iterations
+export const taskSize = 0.13;
+
+let db: mongodb.Db;
+
+export async function before() {
+  await driver.drop();
+  await driver.create();
+
+  db = driver.db;
+}
+
+export async function run() {
+  for (let i = 0; i < 10000; ++i) {
+    await db.command({ hello: true });
+  }
+}
+
+export async function after() {
+  await driver.drop();
+  await driver.close();
+}

--- a/test/benchmarks/driver_bench/src/suites/single_bench/small_doc_insert_one.mts
+++ b/test/benchmarks/driver_bench/src/suites/single_bench/small_doc_insert_one.mts
@@ -1,0 +1,32 @@
+import { driver, type mongodb } from '../../driver.mjs';
+
+export const taskSize = 2.75;
+
+let collection: mongodb.Collection;
+let documents: Record<string, any>[];
+let smallDoc: Record<string, any>;
+
+export async function before() {
+  smallDoc = await driver.load('single_and_multi_document/small_doc.json', 'json');
+}
+
+export async function beforeEach() {
+  await driver.drop();
+  await driver.create();
+
+  // Make new "documents" so the _id field is not carried over from the last run
+  documents = Array.from({ length: 10000 }, () => ({ ...smallDoc }));
+
+  collection = driver.collection;
+}
+
+export async function run() {
+  for (const doc of documents) {
+    await collection.insertOne(doc);
+  }
+}
+
+export async function after() {
+  await driver.drop();
+  await driver.close();
+}

--- a/test/benchmarks/driver_bench/src/suites/single_bench/small_doc_insert_one.mts
+++ b/test/benchmarks/driver_bench/src/suites/single_bench/small_doc_insert_one.mts
@@ -17,7 +17,7 @@ export async function beforeEach() {
   // Make new "documents" so the _id field is not carried over from the last run
   documents = Array.from({ length: 10000 }, () => ({ ...smallDoc }));
 
-  collection = driver.collection;
+  collection = driver.client.db(driver.DB_NAME).collection(driver.COLLECTION_NAME);
 }
 
 export async function run() {


### PR DESCRIPTION
### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

Migrate the single bench to the new format

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
