### PR TITLE
fix(NODE-6792): use driver version of isUint8Array

### DIFF
--- a/src/mongo_logger.ts
+++ b/src/mongo_logger.ts
@@ -1,5 +1,4 @@
 import { inspect, promisify } from 'util';
-import { isUint8Array } from 'util/types';
 
 import {
   type Binary,
@@ -75,7 +74,7 @@ import type {
   ServerSelectionSucceededEvent,
   WaitingForSuitableServerEvent
 } from './sdam/server_selection_events';
-import { HostAddress, isPromiseLike, parseUnsignedInteger } from './utils';
+import { HostAddress, isPromiseLike, isUint8Array, parseUnsignedInteger } from './utils';
 
 /**
  * @public


### PR DESCRIPTION
### Description

#### What is changing?

Switch from util/types to ./utils for isUint8Array

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

Bundlers need to add a target module for util/types for a method we already implement ourselves. No reason to cause that friction.

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Use `isUint8Array` defined in the driver rather than `util/types`

Some users of bundlers for next.js and our very own mongosh noticed a new import from "util/types" that would need to be supported in environments that don't have that module. We already have an internal implementation of `isUint8Array` so we do not need to add an import for "util/types".

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
