### PR TITLE
feat(NODE-6245): add keepAliveInitialDelay config

### DIFF
--- a/src/cmap/connect.ts
+++ b/src/cmap/connect.ts
@@ -307,9 +307,7 @@ function parseConnectOptions(options: ConnectionOptions): SocketConnectOpts {
       (result as Document)[name] = options[name];
     }
   }
-  if (result.keepAliveInitialDelay == null) {
-    result.keepAliveInitialDelay = 120000;
-  }
+result.keepAliveInitialDelay ??= 120000;
   result.keepAlive = true;
   result.noDelay = options.noDelay ?? true;
 

--- a/src/cmap/connect.ts
+++ b/src/cmap/connect.ts
@@ -307,6 +307,10 @@ function parseConnectOptions(options: ConnectionOptions): SocketConnectOpts {
       (result as Document)[name] = options[name];
     }
   }
+  if (result.keepAliveInitialDelay == null) {
+    result.keepAliveInitialDelay = 120000;
+  }
+  result.keepAlive = true;
 
   if (typeof hostAddress.socketPath === 'string') {
     result.path = hostAddress.socketPath;
@@ -377,7 +381,6 @@ export async function makeSocket(options: MakeConnectionOptions): Promise<Stream
     socket = net.createConnection(parseConnectOptions(options));
   }
 
-  socket.setKeepAlive(true, options.keepAliveInitialDelay ?? 120000);
   socket.setTimeout(connectTimeoutMS);
   socket.setNoDelay(noDelay);
 

--- a/src/cmap/connect.ts
+++ b/src/cmap/connect.ts
@@ -289,6 +289,7 @@ export const LEGAL_TLS_SOCKET_OPTIONS = [
 export const LEGAL_TCP_SOCKET_OPTIONS = [
   'autoSelectFamily',
   'autoSelectFamilyAttemptTimeout',
+  'keepAliveInitialDelay',
   'family',
   'hints',
   'localAddress',
@@ -376,7 +377,7 @@ export async function makeSocket(options: MakeConnectionOptions): Promise<Stream
     socket = net.createConnection(parseConnectOptions(options));
   }
 
-  socket.setKeepAlive(true, 300000);
+  socket.setKeepAlive(true, options.keepAliveInitialDelay ?? 120000);
   socket.setTimeout(connectTimeoutMS);
   socket.setNoDelay(noDelay);
 

--- a/src/cmap/connect.ts
+++ b/src/cmap/connect.ts
@@ -307,7 +307,7 @@ function parseConnectOptions(options: ConnectionOptions): SocketConnectOpts {
       (result as Document)[name] = options[name];
     }
   }
-result.keepAliveInitialDelay ??= 120000;
+  result.keepAliveInitialDelay ??= 120000;
   result.keepAlive = true;
   result.noDelay = options.noDelay ?? true;
 

--- a/src/cmap/connect.ts
+++ b/src/cmap/connect.ts
@@ -311,6 +311,7 @@ function parseConnectOptions(options: ConnectionOptions): SocketConnectOpts {
     result.keepAliveInitialDelay = 120000;
   }
   result.keepAlive = true;
