### PR TITLE
fix(NODE-6743)!: add back missing opt deps `aws4`

### DIFF
--- a/.evergreen/run-mongodb-aws-ecs-test.sh
+++ b/.evergreen/run-mongodb-aws-ecs-test.sh
@@ -13,6 +13,3 @@ source ./.evergreen/prepare-shell.sh # should not run git clone
 
 # load node.js
 source $DRIVERS_TOOLS/.evergreen/init-node-and-npm-env.sh
-
-# run the tests
-npm install aws4

--- a/.evergreen/setup-mongodb-aws-auth-tests.sh
+++ b/.evergreen/setup-mongodb-aws-auth-tests.sh
@@ -23,8 +23,6 @@ cd $DRIVERS_TOOLS/.evergreen/auth_aws
 
 cd $BEFORE
 
-npm install --no-save aws4
-
 if [ $MONGODB_AWS_SDK = 'false' ]; then rm -rf ./node_modules/@aws-sdk/credential-providers; fi
 
 # revert to show test output

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@microsoft/api-extractor": "^7.49.2",
         "@microsoft/tsdoc-config": "^0.17.1",
         "@mongodb-js/zstd": "^2.0.0",
+        "@types/aws4": "^1.11.6",
         "@types/chai": "^4.3.17",
         "@types/chai-subset": "^1.3.5",
         "@types/express": "^4.17.21",
@@ -33,6 +34,7 @@
         "@types/whatwg-url": "^11.0.5",
         "@typescript-eslint/eslint-plugin": "8.4.0",
         "@typescript-eslint/parser": "8.4.0",
+        "aws4": "^1.13.2",
         "chai": "^4.4.1",
         "chai-subset": "^1.6.0",
         "chalk": "^4.1.2",
@@ -71,6 +73,7 @@
       "peerDependencies": {
         "@aws-sdk/credential-providers": "^3.632.0",
         "@mongodb-js/zstd": "^1.1.0 || ^2.0.0",
+        "aws4": "^1.13.2",
         "gcp-metadata": "^5.2.0",
         "kerberos": "^2.0.1",
         "mongodb-client-encryption": ">=6.0.0 <7",
@@ -82,6 +85,9 @@
           "optional": true
         },
         "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "aws4": {
           "optional": true
         },
         "gcp-metadata": {
@@ -2846,6 +2852,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/aws4": {
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/@types/aws4/-/aws4-1.11.6.tgz",
+      "integrity": "sha512-5CnVUkHNyLGpD9AnOcK66YyP0qvIh6nhJJoeK8zSl5YKikUcUbdB7SlHevUYVqicgeh6j5AJa1qa/h08dSZHoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.5",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
@@ -3541,6 +3557,13 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/aws4": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
+      "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "peerDependencies": {
     "@aws-sdk/credential-providers": "^3.632.0",
     "@mongodb-js/zstd": "^1.1.0 || ^2.0.0",
+    "aws4": "^1.13.2",
     "gcp-metadata": "^5.2.0",
     "kerberos": "^2.0.1",
     "mongodb-client-encryption": ">=6.0.0 <7",
@@ -43,6 +44,9 @@
       "optional": true
     },
     "@mongodb-js/zstd": {
+      "optional": true
+    },
+    "aws4": {
       "optional": true
     },
     "kerberos": {
@@ -68,6 +72,7 @@
     "@microsoft/api-extractor": "^7.49.2",
     "@microsoft/tsdoc-config": "^0.17.1",
     "@mongodb-js/zstd": "^2.0.0",
+    "@types/aws4": "^1.11.6",
     "@types/chai": "^4.3.17",
     "@types/chai-subset": "^1.3.5",
     "@types/express": "^4.17.21",
@@ -81,6 +86,7 @@
     "@types/whatwg-url": "^11.0.5",
     "@typescript-eslint/eslint-plugin": "8.4.0",
     "@typescript-eslint/parser": "8.4.0",
+    "aws4": "^1.13.2",
     "chai": "^4.4.1",
     "chai-subset": "^1.6.0",
     "chalk": "^4.1.2",

--- a/src/cmap/auth/mongodb_aws.ts
+++ b/src/cmap/auth/mongodb_aws.ts
@@ -138,8 +138,8 @@ export class MongoDBAWS extends AuthProvider {
     );
 
     const payload: AWSSaslContinuePayload = {
-      a: options.headers.Authorization,
-      d: options.headers['X-Amz-Date']
+      a: `${options.headers?.Authorization ?? ''}`,
+      d: `${options.headers?.['X-Amz-Date'] ?? ''}`
     };
 
     if (sessionToken) {

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -244,10 +244,10 @@ interface AWS4 {
   };
 }
 
-export const aws4: AWS4 | { kModuleError: MongoMissingDependencyError } = loadAws4();
+export const aws4 = loadAws4();
 
 function loadAws4() {
-  let aws4: AWS4 | { kModuleError: MongoMissingDependencyError };
+  let aws4: typeof import('aws4') | { kModuleError: MongoMissingDependencyError };
   try {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     aws4 = require('aws4');


### PR DESCRIPTION
### Description

https://jira.mongodb.org/browse/NODE-6743

#### What is changing?

the original PR is https://github.com/mongodb/node-mongodb-native/pull/2606, but seems like opt dep `aws4` is getting lost since `v3`. starting from `v4`, there is no stricted opt dep under `package.json`. this PR is to add it back.

this issue affects all `mongodb` versions after v4, which might need to be patched to: `v6.13.0`, `v5.9.2`, `v4.17.2`

##### Is there new documentation needed for these changes?

n/a

#### What is the motivation for this change?

make developers life easier, since people might don't know what's happening until they see the error message on production env when using mongo aws.

```
[Error] Optional module `aws4` not found. Please install it to enable AWS authentication
```

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
