### PR TITLE
test(NODE-3151): add KMS TLS tests for client-side encryption

### DIFF
--- a/test/csfle-kms-providers.ts
+++ b/test/csfle-kms-providers.ts
@@ -1,4 +1,4 @@
-'use strict';
+import { type KMSProviders } from './mongodb';
 
 const csfleKMSProviders = {
   aws: {
@@ -22,7 +22,7 @@ const csfleKMSProviders = {
   }
 };
 
-function getCSFLEKMSProviders() {
+export function getCSFLEKMSProviders(): KMSProviders {
   return JSON.parse(JSON.stringify(csfleKMSProviders));
 }
 
@@ -37,10 +37,7 @@ const keys = [
 ];
 
 const isInEnvironment = key => typeof process.env[key] === 'string' && process.env[key].length > 0;
-const missingKeys = keys.filter(key => !isInEnvironment(key)).join(',');
 
-module.exports = {
-  getCSFLEKMSProviders,
-  kmsCredentialsPresent: missingKeys === '',
-  missingKeys
-};
+export const missingKeys = keys.filter(key => !isInEnvironment(key)).join(',');
+
+export const kmsCredentialsPresent = missingKeys === '';

--- a/test/integration/client-side-encryption/client_side_encryption.prose.10.kms_tls.test.ts
+++ b/test/integration/client-side-encryption/client_side_encryption.prose.10.kms_tls.test.ts
@@ -5,6 +5,8 @@ import { ClientEncryption, type MongoClient } from '../../mongodb';
 
 const metadata: MongoDBMetadataUI = {
   requires: {
+    os: '!win32',
+    topology: '!load-balanced',
     mongodb: '>=4.2.0'
   }
 };
@@ -25,7 +27,7 @@ describe('10. KMS TLS Tests', function () {
 
     clientEncryption = new ClientEncryption(client, {
       keyVaultNamespace,
-      kmsProviders: getCSFLEKMSProviders(),
+      kmsProviders: { aws: getCSFLEKMSProviders().aws },
       tlsOptions: {
         aws: {
           tlsCAFile: process.env.CSFLE_TLS_CA_FILE,
@@ -47,6 +49,8 @@ describe('10. KMS TLS Tests', function () {
       error => error
     );
 
+    expect(error).to.exist;
+    expect(error, error.stack).to.have.property('cause').that.is.instanceOf(Error);
     expect(error.cause.message, error.stack).to.include('certificate has expired');
   });
 
@@ -58,6 +62,8 @@ describe('10. KMS TLS Tests', function () {
       error => error
     );
 
+    expect(error).to.exist;
+    expect(error, error.stack).to.have.property('cause').that.is.instanceOf(Error);
     expect(error.cause.message, error.stack).to.include('does not match certificate');
   });
 });

--- a/test/integration/client-side-encryption/client_side_encryption.prose.10.kms_tls.test.ts
+++ b/test/integration/client-side-encryption/client_side_encryption.prose.10.kms_tls.test.ts
@@ -5,8 +5,7 @@ import { ClientEncryption, type MongoClient } from '../../mongodb';
 
 const metadata: MongoDBMetadataUI = {
   requires: {
-    os: '!win32',
-    topology: '!load-balanced',
+    clientSideEncryption: true,
     mongodb: '>=4.2.0'
   }
 };

--- a/test/integration/client-side-encryption/client_side_encryption.prose.10.kms_tls.test.ts
+++ b/test/integration/client-side-encryption/client_side_encryption.prose.10.kms_tls.test.ts
@@ -1,0 +1,63 @@
+import { expect } from 'chai';
+
+import { getCSFLEKMSProviders } from '../../csfle-kms-providers';
+import { ClientEncryption, type MongoClient } from '../../mongodb';
+
+const metadata: MongoDBMetadataUI = {
+  requires: {
+    mongodb: '>=4.2.0'
+  }
+};
+
+describe('10. KMS TLS Tests', function () {
+  const keyVaultNamespace = 'keyvault.datakeys';
+  const masterKeyBase = {
+    region: 'us-east-1',
+    key: 'arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0'
+  };
+
+  let client: MongoClient;
+  let clientEncryption: ClientEncryption;
+
+  beforeEach(async function () {
+    client = this.configuration.newClient();
+    await client.connect();
+
+    clientEncryption = new ClientEncryption(client, {
+      keyVaultNamespace,
+      kmsProviders: getCSFLEKMSProviders(),
+      tlsOptions: {
+        aws: {
+          tlsCAFile: process.env.CSFLE_TLS_CA_FILE,
+          tlsCertificateKeyFile: process.env.CSFLE_TLS_CLIENT_CERT_FILE
+        }
+      }
+    });
+  });
+
+  afterEach(async function () {
+    await client.close();
+  });
+
+  it('should fail with an expired certificate', metadata, async function () {
+    const masterKey = { ...masterKeyBase, endpoint: '127.0.0.1:9000' };
+
+    const error = await clientEncryption.createDataKey('aws', { masterKey }).then(
+      () => null,
+      error => error
+    );
+
+    expect(error.cause.message, error.stack).to.include('certificate has expired');
+  });
+
+  it('should fail with an invalid hostname', metadata, async function () {
+    const masterKey = { ...masterKeyBase, endpoint: '127.0.0.1:9001' };
+
+    const error = await clientEncryption.createDataKey('aws', { masterKey }).then(
+      () => null,
+      error => error
+    );
+
+    expect(error.cause.message, error.stack).to.include('does not match certificate');
+  });
+});

--- a/test/integration/client-side-encryption/client_side_encryption.prose.test.js
+++ b/test/integration/client-side-encryption/client_side_encryption.prose.test.js
@@ -1351,11 +1351,6 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
     });
   });
 
-  // TODO(NODE-3151): Implement kms prose tests
-  describe('KMS TLS Tests', () => {
-    it.skip('TBD', () => {}).skipReason = 'TODO(NODE-3151): Implement "KMS TLS Tests"';
-  });
-
   /**
    * - Create client encryption no tls
    * - Create client encryption with tls


### PR DESCRIPTION
### Description

#### What is changing?

Add KMS TLS test: NODE-3151

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

Spec test for specific error messages

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
