### PR TITLE
ci: skip serverless tests

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -4832,14 +4832,6 @@ buildvariants:
       - run-custom-csfle-tests-rapid
       - run-custom-csfle-tests-latest
       - test-latest-driver-mongodb-client-encryption-6.0.0
-  - name: rhel8-test-serverless
-    display_name: Serverless Test
-    run_on: rhel80-large
-    expansions:
-      NODE_LTS_VERSION: 16
-      NPM_VERSION: 9
-    tasks:
-      - serverless_task_group
   - name: rhel8-test-gcp-kms
     display_name: GCP KMS Test
     run_on: debian11-small

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -780,17 +780,18 @@ BUILD_VARIANTS.push({
   tasks: customDependencyTests.map(({ name }) => name)
 });
 
+// TODO(NODE-6748): unskip serverless tests when getParameter and failPoints are possible
 // special case for serverless testing
-BUILD_VARIANTS.push({
-  name: 'rhel8-test-serverless',
-  display_name: 'Serverless Test',
-  run_on: DEFAULT_OS,
-  expansions: {
-    NODE_LTS_VERSION: LOWEST_LTS,
-    NPM_VERSION: 9
-  },
-  tasks: ['serverless_task_group']
-});
+// BUILD_VARIANTS.push({
+//   name: 'rhel8-test-serverless',
+//   display_name: 'Serverless Test',
+//   run_on: DEFAULT_OS,
+//   expansions: {
+//     NODE_LTS_VERSION: LOWEST_LTS,
+//     NPM_VERSION: 9
+//   },
+//   tasks: ['serverless_task_group']
+// });
 
 BUILD_VARIANTS.push({
   name: 'rhel8-test-gcp-kms',


### PR DESCRIPTION
### Description

#### What is changing?

Skip serverless tests

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

Blocked on getParameter and fail points not working.

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