+  result.noDelay = options.noDelay ?? true;
 
   if (typeof hostAddress.socketPath === 'string') {
     result.path = hostAddress.socketPath;
@@ -352,7 +353,6 @@ function parseSslOptions(options: MakeConnectionOptions): TLSConnectionOpts {
 
 export async function makeSocket(options: MakeConnectionOptions): Promise<Stream> {
   const useTLS = options.tls ?? false;
-  const noDelay = options.noDelay ?? true;
   const connectTimeoutMS = options.connectTimeoutMS ?? 30000;
   const existingSocket = options.existingSocket;
 
@@ -382,7 +382,6 @@ export async function makeSocket(options: MakeConnectionOptions): Promise<Stream
   }
 
   socket.setTimeout(connectTimeoutMS);
-  socket.setNoDelay(noDelay);
 
   let cancellationHandler: ((err: Error) => void) | null = null;
 

--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -872,6 +872,9 @@ export const OPTIONS = {
       return wc;
     }
   },
+  keepAliveInitialDelay: {
+    type: 'uint'
+  },
   loadBalanced: {
     default: false,
     type: 'boolean'

--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -872,9 +872,6 @@ export const OPTIONS = {
       return wc;
     }
   },
-  keepAliveInitialDelay: {
-    type: 'uint'
-  },
   loadBalanced: {
     default: false,
     type: 'boolean'
@@ -1276,6 +1273,7 @@ export const OPTIONS = {
   requestCert: { type: 'any' },
   rejectUnauthorized: { type: 'any' },
   checkServerIdentity: { type: 'any' },
+  keepAliveInitialDelay: { type: 'any' },
   ALPNProtocols: { type: 'any' },
   SNICallback: { type: 'any' },
   session: { type: 'any' },

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -115,7 +115,11 @@ export type SupportedTLSSocketOptions = Pick<
 
 /** @public */
 export type SupportedSocketOptions = Pick<
-  TcpNetConnectOpts & { autoSelectFamily?: boolean; autoSelectFamilyAttemptTimeout?: number },
+  TcpNetConnectOpts & {
+    autoSelectFamily?: boolean;
+    autoSelectFamilyAttemptTimeout?: number;
+    keepAliveInitialDelay?: number;
+  },
   (typeof LEGAL_TCP_SOCKET_OPTIONS)[number]
 >;
 

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -118,6 +118,7 @@ export type SupportedSocketOptions = Pick<
   TcpNetConnectOpts & {
     autoSelectFamily?: boolean;
     autoSelectFamilyAttemptTimeout?: number;
+    /** Node.JS socket option to set the time the first keepalive probe is sent on an idle socket. */
     keepAliveInitialDelay?: number;
   },
   (typeof LEGAL_TCP_SOCKET_OPTIONS)[number]

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -118,7 +118,7 @@ export type SupportedSocketOptions = Pick<
   TcpNetConnectOpts & {
     autoSelectFamily?: boolean;
     autoSelectFamilyAttemptTimeout?: number;
-    /** Node.JS socket option to set the time the first keepalive probe is sent on an idle socket. */
+    /** Node.JS socket option to set the time the first keepalive probe is sent on an idle socket. Defaults to 120000ms */
     keepAliveInitialDelay?: number;
   },
   (typeof LEGAL_TCP_SOCKET_OPTIONS)[number]

--- a/test/integration/node-specific/mongo_client.test.ts
+++ b/test/integration/node-specific/mongo_client.test.ts
@@ -154,13 +154,16 @@ describe('class MongoClient', function () {
           spy.restore();
         });
 
-        it('passes through the option', function () {
-          expect(spy).to.have.been.calledWith(
-            sinon.match({
-              keepAlive: true,
-              keepAliveInitialDelay: 0
-            })
-          );
+        it('passes through the option', {
+          metadata: { requires: { apiVersion: false } },
+          test: function () {
+            expect(spy).to.have.been.calledWith(
+              sinon.match({
+                keepAlive: true,
+                keepAliveInitialDelay: 0
+              })
+            );
+          }
         });
       });
 
@@ -181,13 +184,16 @@ describe('class MongoClient', function () {
           spy.restore();
         });
 
-        it('passes through the option', function () {
-          expect(spy).to.have.been.calledWith(
-            sinon.match({
-              keepAlive: true,
-              keepAliveInitialDelay: 100
-            })
-          );
+        it('passes through the option', {
+          metadata: { requires: { apiVersion: false } },
+          test: function () {
+            expect(spy).to.have.been.calledWith(
+              sinon.match({
+                keepAlive: true,
+                keepAliveInitialDelay: 100
+              })
+            );
+          }
         });
       });
 
@@ -208,13 +214,16 @@ describe('class MongoClient', function () {
           spy.restore();
         });
 
-        it('sets the option to 0', function () {
-          expect(spy).to.have.been.calledWith(
-            sinon.match({
-              keepAlive: true,
-              keepAliveInitialDelay: 0
-            })
-          );
+        it('sets the option to 0', {
+          metadata: { requires: { apiVersion: false } },
+          test: function () {
+            expect(spy).to.have.been.calledWith(
+              sinon.match({
+                keepAlive: true,
+                keepAliveInitialDelay: 0
+              })
+            );
+          }
         });
       });
     });
@@ -285,12 +294,15 @@ describe('class MongoClient', function () {
         spy.restore();
       });
 
-      it('sets noDelay', function () {
-        expect(spy).to.have.been.calledWith(
-          sinon.match({
-            noDelay: false
-          })
-        );
+      it('sets noDelay', {
+        metadata: { requires: { apiVersion: false } },
+        test: function () {
+          expect(spy).to.have.been.calledWith(
+            sinon.match({
+              noDelay: false
+            })
+          );
+        }
       });
     });
   });

