### PR TITLE
fix(NODE-6801): set token on connection from cache

### DIFF
--- a/src/cmap/auth/mongodb_oidc/machine_workflow.ts
+++ b/src/cmap/auth/mongodb_oidc/machine_workflow.ts
@@ -94,7 +94,12 @@ export abstract class MachineWorkflow implements Workflow {
     credentials: MongoCredentials
   ): Promise<string> {
     if (this.cache.hasAccessToken) {
-      return this.cache.getAccessToken();
+      const token = this.cache.getAccessToken();
+      // New connections won't have an access token so ensure we set here.
+      if (!connection.accessToken) {
+        connection.accessToken = token;
+      }
+      return token;
     } else {
       const token = await this.callback(credentials);
       this.cache.put({ accessToken: token.access_token, expiresInSeconds: token.expires_in });

--- a/test/unit/cmap/auth/mongodb_oidc/gcp_machine_workflow.test.ts
+++ b/test/unit/cmap/auth/mongodb_oidc/gcp_machine_workflow.test.ts
@@ -19,4 +19,28 @@ describe('GCPMachineFlow', function () {
       });
     });
   });
+
+  describe('#getTokenFromCacheOrEnv', function () {
+    context('when the cache has a token', function () {
+      const connection = sinon.createStubInstance(Connection);
+      const credentials = sinon.createStubInstance(MongoCredentials);
+
+      context('when the connection has no token', function () {
+        let cache;
+        let workflow;
+
+        this.beforeEach(function () {
+          cache = new TokenCache();
+          cache.put({ accessToken: 'test', expiresInSeconds: 7200 });
+          workflow = new GCPMachineWorkflow(cache);
+        });
+
+        it('sets the token on the connection', async function () {
+          const token = await workflow.getTokenFromCacheOrEnv(connection, credentials);
+          expect(token).to.equal('test');
+          expect(connection.accessToken).to.equal('test');
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
### Description

When using OIDC authentication when there is more than one connection in the pool, connections that were created after the first connection would have no access token set on them until after the first reauthentication attempt. This was due to the fact that the first connection that was created retrieved the token and put it in the cache, and all following connections weren't setting their access token properly from the cache if it existed.

#### What is changing?

- Changes the machine workflow to properly set a token from the cache on the connection if the connection's token is undefined.
- Adds a unit test.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

HELP-70195

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fixed an issue in OIDC authentication where 391 reauthentication could fail.

This was due to a bug in setting the properly cached access token on the connection.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
