### PR TITLE
test(NODE-6807): move benchmark tags into correct place

### DIFF
--- a/test/benchmarks/driver_bench/src/driver.mts
+++ b/test/benchmarks/driver_bench/src/driver.mts
@@ -135,6 +135,7 @@ export type Metric = {
   name: 'megabytes_per_second' | 'normalized_throughput';
   value: number;
   metadata: {
+    tags?: string[];
     improvement_direction: 'up' | 'down';
   };
 };
@@ -143,7 +144,6 @@ export type MetricInfo = {
   info: {
     test_name: string;
     args: Record<string, number>;
-    tags?: string[];
   };
   metrics: Metric[];
 };
@@ -159,12 +159,15 @@ export function metrics(test_name: string, result: number, tags?: string[]): Met
           key,
           typeof value === 'number' ? value : value ? 1 : 0
         ])
-      ),
-      tags
+      )
     },
     // FIXME(NODE-6781): For now all of our metrics are of throughput so their improvement_direction is up,
     metrics: [
-      { name: 'megabytes_per_second', value: result, metadata: { improvement_direction: 'up' } }
+      {
+        name: 'megabytes_per_second',
+        value: result,
+        metadata: { tags, improvement_direction: 'up' }
+      }
     ]
   } as const;
 }


### PR DESCRIPTION
### Description

#### What is changing?

Put tags in correct place

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
