### PR TITLE
docs(NODE-6765): sync types for findOneAndUpdate

### DIFF
--- a/src/collection.ts
+++ b/src/collection.ts
@@ -968,7 +968,11 @@ export class Collection<TSchema extends Document = Document> {
    *
    * The value of `update` can be either:
    * - UpdateFilter<TSchema> - A document that contains update operator expressions,
-   * - Document[] - an aggregation pipeline.
+   * - Document[] - an aggregation pipeline consisting of the following stages:
+   *   - $addFields and its alias $set
+   *   - $project and its alias $unset
+   *   - $replaceRoot and its alias $replaceWith.
+   * See the [findAndModify command documentation](https://www.mongodb.com/docs/manual/reference/command/findAndModify) for details.
    *
    * @param filter - The filter used to select the document to update
    * @param update - The modifications to apply

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -976,26 +976,26 @@ export class Collection<TSchema extends Document = Document> {
    */
   async findOneAndUpdate(
     filter: Filter<TSchema>,
-    update: UpdateFilter<TSchema>,
+    update: UpdateFilter<TSchema> | Document[],
     options: FindOneAndUpdateOptions & { includeResultMetadata: true }
   ): Promise<ModifyResult<TSchema>>;
   async findOneAndUpdate(
     filter: Filter<TSchema>,
-    update: UpdateFilter<TSchema>,
+    update: UpdateFilter<TSchema> | Document[],
     options: FindOneAndUpdateOptions & { includeResultMetadata: false }
   ): Promise<WithId<TSchema> | null>;
   async findOneAndUpdate(
     filter: Filter<TSchema>,
-    update: UpdateFilter<TSchema>,
+    update: UpdateFilter<TSchema> | Document[],
     options: FindOneAndUpdateOptions
   ): Promise<WithId<TSchema> | null>;
   async findOneAndUpdate(
     filter: Filter<TSchema>,
-    update: UpdateFilter<TSchema>
+    update: UpdateFilter<TSchema> | Document[]
   ): Promise<WithId<TSchema> | null>;
   async findOneAndUpdate(
     filter: Filter<TSchema>,
-    update: UpdateFilter<TSchema>,
+    update: UpdateFilter<TSchema> | Document[],
     options?: FindOneAndUpdateOptions
   ): Promise<WithId<TSchema> | ModifyResult<TSchema> | null> {
     return await executeOperation(

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -966,8 +966,12 @@ export class Collection<TSchema extends Document = Document> {
   /**
    * Find a document and update it in one atomic operation. Requires a write lock for the duration of the operation.
    *
+   * The value of `update` can be either:
+   * - UpdateFilter<TSchema> - A document that contains update operator expressions,
+   * - Document[] - an aggregation pipeline.
+   *
    * @param filter - The filter used to select the document to update
-   * @param update - Update operations to be performed on the document
+   * @param update - The modifications to apply
    * @param options - Optional settings for the command
    */
   async findOneAndUpdate(

--- a/test/integration/crud/find_and_modify.test.ts
+++ b/test/integration/crud/find_and_modify.test.ts
@@ -1,6 +1,12 @@
 import { expect } from 'chai';
 
-import { Collection, type CommandStartedEvent, MongoClient, MongoServerError, ObjectId } from '../../mongodb';
+import {
+  type Collection,
+  type CommandStartedEvent,
+  type MongoClient,
+  MongoServerError,
+  ObjectId
+} from '../../mongodb';
 import { setupDatabase } from '../shared';
 
 describe('Collection (#findOneAnd...)', function () {
@@ -328,7 +334,7 @@ describe('Collection (#findOneAnd...)', function () {
     context('when updating with an aggregation pipeline', function () {
       context('when passing includeResultMetadata: true', function () {
         let client: MongoClient;
-        let collection: Collection<{ a: number, b: number }>;
+        let collection: Collection<{ a: number; b: number }>;
 
         beforeEach(async function () {
           client = this.configuration.newClient({}, { maxPoolSize: 1 });
@@ -341,22 +347,32 @@ describe('Collection (#findOneAnd...)', function () {
           await client?.close();
         });
 
-        it('the aggregation pipeline updates the matching document', async function () {
-          const { value: {
-            _id,
-            ...document
-          } } = await collection.findOneAndUpdate(
-            { a: 1 },
-            [{ $set: { a: { $add: [1, '$a'] } } }],
-            { includeResultMetadata: true, returnDocument: 'after' }
-          );
-          expect(document).to.deep.equal({ a: 2, b: 1 });
-        });
+        it(
+          'the aggregation pipeline updates the matching document',
+          {
+            requires: {
+              mongodb: '>4.0'
+            }
+          },
+          async function () {
+            const {
+              value: { _id, ...document }
+            } = await collection.findOneAndUpdate(
+              { a: 1 },
+              [{ $set: { a: { $add: [1, '$a'] } } }],
+              {
+                includeResultMetadata: true,
+                returnDocument: 'after'
+              }
+            );
+            expect(document).to.deep.equal({ a: 2, b: 1 });
+          }
+        );
       });
 
       context('when passing includeResultMetadata: false', function () {
         let client: MongoClient;
-        let collection: Collection<{ a: number, b: number }>;
+        let collection: Collection<{ a: number; b: number }>;
 
         beforeEach(async function () {
           client = this.configuration.newClient({}, { maxPoolSize: 1 });
@@ -369,15 +385,22 @@ describe('Collection (#findOneAnd...)', function () {
           await client?.close();
         });
 
-        it('the aggregation pipeline updates the matching document', async function () {
-          const {
-            _id,
-            ...document
-          } = await collection.findOneAndUpdate({ a: 1 }, [
-            { $set: { a: { $add: [1, '$a'] } } }
-          ], { returnDocument: 'after' });
-          expect(document).to.deep.equal({ a: 2, b: 1 });
-        });
+        it(
+          'the aggregation pipeline updates the matching document',
+          {
+            requires: {
+              mongodb: '>4.0'
+            }
+          },
+          async function () {
+            const { _id, ...document } = await collection.findOneAndUpdate(
+              { a: 1 },
+              [{ $set: { a: { $add: [1, '$a'] } } }],
+              { returnDocument: 'after' }
+            );
+            expect(document).to.deep.equal({ a: 2, b: 1 });
+          }
+        );
       });
     });
   });

--- a/test/integration/crud/find_and_modify.test.ts
+++ b/test/integration/crud/find_and_modify.test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 
-import { type CommandStartedEvent, MongoServerError, ObjectId } from '../../mongodb';
+import { Collection, type CommandStartedEvent, MongoClient, MongoServerError, ObjectId } from '../../mongodb';
 import { setupDatabase } from '../shared';
 
 describe('Collection (#findOneAnd...)', function () {
@@ -327,8 +327,8 @@ describe('Collection (#findOneAnd...)', function () {
 
     context('when updating with an aggregation pipeline', function () {
       context('when passing includeResultMetadata: true', function () {
-        let client;
-        let collection;
+        let client: MongoClient;
+        let collection: Collection<{ a: number, b: number }>;
 
         beforeEach(async function () {
           client = this.configuration.newClient({}, { maxPoolSize: 1 });
@@ -341,19 +341,22 @@ describe('Collection (#findOneAnd...)', function () {
           await client?.close();
         });
 
-        it('returns the raw result', async function () {
-          const result = await collection.findOneAndUpdate(
+        it('the aggregation pipeline updates the matching document', async function () {
+          const { value: {
+            _id,
+            ...document
+          } } = await collection.findOneAndUpdate(
             { a: 1 },
-            [{ $set: { a: { $add: [0, '$a'] } } }],
-            { includeResultMetadata: true }
+            [{ $set: { a: { $add: [1, '$a'] } } }],
+            { includeResultMetadata: true, returnDocument: 'after' }
           );
-          expect(result.value.b).to.equal(1);
+          expect(document).to.deep.equal({ a: 2, b: 1 });
         });
       });
 
-      context('when no options are passed', function () {
-        let client;
-        let collection;
+      context('when passing includeResultMetadata: false', function () {
+        let client: MongoClient;
+        let collection: Collection<{ a: number, b: number }>;
 
         beforeEach(async function () {
           client = this.configuration.newClient({}, { maxPoolSize: 1 });
@@ -366,145 +369,14 @@ describe('Collection (#findOneAnd...)', function () {
           await client?.close();
         });
 
-        context('when there is a match', function () {
-          it('returns the modified document', async function () {
-            const result = await collection.findOneAndUpdate({ a: 1 }, [
-              { $set: { a: { $add: [0, '$a'] } } }
-            ]);
-            expect(result.b).to.equal(1);
-          });
-        });
-
-        context('when there is no match', function () {
-          it('returns null', async function () {
-            const result = await collection.findOneAndUpdate({ a: 2 }, [
-              { $set: { a: { $add: [0, '$a'] } } }
-            ]);
-            expect(result).to.equal(null);
-          });
-        });
-      });
-
-      context('when passing an object id filter', function () {
-        let client;
-        let collection;
-        const started: CommandStartedEvent[] = [];
-
-        beforeEach(async function () {
-          client = this.configuration.newClient({}, { maxPoolSize: 1, monitorCommands: true });
-          client.on('commandStarted', function (event) {
-            if (event.commandName === 'findAndModify') started.push(event);
-          });
-          collection = client.db('test').collection('findAndModifyTest');
-          await collection.insertMany([{ a: 1, b: 1 }], { writeConcern: { w: 1 } });
-        });
-
-        afterEach(async function () {
-          await collection.drop();
-          await client?.close();
-        });
-
-        it('does not support object ids as a query predicate', async function () {
-          const oid = new ObjectId();
-          const error = await collection
-            .findOneAndUpdate(oid, [{ $set: { a: { $add: [0, '$a'] } } }])
-            .catch(error => error);
-          expect(error).to.be.instanceOf(MongoServerError);
-          expect(started).to.have.lengthOf(1);
-          expect(started[0].command).to.have.property('query', oid);
-        });
-      });
-
-      context('when passing in a non-primary read preference', {
-        metadata: {
-          requires: { topology: ['replicaset'] }
-        },
-        test: function () {
-          let client;
-          let collection;
-
-          beforeEach(async function () {
-            client = this.configuration.newClient(
-              { readPreference: 'secondary' },
-              { maxPoolSize: 1 }
-            );
-            collection = client.db('test').collection('findAndModifyTest');
-            await collection.insertMany([{ a: 1, b: 1 }], { writeConcern: { w: 1 } });
-          });
-
-          afterEach(async function () {
-            await collection.drop();
-            await client?.close();
-          });
-
-          it('returns the raw result', async function () {
-            const result = await collection.findOneAndUpdate(
-              { a: 1 },
-              [{ $set: { a: { $add: [0, '$a'] } } }],
-              { includeResultMetadata: true }
-            );
-            expect(result.value.b).to.equal(1);
-          });
-        }
-      });
-
-      context('when passing in writeConcern', function () {
-        let client;
-        let collection;
-        const started: CommandStartedEvent[] = [];
-
-        beforeEach(async function () {
-          client = this.configuration.newClient({}, { maxPoolSize: 1, monitorCommands: true });
-          client.on('commandStarted', function (event) {
-            if (event.commandName === 'findAndModify') started.push(event);
-          });
-        });
-
-        afterEach(async function () {
-          await collection.drop();
-          await client?.close();
-        });
-
-        context('when provided at the operation level', function () {
-          beforeEach(async function () {
-            collection = client.db('test').collection('findAndModifyTest');
-            await collection.insertMany([{ a: 1, b: 1 }], { writeConcern: { w: 1 } });
-          });
-
-          it('passes through the writeConcern', async function () {
-            await collection.findOneAndUpdate({}, [{ $set: { a: { $add: [0, '$a'] } } }], {
-              writeConcern: { j: 1 }
-            });
-            expect(started[0].command.writeConcern).to.deep.equal({ j: 1 });
-          });
-        });
-
-        context('when provided at the collection level', function () {
-          beforeEach(async function () {
-            collection = client
-              .db('test')
-              .collection('findAndModifyTest', { writeConcern: { j: 1 } });
-            await collection.insertMany([{ a: 1, b: 1 }], { writeConcern: { w: 1 } });
-          });
-
-          it('passes through the writeConcern', async function () {
-            await collection.findOneAndUpdate({}, [{ $set: { a: { $add: [0, '$a'] } } }]);
-            expect(started[0].command.writeConcern).to.deep.equal({ j: 1 });
-          });
-        });
-
-        context('when provided at the db level', function () {
-          beforeEach(async function () {
-            collection = client
-              .db('test', { writeConcern: { j: 1 } })
-              .collection('findAndModifyTest');
-            await collection.insertMany([{ a: 1, b: 1 }], { writeConcern: { w: 1 } });
-          });
-
-          it('passes through the writeConcern', async function () {
-            await collection.findOneAndUpdate({}, [{ $set: { a: { $add: [0, '$a'] } } }]);
-            expect(started[0].command.writeConcern).to.deep.equal({ j: 1 });
-          });
+        it('the aggregation pipeline updates the matching document', async function () {
+          const {
+            _id,
+            ...document
+          } = await collection.findOneAndUpdate({ a: 1 }, [
+            { $set: { a: { $add: [1, '$a'] } } }
+          ], { returnDocument: 'after' });
+          expect(document).to.deep.equal({ a: 2, b: 1 });
         });
       });
     });

--- a/test/integration/crud/find_and_modify.test.ts
+++ b/test/integration/crud/find_and_modify.test.ts
@@ -324,6 +324,190 @@ describe('Collection (#findOneAnd...)', function () {
         });
       });
     });
+
+    context('when updating with an aggregation pipeline', function () {
+      context('when passing includeResultMetadata: true', function () {
+        let client;
+        let collection;
+
+        beforeEach(async function () {
+          client = this.configuration.newClient({}, { maxPoolSize: 1 });
+          collection = client.db('test').collection('findAndModifyTest');
+          await collection.insertMany([{ a: 1, b: 1 }], { writeConcern: { w: 1 } });
+        });
+
+        afterEach(async function () {
+          await collection.drop();
+          await client?.close();
+        });
+
+        it('returns the raw result', async function () {
+          const result = await collection.findOneAndUpdate(
+            { a: 1 },
+            [{ $set: { a: { $add: [0, '$a'] } } }],
+            { includeResultMetadata: true }
+          );
+          expect(result.value.b).to.equal(1);
+        });
+      });
+
+      context('when no options are passed', function () {
+        let client;
+        let collection;
+
+        beforeEach(async function () {
+          client = this.configuration.newClient({}, { maxPoolSize: 1 });
+          collection = client.db('test').collection('findAndModifyTest');
+          await collection.insertMany([{ a: 1, b: 1 }], { writeConcern: { w: 1 } });
+        });
+
+        afterEach(async function () {
+          await collection.drop();
+          await client?.close();
+        });
+
+        context('when there is a match', function () {
+          it('returns the modified document', async function () {
+            const result = await collection.findOneAndUpdate({ a: 1 }, [
+              { $set: { a: { $add: [0, '$a'] } } }
+            ]);
+            expect(result.b).to.equal(1);
+          });
+        });
+
+        context('when there is no match', function () {
+          it('returns null', async function () {
+            const result = await collection.findOneAndUpdate({ a: 2 }, [
+              { $set: { a: { $add: [0, '$a'] } } }
+            ]);
+            expect(result).to.equal(null);
+          });
+        });
+      });
+
+      context('when passing an object id filter', function () {
+        let client;
+        let collection;
+        const started: CommandStartedEvent[] = [];
+
+        beforeEach(async function () {
+          client = this.configuration.newClient({}, { maxPoolSize: 1, monitorCommands: true });
+          client.on('commandStarted', function (event) {
+            if (event.commandName === 'findAndModify') started.push(event);
+          });
+          collection = client.db('test').collection('findAndModifyTest');
+          await collection.insertMany([{ a: 1, b: 1 }], { writeConcern: { w: 1 } });
+        });
+
+        afterEach(async function () {
+          await collection.drop();
+          await client?.close();
+        });
+
+        it('does not support object ids as a query predicate', async function () {
+          const oid = new ObjectId();
+          const error = await collection
+            .findOneAndUpdate(oid, [{ $set: { a: { $add: [0, '$a'] } } }])
+            .catch(error => error);
+          expect(error).to.be.instanceOf(MongoServerError);
+          expect(started).to.have.lengthOf(1);
+          expect(started[0].command).to.have.property('query', oid);
+        });
+      });
+
+      context('when passing in a non-primary read preference', {
+        metadata: {
+          requires: { topology: ['replicaset'] }
+        },
+        test: function () {
+          let client;
+          let collection;
+
+          beforeEach(async function () {
+            client = this.configuration.newClient(
+              { readPreference: 'secondary' },
+              { maxPoolSize: 1 }
+            );
+            collection = client.db('test').collection('findAndModifyTest');
+            await collection.insertMany([{ a: 1, b: 1 }], { writeConcern: { w: 1 } });
+          });
+
+          afterEach(async function () {
+            await collection.drop();
+            await client?.close();
+          });
+
+          it('returns the raw result', async function () {
+            const result = await collection.findOneAndUpdate(
+              { a: 1 },
+              [{ $set: { a: { $add: [0, '$a'] } } }],
+              { includeResultMetadata: true }
+            );
+            expect(result.value.b).to.equal(1);
+          });
+        }
+      });
+
+      context('when passing in writeConcern', function () {
+        let client;
+        let collection;
+        const started: CommandStartedEvent[] = [];
+
+        beforeEach(async function () {
+          client = this.configuration.newClient({}, { maxPoolSize: 1, monitorCommands: true });
+          client.on('commandStarted', function (event) {
+            if (event.commandName === 'findAndModify') started.push(event);
+          });
+        });
+
+        afterEach(async function () {
+          await collection.drop();
+          await client?.close();
+        });
+
+        context('when provided at the operation level', function () {
+          beforeEach(async function () {
+            collection = client.db('test').collection('findAndModifyTest');
+            await collection.insertMany([{ a: 1, b: 1 }], { writeConcern: { w: 1 } });
+          });
+
+          it('passes through the writeConcern', async function () {
+            await collection.findOneAndUpdate({}, [{ $set: { a: { $add: [0, '$a'] } } }], {
+              writeConcern: { j: 1 }
+            });
+            expect(started[0].command.writeConcern).to.deep.equal({ j: 1 });
+          });
+        });
+
+        context('when provided at the collection level', function () {
+          beforeEach(async function () {
+            collection = client
+              .db('test')
+              .collection('findAndModifyTest', { writeConcern: { j: 1 } });
+            await collection.insertMany([{ a: 1, b: 1 }], { writeConcern: { w: 1 } });
+          });
+
+          it('passes through the writeConcern', async function () {
+            await collection.findOneAndUpdate({}, [{ $set: { a: { $add: [0, '$a'] } } }]);
+            expect(started[0].command.writeConcern).to.deep.equal({ j: 1 });
+          });
+        });
+
+        context('when provided at the db level', function () {
+          beforeEach(async function () {
+            collection = client
+              .db('test', { writeConcern: { j: 1 } })
+              .collection('findAndModifyTest');
+            await collection.insertMany([{ a: 1, b: 1 }], { writeConcern: { w: 1 } });
+          });
+
+          it('passes through the writeConcern', async function () {
+            await collection.findOneAndUpdate({}, [{ $set: { a: { $add: [0, '$a'] } } }]);
+            expect(started[0].command.writeConcern).to.deep.equal({ j: 1 });
+          });
+        });
+      });
+    });
   });
 
   describe('#findOneAndReplace', function () {

--- a/test/types/community/collection/findX.test-d.ts
+++ b/test/types/community/collection/findX.test-d.ts
@@ -388,3 +388,14 @@ expectType<WithId<{ a: number; b: string }> | null>(
     }
   )
 );
+
+// the update operator can be an aggregation pipeline
+expectType<WithId<{ a: number; b: string }> | null>(
+  await coll.findOneAndUpdate({ a: 3 }, [
+    {
+      $set: {
+        a: 5
+      }
+    }
+  ])
+);


### PR DESCRIPTION
### Description

#### What is changing?

In https://github.com/mongodb/node-mongodb-native/pull/3953, the aggregation pipeline signature was added for `updateOne` and `updateMany`, but this was missed for `findOneAndUpdate`

##### Is there new documentation needed for these changes?

Documentation is included.

#### What is the motivation for this change?

The documentation was missing from the node.js driver. The initial motivation is that the downstream mongoose type also need to be updated to allow aggregation pipelines in `findOneAndUpdate`, but for consistency, these types should be updated first, or at least have this update ready while updating the mongoose types.

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

https://jira.mongodb.org/browse/NODE-6765

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
