### PR TITLE
ci(NODE-6926): unskip failing FLE KMS test

### DIFF
--- a/test/integration/client-side-encryption/client_side_encryption.prose.test.js
+++ b/test/integration/client-side-encryption/client_side_encryption.prose.test.js
@@ -853,7 +853,7 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
       const invalidKmsProviders = getKmsProviders();
       invalidKmsProviders.azure.identityPlatformEndpoint = 'doesnotexist.invalid:443';
       invalidKmsProviders.gcp.endpoint = 'doesnotexist.invalid:443';
-      invalidKmsProviders.kmip.endpoint = 'doesnotexist.local:5698';
+      invalidKmsProviders.kmip.endpoint = 'doesnotexist.invalid:5698';
 
       return this.client.connect().then(() => {
         this.clientEncryption = new ClientEncryption(this.client, {
@@ -918,14 +918,9 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
         succeed: true
       },
       {
-        description: '4. aws: custom endpoint with bad url',
-        provider: 'aws',
-        masterKey: {
-          region: 'us-east-1',
-          key: 'arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0',
-          endpoint: 'kms.us-east-1.amazonaws.com:12345'
-        },
-        skipReason: 'TODO(NODE-6928): Fix failing aws bad URI test',
+        description: '4. bad url',
+        provider: 'kmip',
+        masterKey: { keyId: '1', endpoint: 'localhost:12345' },
         succeed: false,
         errorValidator: err => {
           expect(err)
@@ -1029,7 +1024,7 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
         provider: 'kmip',
         masterKey: {
           keyId: '1',
-          endpoint: 'doesnotexist.local:5698'
+          endpoint: 'doesnotexist.invalid:5698'
         },
         succeed: false,
         errorValidator: err => {
@@ -1043,10 +1038,6 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
 
     testCases.forEach(testCase => {
       it(testCase.description, metadata, function () {
-        if (testCase.skipReason) {
-          this.skipReason = testCase.skipReason;
-          this.skip();
-        }
         // Call `client_encryption.createDataKey()` with <provider> as the provider and the following masterKey:
         // .. code:: javascript
         //    {
@@ -1564,7 +1555,7 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
     // Case 2.
     context('Case 2: Azure', metadata, function () {
       const masterKey = {
-        keyVaultEndpoint: 'doesnotexist.local',
+        keyVaultEndpoint: 'doesnotexist.invalid',
         keyName: 'foo'
       };
 
@@ -1834,7 +1825,7 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
           // Call `client_encryption_with_names.createDataKey()` with "aws:no_client_cert" as the provider and the following masterKey.
           const error = await clientEncryptionWithNames
             .createDataKey('azure:no_client_cert', {
-              masterKey: { keyVaultEndpoint: 'doesnotexist.local', keyName: 'foo' }
+              masterKey: { keyVaultEndpoint: 'doesnotexist.invalid', keyName: 'foo' }
             })
             .catch(e => e);
 
@@ -1846,7 +1837,7 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
           // Call `client_encryption_with_names.createDataKey()` with "aws:with_tls" as the provider and the same masterKey.
           const error = await clientEncryptionWithNames
             .createDataKey('azure:with_tls', {
-              masterKey: { keyVaultEndpoint: 'doesnotexist.local', keyName: 'foo' }
+              masterKey: { keyVaultEndpoint: 'doesnotexist.invalid', keyName: 'foo' }
             })
             .catch(e => e);
 

--- a/test/tools/runner/flaky.ts
+++ b/test/tools/runner/flaky.ts
@@ -31,7 +31,6 @@ export const flakyTests = [
   'Client Side Encryption Prose Tests 16. Rewrap Case 1: Rewrap with separate ClientEncryption should rewrap data key from local to kmip',
   'Client Side Encryption Prose Tests 16. Rewrap Case 1: Rewrap with separate ClientEncryption should rewrap data key from local to local',
   'Client Side Encryption Prose Tests 16. Rewrap Case 2: RewrapManyDataKeyOpts.provider is not optional when provider field is missing raises an error',
-  'Client Side Encryption Prose Tests Custom Endpoint Test 4. aws: custom endpoint with bad url',
   'CSOT spec tests legacy timeouts behave correctly for retryable operations operation fails after two consecutive socket timeouts - aggregate on collection',
   'CSOT spec tests legacy timeouts behave correctly for retryable operations operation succeeds after one socket timeout - aggregate on collection',
   'CSOT spec tests operations ignore deprecated timeout options if timeoutMS is set socketTimeoutMS is ignored if timeoutMS is set - dropIndex on collection',


### PR DESCRIPTION
### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
