### PR TITLE
test(NODE-6834): fix flaky x509 test

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1345,7 +1345,7 @@ tasks:
         params:
           updates:
             - {key: VERSION, value: latest}
-            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: TOPOLOGY, value: server}
             - {key: AUTH, value: noauth}
             - {key: SSL, value: ssl}
       - func: install dependencies

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -120,7 +120,7 @@ BASE_TASKS.push({
   commands: [
     updateExpansions({
       VERSION: 'latest',
-      TOPOLOGY: 'sharded_cluster',
+      TOPOLOGY: 'server',
       AUTH: 'noauth',
       SSL: 'ssl'
     }),


### PR DESCRIPTION
### Description

Fixes the flaky x509 test.

#### What is changing?

Change tests to run against a standalone instead of sharded cluster.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-6834

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
