### PR TITLE
test(NODE-6927): skip failing aws uri test

### DIFF
--- a/test/integration/client-side-encryption/client_side_encryption.prose.test.js
+++ b/test/integration/client-side-encryption/client_side_encryption.prose.test.js
@@ -925,6 +925,7 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
           key: 'arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0',
           endpoint: 'kms.us-east-1.amazonaws.com:12345'
         },
+        skipReason: 'TODO(NODE-6928): Fix failing aws bad URI test',
         succeed: false,
         errorValidator: err => {
           expect(err)
@@ -1042,6 +1043,10 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
 
     testCases.forEach(testCase => {
       it(testCase.description, metadata, function () {
+        if (testCase.skipReason) {
+          this.skipReason = testCase.skipReason;
+          this.skip();
+        }
         // Call `client_encryption.createDataKey()` with <provider> as the provider and the following masterKey:
         // .. code:: javascript
         //    {

--- a/test/tools/runner/flaky.ts
+++ b/test/tools/runner/flaky.ts
@@ -31,6 +31,7 @@ export const flakyTests = [
   'Client Side Encryption Prose Tests 16. Rewrap Case 1: Rewrap with separate ClientEncryption should rewrap data key from local to kmip',
   'Client Side Encryption Prose Tests 16. Rewrap Case 1: Rewrap with separate ClientEncryption should rewrap data key from local to local',
   'Client Side Encryption Prose Tests 16. Rewrap Case 2: RewrapManyDataKeyOpts.provider is not optional when provider field is missing raises an error',
+  'Client Side Encryption Prose Tests Custom Endpoint Test 4. aws: custom endpoint with bad url',
   'CSOT spec tests legacy timeouts behave correctly for retryable operations operation fails after two consecutive socket timeouts - aggregate on collection',
   'CSOT spec tests legacy timeouts behave correctly for retryable operations operation succeeds after one socket timeout - aggregate on collection',
   'CSOT spec tests operations ignore deprecated timeout options if timeoutMS is set socketTimeoutMS is ignored if timeoutMS is set - dropIndex on collection',


### PR DESCRIPTION
### Description

Skip the consistently failing FLE AWS bad URI test.

#### What is changing?
- Skip the test
- Add to the flaky list for logging later.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-6927

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
