### PR TITLE
ci(NODE-6749): make Atlas cluster prefix < 23 characters long

### DIFF
--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -1239,7 +1239,7 @@ task_groups:
           binary: bash
           env:
             MONGODB_VERSION: "7.0"
-            CLUSTER_PREFIX: dbx-node-search-indexes
+            CLUSTER_PREFIX: dbx-node-search
           args:
             - ${DRIVERS_TOOLS}/.evergreen/atlas/setup-atlas-cluster.sh
       - command: expansions.update

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -3160,7 +3160,7 @@ task_groups:
           binary: bash
           env:
             MONGODB_VERSION: '7.0'
-            CLUSTER_PREFIX: dbx-node-search-indexes
+            CLUSTER_PREFIX: dbx-node-search
           args:
             - ${DRIVERS_TOOLS}/.evergreen/atlas/setup-atlas-cluster.sh
       - command: expansions.update


### PR DESCRIPTION
### Description

#### What is changing?

Atlas clusters have a 23-character unique prefix requirement.  The search index tests hard-code in a prefix that is 23 characters long, so if two search index runs execute concurrently, one will fail.

This PR shortens the prefix to prevent this issue.

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
