### PR TITLE
fix(NODE-6777): update BSON to 6.10.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@mongodb-js/saslprep": "^1.1.9",
-        "bson": "^6.10.1",
+        "bson": "^6.10.3",
         "mongodb-connection-string-url": "^3.0.0"
       },
       "devDependencies": {
@@ -3599,9 +3599,9 @@
       }
     },
     "node_modules/bson": {
-      "version": "6.10.2",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.2.tgz",
-      "integrity": "sha512-5afhLTjqDSA3akH56E+/2J6kTDuSIlBxyXPdQslj9hcIgOUE378xdOfZvC/9q3LifJNI6KR/juZ+d0NRNYBwXg==",
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.3.tgz",
+      "integrity": "sha512-MTxGsqgYTwfshYWTRdmZRC+M7FnG1b4y7RO7p2k3X24Wq0yv1m77Wsj0BzlPzd/IowgESfsruQCUToa7vbOpPQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=16.20.1"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@mongodb-js/saslprep": "^1.1.9",
-    "bson": "^6.10.1",
+    "bson": "^6.10.3",
     "mongodb-connection-string-url": "^3.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
### Description

#### What is changing?

Update BSON version requirement

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

Pull in BSON fixes

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Update BSON version requirement to 6.10.3

This forces fixes made in [6.10.3](https://github.com/mongodb/js-bson/releases/tag/v6.10.3) and [6.10.2](https://github.com/mongodb/js-bson/releases/tag/v6.10.2) to be pulled into the driver.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
