### PR TITLE
ci: skip flaky tests in retryable reads and sdam suites

### DIFF
--- a/test/integration/retryable-reads/retryable_reads.spec.test.ts
+++ b/test/integration/retryable-reads/retryable_reads.spec.test.ts
@@ -12,11 +12,17 @@ const UNIMPLEMENTED_APIS = [
   'listDatabaseObjects'
 ];
 
+const skippedTests = ['collection.listIndexes succeeds after retryable handshake network error'];
+
 describe('Retryable Reads (unified)', function () {
   runUnifiedSuite(loadSpecTests(path.join('retryable-reads', 'unified')), ({ description }) => {
     for (const apiName of UNIMPLEMENTED_APIS) {
       if (description.toLowerCase().includes(apiName.toLowerCase())) {
         return `The Node.js Driver does not support ${apiName}`;
+      }
+
+      if (skippedTests.includes(description)) {
+        return `TODO(NODE-6832): fix flaky retryable reads tests`;
       }
     }
     return false;

--- a/test/integration/server-discovery-and-monitoring/server_discovery_and_monitoring.prose.test.ts
+++ b/test/integration/server-discovery-and-monitoring/server_discovery_and_monitoring.prose.test.ts
@@ -146,37 +146,40 @@ describe('Server Discovery and Monitoring Prose Tests', function () {
       await client.close();
     });
 
-    it('ensure monitors properly create and unpause connection pools when they discover servers', {
-      metadata: { requires: { mongodb: '>=4.2.9', topology: '!load-balanced' } },
-      test: async function () {
-        await client.connect();
-        expect(events.shift()).to.equal(SERVER_HEARTBEAT_SUCCEEDED);
-        expect(events.shift()).to.equal(CONNECTION_POOL_READY);
+    it.skip(
+      'ensure monitors properly create and unpause connection pools when they discover servers',
+      {
+        metadata: { requires: { mongodb: '>=4.2.9', topology: '!load-balanced' } },
+        test: async function () {
+          await client.connect();
+          expect(events.shift()).to.equal(SERVER_HEARTBEAT_SUCCEEDED);
+          expect(events.shift()).to.equal(CONNECTION_POOL_READY);
 
-        expect(events).to.be.empty;
+          expect(events).to.be.empty;
 
-        const heartBeatFailedEvent = once(client, SERVER_HEARTBEAT_FAILED);
-        await client.db('admin').command({
-          configureFailPoint: 'failCommand',
-          mode: { times: 2 },
-          data: {
-            failCommands: ['hello'],
-            errorCode: 1234,
-            appName: 'SDAMPoolManagementTest'
-          }
-        });
-        await heartBeatFailedEvent;
-        expect(events.shift()).to.equal(SERVER_HEARTBEAT_FAILED);
-        expect(events.shift()).to.equal(CONNECTION_POOL_CLEARED);
+          const heartBeatFailedEvent = once(client, SERVER_HEARTBEAT_FAILED);
+          await client.db('admin').command({
+            configureFailPoint: 'failCommand',
+            mode: { times: 2 },
+            data: {
+              failCommands: ['hello'],
+              errorCode: 1234,
+              appName: 'SDAMPoolManagementTest'
+            }
+          });
+          await heartBeatFailedEvent;
+          expect(events.shift()).to.equal(SERVER_HEARTBEAT_FAILED);
+          expect(events.shift()).to.equal(CONNECTION_POOL_CLEARED);
 
-        expect(events).to.be.empty;
+          expect(events).to.be.empty;
 
-        await once(client, SERVER_HEARTBEAT_SUCCEEDED);
-        expect(events.shift()).to.equal(SERVER_HEARTBEAT_SUCCEEDED);
-        expect(events.shift()).to.equal(CONNECTION_POOL_READY);
+          await once(client, SERVER_HEARTBEAT_SUCCEEDED);
+          expect(events.shift()).to.equal(SERVER_HEARTBEAT_SUCCEEDED);
+          expect(events.shift()).to.equal(CONNECTION_POOL_READY);
 
-        expect(events).to.be.empty;
+          expect(events).to.be.empty;
+        }
       }
-    });
+    ).skipReason = 'TODO(NODE-5206): fix flaky test';
   });
 });


### PR DESCRIPTION
### Description

#### What is changing?

https://spruce.mongodb.com/version/mongo_node_driver_next_4e18803c074231ec9fc3ace8f966e2c49d9874bb_75c01e57abc470e785838d3c6dd0a8c0/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
