### PR TITLE
fix(cursor): ensure documents are cleared correctly to handle emptyGe…

### DIFF
--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -867,7 +867,14 @@ export abstract class AbstractCursor<
     }
 
     this.cursorId = null;
-    this.documents?.clear();
+
+    if (this.documents && typeof this.documents.clear === 'function') {
+      this.documents.clear();
+    } else {
+      // If documents is the emptyGetMore object or doesn't have the clear() method
+      // Simply set it to null to force reinitialization
+      this.documents = null;
+    }
     this.timeoutContext?.clear();
     this.timeoutContext = undefined;
     this.isClosed = false;


### PR DESCRIPTION

# MongoDB Driver: `documents?.clear() is not a function` error in AbstractCursor.rewind()

## Issue Description

When using the MongoDB Node.js driver, there's an issue in the `rewind()` method of `AbstractCursor`. The method attempts to call `this.documents?.clear()` without checking if the `clear()` method exists on the `documents` object.

In certain scenarios, particularly when the MongoDB driver uses an optimization called `emptyGetMore` to avoid unnecessary server calls, `this.documents` is set to a simplified object literal that lacks the `clear()` method:

```javascript
CursorResponse.emptyGetMore = {
    id: new bson_1.Long(0),
    length: 0,
    shift: () => null
    // Note: no clear() method defined
};
```

This causes an error when `rewind()` is called on cursors that have this optimization applied:

```javascript
rewind() {
    if (!this.initialized) {
        return;
    }
    this.cursorId = null;
    this.documents?.clear(); // <-- This line causes the error
    this.isClosed = false;
    this.isKilled = false;
    this.initialized = false;
    // ...
}
```

## Impact

This issue can cause applications to crash when:
1. Using cursor operations that internally call `rewind()`
2. Working with cursors that have been optimized using `emptyGetMore`
3. Attempting to reset or reuse cursors after they've been exhausted

## Reproduction Details

In [this repository](https://github.com/italojs/mongo-bug-repro), the `reproduction.js` script demonstrates this issue by:

1. Creating a MongoDB cursor with a small batch size
2. Consuming all documents to exhaust the cursor
3. Simulating the emptyGetMore optimization by replacing the documents object with one that lacks a clear() method
4. Attempting to rewind the cursor, which triggers the error
5. Trying to reuse the cursor, which would normally work if rewind() succeeded

### Running the Reproduction

```bash
# Install dependencies
npm i

# Run the reproduction script
node reproduction.js
```

Expected output will show the error:
```
Rewind error: this.documents?.clear is not a function
Error name: TypeError
```

## Proposed Solution

The issue can be fixed by modifying the `rewind()` method to safely handle cases where `documents` doesn't have a `clear()` method. Here's the proposed fix:

```javascript
rewind() {
    if (!this.initialized) {
        return;
    }
    this.cursorId = null;
    
    // Check if documents exists and has a clear method before calling it
    if (this.documents && typeof this.documents.clear === 'function') {
        this.documents.clear();
    } else {
        // If documents is the emptyGetMore object or doesn't have the clear() method
        // Simply set it to null to force reinitialization
        this.documents = null;
    }
    
    this.isClosed = false;
    this.isKilled = false;
    this.initialized = false;
    // ... rest of the method
}
```

### Why This Solution Works

1. **Safety**: The solution checks if `clear()` exists before calling it
2. **Functionality**: Setting `documents` to `null` achieves the same goal as `clear()` - it resets the cursor's document buffer
3. **Compatibility**: The solution maintains compatibility with both regular cursors and optimized `emptyGetMore` cursors
4. **Performance**: The solution doesn't introduce any significant overhead

## References

- [Meteor's AsynchronousCursor._rewind() implementation](https://github.com/meteor/meteor/blob/devel/packages/mongo/asynchronous_cursor.js#L120)
- [Meteor's issue](https://github.com/meteor/meteor/issues/13652)


<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->


### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
