### PR TITLE
chore(NODE-6870): add tags to normalized_throughput

### DIFF
--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -111,6 +111,7 @@ functions:
   "perf send":
     - command: attach.artifacts
       params:
+        working_dir: src
         files:
           - ./test/benchmarks/driver_bench/results.json
     - command: subprocess.exec

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -109,11 +109,18 @@ functions:
           - .evergreen/run-tests.sh
 
   "perf send":
-    - command: attach.artifacts
+    - command: s3.put
       params:
-        working_dir: src
-        files:
-          - ./test/benchmarks/driver_bench/results.json
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/test/benchmarks/driver_bench/results.json
+        optional: true
+        # TODO NODE-4707 - change upload directory to ${UPLOAD_BUCKET}
+        remote_file: mongo-node-driver/${revision}/${version_id}/results.${task_name}.json
+        bucket: mciuploads
+        permissions: public-read
+        content_type: application/json
+        display_name: "Performance Results"
     - command: subprocess.exec
       params:
         working_dir: src

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -109,6 +109,10 @@ functions:
           - .evergreen/run-tests.sh
 
   "perf send":
+    - command: attach.artifacts
+      params:
+        files:
+          - ./test/benchmarks/driver_bench/results.json
     - command: subprocess.exec
       params:
         working_dir: src

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -81,6 +81,10 @@ functions:
         args:
           - .evergreen/run-tests.sh
   perf send:
+    - command: attach.artifacts
+      params:
+        files:
+          - ./test/benchmarks/driver_bench/results.json
     - command: subprocess.exec
       params:
         working_dir: src

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -83,6 +83,7 @@ functions:
   perf send:
     - command: attach.artifacts
       params:
+        working_dir: src
         files:
           - ./test/benchmarks/driver_bench/results.json
     - command: subprocess.exec

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -81,11 +81,17 @@ functions:
         args:
           - .evergreen/run-tests.sh
   perf send:
-    - command: attach.artifacts
+    - command: s3.put
       params:
-        working_dir: src
-        files:
-          - ./test/benchmarks/driver_bench/results.json
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/test/benchmarks/driver_bench/results.json
+        optional: true
+        remote_file: mongo-node-driver/${revision}/${version_id}/results.${task_name}.json
+        bucket: mciuploads
+        permissions: public-read
+        content_type: application/json
+        display_name: Performance Results
     - command: subprocess.exec
       params:
         working_dir: src

--- a/.evergreen/perf-send.sh
+++ b/.evergreen/perf-send.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 
-set -euox pipefail
+set -euo pipefail
 
 source $DRIVERS_TOOLS/.evergreen/init-node-and-npm-env.sh
 
 TARGET_FILE=$(realpath "${TARGET_FILE:-./test/benchmarks/driver_bench/results.json}")
+
+set -o xtrace
 
 node ./.evergreen/perf_send.mjs $TARGET_FILE

--- a/test/benchmarks/driver_bench/src/main.mts
+++ b/test/benchmarks/driver_bench/src/main.mts
@@ -110,12 +110,12 @@ for (const [suite, benchmarks] of Object.entries(tests)) {
   console.groupEnd();
 }
 
-const aMetricInfo =
+const metricInfoFilterByName =
   (testName: string) =>
   ({ info: { test_name } }: MetricInfo) =>
     test_name === testName;
 
