### PR TITLE
test(NODE-6835): IPv6 literal in SDAM

### DIFF
--- a/test/spec/server-discovery-and-monitoring/rs/secondary_ipv6_literal.json
+++ b/test/spec/server-discovery-and-monitoring/rs/secondary_ipv6_literal.json
@@ -1,0 +1,38 @@
+{
+  "description": "Secondary with IPv6 literal",
+  "uri": "mongodb://[::1]/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "[::1]:27017",
+          {
+            "ok": 1,
+            "helloOk": true,
+            "isWritablePrimary": false,
+            "secondary": true,
+            "setName": "rs",
+            "me": "[::1]:27017",
+            "hosts": [
+              "[::1]:27017"
+            ],
+            "minWireVersion": 0,
+            "maxWireVersion": 26
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "[::1]:27017": {
+            "type": "RSSecondary",
+            "setName": "rs"
+          }
+        },
+        "topologyType": "ReplicaSetNoPrimary",
+        "setName": "rs",
+        "logicalSessionTimeoutMinutes": null,
+        "compatible": true
+      }
+    }
+  ]
+}

--- a/test/spec/server-discovery-and-monitoring/rs/secondary_ipv6_literal.yml
+++ b/test/spec/server-discovery-and-monitoring/rs/secondary_ipv6_literal.yml
@@ -1,0 +1,25 @@
+# Regression test for bug discovered in HELP-68823.
+description: Secondary with IPv6 literal
+uri: mongodb://[::1]/?replicaSet=rs
+phases:
+- responses:
+  - - "[::1]:27017"
+    - ok: 1
+      helloOk: true
+      isWritablePrimary: false
+      secondary: true
+      setName: rs
+      me: "[::1]:27017"
+      hosts:
+      - "[::1]:27017"
+      minWireVersion: 0
+      maxWireVersion: 26
+  outcome:
+    servers:
+      "[::1]:27017":
+        type: RSSecondary
+        setName: rs
+    topologyType: ReplicaSetNoPrimary
+    setName: rs
+    logicalSessionTimeoutMinutes: null
+    compatible: true


### PR DESCRIPTION
### Description

#### What is changing?

Sync tests from https://github.com/mongodb/specifications/commit/fc495d5a58479a6527d7950c0d4be57f0f8869c4

NODE-6835

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

spec compat

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
