### PR TITLE
chore: add tag to performance variant

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -3200,7 +3200,7 @@ tasks:
       - func: download and merge coverage
     depends_on:
       - name: '*'
-        variant: '*'
+        variant: '* !performance-tests'
         status: '*'
         patch_optional: true
   - name: run-custom-csfle-tests-5.0
@@ -4825,6 +4825,8 @@ buildvariants:
       - run-spec-benchmark-tests-node-server-timeoutMS-0
       - run-spec-benchmark-tests-node-server-monitorCommands-true
       - run-spec-benchmark-tests-node-server-logging
+    tags:
+      - performance
   - name: rhel8-custom-dependency-tests
     display_name: Custom Dependency Version Test
     run_on: rhel80-large

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -718,7 +718,14 @@ const coverageTask = {
       func: 'download and merge coverage'
     }
   ],
-  depends_on: [{ name: '*', variant: '*', status: '*', patch_optional: true }]
+  depends_on: [
+    {
+      name: '*',
+      variant: '* !performance-tests',
+      status: '*',
+      patch_optional: true
+    }
+  ]
 };
 
 SINGLETON_TASKS.push(coverageTask);
@@ -768,7 +775,8 @@ function addPerformanceTasks() {
     name: 'performance-tests',
     display_name: 'Performance Test',
     run_on: 'rhel90-dbx-perf-large',
-    tasks: tasks.map(({ name }) => name)
+    tasks: tasks.map(({ name }) => name),
+    tags: ['performance']
   });
 }
 addPerformanceTasks();
@@ -872,15 +880,17 @@ for (const variant of BUILD_VARIANTS.filter(
 }
 
 const fileData = yaml.load(fs.readFileSync(`${__dirname}/config.in.yml`, 'utf8'));
-fileData.tasks = (fileData.tasks || [])
-  .concat(BASE_TASKS)
-  .concat(TASKS)
-  .concat(SINGLETON_TASKS)
-  .concat(AUTH_DISABLED_TASKS)
-  .concat(AWS_LAMBDA_HANDLER_TASKS)
-  .concat(MONGOCRYPTD_CSFLE_TASKS);
+fileData.tasks = [
+  ...(fileData.tasks ?? []),
+  ...BASE_TASKS,
+  ...TASKS,
+  ...SINGLETON_TASKS,
+  ...AUTH_DISABLED_TASKS,
+  ...AWS_LAMBDA_HANDLER_TASKS,
+  ...MONGOCRYPTD_CSFLE_TASKS
+];
 
-fileData.buildvariants = (fileData.buildvariants || []).concat(BUILD_VARIANTS);
+fileData.buildvariants = [...(fileData.buildvariants ?? []), ...BUILD_VARIANTS];
 
 fs.writeFileSync(
   `${__dirname}/config.yml`,


### PR DESCRIPTION
### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

Adds a tag to the perf variant so we can filter it out of PRs (and coverage)

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
