### PR TITLE
chore: skip azure oidc login setup failure

### DIFF
--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -971,7 +971,7 @@ tasks:
           working_dir: src
           binary: bash
           add_expansions_to_env: true
-          env: 
+          env:
             LAMBDA_STACK_NAME: dbx-node-lambda
             TEST_LAMBDA_DIRECTORY: ${PROJECT_DIRECTORY}/test/lambda
             AWS_REGION: us-east-1

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -4854,7 +4854,6 @@ buildvariants:
     batchtime: 20160
     tasks:
       - testtestoidc_task_group
-      - testazureoidc_task_group
       - testgcpoidc_task_group
       - testk8soidc_task_group_eks
       - testk8soidc_task_group_gke

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -818,7 +818,7 @@ BUILD_VARIANTS.push({
   batchtime: 20160,
   tasks: [
     'testtestoidc_task_group',
-    'testazureoidc_task_group',
+    // 'testazureoidc_task_group', TODO(NODE-6750): Unskip failed azure failed login
     'testgcpoidc_task_group',
     'testk8soidc_task_group_eks',
     'testk8soidc_task_group_gke',


### PR DESCRIPTION
### Description

#### What is changing?

Skip a test that fails to setup currently

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

https://jira.mongodb.org/browse/NODE-6750

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