--- a/test/integration/node-specific/mongo_client.test.ts
+++ b/test/integration/node-specific/mongo_client.test.ts
@@ -214,7 +214,7 @@ describe('class MongoClient', function () {
           spy.restore();
         });
 
-        it('sets the option to 0', {
+        it('the Node.js runtime sets the option to 0', {
           metadata: { requires: { apiVersion: false } },
           test: function () {
             expect(spy).to.have.been.calledWith(
@@ -222,6 +222,34 @@ describe('class MongoClient', function () {
                 keepAlive: true,
                 keepAliveInitialDelay: 0
               })
+            );
+          }
+        });
+      });
+
+      context('when the value is mistyped', function () {
+        // Set server selection timeout to get the error quicker.
+        const options = { keepAliveInitialDelay: 'test', serverSelectionTimeoutMS: 1000 };
+        let client;
+        let spy;
+
+        beforeEach(async function () {
+          spy = sinon.spy(net, 'createConnection');
+          const uri = this.configuration.url();
+          client = new MongoClient(uri, options);
+        });
+
+        afterEach(async function () {
+          await client?.close();
+          spy.restore();
+        });
+
+        it('throws an error', {
+          metadata: { requires: { apiVersion: false } },
+          test: async function () {
+            const error = await client.connect().catch(error => error);
+            expect(error.message).to.include(
+              'property must be of type number. Received type string'
             );
           }
         });

--- a/test/integration/node-specific/mongo_client.test.ts
+++ b/test/integration/node-specific/mongo_client.test.ts
@@ -188,7 +188,6 @@ describe('class MongoClient', function () {
         beforeEach(async function () {
           spy = sinon.spy(Socket.prototype, 'setKeepAlive');
           client = this.configuration.newClient(options);
-          await client.connect();
         });
 
         afterEach(async function () {
@@ -196,8 +195,10 @@ describe('class MongoClient', function () {
           spy.restore();
         });
 
-        it('passes through the option', function () {
-          expect(spy).to.have.been.calledWith(true, -100);
+        it('raises an error', function () {
+          expect(async () => {
+            await client.connect();
+          }).to.throw(/keepAliveInitialDelay can only be a positive int value/);
         });
       });
     });

--- a/test/integration/node-specific/mongo_client.test.ts
+++ b/test/integration/node-specific/mongo_client.test.ts
@@ -243,6 +243,56 @@ describe('class MongoClient', function () {
         );
       });
     });
+
+    context('when noDelay is not provided', function () {
+      let client;
+      let spy;
+
+      beforeEach(async function () {
+        spy = sinon.spy(net, 'createConnection');
+        client = this.configuration.newClient();
+        await client.connect();
+      });
+
+      afterEach(async function () {
+        await client?.close();
+        spy.restore();
+      });
+
+      it('sets noDelay to true', function () {
+        expect(spy).to.have.been.calledWith(
+          sinon.match({
+            noDelay: true
+          })
+        );
+      });
+    });
+
+    context('when noDelay is provided', function () {
+      let client;
+      let spy;
+
+      beforeEach(async function () {
+        const options = { noDelay: false };
+        spy = sinon.spy(net, 'createConnection');
+        const uri = this.configuration.url();
+        client = new MongoClient(uri, options);
+        await client.connect();
+      });
+
+      afterEach(async function () {
+        await client?.close();
+        spy.restore();
+      });
+
+      it('sets noDelay', function () {
+        expect(spy).to.have.been.calledWith(
+          sinon.match({
+            noDelay: false
+          })
+        );
+      });
+    });
   });
 
   it('Should correctly pass through appname', {
@@ -999,12 +1049,12 @@ describe('class MongoClient', function () {
         metadata: { requires: { topology: ['single'] } },
         test: async function () {
           await client.connect();
-          expect(netSpy).to.have.been.calledWith({
-            autoSelectFamily: false,
-            autoSelectFamilyAttemptTimeout: 100,
-            host: 'localhost',
-            port: 27017
-          });
+          expect(netSpy).to.have.been.calledWith(
+            sinon.match({
+              autoSelectFamily: false,
+              autoSelectFamilyAttemptTimeout: 100
+            })
+          );
         }
       });
     });
