### PR TITLE
ci: skip flaky tests

### DIFF
--- a/src/cmap/connect.ts
+++ b/src/cmap/connect.ts
@@ -35,12 +35,19 @@ import {
 /** @public */
 export type Stream = Socket | TLSSocket;
 
+export const log = (...args) => _log && console.error(...args);
+export let _log = false;
+export const enable = () => (_log = true);
+export const disable = () => (_log = false);
+
 export async function connect(options: ConnectionOptions): Promise<Connection> {
+  const start = performance.now();
   let connection: Connection | null = null;
   try {
     const socket = await makeSocket(options);
     connection = makeConnection(options, socket);
     await performInitialHandshake(connection, options);
+    log('established: ', performance.now() - start);
     return connection;
   } catch (error) {
     connection?.destroy();

--- a/src/sdam/server.ts
+++ b/src/sdam/server.ts
@@ -1,5 +1,6 @@
 import type { Document } from '../bson';
 import { type AutoEncrypter } from '../client-side-encryption/auto_encrypter';
+import { log } from '../cmap/connect';
 import { type CommandOptions, Connection } from '../cmap/connection';
 import {
   ConnectionPool,
@@ -48,6 +49,7 @@ import {
   maxWireVersion,
   type MongoDBNamespace,
   noop,
+  now,
   squashError,
   supportsRetryableWrites
 } from '../utils';
@@ -320,7 +322,10 @@ export class Server extends TypedEventEmitter<ServerEvents> {
     this.incrementOperationCount();
     if (conn == null) {
       try {
+        log('starting checkout, ', now());
         conn = await this.pool.checkOut(options);
+        log('checked out', now());
+
         if (this.loadBalanced && isPinnableCommand(cmd, session)) {
           session?.pin(conn);
         }

--- a/test/integration/client-side-operations-timeout/client_side_operations_timeout.spec.test.ts
+++ b/test/integration/client-side-operations-timeout/client_side_operations_timeout.spec.test.ts
@@ -21,20 +21,26 @@ const skippedTests = {
   'timeoutMS is refreshed for getMore if maxAwaitTimeMS is set': 'TODO(DRIVERS-3018)'
 };
 
-describe('CSOT spec tests', function () {
-  const specs = loadSpecTests('client-side-operations-timeout');
-  for (const spec of specs) {
-    for (const test of spec.tests) {
-      if (skippedSpecs[spec.name] != null) {
-        test.skipReason = skippedSpecs[spec.name];
-      }
-      if (skippedTests[test.description] != null) {
-        test.skipReason = skippedTests[test.description];
-      }
+const specs = loadSpecTests('client-side-operations-timeout');
+for (const spec of specs) {
+  for (const test of spec.tests) {
+    if (skippedSpecs[spec.name] != null) {
+      test.skipReason = skippedSpecs[spec.name];
+    }
+    if (skippedTests[test.description] != null) {
+      test.skipReason = skippedTests[test.description];
     }
   }
+}
 
+describe('CSOT spec tests', function () {
   runUnifiedSuite(specs, (test, configuration) => {
+    if (
+      test.description !==
+      'Non-tailable cursor lifetime remaining timeoutMS applied to getMore if timeoutMode is unset'
+    ) {
+      return 'skipped for now';
+    }
     const sessionCSOTTests = ['timeoutMS applied to withTransaction'];
     if (
       configuration.topologyType === 'LoadBalanced' &&

--- a/test/spec/client-side-operations-timeout/runCursorCommand.json
+++ b/test/spec/client-side-operations-timeout/runCursorCommand.json
@@ -134,6 +134,16 @@
       ],
       "operations": [
         {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": 0
+            }
+          },
+          "expectResult": []
+        },
+        {
           "name": "failPoint",
           "object": "testRunner",
           "arguments": {
@@ -174,6 +184,11 @@
         {
           "client": "client",
           "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "find"
+              }
+            },
             {
               "commandStartedEvent": {
                 "commandName": "find",

--- a/test/spec/client-side-operations-timeout/runCursorCommand.json
+++ b/test/spec/client-side-operations-timeout/runCursorCommand.json
@@ -149,7 +149,7 @@
                   "getMore"
                 ],
                 "blockConnection": true,
-                "blockTimeMS": 60
+                "blockTimeMS": 120
               }
             }
           }
@@ -159,7 +159,7 @@
           "object": "db",
           "arguments": {
             "commandName": "find",
-            "timeoutMS": 100,
+            "timeoutMS": 200,
             "command": {
               "find": "collection",
               "batchSize": 2

--- a/test/spec/client-side-operations-timeout/runCursorCommand.json
+++ b/test/spec/client-side-operations-timeout/runCursorCommand.json
@@ -149,7 +149,7 @@
                   "getMore"
                 ],
                 "blockConnection": true,
-                "blockTimeMS": 120
+                "blockTimeMS": 60
               }
             }
           }
@@ -159,7 +159,7 @@
           "object": "db",
           "arguments": {
             "commandName": "find",
-            "timeoutMS": 200,
+            "timeoutMS": 100,
             "command": {
               "find": "collection",
               "batchSize": 2

--- a/test/spec/client-side-operations-timeout/runCursorCommand.yml
+++ b/test/spec/client-side-operations-timeout/runCursorCommand.yml
@@ -70,7 +70,7 @@ tests:
     runOnRequirements:
       - serverless: forbid
     operations:
-      # Block find/getMore for 60ms.
+      # Block find/getMore for 120ms.
       - name: failPoint
         object: testRunner
         arguments:
@@ -81,16 +81,16 @@ tests:
             data:
               failCommands: [find, getMore]
               blockConnection: true
-              blockTimeMS: 60
+              blockTimeMS: 120
       # Run a find with timeoutMS less than double our failPoint blockTimeMS and
       # batchSize less than the total document count will cause a find and a 
-      # getMore to be sent. Both will block for 60ms so together they will go 
+      # getMore to be sent. Both will block for 120ms so together they will go 
       # over the timeout.
       - name: runCursorCommand
         object: *db
         arguments:
           commandName: find
-          timeoutMS: 100
+          timeoutMS: 200
           command: { find: *collection, batchSize: 2 }
         expectError:
           isTimeoutError: true

--- a/test/spec/client-side-operations-timeout/runCursorCommand.yml
+++ b/test/spec/client-side-operations-timeout/runCursorCommand.yml
@@ -70,7 +70,13 @@ tests:
     runOnRequirements:
       - serverless: forbid
     operations:
-      # Block find/getMore for 120ms.
+      # pre-populate the pool with a connection
+      - name: find
+        object: collection
+        arguments:
+          filter: { _id: 0 }
+        expectResult: []
+      # Block find/getMore for 60ms.
       - name: failPoint
         object: testRunner
         arguments:
@@ -81,22 +87,25 @@ tests:
             data:
               failCommands: [find, getMore]
               blockConnection: true
-              blockTimeMS: 120
+              blockTimeMS: 60
       # Run a find with timeoutMS less than double our failPoint blockTimeMS and
       # batchSize less than the total document count will cause a find and a 
-      # getMore to be sent. Both will block for 120ms so together they will go 
+      # getMore to be sent. Both will block for 60ms so together they will go 
       # over the timeout.
       - name: runCursorCommand
         object: *db
         arguments:
           commandName: find
-          timeoutMS: 200
+          timeoutMS: 100
           command: { find: *collection, batchSize: 2 }
         expectError:
           isTimeoutError: true
     expectEvents:
       - client: *client
         events:
+          # first find is from the initial find to populate the connection poo
+          - commandStartedEvent:
+              commandName: find
           - commandStartedEvent:
               commandName: find
               command:

--- a/test/tools/unified-spec-runner/runner.ts
+++ b/test/tools/unified-spec-runner/runner.ts
@@ -319,23 +319,28 @@ export function runUnifiedSuite(
   for (const unifiedSuite of specTests) {
     context(String(unifiedSuite.description), function () {
       for (const [index, test] of unifiedSuite.tests.entries()) {
-        it(String(test.description === '' ? `Test ${index}` : test.description), async function () {
-          if (expectRuntimeError) {
-            const error = await runUnifiedTest(this, unifiedSuite, test, skipFilter).catch(
-              error => error
-            );
-            expect(error).to.satisfy(value => {
-              return (
-                value instanceof AssertionError ||
-                value instanceof MongoServerError ||
-                value instanceof TypeError ||
-                value instanceof MongoParseError
-              );
-            });
-          } else {
-            await runUnifiedTest(this, unifiedSuite, test, skipFilter);
-          }
-        });
+        for (let i = 0; i < 1000; ++i) {
+          it(
+            String(test.description === '' ? `Test ${index}` : test.description) + i,
+            async function () {
+              if (expectRuntimeError) {
+                const error = await runUnifiedTest(this, unifiedSuite, test, skipFilter).catch(
+                  error => error
+                );
+                expect(error).to.satisfy(value => {
+                  return (
+                    value instanceof AssertionError ||
+                    value instanceof MongoServerError ||
+                    value instanceof TypeError ||
+                    value instanceof MongoParseError
+                  );
+                });
+              } else {
+                await runUnifiedTest(this, unifiedSuite, test, skipFilter);
+              }
+            }
+          );
+        }
       }
     });
   }


### PR DESCRIPTION
### Description

https://spruce.mongodb.com/version/67d450f10f5a9c0007908420/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
