### PR TITLE
test(NODE-6868): sync bulk write monitoring tests

### DIFF
--- a/test/spec/command-logging-and-monitoring/monitoring/unacknowledged-client-bulkWrite.json
+++ b/test/spec/command-logging-and-monitoring/monitoring/unacknowledged-client-bulkWrite.json
@@ -95,29 +95,34 @@
             "ordered": false
           },
           "expectResult": {
-            "insertedCount": {
-              "$$unsetOrMatches": 0
-            },
-            "upsertedCount": {
-              "$$unsetOrMatches": 0
-            },
-            "matchedCount": {
-              "$$unsetOrMatches": 0
-            },
-            "modifiedCount": {
-              "$$unsetOrMatches": 0
-            },
-            "deletedCount": {
-              "$$unsetOrMatches": 0
-            },
-            "insertResults": {
-              "$$unsetOrMatches": {}
-            },
-            "updateResults": {
-              "$$unsetOrMatches": {}
-            },
-            "deleteResults": {
-              "$$unsetOrMatches": {}
+            "$$unsetOrMatches": {
+              "acknowledged": {
+                "$$unsetOrMatches": false
+              },
+              "insertedCount": {
+                "$$unsetOrMatches": 0
+              },
+              "upsertedCount": {
+                "$$unsetOrMatches": 0
+              },
+              "matchedCount": {
+                "$$unsetOrMatches": 0
+              },
+              "modifiedCount": {
+                "$$unsetOrMatches": 0
+              },
+              "deletedCount": {
+                "$$unsetOrMatches": 0
+              },
+              "insertResults": {
+                "$$unsetOrMatches": {}
+              },
+              "updateResults": {
+                "$$unsetOrMatches": {}
+              },
+              "deleteResults": {
+                "$$unsetOrMatches": {}
+              }
             }
           }
         },

--- a/test/spec/command-logging-and-monitoring/monitoring/unacknowledged-client-bulkWrite.yml
+++ b/test/spec/command-logging-and-monitoring/monitoring/unacknowledged-client-bulkWrite.yml
@@ -52,22 +52,16 @@ tests:
                 update: { $set: { x: 333 } }
           ordered: false
         expectResult:
-          insertedCount:
-            $$unsetOrMatches: 0
-          upsertedCount:
-            $$unsetOrMatches: 0
-          matchedCount:
-            $$unsetOrMatches: 0
-          modifiedCount:
-            $$unsetOrMatches: 0
-          deletedCount:
-            $$unsetOrMatches: 0
-          insertResults:
-            $$unsetOrMatches: {}
-          updateResults:
-            $$unsetOrMatches: {}
-          deleteResults:
-            $$unsetOrMatches: {}
+          $$unsetOrMatches:
+            acknowledged: { $$unsetOrMatches: false }
+            insertedCount: { $$unsetOrMatches: 0 }
+            upsertedCount: { $$unsetOrMatches: 0 }
+            matchedCount: { $$unsetOrMatches: 0 }
+            modifiedCount: { $$unsetOrMatches: 0 }
+            deletedCount: { $$unsetOrMatches: 0 }
+            insertResults: { $$unsetOrMatches: {} }
+            updateResults: { $$unsetOrMatches: {} }
+            deleteResults: { $$unsetOrMatches: {} }
       # Force completion of the w:0 write by executing a find on the same connection
       - object: *collection
         name: find


### PR DESCRIPTION
### Description

#### What is changing?

NODE-6868

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
