### PR TITLE
feat(NODE-6290): add sort support to updateOne and replaceOne

### DIFF
--- a/src/bulk/common.ts
+++ b/src/bulk/common.ts
@@ -69,7 +69,7 @@ export interface DeleteManyModel<TSchema extends Document = Document> {
 
 /** @public */
 export interface ReplaceOneModel<TSchema extends Document = Document> {
-  /** The filter to limit the replaced document. */
+  /** The filter that specifies which document to replace. In the case of multiple matches, the first document matched is replaced. */
   filter: Filter<TSchema>;
   /** The document with which to replace the matched document. */
   replacement: WithoutId<TSchema>;
@@ -79,13 +79,13 @@ export interface ReplaceOneModel<TSchema extends Document = Document> {
   hint?: Hint;
   /** When true, creates a new document if no document matches the query. */
   upsert?: boolean;
-  /** if the filter matches more than one document the first one matched by the sort order will be updated */
+  /** Specifies the sort order for the documents matched by the filter. */
   sort?: Sort;
 }
 
 /** @public */
 export interface UpdateOneModel<TSchema extends Document = Document> {
-  /** The filter to limit the updated documents. */
+  /** The filter that specifies which document to update. In the case of multiple matches, the first document matched is updated. */
   filter: Filter<TSchema>;
   /**
    * The modifications to apply. The value can be either:
@@ -101,7 +101,7 @@ export interface UpdateOneModel<TSchema extends Document = Document> {
   hint?: Hint;
   /** When true, creates a new document if no document matches the query. */
   upsert?: boolean;
-  /** if the filter matches more than one document the first one matched by the sort order will be updated */
+  /** Specifies the sort order for the documents matched by the filter. */
   sort?: Sort;
 }
 

--- a/src/bulk/common.ts
+++ b/src/bulk/common.ts
@@ -19,6 +19,7 @@ import { makeUpdateStatement, UpdateOperation, type UpdateStatement } from '../o
 import type { Server } from '../sdam/server';
 import type { Topology } from '../sdam/topology';
 import type { ClientSession } from '../sessions';
+import { type Sort } from '../sort';
 import { type TimeoutContext } from '../timeout';
 import {
   applyRetryableWrites,
@@ -78,6 +79,8 @@ export interface ReplaceOneModel<TSchema extends Document = Document> {
   hint?: Hint;
   /** When true, creates a new document if no document matches the query. */
   upsert?: boolean;
+  /** if the filter matches more than one document the first one matched by the sort order will be updated */
+  sort?: Sort;
 }
 
 /** @public */
@@ -98,6 +101,8 @@ export interface UpdateOneModel<TSchema extends Document = Document> {
   hint?: Hint;
   /** When true, creates a new document if no document matches the query. */
   upsert?: boolean;
+  /** if the filter matches more than one document the first one matched by the sort order will be updated */
+  sort?: Sort;
 }
 
 /** @public */

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -87,6 +87,7 @@ import {
 } from './operations/update';
 import { ReadConcern, type ReadConcernLike } from './read_concern';
 import { ReadPreference, type ReadPreferenceLike } from './read_preference';
+import { type Sort } from './sort';
 import {
   DEFAULT_PK_FACTORY,
   MongoDBCollectionNamespace,
@@ -365,7 +366,7 @@ export class Collection<TSchema extends Document = Document> {
   async updateOne(
     filter: Filter<TSchema>,
     update: UpdateFilter<TSchema> | Document[],
-    options?: UpdateOptions
+    options?: UpdateOptions & { sort?: Sort }
   ): Promise<UpdateResult<TSchema>> {
     return await executeOperation(
       this.client,

--- a/src/operations/client_bulk_write/command_builder.ts
+++ b/src/operations/client_bulk_write/command_builder.ts
@@ -3,6 +3,7 @@ import { DocumentSequence } from '../../cmap/commands';
 import { MongoAPIError, MongoInvalidArgumentError } from '../../error';
 import { type PkFactory } from '../../mongo_client';
 import type { Filter, OptionalId, UpdateFilter, WithoutId } from '../../mongo_types';
+import { formatSort, type SortForCmd } from '../../sort';
 import { DEFAULT_PK_FACTORY, hasAtomicOperators } from '../../utils';
 import { type CollationOptions } from '../command';
 import { type Hint } from '../operation';
@@ -327,6 +328,7 @@ export interface ClientUpdateOperation {
   upsert?: boolean;
   arrayFilters?: Document[];
   collation?: CollationOptions;
+  sort?: SortForCmd;
 }
 
 /**
@@ -398,6 +400,9 @@ function createUpdateOperation(
   if (model.collation) {
     document.collation = model.collation;
   }
+  if (!multi && 'sort' in model && model.sort != null) {
+    document.sort = formatSort(model.sort);
+  }
   return document;
 }
 
@@ -410,6 +415,7 @@ export interface ClientReplaceOneOperation {
   hint?: Hint;
   upsert?: boolean;
   collation?: CollationOptions;
+  sort?: SortForCmd;
 }
 
 /**
@@ -442,6 +448,9 @@ export const buildReplaceOneOperation = (
   }
   if (model.collation) {
     document.collation = model.collation;
+  }
+  if (model.sort != null) {
+    document.sort = formatSort(model.sort);
   }
   return document;
 };

--- a/src/operations/client_bulk_write/common.ts
+++ b/src/operations/client_bulk_write/common.ts
@@ -2,6 +2,7 @@ import { type Document } from '../../bson';
 import type { Filter, OptionalId, UpdateFilter, WithoutId } from '../../mongo_types';
 import type { CollationOptions, CommandOperationOptions } from '../../operations/command';
 import type { Hint } from '../../operations/operation';
+import { type Sort } from '../../sort';
 
 /** @public */
 export interface ClientBulkWriteOptions extends CommandOperationOptions {
@@ -89,6 +90,8 @@ export interface ClientReplaceOneModel<TSchema> extends ClientWriteModel {
   hint?: Hint;
   /** When true, creates a new document if no document matches the query. */
   upsert?: boolean;
+  /** if the filter matches more than one document the first one matched by the sort order will be updated */
+  sort?: Sort;
 }
 
 /** @public */
@@ -113,6 +116,8 @@ export interface ClientUpdateOneModel<TSchema> extends ClientWriteModel {
   hint?: Hint;
   /** When true, creates a new document if no document matches the query. */
   upsert?: boolean;
+  /** if the filter matches more than one document the first one matched by the sort order will be updated */
+  sort?: Sort;
 }
 
 /** @public */

--- a/src/operations/client_bulk_write/common.ts
+++ b/src/operations/client_bulk_write/common.ts
@@ -90,7 +90,7 @@ export interface ClientReplaceOneModel<TSchema> extends ClientWriteModel {
   hint?: Hint;
   /** When true, creates a new document if no document matches the query. */
   upsert?: boolean;
-  /** if the filter matches more than one document the first one matched by the sort order will be updated */
+  /** Specifies the sort order for the documents matched by the filter. */
   sort?: Sort;
 }
 
@@ -116,7 +116,7 @@ export interface ClientUpdateOneModel<TSchema> extends ClientWriteModel {
   hint?: Hint;
   /** When true, creates a new document if no document matches the query. */
   upsert?: boolean;
-  /** if the filter matches more than one document the first one matched by the sort order will be updated */
+  /** Specifies the sort order for the documents matched by the filter. */
   sort?: Sort;
 }
 

--- a/src/operations/update.ts
+++ b/src/operations/update.ts
@@ -59,7 +59,7 @@ export interface UpdateStatement {
   arrayFilters?: Document[];
   /** A document or string that specifies the index to use to support the query predicate. */
   hint?: Hint;
-  /** if the filter matches more than one document the first one matched by the sort order will be updated */
+  /** Specifies the sort order for the documents matched by the filter. */
   sort?: SortForCmd;
 }
 
@@ -217,7 +217,7 @@ export interface ReplaceOptions extends CommandOperationOptions {
   upsert?: boolean;
   /** Map of parameter names and values that can be accessed using $$var (requires MongoDB 5.0). */
   let?: Document;
-  /** if the filter matches more than one document the first one matched by the sort order will be updated */
+  /** Specifies the sort order for the documents matched by the filter. */
   sort?: Sort;
 }
 

--- a/src/operations/update.ts
+++ b/src/operations/update.ts
@@ -4,6 +4,7 @@ import { MongoCompatibilityError, MongoInvalidArgumentError, MongoServerError } 
 import type { InferIdType, TODO_NODE_3286 } from '../mongo_types';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
+import { formatSort, type Sort, type SortForCmd } from '../sort';
 import { type TimeoutContext } from '../timeout';
 import { hasAtomicOperators, type MongoDBNamespace } from '../utils';
 import { type CollationOptions, CommandOperation, type CommandOperationOptions } from './command';
@@ -58,6 +59,8 @@ export interface UpdateStatement {
   arrayFilters?: Document[];
   /** A document or string that specifies the index to use to support the query predicate. */
   hint?: Hint;
+  /** if the filter matches more than one document the first one matched by the sort order will be updated */
+  sort?: SortForCmd;
 }
 
 /**
@@ -214,6 +217,8 @@ export interface ReplaceOptions extends CommandOperationOptions {
   upsert?: boolean;
   /** Map of parameter names and values that can be accessed using $$var (requires MongoDB 5.0). */
   let?: Document;
+  /** if the filter matches more than one document the first one matched by the sort order will be updated */
+  sort?: Sort;
 }
 
 /** @internal */
@@ -259,7 +264,7 @@ export class ReplaceOneOperation extends UpdateOperation {
 export function makeUpdateStatement(
   filter: Document,
   update: Document | Document[],
-  options: UpdateOptions & { multi?: boolean }
+  options: UpdateOptions & { multi?: boolean } & { sort?: Sort }
 ): UpdateStatement {
   if (filter == null || typeof filter !== 'object') {
     throw new MongoInvalidArgumentError('Selector must be a valid JavaScript object');
@@ -288,6 +293,10 @@ export function makeUpdateStatement(
 
   if (options.collation) {
     op.collation = options.collation;
+  }
+
+  if (!options.multi && options.sort != null) {
+    op.sort = formatSort(options.sort);
   }
 
   return op;

--- a/test/spec/crud/unified/bulkWrite-replaceOne-sort.json
+++ b/test/spec/crud/unified/bulkWrite-replaceOne-sort.json
@@ -1,0 +1,239 @@
+{
+  "description": "BulkWrite replaceOne-sort",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent",
+          "commandSucceededEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        },
+        {
+          "_id": 2,
+          "x": 22
+        },
+        {
+          "_id": 3,
+          "x": 33
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "BulkWrite replaceOne with sort option",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "8.0"
+        }
+      ],
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "bulkWrite",
+          "arguments": {
+            "requests": [
+              {
+                "replaceOne": {
+                  "filter": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  },
+                  "sort": {
+                    "_id": -1
+                  },
+                  "replacement": {
+                    "x": 1
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": {
+                          "$gt": 1
+                        }
+                      },
+                      "u": {
+                        "x": 1
+                      },
+                      "sort": {
+                        "_id": -1
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "reply": {
+                  "ok": 1,
+                  "n": 1
+                },
+                "commandName": "update"
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "BulkWrite replaceOne with sort option unsupported (server-side error)",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "7.99"
+        }
+      ],
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "bulkWrite",
+          "arguments": {
+            "requests": [
+              {
+                "replaceOne": {
+                  "filter": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  },
+                  "sort": {
+                    "_id": -1
+                  },
+                  "replacement": {
+                    "x": 1
+                  }
+                }
+              }
+            ]
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": {
+                          "$gt": 1
+                        }
+                      },
+                      "u": {
+                        "x": 1
+                      },
+                      "sort": {
+                        "_id": -1
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/crud/unified/bulkWrite-replaceOne-sort.yml
+++ b/test/spec/crud/unified/bulkWrite-replaceOne-sort.yml
@@ -1,0 +1,94 @@
+description: BulkWrite replaceOne-sort
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent, commandSucceededEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1, x: 11 }
+      - { _id: 2, x: 22 }
+      - { _id: 3, x: 33 }
+
+tests:
+  - description: BulkWrite replaceOne with sort option
+    runOnRequirements:
+      - minServerVersion: "8.0"
+    operations:
+      - object: *collection0
+        name: bulkWrite
+        arguments:
+          requests:
+            - replaceOne:
+                filter: { _id: { $gt: 1 } }
+                sort: { _id: -1 }
+                replacement: { x: 1 }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection0Name
+                updates:
+                  - q: { _id: { $gt: 1 } }
+                    u: { x: 1 }
+                    sort: { _id: -1 }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+          - commandSucceededEvent:
+              reply: { ok: 1, n: 1 }
+              commandName: update
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1, x: 11 }
+          - { _id: 2, x: 22 }
+          - { _id: 3, x: 1 }
+
+  - description: BulkWrite replaceOne with sort option unsupported (server-side error)
+    runOnRequirements:
+      - maxServerVersion: "7.99"
+    operations:
+      - object: *collection0
+        name: bulkWrite
+        arguments:
+          requests:
+            - replaceOne:
+                filter: { _id: { $gt: 1 } }
+                sort: { _id: -1 }
+                replacement: { x: 1 }
+        expectError:
+          isClientError: false
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection0Name
+                updates:
+                  - q: { _id: { $gt: 1 } }
+                    u: { x: 1 }
+                    sort: { _id: -1 }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1, x: 11 }
+          - { _id: 2, x: 22 }
+          - { _id: 3, x: 33 }

--- a/test/spec/crud/unified/bulkWrite-updateOne-sort.json
+++ b/test/spec/crud/unified/bulkWrite-updateOne-sort.json
@@ -1,0 +1,255 @@
+{
+  "description": "BulkWrite updateOne-sort",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent",
+          "commandSucceededEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        },
+        {
+          "_id": 2,
+          "x": 22
+        },
+        {
+          "_id": 3,
+          "x": 33
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "BulkWrite updateOne with sort option",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "8.0"
+        }
+      ],
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "bulkWrite",
+          "arguments": {
+            "requests": [
+              {
+                "updateOne": {
+                  "filter": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  },
+                  "sort": {
+                    "_id": -1
+                  },
+                  "update": [
+                    {
+                      "$set": {
+                        "x": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": {
+                          "$gt": 1
+                        }
+                      },
+                      "u": [
+                        {
+                          "$set": {
+                            "x": 1
+                          }
+                        }
+                      ],
+                      "sort": {
+                        "_id": -1
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "reply": {
+                  "ok": 1,
+                  "n": 1
+                },
+                "commandName": "update"
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "BulkWrite updateOne with sort option unsupported (server-side error)",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "7.99"
+        }
+      ],
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "bulkWrite",
+          "arguments": {
+            "requests": [
+              {
+                "updateOne": {
+                  "filter": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  },
+                  "sort": {
+                    "_id": -1
+                  },
+                  "update": [
+                    {
+                      "$set": {
+                        "x": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": {
+                          "$gt": 1
+                        }
+                      },
+                      "u": [
+                        {
+                          "$set": {
+                            "x": 1
+                          }
+                        }
+                      ],
+                      "sort": {
+                        "_id": -1
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/crud/unified/bulkWrite-updateOne-sort.yml
+++ b/test/spec/crud/unified/bulkWrite-updateOne-sort.yml
@@ -1,0 +1,94 @@
+description: BulkWrite updateOne-sort
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent, commandSucceededEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1, x: 11 }
+      - { _id: 2, x: 22 }
+      - { _id: 3, x: 33 }
+
+tests:
+  - description: BulkWrite updateOne with sort option
+    runOnRequirements:
+      - minServerVersion: "8.0"
+    operations:
+      - object: *collection0
+        name: bulkWrite
+        arguments:
+          requests:
+            - updateOne:
+                filter: { _id: { $gt: 1 } }
+                sort: { _id: -1 }
+                update: [ $set: { x: 1 } ]
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection0Name
+                updates:
+                  - q: { _id: { $gt: 1 } }
+                    u: [ $set: { x: 1 } ]
+                    sort: { _id: -1 }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+          - commandSucceededEvent:
+              reply: { ok: 1, n: 1 }
+              commandName: update
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1, x: 11 }
+          - { _id: 2, x: 22 }
+          - { _id: 3, x: 1 }
+
+  - description: BulkWrite updateOne with sort option unsupported (server-side error)
+    runOnRequirements:
+      - maxServerVersion: "7.99"
+    operations:
+      - object: *collection0
+        name: bulkWrite
+        arguments:
+          requests:
+            - updateOne:
+                filter: { _id: { $gt: 1 } }
+                sort: { _id: -1 }
+                update: [ $set: { x: 1 } ]
+        expectError:
+          isClientError: false
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection0Name
+                updates:
+                  - q: { _id: { $gt: 1 } }
+                    u: [ $set: { x: 1 } ]
+                    sort: { _id: -1 }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1, x: 11 }
+          - { _id: 2, x: 22 }
+          - { _id: 3, x: 33 }

--- a/test/spec/crud/unified/client-bulkWrite-replaceOne-sort.json
+++ b/test/spec/crud/unified/client-bulkWrite-replaceOne-sort.json
@@ -1,0 +1,163 @@
+{
+  "description": "client bulkWrite replaceOne-sort",
+  "schemaVersion": "1.4",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "8.0",
+      "serverless": "forbid"
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent",
+          "commandSucceededEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        },
+        {
+          "_id": 2,
+          "x": 22
+        },
+        {
+          "_id": 3,
+          "x": 33
+        }
+      ]
+    }
+  ],
+  "_yamlAnchors": {
+    "namespace": "crud-tests.coll0"
+  },
+  "tests": [
+    {
+      "description": "client bulkWrite replaceOne with sort option",
+      "operations": [
+        {
+          "object": "client0",
+          "name": "clientBulkWrite",
+          "arguments": {
+            "models": [
+              {
+                "replaceOne": {
+                  "namespace": "crud-tests.coll0",
+                  "filter": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  },
+                  "sort": {
+                    "_id": -1
+                  },
+                  "replacement": {
+                    "x": 1
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "bulkWrite",
+                "databaseName": "admin",
+                "command": {
+                  "bulkWrite": 1,
+                  "ops": [
+                    {
+                      "update": 0,
+                      "filter": {
+                        "_id": {
+                          "$gt": 1
+                        }
+                      },
+                      "updateMods": {
+                        "x": 1
+                      },
+                      "sort": {
+                        "_id": -1
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ],
+                  "nsInfo": [
+                    {
+                      "ns": "crud-tests.coll0"
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "reply": {
+                  "ok": 1,
+                  "nErrors": 0,
+                  "nMatched": 1,
+                  "nModified": 1
+                },
+                "commandName": "bulkWrite"
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 1
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/crud/unified/client-bulkWrite-replaceOne-sort.yml
+++ b/test/spec/crud/unified/client-bulkWrite-replaceOne-sort.yml
@@ -1,0 +1,77 @@
+description: client bulkWrite replaceOne-sort
+
+schemaVersion: "1.4"
+
+runOnRequirements:
+  - minServerVersion: "8.0"
+    serverless: forbid # Serverless does not support bulkWrite: CLOUDP-256344.
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents:
+        - commandStartedEvent
+        - commandSucceededEvent
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1, x: 11 }
+      - { _id: 2, x: 22 }
+      - { _id: 3, x: 33 }
+
+_yamlAnchors:
+  namespace: &namespace "crud-tests.coll0"
+
+tests:
+  - description: client bulkWrite replaceOne with sort option
+    operations:
+      - object: *client0
+        name: clientBulkWrite
+        arguments:
+          models:
+            - replaceOne:
+                namespace: *namespace
+                filter: { _id: { $gt: 1 } }
+                sort: { _id: -1 }
+                replacement: { x: 1 }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              commandName: bulkWrite
+              databaseName: admin
+              command:
+                bulkWrite: 1
+                ops:
+                  - update: 0
+                    filter: { _id: { $gt: 1 } }
+                    updateMods: { x: 1 }
+                    sort: { _id: -1 }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                nsInfo:
+                  - ns: *namespace
+          - commandSucceededEvent:
+              reply:
+                ok: 1
+                nErrors: 0
+                nMatched: 1
+                nModified: 1
+              commandName: bulkWrite
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1, x: 11 }
+          - { _id: 2, x: 22 }
+          - { _id: 3, x: 1 }

--- a/test/spec/crud/unified/client-bulkWrite-updateOne-sort.json
+++ b/test/spec/crud/unified/client-bulkWrite-updateOne-sort.json
@@ -1,0 +1,167 @@
+{
+  "description": "client bulkWrite updateOne-sort",
+  "schemaVersion": "1.4",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "8.0",
+      "serverless": "forbid"
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent",
+          "commandSucceededEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        },
+        {
+          "_id": 2,
+          "x": 22
+        },
+        {
+          "_id": 3,
+          "x": 33
+        }
+      ]
+    }
+  ],
+  "_yamlAnchors": {
+    "namespace": "crud-tests.coll0"
+  },
+  "tests": [
+    {
+      "description": "client bulkWrite updateOne with sort option",
+      "operations": [
+        {
+          "object": "client0",
+          "name": "clientBulkWrite",
+          "arguments": {
+            "models": [
+              {
+                "updateOne": {
+                  "namespace": "crud-tests.coll0",
+                  "filter": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  },
+                  "sort": {
+                    "_id": -1
+                  },
+                  "update": {
+                    "$inc": {
+                      "x": 1
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "bulkWrite",
+                "databaseName": "admin",
+                "command": {
+                  "bulkWrite": 1,
+                  "ops": [
+                    {
+                      "update": 0,
+                      "filter": {
+                        "_id": {
+                          "$gt": 1
+                        }
+                      },
+                      "updateMods": {
+                        "$inc": {
+                          "x": 1
+                        }
+                      },
+                      "sort": {
+                        "_id": -1
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ],
+                  "nsInfo": [
+                    {
+                      "ns": "crud-tests.coll0"
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "reply": {
+                  "ok": 1,
+                  "nErrors": 0,
+                  "nMatched": 1,
+                  "nModified": 1
+                },
+                "commandName": "bulkWrite"
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 34
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/crud/unified/client-bulkWrite-updateOne-sort.yml
+++ b/test/spec/crud/unified/client-bulkWrite-updateOne-sort.yml
@@ -1,0 +1,77 @@
+description: client bulkWrite updateOne-sort
+
+schemaVersion: "1.4"
+
+runOnRequirements:
+  - minServerVersion: "8.0"
+    serverless: forbid # Serverless does not support bulkWrite: CLOUDP-256344.
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents:
+        - commandStartedEvent
+        - commandSucceededEvent
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1, x: 11 }
+      - { _id: 2, x: 22 }
+      - { _id: 3, x: 33 }
+
+_yamlAnchors:
+  namespace: &namespace "crud-tests.coll0"
+
+tests:
+  - description: client bulkWrite updateOne with sort option
+    operations:
+      - object: *client0
+        name: clientBulkWrite
+        arguments:
+          models:
+            - updateOne:
+                namespace: *namespace
+                filter: { _id: { $gt: 1 } }
+                sort: { _id: -1 }
+                update: { $inc: { x: 1 } }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              commandName: bulkWrite
+              databaseName: admin
+              command:
+                bulkWrite: 1
+                ops:
+                  - update: 0
+                    filter: { _id: { $gt: 1 } }
+                    updateMods: { $inc: { x: 1 } }
+                    sort: { _id: -1 }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                nsInfo:
+                  - ns: *namespace
+          - commandSucceededEvent:
+              reply:
+                ok: 1
+                nErrors: 0
+                nMatched: 1
+                nModified: 1
+              commandName: bulkWrite
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1, x: 11 }
+          - { _id: 2, x: 22 }
+          - { _id: 3, x: 34 }

--- a/test/spec/crud/unified/replaceOne-sort.json
+++ b/test/spec/crud/unified/replaceOne-sort.json
@@ -1,0 +1,232 @@
+{
+  "description": "replaceOne-sort",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent",
+          "commandSucceededEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        },
+        {
+          "_id": 2,
+          "x": 22
+        },
+        {
+          "_id": 3,
+          "x": 33
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "ReplaceOne with sort option",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "8.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "replaceOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
+            },
+            "sort": {
+              "_id": -1
+            },
+            "replacement": {
+              "x": 1
+            }
+          },
+          "expectResult": {
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": {
+                          "$gt": 1
+                        }
+                      },
+                      "u": {
+                        "x": 1
+                      },
+                      "sort": {
+                        "_id": -1
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "reply": {
+                  "ok": 1,
+                  "n": 1
+                },
+                "commandName": "update"
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "replaceOne with sort option unsupported (server-side error)",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "7.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "replaceOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
+            },
+            "sort": {
+              "_id": -1
+            },
+            "replacement": {
+              "x": 1
+            }
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": {
+                          "$gt": 1
+                        }
+                      },
+                      "u": {
+                        "x": 1
+                      },
+                      "sort": {
+                        "_id": -1
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/crud/unified/replaceOne-sort.yml
+++ b/test/spec/crud/unified/replaceOne-sort.yml
@@ -1,0 +1,94 @@
+description: replaceOne-sort
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent, commandSucceededEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1, x: 11 }
+      - { _id: 2, x: 22 }
+      - { _id: 3, x: 33 }
+
+tests:
+  - description: ReplaceOne with sort option
+    runOnRequirements:
+      - minServerVersion: "8.0"
+    operations:
+      - name: replaceOne
+        object: *collection0
+        arguments:
+          filter: { _id: { $gt: 1 } }
+          sort: { _id: -1 }
+          replacement: { x: 1 }
+        expectResult:
+          matchedCount: 1
+          modifiedCount: 1
+          upsertedCount: 0
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection0Name
+                updates:
+                  - q: { _id: { $gt: 1 } }
+                    u: { x: 1 }
+                    sort: { _id: -1 }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+          - commandSucceededEvent:
+              reply: { ok: 1, n: 1 }
+              commandName: update
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1, x: 11 }
+          - { _id: 2, x: 22 }
+          - { _id: 3, x: 1 }
+
+  - description: replaceOne with sort option unsupported (server-side error)
+    runOnRequirements:
+      - maxServerVersion: "7.99"
+    operations:
+      - name: replaceOne
+        object: *collection0
+        arguments:
+          filter: { _id: { $gt: 1 } }
+          sort: { _id: -1 }
+          replacement: { x: 1 }
+        expectError:
+          isClientError: false
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection0Name
+                updates:
+                  - q: { _id: { $gt: 1 } }
+                    u: { x: 1 }
+                    sort: { _id: -1 }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1, x: 11 }
+          - { _id: 2, x: 22 }
+          - { _id: 3, x: 33 }

--- a/test/spec/crud/unified/updateOne-sort.json
+++ b/test/spec/crud/unified/updateOne-sort.json
@@ -1,0 +1,240 @@
+{
+  "description": "updateOne-sort",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent",
+          "commandSucceededEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        },
+        {
+          "_id": 2,
+          "x": 22
+        },
+        {
+          "_id": 3,
+          "x": 33
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "UpdateOne with sort option",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "8.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
+            },
+            "sort": {
+              "_id": -1
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            }
+          },
+          "expectResult": {
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": {
+                          "$gt": 1
+                        }
+                      },
+                      "u": {
+                        "$inc": {
+                          "x": 1
+                        }
+                      },
+                      "sort": {
+                        "_id": -1
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "reply": {
+                  "ok": 1,
+                  "n": 1
+                },
+                "commandName": "update"
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 34
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "updateOne with sort option unsupported (server-side error)",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "7.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
+            },
+            "sort": {
+              "_id": -1
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            }
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": {
+                          "$gt": 1
+                        }
+                      },
+                      "u": {
+                        "$inc": {
+                          "x": 1
+                        }
+                      },
+                      "sort": {
+                        "_id": -1
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/crud/unified/updateOne-sort.yml
+++ b/test/spec/crud/unified/updateOne-sort.yml
@@ -1,0 +1,96 @@
+description: updateOne-sort
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents:
+        - commandStartedEvent
+        - commandSucceededEvent
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1, x: 11 }
+      - { _id: 2, x: 22 }
+      - { _id: 3, x: 33 }
+
+tests:
+  - description: UpdateOne with sort option
+    runOnRequirements:
+      - minServerVersion: "8.0"
+    operations:
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: { $gt: 1 } }
+          sort: { _id: -1 }
+          update: { $inc: { x: 1 } }
+        expectResult:
+          matchedCount: 1
+          modifiedCount: 1
+          upsertedCount: 0
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection0Name
+                updates:
+                  - q: { _id: { $gt: 1 } }
+                    u: { $inc: { x: 1 } }
+                    sort: { _id: -1 }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+          - commandSucceededEvent:
+              reply: { ok: 1, n: 1 }
+              commandName: update
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1, x: 11 }
+          - { _id: 2, x: 22 }
+          - { _id: 3, x: 34 }
+
+  - description: updateOne with sort option unsupported (server-side error)
+    runOnRequirements:
+      - maxServerVersion: "7.99"
+    operations:
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: { $gt: 1 } }
+          sort: { _id: -1 }
+          update: { $inc: { x: 1 } }
+        expectError:
+          isClientError: false
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection0Name
+                updates:
+                  - q: { _id: { $gt: 1 } }
+                    u: { $inc: { x: 1 } }
+                    sort: { _id: -1 }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1, x: 11 }
+          - { _id: 2, x: 22 }
+          - { _id: 3, x: 33 }

--- a/test/types/sort.test-d.ts
+++ b/test/types/sort.test-d.ts
@@ -8,6 +8,19 @@ import {
   type Sort
 } from '../mongodb';
 
+const sortFieldName: Sort = 'a';
+const sortFieldNameObject: Sort = { a: 1, b: -1 };
+const sortFieldNameList: Sort = ['a', 'b'];
+const sortFieldNameTuple: Sort = ['a', 1];
+const sortFieldNameTuples: Sort = [
+  ['a', 1],
+  ['b', -1]
+];
+const sortFieldNameMap: Sort = new Map([
+  ['a', 1],
+  ['b', -1]
+]);
+
 const sorts = [
   // field names
   'a',

--- a/test/types/sort.test-d.ts
+++ b/test/types/sort.test-d.ts
@@ -1,0 +1,95 @@
+import { expectError } from 'tsd';
+
+import {
+  type Collection,
+  type GridFSBucket,
+  type MongoClient,
+  ObjectId,
+  type Sort
+} from '../mongodb';
+
+const sorts = [
+  // field names
+  'a',
+  'b',
+
+  // sort object
+  { a: 1, b: -1 } as const,
+  { a: 'ascending', b: 'ascending' } as const,
+  { a: 'asc', b: 'desc' } as const,
+  { a: 1, b: { $meta: 'textScore' } } as const,
+
+  // field name list
+  ['a', 'b'],
+  ['a'],
+
+  // field name to sort direction tuple
+  ['a', 1] as const,
+  ['a', -1] as const,
+  ['a', 'asc'] as const,
+  ['a', 'desc'] as const,
+  ['a', 'ascending'] as const,
+  ['a', 'descending'] as const,
+  ['a', { $meta: 'textScore' }] as const,
+
+  // field name to sort direction tuples
+  [
+    ['a', 1],
+    ['b', -1]
+  ] as const,
+  [
+    ['a', 'ascending'],
+    ['b', 'ascending']
+  ] as const,
+  [
+    ['a', 'asc'],
+    ['b', 'desc']
+  ] as const,
+  [
+    ['a', 1],
+    ['b', { $meta: 'textScore' }]
+  ] as const,
+
+  // field name to sort direction map
+  new Map().set('a', 1).set('b', -1),
+  new Map().set('a', 'ascending').set('b', 'ascending'),
+  new Map().set('a', 'asc').set('b', 'desc'),
+  new Map().set('a', 1).set('b', { $meta: 'textScore' })
+];
+
+declare const bucket: GridFSBucket;
+declare const collection: Collection;
+declare const client: MongoClient;
+declare const anyIndex: number;
+const sort = sorts[anyIndex];
+
+collection.findOne({}, { sort });
+collection.find({}, { sort });
+collection.find({}).sort(sort);
+
+collection.aggregate([]).sort(sort);
+
+collection.findOneAndDelete({}, { sort });
+collection.findOneAndReplace({}, { sort });
+collection.findOneAndUpdate({}, { sort });
+
+bucket.openDownloadStream(new ObjectId(), { sort });
+bucket.openDownloadStreamByName('', { sort });
+
+collection.updateOne({}, {}, { sort });
+collection.replaceOne({}, {}, { sort });
+
+collection.bulkWrite([{ updateOne: { filter: {}, update: {}, sort } }]);
+collection.bulkWrite([{ replaceOne: { filter: {}, replacement: {}, sort } }]);
+
+client.bulkWrite([
+  { name: 'updateOne', namespace: 'blah', filter: {}, update: {}, sort },
+  { name: 'replaceOne', namespace: 'blah', filter: {}, replacement: {}, sort }
+]);
+
+// UpdateMany does not support sort
+expectError(collection.updateMany({}, {}, { sort }));
+expectError(
+  client.bulkWrite([{ name: 'updateMany', namespace: 'blah', filter: {}, update: {}, sort }])
+);
+expectError(collection.bulkWrite([{ updateMany: { filter: {}, update: {}, sort } }]));


### PR DESCRIPTION
### Description

#### What is changing?

- Adds support for sort on updateOne and replaceOne operations
  - client bulkWrite and collection bulkWrite versions of these operations support it as well

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

The server now supports a sort on these operations, so we do too!

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### `updateOne` and `replaceOne` now support a `sort` option

The updateOne and replaceOne operations in each of the ways they can be performed support a sort option starting in MongoDB 8.0. The driver now supports the sort option the same way it does for find or findOneAndModify-style commands:

```js
const sort = { fieldName: -1 };
collection.updateOne({}, {}, { sort });
collection.replaceOne({}, {}, { sort }); 
collection.bulkWrite([ { updateOne: { filter: {}, update: {}, sort } } ]);
client.bulkWrite([
  { name: 'updateOne', namespace: 'db.test', filter: {}, update: {}, sort },
  { name: 'replaceOne', namespace: 'db.test', filter: {}, replacement: {}, sort }
]);
```

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
