### PR TITLE
chore: fix coverage downloading perf results

### DIFF
--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -650,6 +650,7 @@ functions:
           #       compression tests.
           aws s3 cp --recursive s3://mciuploads/mongo-node-driver/${revision}/${version_id}/ \
             coverage/ \
+            --exclude "results.*.json" \
             --exclude "*rhel80-large*" \
             --include "*fermiun"
 

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -576,6 +576,7 @@ functions:
           #       compression tests.
           aws s3 cp --recursive s3://mciuploads/mongo-node-driver/${revision}/${version_id}/ \
             coverage/ \
+            --exclude "results.*.json" \
             --exclude "*rhel80-large*" \
             --include "*fermiun"
 


### PR DESCRIPTION
### Description

#### What is changing?

Performance uploads to the same place as coverage and coverage downloads everything

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

### Release Highlight

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