@@ -1018,11 +1068,11 @@ describe('class MongoClient', function () {
         metadata: { requires: { topology: ['single'] } },
         test: async function () {
           await client.connect();
-          expect(netSpy).to.have.been.calledWith({
-            autoSelectFamily: true,
-            host: 'localhost',
-            port: 27017
-          });
+          expect(netSpy).to.have.been.calledWith(
+            sinon.match({
+              autoSelectFamily: true
+            })
+          );
         }
       });
     });

--- a/test/integration/node-specific/mongo_client.test.ts
+++ b/test/integration/node-specific/mongo_client.test.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { once } from 'events';
 import * as net from 'net';
+import { Socket } from 'net';
 import * as sinon from 'sinon';
 
 import {
@@ -133,6 +134,93 @@ describe('class MongoClient', function () {
 
     const error = await client.connect().catch(error => error);
     expect(error).to.be.instanceOf(MongoServerSelectionError);
+  });
+
+  describe('#connect', function () {
+    context('when keepAliveInitialDelay is provided', function () {
+      context('when the value is 0', function () {
+        const options = { keepAliveInitialDelay: 0 };
+        let client;
+        let spy;
+
+        beforeEach(async function () {
+          spy = sinon.spy(Socket.prototype, 'setKeepAlive');
+          client = this.configuration.newClient(options);
+          await client.connect();
+        });
+
+        afterEach(async function () {
+          await client?.close();
+          spy.restore();
+        });
+
+        it('passes through the option', function () {
+          expect(spy).to.have.been.calledWith(true, 0);
+        });
+      });
+
+      context('when the value is positive', function () {
+        const options = { keepAliveInitialDelay: 100 };
+        let client;
+        let spy;
+
+        beforeEach(async function () {
+          spy = sinon.spy(Socket.prototype, 'setKeepAlive');
+          client = this.configuration.newClient(options);
+          await client.connect();
+        });
+
+        afterEach(async function () {
+          await client?.close();
+          spy.restore();
+        });
+
+        it('passes through the option', function () {
+          expect(spy).to.have.been.calledWith(true, 100);
+        });
+      });
+
+      context('when the value is negative', function () {
+        const options = { keepAliveInitialDelay: -100 };
+        let client;
+        let spy;
+
+        beforeEach(async function () {
+          spy = sinon.spy(Socket.prototype, 'setKeepAlive');
+          client = this.configuration.newClient(options);
+          await client.connect();
+        });
+
+        afterEach(async function () {
+          await client?.close();
+          spy.restore();
+        });
+
+        it('passes through the option', function () {
+          expect(spy).to.have.been.calledWith(true, -100);
+        });
+      });
+    });
+
+    context('when keepAliveInitialDelay is not provided', function () {
+      let client;
+      let spy;
+
+      beforeEach(async function () {
+        spy = sinon.spy(Socket.prototype, 'setKeepAlive');
+        client = this.configuration.newClient();
+        await client.connect();
+      });
+
+      afterEach(async function () {
+        await client?.close();
+        spy.restore();
+      });
+
+      it('sets keepalive to 120000', function () {
+        expect(spy).to.have.been.calledWith(true, 120000);
+      });
+    });
   });
 
   it('Should correctly pass through appname', {

--- a/test/integration/node-specific/mongo_client.test.ts
+++ b/test/integration/node-specific/mongo_client.test.ts
@@ -182,22 +182,10 @@ describe('class MongoClient', function () {
 
       context('when the value is negative', function () {
         const options = { keepAliveInitialDelay: -100 };
-        let client;
-        let spy;
-
-        beforeEach(async function () {
-          spy = sinon.spy(Socket.prototype, 'setKeepAlive');
-          client = this.configuration.newClient(options);
-        });
-
-        afterEach(async function () {
-          await client?.close();
-          spy.restore();
-        });
 
         it('raises an error', function () {
           expect(async () => {
-            await client.connect();
+            this.configuration.newClient(options);
           }).to.throw(/keepAliveInitialDelay can only be a positive int value/);
         });
       });

--- a/test/integration/node-specific/mongo_client.test.ts
+++ b/test/integration/node-specific/mongo_client.test.ts
@@ -184,7 +184,7 @@ describe('class MongoClient', function () {
         const options = { keepAliveInitialDelay: -100 };
 
         it('raises an error', function () {
-          expect(async () => {
+          expect(() => {
             this.configuration.newClient(options);
           }).to.throw(/keepAliveInitialDelay can only be a positive int value/);
         });

--- a/test/manual/tls_support.test.ts
+++ b/test/manual/tls_support.test.ts
@@ -77,19 +77,17 @@ describe('TLS Support', function () {
 
         it('sets the default options', async function () {
           await client.connect();
-          expect(tlsSpy).to.have.been.calledWith({
-            autoSelectFamily: true,
-            host: 'localhost',
-            port: 27017,
-            servername: 'localhost',
-            ca: sinon.match.defined,
-            cert: sinon.match.defined,
-            key: sinon.match.defined
-          });
+          expect(tlsSpy).to.have.been.calledWith(
+            sinon.match({
+              ca: sinon.match.defined,
+              cert: sinon.match.defined,
+              key: sinon.match.defined
+            })
+          );
         });
       });
 
-      context('when auto family options are set', function () {
+      context('when auto select family options are set', function () {
         let tlsSpy;
 
         afterEach(function () {
@@ -107,16 +105,15 @@ describe('TLS Support', function () {
 
         it('sets the provided options', async function () {
           await client.connect();
-          expect(tlsSpy).to.have.been.calledWith({
-            autoSelectFamily: false,
-            autoSelectFamilyAttemptTimeout: 100,
-            host: 'localhost',
-            port: 27017,
-            servername: 'localhost',
-            ca: sinon.match.defined,
-            cert: sinon.match.defined,
-            key: sinon.match.defined
-          });
+          expect(tlsSpy).to.have.been.calledWith(
+            sinon.match({
+              autoSelectFamily: false,
+              autoSelectFamilyAttemptTimeout: 100,
+              ca: sinon.match.defined,
+              cert: sinon.match.defined,
+              key: sinon.match.defined
+            })
+          );
         });
       });
 


### PR DESCRIPTION
### Description

Brings back the `keepAliveInitialDelay` option.

#### What is changing?
- Adds `keepAliveInitialDelay` as an option to pass to the socket.
- Removed the explicit calls to `setKeepAlive` and `setNoDelay`
- Defaults now to 120 seconds instead of 300

##### Is there new documentation needed for these changes?

Yes, driver docs.

#### What is the motivation for this change?

NODE-6245

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### `keepAliveInitialDelay` may now be configured at the `MongoClient` level

When not present will default to 120 seconds. The option value must be specified in milliseconds.

```typescript
import { MongoClient } from 'mongodb';

const client = new MongoClient(process.env.MONGODB_URI, { keepAliveInitialDelay: 100000 });
```

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
