### PR TITLE
chore(NODE-6724): report composite benchmark scores

### DIFF
--- a/test/benchmarks/driver_bench/src/driver.mts
+++ b/test/benchmarks/driver_bench/src/driver.mts
@@ -112,7 +112,20 @@ const COLLECTION_NAME = 'corpus';
 
 const SPEC_DIRECTORY = path.resolve(__dirname, '..', '..', 'driverBench', 'spec');
 
-export function metrics(test_name: string, result: number, count: number) {
+export type Metric = {
+  name: 'megabytes_per_second';
+  value: number;
+};
+
+export type MetricInfo = {
+  info: {
+    test_name: string;
+    args: Record<string, number>;
+  };
+  metrics: Metric[];
+};
+
+export function metrics(test_name: string, result: number): MetricInfo {
   return {
     info: {
       test_name,
@@ -125,11 +138,7 @@ export function metrics(test_name: string, result: number, count: number) {
         ])
       )
     },
-    metrics: [
-      { name: 'megabytes_per_second', value: result },
-      // Reporting the count so we can verify programmatically or in UI how many iterations we reached
-      { name: 'count', value: count }
-    ]
+    metrics: [{ name: 'megabytes_per_second', value: result }]
   } as const;
 }
 

--- a/test/benchmarks/driver_bench/src/runner.mts
+++ b/test/benchmarks/driver_bench/src/runner.mts
@@ -101,6 +101,6 @@ console.log(
 
 await fs.writeFile(
   `results_${path.basename(benchmarkFile, '.mjs')}.json`,
-  JSON.stringify(metrics(benchmarkName, megabytesPerSecond, count), undefined, 2) + '\n',
+  JSON.stringify(metrics(benchmarkName, megabytesPerSecond), undefined, 2) + '\n',
   'utf8'
 );

--- a/test/benchmarks/driver_bench/src/suites/single_bench/primes.mts
+++ b/test/benchmarks/driver_bench/src/suites/single_bench/primes.mts
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+
+const findPrimesBelow = 1_000_000;
+const expectedPrimes = 78_498;
+
+// byteLength of
+// BSON.serialize({ primes: Buffer.from(new Int32Array(sieveOfEratosthenes(findPrimesBelow)).buffer) }).byteLength)
+// a bin data of int32s
+const byteLength = 314_010;
+
+export const taskSize = 3.1401000000000003; // ~3MB worth of work
+
+assert.equal(taskSize, byteLength * 10e-6); // taskSize should stay hardcoded, checking here the math is done right.
+
+/** @see https://en.wikipedia.org/wiki/Sieve_of_Eratosthenes */
+export function sieveOfEratosthenes(n: number) {
+  // Create a boolean array "prime[0..n]" and initialize
+  // all entries as true. A value in prime[i] will
+  // become false if i is Not a prime
+  const prime = Array.from({ length: n + 1 }, () => true);
+
+  // We know 0 and 1 are not prime
+  prime[0] = false;
+  prime[1] = false;
+
+  for (let p = 2; p * p <= n; p++) {
+    // If prime[p] is not changed, then it is a prime
+    if (prime[p] === true) {
+      // Update all multiples of p as false
+      for (let i = p * p; i <= n; i += p) {
+        prime[i] = false;
+      }
+    }
+  }
+
+  // Collecting all prime numbers
+  const primes = [];
+  for (let i = 2; i <= n; i++) {
+    if (prime[i] === true) {
+      primes.push(i);
+    }
+  }
+
+  return primes;
+}
+
+export async function run() {
+  assert.equal(sieveOfEratosthenes(findPrimesBelow).length, expectedPrimes);
+}


### PR DESCRIPTION
### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

We need to keep reporting the composite scores. Remove reporting count

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
