### PR TITLE
ci: skip flaky test in abort signal test suite

### DIFF
--- a/test/integration/node-specific/abort_signal.test.ts
+++ b/test/integration/node-specific/abort_signal.test.ts
@@ -932,7 +932,7 @@ describe('AbortSignal support', () => {
       await clearFailPoint(this.configuration);
     });
 
-    it.skip(`rejects findOne`, async () => {
+    it(`rejects findOne`, async () => {
       client.on(
         'commandStarted',
         // Abort a bit after find has started:
@@ -942,10 +942,11 @@ describe('AbortSignal support', () => {
       const start = performance.now();
       const result = await collection.findOne({}, { signal }).catch(error => error);
       const end = performance.now();
-      expect(end - start).to.be.lessThan(10); // shouldn't wait for the blocked connection
+      // TODO(NODE-6833): This duration was bumped from 10 to 40 to reduce flakiness, if this fails again investigate it.
+      expect(end - start).to.be.lessThan(40); // shouldn't wait for the blocked connection
 
       expect(result).to.be.instanceOf(DOMException);
-    }).skipReason = 'TODO(NODE-6833): fix flaky test';
+    });
   });
 
   describe('when a signal passed to db.command() is aborted', failPointMetadata, () => {

--- a/test/integration/node-specific/abort_signal.test.ts
+++ b/test/integration/node-specific/abort_signal.test.ts
@@ -932,7 +932,7 @@ describe('AbortSignal support', () => {
       await clearFailPoint(this.configuration);
     });
 
-    it(`rejects findOne`, async () => {
+    it.skip(`rejects findOne`, async () => {
       client.on(
         'commandStarted',
         // Abort a bit after find has started:
@@ -945,7 +945,7 @@ describe('AbortSignal support', () => {
       expect(end - start).to.be.lessThan(10); // shouldn't wait for the blocked connection
 
       expect(result).to.be.instanceOf(DOMException);
-    });
+    }).skipReason = 'TODO(NODE-6833): fix flaky test';
   });
 
   describe('when a signal passed to db.command() is aborted', failPointMetadata, () => {


### PR DESCRIPTION
### Description

#### What is changing?

https://spruce.mongodb.com/version/67d450f10f5a9c0007908420/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC
##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
