### PR TITLE
chore: add logging to flaky tests

### DIFF
--- a/test/tools/runner/flaky.ts
+++ b/test/tools/runner/flaky.ts
@@ -1,7 +1,10 @@
+import { expect } from 'chai';
+
+import { alphabetically } from '../utils';
+
 export const flakyTests = [
+  'Change Streams should properly handle a changeStream event being processed mid-close when invoked with promises',
   'Client Side Encryption (Unified) namedKMS-rewrapManyDataKey rewrap to azure:name1',
-  'Server Discovery and Monitoring Prose Tests Connection Pool Management ensure monitors properly create and unpause connection pools when they discover servers',
-  'CSOT spec tests legacy timeouts behave correctly for retryable operations operation succeeds after one socket timeout - aggregate on collection',
   'Client Side Encryption Prose Tests 16. Rewrap Case 1: Rewrap with separate ClientEncryption should rewrap data key from aws to aws',
   'Client Side Encryption Prose Tests 16. Rewrap Case 1: Rewrap with separate ClientEncryption should rewrap data key from aws to azure',
   'Client Side Encryption Prose Tests 16. Rewrap Case 1: Rewrap with separate ClientEncryption should rewrap data key from aws to gcp',
@@ -28,12 +31,18 @@ export const flakyTests = [
   'Client Side Encryption Prose Tests 16. Rewrap Case 1: Rewrap with separate ClientEncryption should rewrap data key from local to kmip',
   'Client Side Encryption Prose Tests 16. Rewrap Case 1: Rewrap with separate ClientEncryption should rewrap data key from local to local',
   'Client Side Encryption Prose Tests 16. Rewrap Case 2: RewrapManyDataKeyOpts.provider is not optional when provider field is missing raises an error',
-  'Transactions Convenient API Spec Unified Tests transaction-options withTransaction inherits transaction options from defaultTransactionOptions',
-  'CSOT spec tests timeoutMS behaves correctly for GridFS download operations timeoutMS applied to entire download, not individual parts',
-  'Retryable Writes (unified) retryable writes handshake failures collection.updateOne succeeds after retryable handshake network error',
-  'Retryable Reads (unified) retryable reads handshake failures collection.aggregate succeeds after retryable handshake network error',
   'CSOT spec tests legacy timeouts behave correctly for retryable operations operation fails after two consecutive socket timeouts - aggregate on collection',
-  'Server Discovery and Monitoring Prose Tests Connection Pool Management ensure monitors properly create and unpause connection pools when they discover servers',
   'CSOT spec tests legacy timeouts behave correctly for retryable operations operation succeeds after one socket timeout - aggregate on collection',
-  'CSOT spec tests operations ignore deprecated timeout options if timeoutMS is set socketTimeoutMS is ignored if timeoutMS is set - dropIndex on collection'
+  'CSOT spec tests operations ignore deprecated timeout options if timeoutMS is set socketTimeoutMS is ignored if timeoutMS is set - dropIndex on collection',
+  'CSOT spec tests runCursorCommand Non-tailable cursor lifetime remaining timeoutMS applied to getMore if timeoutMode is unset',
+  'CSOT spec tests timeoutMS behaves correctly for GridFS download operations timeoutMS applied to entire download, not individual parts',
+  'Retryable Reads (unified) retryable reads handshake failures collection.aggregate succeeds after retryable handshake network error',
+  'Retryable Writes (unified) retryable writes handshake failures collection.updateOne succeeds after retryable handshake network error',
+  'Server Discovery and Monitoring Prose Tests Connection Pool Management ensure monitors properly create and unpause connection pools when they discover servers',
+  'Transactions Convenient API Spec Unified Tests transaction-options withTransaction inherits transaction options from defaultTransactionOptions'
 ];
+
+expect(flakyTests, 'expected list to be alphabetized').to.deep.equal(
+  [...flakyTests].sort(alphabetically)
+);
+expect(flakyTests, 'expected to have no duplicates').to.have.lengthOf(new Set(flakyTests).size);


### PR DESCRIPTION
### Description

#### What is changing?

New flakes to gather logs for:
- Change Streams should properly handle a changeStream event being processed mid-close when invoked with promises
- CSOT spec tests runCursorCommand Non-tailable cursor lifetime remaining timeoutMS applied to getMore if timeoutMode is unset

##### Is there new documentation needed for these changes?
No
#### What is the motivation for this change?

Next time we see it, we will know more!

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
