### PR TITLE
types(ModifyResult): update lastErrorObject

### DIFF
--- a/src/collection.ts
+++ b/src/collection.ts
@@ -98,7 +98,11 @@ import { WriteConcern, type WriteConcernOptions } from './write_concern';
 /** @public */
 export interface ModifyResult<TSchema = Document> {
   value: WithId<TSchema> | null;
-  lastErrorObject?: Document;
+  lastErrorObject?: {
+    n: integer;
+    updatedExisting: boolean;
+    upserted: WithId<TSchema>;
+  };
   ok: 0 | 1;
 }
 


### PR DESCRIPTION
This pull request includes a modification to the `ModifyResult` interface in the `src/collection.ts` file to provide more detailed information about the last error object.

Changes to `ModifyResult` interface:

* [`src/collection.ts`](diffhunk://#diff-13b5100fa0acd2c3b6be6e5478d6ccf278ff05a0d74635abeb9720e6823c4642L101-R105): Updated the `lastErrorObject` property in the `ModifyResult` interface to include more specific fields: `n`, `updatedExisting`, and `upserted`.

https://www.mongodb.com/docs/manual/reference/command/findAndModify/#lasterrorobject
 
### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
