### PR TITLE
test(NODE-5850): skip flaky scram tests

### DIFF
--- a/test/integration/auth/auth.prose.test.ts
+++ b/test/integration/auth/auth.prose.test.ts
@@ -305,7 +305,8 @@ describe('Authentication Spec Prose Tests', function () {
       );
     });
 
-    describe('Step 4', function () {
+    // TODO(NODE-6752): Fix flaky SCRAM-SHA-256 tests
+    describe.skip('Step 4', function () {
       /**
        * Step 4
        * To test SASLprep behavior, create two users:
@@ -376,8 +377,7 @@ describe('Authentication Spec Prose Tests', function () {
           expect(stats).to.exist;
         });
 
-        // TODO(NODE-6752): Fix flaky SCRAM-SHA-256 test
-        it.skip(
+        it(
           'logs in with non-normalized username and normalized password',
           metadata,
           async function () {


### PR DESCRIPTION
### Description

Skips all flaky scram specific tests.

#### What is changing?

Skips all the auth prose tests related to scram-sha-256.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-5850

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
