### PR TITLE
test(NODE-6766): skip serverless tests

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -3720,14 +3720,6 @@ buildvariants:
       - run-custom-csfle-tests-rapid
       - run-custom-csfle-tests-latest
       - test-latest-driver-mongodb-client-encryption-6.0.0
-  - name: rhel8-test-serverless
-    display_name: Serverless Test
-    run_on: rhel80-large
-    expansions:
-      NODE_LTS_VERSION: 16
-      NPM_VERSION: 9
-    tasks:
-      - serverless_task_group
   - name: rhel8-test-gcp-kms
     display_name: GCP KMS Test
     run_on: debian11-small

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -807,16 +807,16 @@ BUILD_VARIANTS.push({
 });
 
 // special case for serverless testing
-BUILD_VARIANTS.push({
-  name: 'rhel8-test-serverless',
-  display_name: 'Serverless Test',
-  run_on: DEFAULT_OS,
-  expansions: {
-    NODE_LTS_VERSION: LOWEST_LTS,
-    NPM_VERSION: 9
-  },
-  tasks: ['serverless_task_group']
-});
+// BUILD_VARIANTS.push({
+//   name: 'rhel8-test-serverless',
+//   display_name: 'Serverless Test',
+//   run_on: DEFAULT_OS,
+//   expansions: {
+//     NODE_LTS_VERSION: LOWEST_LTS,
+//     NPM_VERSION: 9
+//   },
+//   tasks: ['serverless_task_group']
+// });
 
 BUILD_VARIANTS.push({
   name: 'rhel8-test-gcp-kms',

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -806,7 +806,7 @@ BUILD_VARIANTS.push({
   tasks: customDependencyTests.map(({ name }) => name)
 });
 
-// special case for serverless testing
+// TODO(NODE-6786): Reenable serverless testing.
 // BUILD_VARIANTS.push({
 //   name: 'rhel8-test-serverless',
 //   display_name: 'Serverless Test',


### PR DESCRIPTION
### Description

Disables serverless testing.

#### What is changing?

Comment out the serverless variant in CI.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-6766

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
