### PR TITLE
chore(NODE-6846): remove legacy callback change stream test

### DIFF
--- a/test/integration/change-streams/change_stream.test.ts
+++ b/test/integration/change-streams/change_stream.test.ts
@@ -826,38 +826,6 @@ describe('Change Streams', function () {
       }
     });
 
-    it('when invoked with callbacks', {
-      metadata: { requires: { topology: 'replicaset' } },
-      test: function (done) {
-        const ops = [];
-        changeStream.next(() => {
-          changeStream.next(() => {
-            ops.push(lastWrite());
-
-            // explicitly close the change stream after the write has begun
-            ops.push(changeStream.close());
-
-            changeStream.next(err => {
-              try {
-                expect(err)
-                  .property('message')
-                  .to.match(/ChangeStream is closed/);
-                Promise.all(ops).then(() => done(), done);
-              } catch (e) {
-                done(e);
-              }
-            });
-          });
-        });
-
-        ops.push(
-          write().catch(() => {
-            // ignore
-          })
-        );
-      }
-    });
-
     it.skip('when invoked using eventEmitter API', {
       metadata: {
         requires: { topology: 'replicaset' }


### PR DESCRIPTION
### Description

#### What is changing?

- remove callback based test

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

The test flaked but it isn't the correct coverage for our API. The promises test covers the same concept

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
