### PR TITLE
docs: update readme to mention yarn and bun

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,12 +106,18 @@ Additionally, our Typescript types are compatible with the ECMAScript standard f
 
 The recommended way to get started using the Node.js 5.x driver is by using the `npm` (Node Package Manager) to install the dependency in your project.
 
-After you've created your own project using `npm init`, you can run:
+First, create your own project using `npm init`. Then, you can run:
 
 ```bash
 npm install mongodb
-# or ...
+```
+
+You can also use a `npm`-compatible package manager, like yarn or bun to install:
+
+```bash
 yarn add mongodb
+# or
+bun install mongodb
 ```
 
 This will download the MongoDB driver and add a dependency entry in your `package.json` file.


### PR DESCRIPTION
### Description

#### What is changing?

Updating the `README.md` to mention alternative package managers: yarn and bun.

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

Alternative package managers are popular, the README already mentioned yarn. Cleaned it up to show bun as well.

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
