### PR TITLE
test(NODE-6867): unskip csot double timeout test

### DIFF
--- a/test/integration/client-side-operations-timeout/client_side_operations_timeout.spec.test.ts
+++ b/test/integration/client-side-operations-timeout/client_side_operations_timeout.spec.test.ts
@@ -22,9 +22,7 @@ const skippedTests = {
   'operation succeeds after one socket timeout - aggregate on collection':
     'TODO(NODE-6863): fix flaky test',
   'socketTimeoutMS is ignored if timeoutMS is set - dropIndex on collection':
-    'TODO(NODE-6862): fix flaky test',
-  'operation fails after two consecutive socket timeouts - aggregate on collection':
-    'TODO(NODE-6867): fix flaky test'
+    'TODO(NODE-6862): fix flaky test'
 };
 
 describe('CSOT spec tests', function () {

--- a/test/tools/runner/flaky.ts
+++ b/test/tools/runner/flaky.ts
@@ -31,5 +31,6 @@ export const flakyTests = [
   'Transactions Convenient API Spec Unified Tests transaction-options withTransaction inherits transaction options from defaultTransactionOptions',
   'CSOT spec tests timeoutMS behaves correctly for GridFS download operations timeoutMS applied to entire download, not individual parts',
   'Retryable Writes (unified) retryable writes handshake failures collection.updateOne succeeds after retryable handshake network error',
-  'Retryable Reads (unified) retryable reads handshake failures collection.aggregate succeeds after retryable handshake network error'
+  'Retryable Reads (unified) retryable reads handshake failures collection.aggregate succeeds after retryable handshake network error',
+  'CSOT spec tests legacy timeouts behave correctly for retryable operations operation fails after two consecutive socket timeouts - aggregate on collection'
 ];


### PR DESCRIPTION
### Description

Unskip the flaky CSOT double timeout test.

#### What is changing?

- Unskip the flaky test
- Add the test to the flaky logging list.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-6867

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
