### PR TITLE
fix(NODE-6638): throw if all atomic updates are undefined

### DIFF
--- a/src/bulk/common.ts
+++ b/src/bulk/common.ts
@@ -705,7 +705,7 @@ export class FindOperators {
 
   /** Add a single update operation to the bulk operation */
   updateOne(updateDocument: Document | Document[]): BulkOperationBase {
-    if (!hasAtomicOperators(updateDocument)) {
+    if (!hasAtomicOperators(updateDocument, this.bulkOperation.bsonOptions)) {
       throw new MongoInvalidArgumentError('Update document requires atomic operators');
     }
 
@@ -1115,7 +1115,7 @@ export abstract class BulkOperationBase {
           ...op.updateOne,
           multi: false
         });
-        if (!hasAtomicOperators(updateStatement.u)) {
+        if (!hasAtomicOperators(updateStatement.u, this.bsonOptions)) {
           throw new MongoInvalidArgumentError('Update document requires atomic operators');
         }
         return this.addToOperationsList(BatchType.UPDATE, updateStatement);
@@ -1129,7 +1129,7 @@ export abstract class BulkOperationBase {
           ...op.updateMany,
           multi: true
         });
-        if (!hasAtomicOperators(updateStatement.u)) {
+        if (!hasAtomicOperators(updateStatement.u, this.bsonOptions)) {
           throw new MongoInvalidArgumentError('Update document requires atomic operators');
         }
         return this.addToOperationsList(BatchType.UPDATE, updateStatement);

--- a/src/operations/find_and_modify.ts
+++ b/src/operations/find_and_modify.ts
@@ -273,7 +273,7 @@ export class FindOneAndUpdateOperation extends FindAndModifyOperation {
       throw new MongoInvalidArgumentError('Argument "update" must be an object');
     }
 
-    if (!hasAtomicOperators(update)) {
+    if (!hasAtomicOperators(update, options)) {
       throw new MongoInvalidArgumentError('Update document requires atomic operators');
     }
 

--- a/src/operations/update.ts
+++ b/src/operations/update.ts
@@ -144,7 +144,7 @@ export class UpdateOneOperation extends UpdateOperation {
       options
     );
 
-    if (!hasAtomicOperators(update)) {
+    if (!hasAtomicOperators(update, options)) {
       throw new MongoInvalidArgumentError('Update document requires atomic operators');
     }
   }
@@ -179,7 +179,7 @@ export class UpdateManyOperation extends UpdateOperation {
       options
     );
 
-    if (!hasAtomicOperators(update)) {
+    if (!hasAtomicOperators(update, options)) {
       throw new MongoInvalidArgumentError('Update document requires atomic operators');
     }
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -501,7 +501,9 @@ export function hasAtomicOperators(
       }
     }
     if (allUndefined) {
-      throw new MongoInvalidArgumentError('All atomic operators provided have undefined values.');
+      throw new MongoInvalidArgumentError(
+        'Update operations require that all atomic operators have defined values, but none were provided.'
+      );
     }
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -476,7 +476,10 @@ export function calculateDurationInMs(started: number | undefined): number {
 }
 
 /** @internal */
-export function hasAtomicOperators(doc: Document | Document[]): boolean {
+export function hasAtomicOperators(
+  doc: Document | Document[],
+  options?: CommandOperationOptions
+): boolean {
   if (Array.isArray(doc)) {
     for (const document of doc) {
       if (hasAtomicOperators(document)) {
@@ -487,6 +490,21 @@ export function hasAtomicOperators(doc: Document | Document[]): boolean {
   }
 
   const keys = Object.keys(doc);
+  // In this case we need to throw if all the atomic operators are undefined.
+  if (options?.ignoreUndefined) {
+    let allUndefined = true;
+    for (const key of keys) {
+      // eslint-disable-next-line no-restricted-syntax
+      if (doc[key] !== undefined) {
+        allUndefined = false;
+        break;
+      }
+    }
+    if (allUndefined) {
+      throw new MongoInvalidArgumentError('All atomic operators provided have undefined values.');
+    }
+  }
+
   return keys.length > 0 && keys[0][0] === '$';
 }
 

--- a/test/integration/crud/bulk.test.ts
+++ b/test/integration/crud/bulk.test.ts
@@ -66,7 +66,7 @@ describe('Bulk', function () {
               )
               .catch(error => error);
             expect(error.message).to.include(
-              'All atomic operators provided have undefined values.'
+              'Update operations require that all atomic operators have defined values, but none were provided'
             );
           });
         });
@@ -88,7 +88,7 @@ describe('Bulk', function () {
               )
               .catch(error => error);
             expect(error.message).to.include(
-              'All atomic operators provided have undefined values.'
+              'Update operations require that all atomic operators have defined values, but none were provided'
             );
           });
         });

--- a/test/integration/crud/bulk.test.ts
+++ b/test/integration/crud/bulk.test.ts
@@ -46,6 +46,44 @@ describe('Bulk', function () {
     client = null;
   });
 
+  describe('#bulkWrite', function () {
+    context('when including an update with all undefined atomic operators', function () {
+      context('when performing an update many', function () {
+        it('throws an error', async function () {
+          const collection = client.db('test').collection('test');
+          const error = await collection
+            .bulkWrite([
+              {
+                updateMany: {
+                  filter: { age: { $lte: 5 } },
+                  update: { $set: undefined, $unset: undefined }
+                }
+              }
+            ])
+            .catch(error => error);
+          expect(error.message).to.include('All atomic operators provided have undefined values.');
+        });
+      });
+
+      context('when performing an update one', function () {
+        it('throws an error', async function () {
+          const collection = client.db('test').collection('test');
+          const error = await collection
+            .bulkWrite([
+              {
+                updateOne: {
+                  filter: { age: { $lte: 5 } },
+                  update: { $set: undefined, $unset: undefined }
+                }
+              }
+            ])
+            .catch(error => error);
+          expect(error.message).to.include('All atomic operators provided have undefined values.');
+        });
+      });
+    });
+  });
+
   describe('BulkOperationBase', () => {
     describe('#raw()', function () {
       context('when called with an undefined operation', function () {

--- a/test/integration/crud/bulk.test.ts
+++ b/test/integration/crud/bulk.test.ts
@@ -48,37 +48,49 @@ describe('Bulk', function () {
 
   describe('#bulkWrite', function () {
     context('when including an update with all undefined atomic operators', function () {
-      context('when performing an update many', function () {
-        it('throws an error', async function () {
-          const collection = client.db('test').collection('test');
-          const error = await collection
-            .bulkWrite([
-              {
-                updateMany: {
-                  filter: { age: { $lte: 5 } },
-                  update: { $set: undefined, $unset: undefined }
-                }
-              }
-            ])
-            .catch(error => error);
-          expect(error.message).to.include('All atomic operators provided have undefined values.');
+      context('when ignoreUndefined is true', function () {
+        context('when performing an update many', function () {
+          it('throws an error', async function () {
+            const collection = client.db('test').collection('test');
+            const error = await collection
+              .bulkWrite(
+                [
+                  {
+                    updateMany: {
+                      filter: { age: { $lte: 5 } },
+                      update: { $set: undefined, $unset: undefined }
+                    }
+                  }
+                ],
+                { ignoreUndefined: true }
+              )
+              .catch(error => error);
+            expect(error.message).to.include(
+              'All atomic operators provided have undefined values.'
+            );
+          });
         });
-      });
 
-      context('when performing an update one', function () {
-        it('throws an error', async function () {
-          const collection = client.db('test').collection('test');
-          const error = await collection
-            .bulkWrite([
-              {
-                updateOne: {
-                  filter: { age: { $lte: 5 } },
-                  update: { $set: undefined, $unset: undefined }
-                }
-              }
-            ])
-            .catch(error => error);
-          expect(error.message).to.include('All atomic operators provided have undefined values.');
+        context('when performing an update one', function () {
+          it('throws an error', async function () {
+            const collection = client.db('test').collection('test');
+            const error = await collection
+              .bulkWrite(
+                [
+                  {
+                    updateOne: {
+                      filter: { age: { $lte: 5 } },
+                      update: { $set: undefined, $unset: undefined }
+                    }
+                  }
+                ],
+                { ignoreUndefined: true }
+              )
+              .catch(error => error);
+            expect(error.message).to.include(
+              'All atomic operators provided have undefined values.'
+            );
+          });
         });
       });
     });

--- a/test/integration/crud/client_bulk_write.test.ts
+++ b/test/integration/crud/client_bulk_write.test.ts
@@ -35,44 +35,56 @@ describe('Client Bulk Write', function () {
   });
 
   describe('#bulkWrite', function () {
-    context('when including an update with all undefined atomic operators', function () {
-      context('when performing an update many', function () {
-        beforeEach(async function () {
-          client = this.configuration.newClient();
+    context('when ignoreUndefined is true', function () {
+      context('when including an update with all undefined atomic operators', function () {
+        context('when performing an update many', function () {
+          beforeEach(async function () {
+            client = this.configuration.newClient();
+          });
+
+          it('throws an error', async function () {
+            const error = await client
+              .bulkWrite(
+                [
+                  {
+                    name: 'updateMany',
+                    namespace: 'foo.bar',
+                    filter: { age: { $lte: 5 } },
+                    update: { $set: undefined, $unset: undefined }
+                  }
+                ],
+                { ignoreUndefined: true }
+              )
+              .catch(error => error);
+            expect(error.message).to.include(
+              'All atomic operators provided have undefined values.'
+            );
+          });
         });
 
-        it('throws an error', async function () {
-          const error = await client
-            .bulkWrite([
-              {
-                name: 'updateMany',
-                namespace: 'foo.bar',
-                filter: { age: { $lte: 5 } },
-                update: { $set: undefined, $unset: undefined }
-              }
-            ])
-            .catch(error => error);
-          expect(error.message).to.include('All atomic operators provided have undefined values.');
-        });
-      });
+        context('when performing an update one', function () {
+          beforeEach(async function () {
+            client = this.configuration.newClient();
+          });
 
-      context('when performing an update one', function () {
-        beforeEach(async function () {
-          client = this.configuration.newClient();
-        });
-
-        it('throws an error', async function () {
-          const error = await client
-            .bulkWrite([
-              {
-                name: 'updateOne',
-                namespace: 'foo.bar',
-                filter: { age: { $lte: 5 } },
-                update: { $set: undefined, $unset: undefined }
-              }
-            ])
-            .catch(error => error);
-          expect(error.message).to.include('All atomic operators provided have undefined values.');
+          it('throws an error', async function () {
+            const error = await client
+              .bulkWrite(
+                [
+                  {
+                    name: 'updateOne',
+                    namespace: 'foo.bar',
+                    filter: { age: { $lte: 5 } },
+                    update: { $set: undefined, $unset: undefined }
+                  }
+                ],
+                { ignoreUndefined: true }
+              )
+              .catch(error => error);
+            expect(error.message).to.include(
+              'All atomic operators provided have undefined values.'
+            );
+          });
         });
       });
     });

--- a/test/integration/crud/client_bulk_write.test.ts
+++ b/test/integration/crud/client_bulk_write.test.ts
@@ -57,7 +57,7 @@ describe('Client Bulk Write', function () {
               )
               .catch(error => error);
             expect(error.message).to.include(
-              'All atomic operators provided have undefined values.'
+              'Update operations require that all atomic operators have defined values, but none were provided'
             );
           });
         });
@@ -82,7 +82,7 @@ describe('Client Bulk Write', function () {
               )
               .catch(error => error);
             expect(error.message).to.include(
-              'All atomic operators provided have undefined values.'
+              'Update operations require that all atomic operators have defined values, but none were provided'
             );
           });
         });

--- a/test/integration/crud/client_bulk_write.test.ts
+++ b/test/integration/crud/client_bulk_write.test.ts
@@ -31,7 +31,7 @@ describe('Client Bulk Write', function () {
 
   afterEach(async function () {
     await client?.close();
-    await clearFailPoint(this.configuration);
+    await clearFailPoint(this.configuration).catch(() => null);
   });
 
   describe('#bulkWrite', function () {

--- a/test/integration/crud/client_bulk_write.test.ts
+++ b/test/integration/crud/client_bulk_write.test.ts
@@ -34,6 +34,50 @@ describe('Client Bulk Write', function () {
     await clearFailPoint(this.configuration);
   });
 
+  describe('#bulkWrite', function () {
+    context('when including an update with all undefined atomic operators', function () {
+      context('when performing an update many', function () {
+        beforeEach(async function () {
+          client = this.configuration.newClient();
+        });
+
+        it('throws an error', async function () {
+          const error = await client
+            .bulkWrite([
+              {
+                name: 'updateMany',
+                namespace: 'foo.bar',
+                filter: { age: { $lte: 5 } },
+                update: { $set: undefined, $unset: undefined }
+              }
+            ])
+            .catch(error => error);
+          expect(error.message).to.include('All atomic operators provided have undefined values.');
+        });
+      });
+
+      context('when performing an update one', function () {
+        beforeEach(async function () {
+          client = this.configuration.newClient();
+        });
+
+        it('throws an error', async function () {
+          const error = await client
+            .bulkWrite([
+              {
+                name: 'updateOne',
+                namespace: 'foo.bar',
+                filter: { age: { $lte: 5 } },
+                update: { $set: undefined, $unset: undefined }
+              }
+            ])
+            .catch(error => error);
+          expect(error.message).to.include('All atomic operators provided have undefined values.');
+        });
+      });
+    });
+  });
+
   describe('CSOT enabled', function () {
     describe('when timeoutMS is set on the client', function () {
       beforeEach(async function () {

--- a/test/integration/crud/crud_api.test.ts
+++ b/test/integration/crud/crud_api.test.ts
@@ -959,7 +959,11 @@ describe('CRUD API', function () {
 
         it('throws an error', async function () {
           const error = await collection
-            .findOneAndUpdate({ a: 1 }, { $set: undefined, $unset: undefined })
+            .findOneAndUpdate(
+              { a: 1 },
+              { $set: undefined, $unset: undefined },
+              { ignoreUndefined: true }
+            )
             .catch(error => error);
           expect(error.message).to.include('All atomic operators provided have undefined values.');
         });

--- a/test/integration/crud/crud_api.test.ts
+++ b/test/integration/crud/crud_api.test.ts
@@ -15,8 +15,6 @@ import {
   ReturnDocument
 } from '../../mongodb';
 import { type FailPoint } from '../../tools/utils';
-import { assert as test } from '../shared';
-
 // instanceof cannot be use reliably to detect the new models in js due to scoping and new
 // contexts killing class info find/distinct/count thus cannot be overloaded without breaking
 // backwards compatibility in a fundamental way
@@ -908,18 +906,21 @@ describe('CRUD API', function () {
       await collection.drop();
     });
 
-    context('when including an update with all undefined atomic operators', function () {
-      beforeEach(async function () {
-        client = this.configuration.newClient();
-      });
+    context(
+      'when including an update with all undefined atomic operators ignoring undefined',
+      function () {
+        beforeEach(async function () {
+          client = this.configuration.newClient();
+        });
 
-      it('throws an error', async function () {
-        const error = await collection
-          .updateOne({ a: 1 }, { $set: undefined, $unset: undefined })
-          .catch(error => error);
-        expect(error.message).to.include('All atomic operators provided have undefined values.');
-      });
-    });
+        it('throws an error', async function () {
+          const error = await collection
+            .updateOne({ a: 1 }, { $set: undefined, $unset: undefined }, { ignoreUndefined: true })
+            .catch(error => error);
+          expect(error.message).to.include('All atomic operators provided have undefined values.');
+        });
+      }
+    );
   });
 
   describe('#updateMany', function () {
@@ -934,18 +935,21 @@ describe('CRUD API', function () {
       await collection.drop();
     });
 
-    context('when including an update with all undefined atomic operators', function () {
-      beforeEach(async function () {
-        client = this.configuration.newClient();
-      });
+    context(
+      'when including an update with all undefined atomic operators ignoring undefined',
+      function () {
+        beforeEach(async function () {
+          client = this.configuration.newClient();
+        });
 
-      it('throws an error', async function () {
-        const error = await collection
-          .updateMany({ a: 1 }, { $set: undefined, $unset: undefined })
-          .catch(error => error);
-        expect(error.message).to.include('All atomic operators provided have undefined values.');
-      });
-    });
+        it('throws an error', async function () {
+          const error = await collection
+            .updateMany({ a: 1 }, { $set: undefined, $unset: undefined }, { ignoreUndefined: true })
+            .catch(error => error);
+          expect(error.message).to.include('All atomic operators provided have undefined values.');
+        });
+      }
+    );
   });
 
   describe('#findOneAndUpdate', function () {
@@ -960,18 +964,21 @@ describe('CRUD API', function () {
       await collection.drop();
     });
 
-    context('when including an update with all undefined atomic operators', function () {
-      beforeEach(async function () {
-        client = this.configuration.newClient();
-      });
+    context(
+      'when including an update with all undefined atomic operators ignoring undefined',
+      function () {
+        beforeEach(async function () {
+          client = this.configuration.newClient();
+        });
 
-      it('throws an error', async function () {
-        const error = await collection
-          .findOneAndUpdate({ a: 1 }, { $set: undefined, $unset: undefined })
-          .catch(error => error);
-        expect(error.message).to.include('All atomic operators provided have undefined values.');
-      });
-    });
+        it('throws an error', async function () {
+          const error = await collection
+            .findOneAndUpdate({ a: 1 }, { $set: undefined, $unset: undefined })
+            .catch(error => error);
+          expect(error.message).to.include('All atomic operators provided have undefined values.');
+        });
+      }
+    );
 
     context('when includeResultMetadata is true', function () {
       beforeEach(async function () {

--- a/test/integration/crud/crud_api.test.ts
+++ b/test/integration/crud/crud_api.test.ts
@@ -896,6 +896,58 @@ describe('CRUD API', function () {
     });
   });
 
+  describe('#updateOne', function () {
+    let collection;
+
+    beforeEach(async function () {
+      await client.connect();
+      collection = client.db().collection('updateOneTest');
+    });
+
+    afterEach(async function () {
+      await collection.drop();
+    });
+
+    context('when including an update with all undefined atomic operators', function () {
+      beforeEach(async function () {
+        client = this.configuration.newClient();
+      });
+
+      it('throws an error', async function () {
+        const error = await collection
+          .updateOne({ a: 1 }, { $set: undefined, $unset: undefined })
+          .catch(error => error);
+        expect(error.message).to.include('All atomic operators provided have undefined values.');
+      });
+    });
+  });
+
+  describe('#updateMany', function () {
+    let collection;
+
+    beforeEach(async function () {
+      await client.connect();
+      collection = client.db().collection('updateManyTest');
+    });
+
+    afterEach(async function () {
+      await collection.drop();
+    });
+
+    context('when including an update with all undefined atomic operators', function () {
+      beforeEach(async function () {
+        client = this.configuration.newClient();
+      });
+
+      it('throws an error', async function () {
+        const error = await collection
+          .updateMany({ a: 1 }, { $set: undefined, $unset: undefined })
+          .catch(error => error);
+        expect(error.message).to.include('All atomic operators provided have undefined values.');
+      });
+    });
+  });
+
   describe('#findOneAndUpdate', function () {
     let collection;
 
@@ -906,6 +958,19 @@ describe('CRUD API', function () {
 
     afterEach(async function () {
       await collection.drop();
+    });
+
+    context('when including an update with all undefined atomic operators', function () {
+      beforeEach(async function () {
+        client = this.configuration.newClient();
+      });
+
+      it('throws an error', async function () {
+        const error = await collection
+          .findOneAndUpdate({ a: 1 }, { $set: undefined, $unset: undefined })
+          .catch(error => error);
+        expect(error.message).to.include('All atomic operators provided have undefined values.');
+      });
     });
 
     context('when includeResultMetadata is true', function () {

--- a/test/integration/crud/crud_api.test.ts
+++ b/test/integration/crud/crud_api.test.ts
@@ -903,10 +903,6 @@ describe('CRUD API', function () {
       collection = client.db().collection('updateOneTest');
     });
 
-    afterEach(async function () {
-      await collection.drop();
-    });
-
     context(
       'when including an update with all undefined atomic operators ignoring undefined',
       function () {
@@ -932,10 +928,6 @@ describe('CRUD API', function () {
       collection = client.db().collection('updateManyTest');
     });
 
-    afterEach(async function () {
-      await collection.drop();
-    });
-
     context(
       'when including an update with all undefined atomic operators ignoring undefined',
       function () {
@@ -959,10 +951,6 @@ describe('CRUD API', function () {
     beforeEach(async function () {
       await client.connect();
       collection = client.db().collection('findAndModifyTest');
-    });
-
-    afterEach(async function () {
-      await collection.drop();
     });
 
     context(

--- a/test/integration/crud/crud_api.test.ts
+++ b/test/integration/crud/crud_api.test.ts
@@ -15,6 +15,7 @@ import {
   ReturnDocument
 } from '../../mongodb';
 import { type FailPoint } from '../../tools/utils';
+import { assert as test } from '../shared';
 // instanceof cannot be use reliably to detect the new models in js due to scoping and new
 // contexts killing class info find/distinct/count thus cannot be overloaded without breaking
 // backwards compatibility in a fundamental way

--- a/test/integration/crud/crud_api.test.ts
+++ b/test/integration/crud/crud_api.test.ts
@@ -913,7 +913,9 @@ describe('CRUD API', function () {
           const error = await collection
             .updateOne({ a: 1 }, { $set: undefined, $unset: undefined }, { ignoreUndefined: true })
             .catch(error => error);
-          expect(error.message).to.include('All atomic operators provided have undefined values.');
+          expect(error.message).to.include(
+            'Update operations require that all atomic operators have defined values, but none were provided'
+          );
         });
       }
     );
@@ -937,7 +939,9 @@ describe('CRUD API', function () {
           const error = await collection
             .updateMany({ a: 1 }, { $set: undefined, $unset: undefined }, { ignoreUndefined: true })
             .catch(error => error);
-          expect(error.message).to.include('All atomic operators provided have undefined values.');
+          expect(error.message).to.include(
+            'Update operations require that all atomic operators have defined values, but none were provided'
+          );
         });
       }
     );
@@ -965,7 +969,9 @@ describe('CRUD API', function () {
               { ignoreUndefined: true }
             )
             .catch(error => error);
-          expect(error.message).to.include('All atomic operators provided have undefined values.');
+          expect(error.message).to.include(
+            'Update operations require that all atomic operators have defined values, but none were provided'
+          );
         });
       }
     );

--- a/test/integration/crud/crud_api.test.ts
+++ b/test/integration/crud/crud_api.test.ts
@@ -899,7 +899,6 @@ describe('CRUD API', function () {
     let collection;
 
     beforeEach(async function () {
-      await client.connect();
       collection = client.db().collection('updateOneTest');
     });
 
@@ -924,7 +923,6 @@ describe('CRUD API', function () {
     let collection;
 
     beforeEach(async function () {
-      await client.connect();
       collection = client.db().collection('updateManyTest');
     });
 
@@ -949,7 +947,6 @@ describe('CRUD API', function () {
     let collection;
 
     beforeEach(async function () {
-      await client.connect();
       collection = client.db().collection('findAndModifyTest');
     });
 

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -28,7 +28,7 @@ import {
 import { sleep } from '../tools/utils';
 
 describe('driver utils', function () {
-  describe.only('.hasAtomicOperators', function () {
+  describe('.hasAtomicOperators', function () {
     context('when ignoreUndefined is true', function () {
       const options = { ignoreUndefined: true };
 

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -11,6 +11,7 @@ import {
   compareObjectId,
   decorateWithExplain,
   Explain,
+  hasAtomicOperators,
   HostAddress,
   hostMatchesWildcards,
   isHello,
@@ -19,6 +20,7 @@ import {
   List,
   MongoDBCollectionNamespace,
   MongoDBNamespace,
+  MongoInvalidArgumentError,
   MongoRuntimeError,
   ObjectId,
   shuffle
@@ -26,6 +28,66 @@ import {
 import { sleep } from '../tools/utils';
 
 describe('driver utils', function () {
+  describe.only('.hasAtomicOperators', function () {
+    context('when ignoreUndefined is true', function () {
+      const options = { ignoreUndefined: true };
+
+      context('when no operator is undefined', function () {
+        const document = { $set: { n: 1 }, $unset: '' };
+
+        it('returns true', function () {
+          expect(hasAtomicOperators(document, options)).to.be.true;
+        });
+      });
+
+      context('when some operators are undefined', function () {
+        const document = { $set: { n: 1 }, $unset: undefined };
+
+        it('returns true', function () {
+          expect(hasAtomicOperators(document, options)).to.be.true;
+        });
+      });
+
+      context('when all operators are undefined', function () {
+        const document = { $set: undefined, $unset: undefined };
+
+        it('throws an error', function () {
+          expect(() => {
+            hasAtomicOperators(document, options);
+          }).to.throw(MongoInvalidArgumentError);
+        });
+      });
+    });
+
+    context('when ignoreUndefined is false', function () {
+      const options = { ignoreUndefined: false };
+
+      context('when no operator is undefined', function () {
+        const document = { $set: { n: 1 }, $unset: '' };
+
+        it('returns true', function () {
+          expect(hasAtomicOperators(document, options)).to.be.true;
+        });
+      });
+
+      context('when some operators are undefined', function () {
+        const document = { $set: { n: 1 }, $unset: undefined };
+
+        it('returns true', function () {
+          expect(hasAtomicOperators(document, options)).to.be.true;
+        });
+      });
+
+      context('when all operators are undefined', function () {
+        const document = { $set: undefined, $unset: undefined };
+
+        it('returns true', function () {
+          expect(hasAtomicOperators(document, options)).to.be.true;
+        });
+      });
+    });
+  });
+
   describe('.hostMatchesWildcards', function () {
     context('when using domains', function () {
       context('when using exact match', function () {


### PR DESCRIPTION
### Description

Will throw on any update where all the atomic operations in the update are undefined and `ignoreUndefined` is true.

#### What is changing?
- Updates `hasAtomicUpdates` to throw when all updates are undefined and `ignoreUndefined` is true.
- Updates all operations that leverage atomic updates to pass through the bson options.
- Adds both unit tests and new integration tests.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-6638

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Update operations will now throw if `ignoreUndefined` is true and all operations are undefined.

When using any of the following operations they will now throw if all atomic operations in the update are undefined and the `ignoreUndefined` option is `true`. This is to avoid accidental replacement of the entire document with an empty document. Examples of this scenario:

```typescript
import { MongoClient } from 'mongodb';

const client = new MongoClient(process.env.MONGODB_URI);

client.bulkWrite(
  [
    {
      name: 'updateMany',
      namespace: 'foo.bar',
      filter: { age: { $lte: 5 } },
      update: { $set: undefined, $unset: undefined }
    }
  ],
  { ignoreUndefined: true }
);

const collection = client.db('test').collection('test');

collection.bulkWrite(
  [
    {
      updateMany: {
        filter: { age: { $lte: 5 } },
        update: { $set: undefined, $unset: undefined }
      }
    }
  ],
  { ignoreUndefined: true }
);

collection.findOneAndUpdate(
  { a: 1 },
  { $set: undefined, $unset: undefined },
  { ignoreUndefined: true }
);

collection.updateOne({ a: 1 }, { $set: undefined, $unset: undefined }, { ignoreUndefined: true });

collection.updateMany({ a: 1 }, { $set: undefined, $unset: undefined }, { ignoreUndefined: true });
```

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
