### PR TITLE
chore(NODE-6848): reduce flakiness of Client Bulk Write CSOT enabled acknowledged writes when the timeout is reached while iterating the result cursor the bulk write operation times out

### DIFF
--- a/test/integration/crud/client_bulk_write.test.ts
+++ b/test/integration/crud/client_bulk_write.test.ts
@@ -289,12 +289,13 @@ describe('Client Bulk Write', function () {
             }
           }),
           async function () {
+            const timeoutMS = 1500;
             const models = await makeMultiResponseBatchModelArray(this.configuration);
             const start = now();
             const timeoutError = await client
               .bulkWrite(models, {
                 verboseResults: true,
-                timeoutMS: 1500
+                timeoutMS
               })
               .catch(e => e);
 
@@ -304,7 +305,7 @@ describe('Client Bulk Write', function () {
             // DRIVERS-3005 - killCursors causes cursor cleanup to extend past timeoutMS.
             // The amount of time killCursors takes is wildly variable and can take up to almost
             // 600-700ms sometimes.
-            expect(end - start).to.be.within(1498, 1500 + 800);
+            expect(end - start).to.be.within(timeoutMS - 100, timeoutMS + 800);
             expect(commands.map(({ commandName }) => commandName)).to.have.lengthOf(2);
           }
         );

--- a/test/integration/crud/client_bulk_write.test.ts
+++ b/test/integration/crud/client_bulk_write.test.ts
@@ -304,7 +304,7 @@ describe('Client Bulk Write', function () {
             // DRIVERS-3005 - killCursors causes cursor cleanup to extend past timeoutMS.
             // The amount of time killCursors takes is wildly variable and can take up to almost
             // 600-700ms sometimes.
-            expect(end - start).to.be.within(1500, 1500 + 800);
+            expect(end - start).to.be.within(1498, 1500 + 800);
             expect(commands.map(({ commandName }) => commandName)).to.have.lengthOf(2);
           }
         );


### PR DESCRIPTION
### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

Flaky test

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
