### PR TITLE
ci: skip flaky test in CSOT test suite

### DIFF
--- a/test/integration/client-side-operations-timeout/client_side_operations_timeout.spec.test.ts
+++ b/test/integration/client-side-operations-timeout/client_side_operations_timeout.spec.test.ts
@@ -22,7 +22,9 @@ const skippedTests = {
   'operation succeeds after one socket timeout - aggregate on collection':
     'TODO(NODE-6863): fix flaky test',
   'socketTimeoutMS is ignored if timeoutMS is set - dropIndex on collection':
-    'TODO(NODE-6862): fix flaky test'
+    'TODO(NODE-6862): fix flaky test',
+  'operation fails after two consecutive socket timeouts - aggregate on collection':
+    'TODO(NODE-6867): fix flaky test'
 };
 
 describe('CSOT spec tests', function () {


### PR DESCRIPTION
### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

skip

https://spruce.mongodb.com/task/mongo_node_driver_next_rhel80_large_node_latest_test_4.4_sharded_cluster_91d235221cc42a49bcfa85e428f83d8e6ba258d0_75c01e57abc470e785838d3c6dd0a8c0_25_03_18_15_22_09/logs?execution=0&sortBy=STATUS&sortDir=ASC

Will unskip in: NODE-6867

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
