### PR TITLE
fix(NODE-6763): pass WriteConcernOptions instead on WriteConcernSettings

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -531,9 +531,11 @@ export function resolveOptions<T extends CommandOperationOptions>(
     if (writeConcern) {
       if (timeoutMS != null) {
         writeConcern = WriteConcern.fromOptions({
-          ...writeConcern,
-          wtimeout: undefined,
-          wtimeoutMS: undefined
+          writeConcern: {
+            ...writeConcern,
+            wtimeout: undefined,
+            wtimeoutMS: undefined
+          }
         });
       }
       result.writeConcern = writeConcern;

--- a/test/integration/read-write-concern/write_concern.test.ts
+++ b/test/integration/read-write-concern/write_concern.test.ts
@@ -309,45 +309,46 @@ describe('Write Concern', function () {
     let client: MongoClient;
     let collection: Collection;
     const commands: CommandStartedEvent[] = [];
+
     beforeEach(async function () {
       client = this.configuration.newClient({}, { monitorCommands: true });
       client.on('commandStarted', filterForCommands('insert', commands));
       collection = client.db('foo').collection('bar');
-    })
-
+    });
 
     afterEach(async function () {
       await client.close();
       commands.length = 0;
-    })
+    });
 
     context('when the write concern includes only timeouts', function () {
       it('the writeConcern is not added to the command.', async function () {
-        await collection.insertOne({ name: 'john doe' }, { timeoutMS: 1000, writeConcern: { wtimeout: 1000 } });
+        await collection.insertOne(
+          { name: 'john doe' },
+          { timeoutMS: 1000, writeConcern: { wtimeout: 1000 } }
+        );
         const [
           {
-            command: {
-              writeConcern
-            }
+            command: { writeConcern }
           }
         ] = commands;
         expect(writeConcern).not.to.exist;
-      })
-    })
+      });
+    });
 
     context('when the write concern includes only non-timeout values (`w`)', function () {
       it('the writeConcern is added to the command.', async function () {
-        await collection.insertOne({ name: 'john doe' }, { timeoutMS: 1000, writeConcern: { wtimeout: 1000, w: 'majority' } });
+        await collection.insertOne(
+          { name: 'john doe' },
+          { timeoutMS: 1000, writeConcern: { wtimeout: 1000, w: 'majority' } }
+        );
         const [
           {
-            command: {
-              writeConcern
-            }
+            command: { writeConcern }
           }
         ] = commands;
-        expect(writeConcern).to.deep.equal({ w: 'majority' })
-      })
-
-    })
-  })
+        expect(writeConcern).to.deep.equal({ w: 'majority' });
+      });
+    });
+  });
 });

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -403,7 +403,7 @@ describe('driver utils', function () {
       it('should be instanceof GeneratorFunction', () => {
         const list = new List<number>();
         // eslint-disable-next-line @typescript-eslint/no-empty-function
-        expect(list[Symbol.iterator]).to.be.instanceOf(function* () {}.constructor);
+        expect(list[Symbol.iterator]).to.be.instanceOf(function* () { }.constructor);
       });
 
       it('should only run generator for the number of items in the list', () => {
@@ -857,9 +857,8 @@ describe('driver utils', function () {
         continue;
       }
 
-      const title = `comparing ${oid1} to ${oid2} returns ${
-        result === 0 ? 'equal' : result === -1 ? 'less than' : 'greater than'
-      }`;
+      const title = `comparing ${oid1} to ${oid2} returns ${result === 0 ? 'equal' : result === -1 ? 'less than' : 'greater than'
+        }`;
       // @ts-expect-error: not narrowed based on numeric result, but these values are correct
       it(title, () => expect(compareObjectId(oid1, oid2)).to.equal(result));
     }

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -403,7 +403,7 @@ describe('driver utils', function () {
       it('should be instanceof GeneratorFunction', () => {
         const list = new List<number>();
         // eslint-disable-next-line @typescript-eslint/no-empty-function
-        expect(list[Symbol.iterator]).to.be.instanceOf(function* () { }.constructor);
+        expect(list[Symbol.iterator]).to.be.instanceOf(function* () {}.constructor);
       });
 
       it('should only run generator for the number of items in the list', () => {
@@ -857,8 +857,9 @@ describe('driver utils', function () {
         continue;
       }
 
-      const title = `comparing ${oid1} to ${oid2} returns ${result === 0 ? 'equal' : result === -1 ? 'less than' : 'greater than'
-        }`;
+      const title = `comparing ${oid1} to ${oid2} returns ${
+        result === 0 ? 'equal' : result === -1 ? 'less than' : 'greater than'
+      }`;
       // @ts-expect-error: not narrowed based on numeric result, but these values are correct
       it(title, () => expect(compareObjectId(oid1, oid2)).to.equal(result));
     }


### PR DESCRIPTION
### Description

That PR should fix case of loosing write-concern options while using `timeoutMS` option.
`WriteConcern.fromOptions` static method accepts 3 options formats:
* `WriteConcernOptions` object
* `WriteConcern` instance
* `W` type

But in case of using `timeoutMS` options, utils function `resolveOptions` calls ([link to code](https://github.com/mongodb/node-mongodb-native/blob/main/src/utils.ts#L533)) `WriteConcern.fromOptions` with options, which looks like `WriteConcern` instance, but there is no instance and more look like `WriteConcernSettings` type:
```ts
        writeConcern = WriteConcern.fromOptions({
          ...writeConcern,
          wtimeout: undefined,
          wtimeoutMS: undefined
        });
```

So that call return `undefined` as "parsing failed" and command losses write-concern context.

#### What is changing?

I changed options format to be consistent with `WriteConcern.fromOptions` type and use `WriteConcernOptions` format.

##### Is there new documentation needed for these changes?

No.

#### What is the motivation for this change?

It's a probably bug.

I used mongodb driver within mongoose and find out `updateMany` command with `writeConcern` and `timeoutMS` options does not pass write-concern context to `CommanStartedEvent`. This small fix should be helpful.

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### WriteConcern omitted with timeoutMS is provided

When timeoutMS and a write concern were provided, the writeConcern was incorrectly omitted from the final command executed by the driver. 

Thanks @stepanho for the contribution! 

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
