### PR TITLE
test(NODE-6500): sync UTR isClientError asserts true for network errors tests

### DIFF
--- a/test/spec/crud/unified/estimatedDocumentCount.json
+++ b/test/spec/crud/unified/estimatedDocumentCount.json
@@ -249,7 +249,7 @@
           "name": "estimatedDocumentCount",
           "object": "collection0",
           "expectError": {
-            "isError": true
+            "isClientError": true
           }
         }
       ],

--- a/test/spec/crud/unified/estimatedDocumentCount.yml
+++ b/test/spec/crud/unified/estimatedDocumentCount.yml
@@ -130,7 +130,7 @@ tests:
       - name: estimatedDocumentCount
         object: *collection0
         expectError:
-          isError: true
+          isClientError: true
     expectEvents:
       - client: *client0
         events:

--- a/test/spec/retryable-reads/unified/estimatedDocumentCount.json
+++ b/test/spec/retryable-reads/unified/estimatedDocumentCount.json
@@ -195,7 +195,7 @@
           "object": "collection1",
           "name": "estimatedDocumentCount",
           "expectError": {
-            "isError": true
+            "isClientError": true
           }
         }
       ],
@@ -241,7 +241,7 @@
           "object": "collection0",
           "name": "estimatedDocumentCount",
           "expectError": {
-            "isError": true
+            "isClientError": true
           }
         }
       ],

--- a/test/spec/retryable-reads/unified/estimatedDocumentCount.yml
+++ b/test/spec/retryable-reads/unified/estimatedDocumentCount.yml
@@ -116,7 +116,7 @@ tests:
         object: *collection1
         name: estimatedDocumentCount
         expectError:
-          isError: true
+          isClientError: true
     expectEvents:
       -
         client: *client1

--- a/test/spec/unified-test-format/valid-pass/expectedError-isClientError.json
+++ b/test/spec/unified-test-format/valid-pass/expectedError-isClientError.json
@@ -1,0 +1,74 @@
+{
+  "description": "expectedError-isClientError",
+  "schemaVersion": "1.3",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "4.0",
+      "topologies": [
+        "single",
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topologies": [
+        "sharded",
+        "load-balanced"
+      ]
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": false
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "test"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "isClientError considers network errors",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "ping"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "ping",
+            "command": {
+              "ping": 1
+            }
+          },
+          "expectError": {
+            "isClientError": true
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/unified-test-format/valid-pass/expectedError-isClientError.yml
+++ b/test/spec/unified-test-format/valid-pass/expectedError-isClientError.yml
@@ -1,0 +1,39 @@
+description: "expectedError-isClientError"
+
+schemaVersion: "1.3"
+
+runOnRequirements:
+  - minServerVersion: "4.0"
+    topologies: [single, replicaset]
+  - minServerVersion: "4.1.7"
+    topologies: [sharded, load-balanced]
+
+createEntities:
+  - client:
+      id: &client0 client0
+      useMultipleMongoses: false
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name test
+
+tests:
+  - description: "isClientError considers network errors"
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+                failCommands: [ ping ]
+                closeConnection: true
+      - name: runCommand
+        object: *database0
+        arguments:
+          commandName: ping
+          command: { ping: 1 }
+        expectError:
+          isClientError: true


### PR DESCRIPTION
### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
