### PR TITLE
ci: rename secrets manager ARN

### DIFF
--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -132,7 +132,7 @@ functions:
   "run tests":
     - command: ec2.assume_role
       params:
-        role_arn: ${OIDC_AWS_ROLE_ARN}
+        role_arn: ${DRIVERS_SECRETS_ARN}
     - command: subprocess.exec
       type: test
       params:
@@ -151,7 +151,7 @@ functions:
         exec_timeout_secs: 1800
     - command: ec2.assume_role
       params:
-        role_arn: ${OIDC_AWS_ROLE_ARN}
+        role_arn: ${DRIVERS_SECRETS_ARN}
     - command: subprocess.exec
       type: test
       params:
@@ -394,7 +394,7 @@ functions:
   "run socks5 tests":
     - command: ec2.assume_role
       params:
-        role_arn: ${OIDC_AWS_ROLE_ARN}
+        role_arn: ${DRIVERS_SECRETS_ARN}
     - command: subprocess.exec
       type: test
       params:
@@ -459,7 +459,7 @@ functions:
   "assume secrets manager rule":
     - command: ec2.assume_role
       params:
-        role_arn: ${OIDC_AWS_ROLE_ARN}
+        role_arn: ${DRIVERS_SECRETS_ARN}
 
   "run aws auth test with regular aws credentials":
     - command: subprocess.exec
@@ -1089,7 +1089,7 @@ task_groups:
       - func: fetch source
       - command: ec2.assume_role
         params:
-          role_arn: ${OIDC_AWS_ROLE_ARN}
+          role_arn: ${DRIVERS_SECRETS_ARN}
       - command: subprocess.exec
         params:
           binary: bash
@@ -1111,7 +1111,7 @@ task_groups:
       - func: fetch source
       - command: ec2.assume_role
         params:
-          role_arn: ${OIDC_AWS_ROLE_ARN}
+          role_arn: ${DRIVERS_SECRETS_ARN}
       - command: subprocess.exec
         params:
           binary: bash
@@ -1133,7 +1133,7 @@ task_groups:
       - func: fetch source
       - command: ec2.assume_role
         params:
-          role_arn: ${OIDC_AWS_ROLE_ARN}
+          role_arn: ${DRIVERS_SECRETS_ARN}
       - command: subprocess.exec
         params:
           binary: bash
@@ -1155,7 +1155,7 @@ task_groups:
       - func: fetch source
       - command: ec2.assume_role
         params:
-          role_arn: ${OIDC_AWS_ROLE_ARN}
+          role_arn: ${DRIVERS_SECRETS_ARN}
       - command: subprocess.exec
         params:
           binary: bash

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -104,7 +104,7 @@ functions:
   run tests:
     - command: ec2.assume_role
       params:
-        role_arn: ${OIDC_AWS_ROLE_ARN}
+        role_arn: ${DRIVERS_SECRETS_ARN}
     - command: subprocess.exec
       type: test
       params:
@@ -122,7 +122,7 @@ functions:
         exec_timeout_secs: 1800
     - command: ec2.assume_role
       params:
-        role_arn: ${OIDC_AWS_ROLE_ARN}
+        role_arn: ${DRIVERS_SECRETS_ARN}
     - command: subprocess.exec
       type: test
       params:
@@ -344,7 +344,7 @@ functions:
   run socks5 tests:
     - command: ec2.assume_role
       params:
-        role_arn: ${OIDC_AWS_ROLE_ARN}
+        role_arn: ${DRIVERS_SECRETS_ARN}
     - command: subprocess.exec
       type: test
       params:
@@ -404,7 +404,7 @@ functions:
   assume secrets manager rule:
     - command: ec2.assume_role
       params:
-        role_arn: ${OIDC_AWS_ROLE_ARN}
+        role_arn: ${DRIVERS_SECRETS_ARN}
   run aws auth test with regular aws credentials:
     - command: subprocess.exec
       type: test
@@ -4010,7 +4010,7 @@ task_groups:
       - func: fetch source
       - command: ec2.assume_role
         params:
-          role_arn: ${OIDC_AWS_ROLE_ARN}
+          role_arn: ${DRIVERS_SECRETS_ARN}
       - command: subprocess.exec
         params:
           binary: bash
@@ -4031,7 +4031,7 @@ task_groups:
       - func: fetch source
       - command: ec2.assume_role
         params:
-          role_arn: ${OIDC_AWS_ROLE_ARN}
+          role_arn: ${DRIVERS_SECRETS_ARN}
       - command: subprocess.exec
         params:
           binary: bash
@@ -4052,7 +4052,7 @@ task_groups:
       - func: fetch source
       - command: ec2.assume_role
         params:
-          role_arn: ${OIDC_AWS_ROLE_ARN}
+          role_arn: ${DRIVERS_SECRETS_ARN}
       - command: subprocess.exec
         params:
           binary: bash
@@ -4073,7 +4073,7 @@ task_groups:
       - func: fetch source
       - command: ec2.assume_role
         params:
-          role_arn: ${OIDC_AWS_ROLE_ARN}
+          role_arn: ${DRIVERS_SECRETS_ARN}
       - command: subprocess.exec
         params:
           binary: bash


### PR DESCRIPTION
### Description

#### What is changing?

Renaming the ARN we use for secrets manager so the name more accurately describes what the secret is.  We use the same ARN for all secrets, not just OIDC.

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
