### PR TITLE
feat(NODE-6855): add WithTimestamp type for document timestamps

### DIFF
--- a/src/mongo_types.ts
+++ b/src/mongo_types.ts
@@ -45,6 +45,9 @@ export type InferIdType<TSchema> = TSchema extends { _id: infer IdType }
 /** Add an _id field to an object shaped type @public */
 export type WithId<TSchema> = EnhancedOmit<TSchema, '_id'> & { _id: InferIdType<TSchema> };
 
+/** Add timestamp fields (createdAt and updatedAt) to an object shaped type @public */
+export type WithTimestamp<TSchema> = TSchema & { createdAt: Date; updatedAt: Date };
+
 /**
  * Add an optional _id field to an object shaped type
  * @public


### PR DESCRIPTION
### Description

Added a new WithTimestamp type that adds createdAt and updatedAt fields
of type Date to any object shaped type. This follows the same pattern as
the existing WithId type and allows for easy addition of timestamp fields
to MongoDB document types.

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

https://jira.mongodb.org/browse/NODE-6855

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
