### PR TITLE
ci: skip flaky x509 authentication test

### DIFF
--- a/test/manual/x509_auth.test.ts
+++ b/test/manual/x509_auth.test.ts
@@ -57,7 +57,7 @@ describe('x509 Authentication', function () {
   context(
     'when a valid cert is provided but the certificate does not correspond to a user',
     function () {
-      it('fails to authenticate', async function () {
+      it.skip('fails to authenticate', async function () {
         client = new MongoClient(connectionString.toString(), validOptions);
         const error = await client.connect().then(
           () => null,
@@ -66,7 +66,7 @@ describe('x509 Authentication', function () {
 
         expect(error).to.be.instanceOf(MongoServerError);
         expect(error.codeName).to.match(/UserNotFound/i);
-      });
+      }).skipReason = 'TODO(NODE-6834): fix flaky test';
     }
   );
 


### PR DESCRIPTION
### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
