### PR TITLE
test(NODE-5206): add logging to flaky SDAM test

### DIFF
--- a/test/tools/runner/flaky.ts
+++ b/test/tools/runner/flaky.ts
@@ -32,5 +32,6 @@ export const flakyTests = [
   'CSOT spec tests timeoutMS behaves correctly for GridFS download operations timeoutMS applied to entire download, not individual parts',
   'Retryable Writes (unified) retryable writes handshake failures collection.updateOne succeeds after retryable handshake network error',
   'Retryable Reads (unified) retryable reads handshake failures collection.aggregate succeeds after retryable handshake network error',
-  'CSOT spec tests legacy timeouts behave correctly for retryable operations operation fails after two consecutive socket timeouts - aggregate on collection'
+  'CSOT spec tests legacy timeouts behave correctly for retryable operations operation fails after two consecutive socket timeouts - aggregate on collection',
+  'Server Discovery and Monitoring Prose Tests Connection Pool Management ensure monitors properly create and unpause connection pools when they discover servers'
 ];


### PR DESCRIPTION
### Description

Unskip flaky SDAM prose test.

#### What is changing?

- Unskip the flaky test
- Add the test to the flaky logging list.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-5206

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
