### PR TITLE
test(NODE-6885): sync new change stream disambiguated path changes

### DIFF
--- a/test/spec/change-streams/unified/change-streams-disambiguatedPaths.json
+++ b/test/spec/change-streams/unified/change-streams-disambiguatedPaths.json
@@ -28,7 +28,6 @@
       "minServerVersion": "6.1.0",
       "topologies": [
         "replicaset",
-        "sharded-replicaset",
         "load-balanced",
         "sharded"
       ],
@@ -43,70 +42,6 @@
     }
   ],
   "tests": [
-    {
-      "description": "disambiguatedPaths is not present when showExpandedEvents is false/unset",
-      "operations": [
-        {
-          "name": "insertOne",
-          "object": "collection0",
-          "arguments": {
-            "document": {
-              "_id": 1,
-              "a": {
-                "1": 1
-              }
-            }
-          }
-        },
-        {
-          "name": "createChangeStream",
-          "object": "collection0",
-          "arguments": {
-            "pipeline": []
-          },
-          "saveResultAsEntity": "changeStream0"
-        },
-        {
-          "name": "updateOne",
-          "object": "collection0",
-          "arguments": {
-            "filter": {
-              "_id": 1
-            },
-            "update": {
-              "$set": {
-                "a.1": 2
-              }
-            }
-          }
-        },
-        {
-          "name": "iterateUntilDocumentOrError",
-          "object": "changeStream0",
-          "expectResult": {
-            "operationType": "update",
-            "ns": {
-              "db": "database0",
-              "coll": "collection0"
-            },
-            "updateDescription": {
-              "updatedFields": {
-                "$$exists": true
-              },
-              "removedFields": {
-                "$$exists": true
-              },
-              "truncatedArrays": {
-                "$$exists": true
-              },
-              "disambiguatedPaths": {
-                "$$exists": false
-              }
-            }
-          }
-        }
-      ]
-    },
     {
       "description": "disambiguatedPaths is present on updateDescription when an ambiguous path is present",
       "operations": [

--- a/test/spec/change-streams/unified/change-streams-disambiguatedPaths.yml
+++ b/test/spec/change-streams/unified/change-streams-disambiguatedPaths.yml
@@ -24,32 +24,6 @@ initialData:
     documents: []
 
 tests:
-  - description: "disambiguatedPaths is not present when showExpandedEvents is false/unset"
-    operations:
-      - name: insertOne
-        object: *collection0
-        arguments:
-          document: { _id: 1, 'a': { '1': 1 } }
-      - name: createChangeStream
-        object: *collection0
-        arguments: { pipeline: [] }
-        saveResultAsEntity: &changeStream0 changeStream0
-      - name: updateOne
-        object: *collection0
-        arguments:
-          filter: { _id: 1 }
-          update: { $set: { 'a.1': 2 } }
-      - name: iterateUntilDocumentOrError
-        object: *changeStream0
-        expectResult:
-          operationType: "update"
-          ns: { db: *database0, coll: *collection0 }
-          updateDescription:
-            updatedFields: { $$exists: true }
-            removedFields: { $$exists: true }
-            truncatedArrays: { $$exists: true }
-            disambiguatedPaths: { $$exists: false }
-
   - description: "disambiguatedPaths is present on updateDescription when an ambiguous path is present"
     operations:
       - name: insertOne

--- a/test/spec/change-streams/unified/change-streams.json
+++ b/test/spec/change-streams/unified/change-streams.json
@@ -181,7 +181,12 @@
                   "field": "array",
                   "newSize": 2
                 }
-              ]
+              ],
+              "disambiguatedPaths": {
+                "$$unsetOrMatches": {
+                  "$$exists": true
+                }
+              }
             }
           }
         }
@@ -1405,6 +1410,11 @@
               },
               "removedFields": [],
               "truncatedArrays": {
+                "$$unsetOrMatches": {
+                  "$$exists": true
+                }
+              },
+              "disambiguatedPaths": {
                 "$$unsetOrMatches": {
                   "$$exists": true
                 }

--- a/test/spec/change-streams/unified/change-streams.yml
+++ b/test/spec/change-streams/unified/change-streams.yml
@@ -115,7 +115,8 @@ tests:
                 "field": "array",
                 "newSize": 2
               }
-            ]
+            ],
+            disambiguatedPaths: { $$unsetOrMatches: { $$exists: true } }
           }
         }
 
@@ -722,6 +723,7 @@ tests:
             updatedFields: { x: 2 }
             removedFields: []
             truncatedArrays: { $$unsetOrMatches: { $$exists: true } }
+            disambiguatedPaths: { $$unsetOrMatches: { $$exists: true } }
       - name: iterateUntilDocumentOrError
         object: *changeStream0
         expectResult:


### PR DESCRIPTION
### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
