### PR TITLE
chore(NODE-6859): sleep for longer to reduce flaky CSOT State machine #markCommand when csot is enabled and markCommand() takes longer than the remaining timeoutMS the command should fail due to a timeout error test

### DIFF
--- a/test/integration/client-side-encryption/driver.test.ts
+++ b/test/integration/client-side-encryption/driver.test.ts
@@ -827,7 +827,7 @@ describe('CSOT', function () {
               // @ts-expect-error accessing private method
               .stub(Connection.prototype, 'sendCommand')
               .callsFake(async function* (...args) {
-                await sleep(1000);
+                await sleep(1010);
                 yield* stub.wrappedMethod.call(this, ...args);
               });
           });


### PR DESCRIPTION
### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

Flaky test

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
