### PR TITLE
chore(NODE-6847): fix flaky KMS closed error in should pass corpus without client schema

### DIFF
--- a/src/client-side-encryption/state_machine.ts
+++ b/src/client-side-encryption/state_machine.ts
@@ -367,8 +367,9 @@ export class StateMachine {
       return new MongoCryptError('KMS request failed', { cause });
     }
 
+    const closeError = new MongoCryptError('KMS request will close');
     function onclose() {
-      return new MongoCryptError('KMS request closed');
+      return new MongoCryptError('KMS request closed', { cause: closeError });
     }
 
     const tlsOptions = this.options.tlsOptions;


### PR DESCRIPTION
### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

Flaky test

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
