### PR TITLE
test(NODE-6745): only find python when installing native

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1520,6 +1520,11 @@ tasks:
       - auth
       - kerberos
     commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NATIVE, value: 'true'}
       - func: install dependencies
       - func: run kerberos tests
   - name: test-auth-ldap

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -162,7 +162,13 @@ TASKS.push(
     {
       name: 'test-auth-kerberos',
       tags: ['auth', 'kerberos'],
-      commands: [{ func: 'install dependencies' }, { func: 'run kerberos tests' }]
+      commands: [
+        updateExpansions({
+          NATIVE: 'true'
+        }),
+        { func: 'install dependencies' },
+        { func: 'run kerberos tests' }
+      ]   
     },
     {
       name: 'test-auth-ldap',

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -11,6 +11,13 @@ export NODE_LTS_VERSION=${NODE_LTS_VERSION:-16}
 # be handled by this script in drivers tools.
 source $DRIVERS_TOOLS/.evergreen/install-node.sh
 
+if [ "$NATIVE" = "true" ]; then
+  # https://github.com/nodejs/node-gyp#configuring-python-dependency
+  . $DRIVERS_TOOLS/.evergreen/find-python3.sh
+  NODE_GYP_FORCE_PYTHON=$(find_python3)
+  export NODE_GYP_FORCE_PYTHON
+fi
+
 npm install "${NPM_OPTIONS}"
 
 source $DRIVERS_TOOLS/.evergreen/init-node-and-npm-env.sh

--- a/.evergreen/prepare-shell.sh
+++ b/.evergreen/prepare-shell.sh
@@ -32,7 +32,7 @@ export PATH="$MONGODB_BINARIES:$PATH"
 
 if [ ! -d "$DRIVERS_TOOLS" ]; then
   # Only clone driver tools if it does not exist
-  git clone --depth=1 --branch NODE-6745 "https://github.com/mongodb-labs/drivers-evergreen-tools.git" "${DRIVERS_TOOLS}"
+  git clone --depth=1 "https://github.com/mongodb-labs/drivers-evergreen-tools.git" "${DRIVERS_TOOLS}"
 fi
 
 echo "installed DRIVERS_TOOLS from commit $(git -C "${DRIVERS_TOOLS}" rev-parse HEAD)"

--- a/.evergreen/prepare-shell.sh
+++ b/.evergreen/prepare-shell.sh
@@ -32,7 +32,7 @@ export PATH="$MONGODB_BINARIES:$PATH"
 
 if [ ! -d "$DRIVERS_TOOLS" ]; then
   # Only clone driver tools if it does not exist
-  git clone --depth=1 "https://github.com/mongodb-labs/drivers-evergreen-tools.git" "${DRIVERS_TOOLS}"
+  git clone --depth=1 --branch NODE-6745 "https://github.com/mongodb-labs/drivers-evergreen-tools.git" "${DRIVERS_TOOLS}"
 fi
 
 echo "installed DRIVERS_TOOLS from commit $(git -C "${DRIVERS_TOOLS}" rev-parse HEAD)"


### PR DESCRIPTION
### Description

Reverts changes in tools for finding python3 that broken the AWS ECS tests. Companion PR: https://github.com/mongodb-labs/drivers-evergreen-tools/pull/602

#### What is changing?

Moves the forced python3 find into our install dependencies script only when testing functionality with a native module.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-6745

https://github.com/mongodb-labs/drivers-evergreen-tools/pull/602

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
