### PR TITLE
test(NODE-6802): unskip operations against non-load balanced clusters fail if URI contains loadBalanced=true on latest

### DIFF
--- a/test/spec/load-balancers/non-lb-connection-establishment.json
+++ b/test/spec/load-balancers/non-lb-connection-establishment.json
@@ -57,19 +57,6 @@
   "tests": [
     {
       "description": "operations against non-load balanced clusters fail if URI contains loadBalanced=true",
-      "runOnRequirements": [
-        {
-          "maxServerVersion": "8.0.99",
-          "topologies": [
-            "single"
-          ]
-        },
-        {
-          "topologies": [
-            "sharded"
-          ]
-        }
-      ],
       "operations": [
         {
           "name": "runCommand",

--- a/test/spec/load-balancers/non-lb-connection-establishment.yml
+++ b/test/spec/load-balancers/non-lb-connection-establishment.yml
@@ -42,11 +42,6 @@ tests:
   # If the server is not configured to be behind a load balancer and the URI contains loadBalanced=true, the driver
   # should error during the connection handshake because the server's hello response does not contain a serviceId field.
   - description: operations against non-load balanced clusters fail if URI contains loadBalanced=true
-    runOnRequirements:
-      - maxServerVersion: 8.0.99 # DRIVERS-3108: Skip test on >=8.1 mongod. SERVER-85804 changes a non-LB mongod to close connection.
-        topologies: [ single ]
-      - topologies: [ sharded ]
-
     operations:
       - name: runCommand
         object: *lbTrueDatabase


### PR DESCRIPTION
### Description

#### What is changing?

Unskip lb test on latest

spec: https://github.com/mongodb/specifications/commit/f04df7d667e20fa7f9ae067e6951662c68da85b6

NODE-6802

_update:_ This test runs on non-lb hosts
https://parsley.mongodb.com/evergreen/mongo_node_driver_next_rhel8_no_auth_tests_test_latest_server_noauth_patch_5ce0a4ec855fd1d609fbb17f85b014e5b0fa8157_67e1c3fbf504270007ffbd67_25_03_24_20_43_41/0/task?bookmarks=0,11408&shareLine=7718

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

spec compat

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
