### PR TITLE
test(NODE-6863): unskip flaky csot legacy timeout spec test

### DIFF
--- a/test/integration/client-side-operations-timeout/client_side_operations_timeout.spec.test.ts
+++ b/test/integration/client-side-operations-timeout/client_side_operations_timeout.spec.test.ts
@@ -19,8 +19,6 @@ const skippedTests = {
     'TODO(DRIVERS-2965): see modified test in unified-csot-node-specs',
   'timeoutMS applies to full resume attempt in a next call': 'TODO(DRIVERS-3006)',
   'timeoutMS is refreshed for getMore if maxAwaitTimeMS is set': 'TODO(DRIVERS-3018)',
-  'operation succeeds after one socket timeout - aggregate on collection':
-    'TODO(NODE-6863): fix flaky test',
   'socketTimeoutMS is ignored if timeoutMS is set - dropIndex on collection':
     'TODO(NODE-6862): fix flaky test'
 };

--- a/test/tools/runner/flaky.ts
+++ b/test/tools/runner/flaky.ts
@@ -33,5 +33,6 @@ export const flakyTests = [
   'Retryable Writes (unified) retryable writes handshake failures collection.updateOne succeeds after retryable handshake network error',
   'Retryable Reads (unified) retryable reads handshake failures collection.aggregate succeeds after retryable handshake network error',
   'CSOT spec tests legacy timeouts behave correctly for retryable operations operation fails after two consecutive socket timeouts - aggregate on collection',
-  'Server Discovery and Monitoring Prose Tests Connection Pool Management ensure monitors properly create and unpause connection pools when they discover servers'
+  'Server Discovery and Monitoring Prose Tests Connection Pool Management ensure monitors properly create and unpause connection pools when they discover servers',
+  'CSOT spec tests legacy timeouts behave correctly for retryable operations operation succeeds after one socket timeout - aggregate on collection'
 ];


### PR DESCRIPTION
### Description

Unskip the flaky CSOT legacy single timeout test.

#### What is changing?

- Unskip the flaky test
- Add the test to the flaky logging list.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-6863

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