-const anMBsMetric = ({ name }: Metric) => name === 'megabytes_per_second';
+const isMBsMetric = ({ name }: Metric) => name === 'megabytes_per_second';
 
 function calculateCompositeBenchmarks(results: MetricInfo[]) {
   const composites = {
@@ -162,10 +162,10 @@ function calculateCompositeBenchmarks(results: MetricInfo[]) {
 
     let sum = 0;
     for (const testName of compositeTests) {
-      const testScore = results.find(aMetricInfo(testName));
+      const testScore = results.find(metricInfoFilterByName(testName));
       assert.ok(testScore, `${compositeName} suite requires ${testName} for composite score`);
 
-      const metric = testScore.metrics.find(anMBsMetric);
+      const metric = testScore.metrics.find(isMBsMetric);
       assert.ok(metric, `${testName} is missing a megabytes_per_second metric`);
 
       sum += metric.value;
@@ -199,14 +199,14 @@ function calculateCompositeBenchmarks(results: MetricInfo[]) {
 }
 
 function calculateNormalizedResults(results: MetricInfo[]): MetricInfo[] {
-  const baselineBench = results.find(aMetricInfo('cpuBaseline'));
-  const pingBench = results.find(aMetricInfo('ping'));
+  const baselineBench = results.find(metricInfoFilterByName('cpuBaseline'));
+  const pingBench = results.find(metricInfoFilterByName('ping'));
 
   assert.ok(pingBench, 'ping bench results not found!');
   assert.ok(baselineBench, 'cpuBaseline results not found!');
 
-  const cpuBaseline = baselineBench.metrics.find(anMBsMetric);
-  const pingThroughput = pingBench.metrics.find(anMBsMetric);
+  const cpuBaseline = baselineBench.metrics.find(isMBsMetric);
+  const pingThroughput = pingBench.metrics.find(isMBsMetric);
 
   assert.ok(cpuBaseline, 'cpu benchmark does not have a MB/s metric');
   assert.ok(pingThroughput, 'ping does not have a MB/s metric');
@@ -214,7 +214,7 @@ function calculateNormalizedResults(results: MetricInfo[]): MetricInfo[] {
   for (const bench of results) {
     if (bench.info.test_name === 'cpuBaseline') continue;
 
-    const currentMetric = bench.metrics.find(anMBsMetric);
+    const currentMetric = bench.metrics.find(isMBsMetric);
     assert.ok(currentMetric, `${bench.info.test_name} does not have a MB/s metric`);
 
     if (bench.info.test_name === 'ping') {

--- a/test/benchmarks/driver_bench/src/main.mts
+++ b/test/benchmarks/driver_bench/src/main.mts
@@ -110,6 +110,13 @@ for (const [suite, benchmarks] of Object.entries(tests)) {
   console.groupEnd();
 }
 
+const aMetricInfo =
+  (testName: string) =>
+  ({ info: { test_name } }: MetricInfo) =>
+    test_name === testName;
+
+const anMBsMetric = ({ name }: Metric) => name === 'megabytes_per_second';
+
 function calculateCompositeBenchmarks(results: MetricInfo[]) {
   const composites = {
     singleBench: ['findOne', 'smallDocInsertOne', 'largeDocInsertOne'],
@@ -143,13 +150,6 @@ function calculateCompositeBenchmarks(results: MetricInfo[]) {
       'gridfsMultiFileUpload'
     ]
   };
-
-  const aMetricInfo =
-    (testName: string) =>
-    ({ info: { test_name } }: MetricInfo) =>
-      test_name === testName;
-
-  const anMBsMetric = ({ name }: Metric) => name === 'megabytes_per_second';
 
   let readBenchResult;
   let writeBenchResult;
@@ -199,31 +199,40 @@ function calculateCompositeBenchmarks(results: MetricInfo[]) {
 }
 
 function calculateNormalizedResults(results: MetricInfo[]): MetricInfo[] {
-  const baselineBench = results.find(r => r.info.test_name === 'cpuBaseline');
-  const pingBench = results.find(r => r.info.test_name === 'ping');
+  const baselineBench = results.find(aMetricInfo('cpuBaseline'));
+  const pingBench = results.find(aMetricInfo('ping'));
 
   assert.ok(pingBench, 'ping bench results not found!');
-  assert.ok(baselineBench, 'baseline results not found!');
-  const pingThroughput = pingBench.metrics[0].value;
-  const cpuBaseline = baselineBench.metrics[0].value;
+  assert.ok(baselineBench, 'cpuBaseline results not found!');
+
+  const cpuBaseline = baselineBench.metrics.find(anMBsMetric);
+  const pingThroughput = pingBench.metrics.find(anMBsMetric);
+
+  assert.ok(cpuBaseline, 'cpu benchmark does not have a MB/s metric');
+  assert.ok(pingThroughput, 'ping does not have a MB/s metric');
 
   for (const bench of results) {
     if (bench.info.test_name === 'cpuBaseline') continue;
+
+    const currentMetric = bench.metrics.find(anMBsMetric);
+    assert.ok(currentMetric, `${bench.info.test_name} does not have a MB/s metric`);
+
     if (bench.info.test_name === 'ping') {
       bench.metrics.push({
         name: 'normalized_throughput',
-        value: bench.metrics[0].value / cpuBaseline,
+        value: currentMetric.value / cpuBaseline.value,
         metadata: {
+          tags: currentMetric.metadata.tags,
           improvement_direction: 'up'
         }
       });
-    }
-    // Compute normalized_throughput of benchmarks against ping bench
-    else {
+    } else {
+      // Compute normalized_throughput of benchmarks against ping bench
       bench.metrics.push({
         name: 'normalized_throughput',
-        value: bench.metrics[0].value / pingThroughput,
+        value: currentMetric.value / pingThroughput.value,
         metadata: {
+          tags: currentMetric.metadata.tags,
           improvement_direction: 'up'
         }
       });


### PR DESCRIPTION
### Description

#### What is changing?

NODE-6870

normalized_throughput didn't have the tags from the original metric

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

Tags are needed to add metrics to a context

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
