### PR TITLE
test(NODE-6751): skip flaky scram test

### DIFF
--- a/test/integration/auth/auth.prose.test.ts
+++ b/test/integration/auth/auth.prose.test.ts
@@ -376,7 +376,8 @@ describe('Authentication Spec Prose Tests', function () {
           expect(stats).to.exist;
         });
 
-        it(
+        // TODO(NODE-6752): Fix flaky test
+        it.skip(
           'logs in with non-normalized username and normalized password',
           metadata,
           async function () {

--- a/test/integration/auth/auth.prose.test.ts
+++ b/test/integration/auth/auth.prose.test.ts
@@ -376,7 +376,7 @@ describe('Authentication Spec Prose Tests', function () {
           expect(stats).to.exist;
         });
 
-        // TODO(NODE-6752): Fix flaky test
+        // TODO(NODE-6752): Fix flaky SCRAM-SHA-256 test
         it.skip(
           'logs in with non-normalized username and normalized password',
           metadata,
@@ -391,7 +391,7 @@ describe('Authentication Spec Prose Tests', function () {
             const stats = await client.db('admin').stats();
             expect(stats).to.exist;
           }
-        );
+        ).skipReason = 'TODO(NODE-6752): Fix flaky SCRAM-SHA-256 test';
 
         it(
           'logs in with normalized username and non-normalized password',


### PR DESCRIPTION
### Description

Skips the failing SCRAM test.

#### What is changing?

Skips the failing test with TODO.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-6751

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
