### PR TITLE
feat(NODE-6952): support configuring DEK cache expiration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "js-yaml": "^4.1.0",
         "mocha": "^10.8.2",
         "mocha-sinon": "^2.1.2",
-        "mongodb-client-encryption": "^6.3.0",
+        "mongodb-client-encryption": "^6.4.0",
         "mongodb-legacy": "^6.1.3",
         "nyc": "^15.1.0",
         "prettier": "^3.5.3",
@@ -6676,9 +6676,9 @@
       }
     },
     "node_modules/mongodb-client-encryption": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-6.3.0.tgz",
-      "integrity": "sha512-OaOg02vglPxxrfY01alC0ER0W4WMuNO2ZJR3ehAUcuGYreJaJ+aX+rUQiQkdQHiXvnVPDUx/4QDr2CR1/FvpcQ==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-6.4.0.tgz",
+      "integrity": "sha512-Un1W/5P4KjcUBPeJeSKFNaWH0/8PVsoSatDqyWM2bMK0Vu2Jjxy7ZTgDj1g+uChuqroB09s8LvppdsHpwxSTVA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "js-yaml": "^4.1.0",
     "mocha": "^10.8.2",
     "mocha-sinon": "^2.1.2",
-    "mongodb-client-encryption": "^6.3.0",
+    "mongodb-client-encryption": "^6.4.0",
     "mongodb-legacy": "^6.1.3",
     "nyc": "^15.1.0",
     "prettier": "^3.5.3",

--- a/src/client-side-encryption/auto_encrypter.ts
+++ b/src/client-side-encryption/auto_encrypter.ts
@@ -52,6 +52,10 @@ export interface AutoEncryptionOptions {
   bypassAutoEncryption?: boolean;
   /** Allows users to bypass query analysis */
   bypassQueryAnalysis?: boolean;
+  /**
+   * Sets the expiration time for the DEK in the cache in milliseconds. Defaults to 60000.
+   */
+  keyExpirationMS?: number;
   options?: {
     /** An optional hook to catch logging messages from the underlying encryption engine */
     logger?: (level: AutoEncryptionLoggerLevel, message: string) => void;
@@ -283,6 +287,10 @@ export class AutoEncrypter {
 
     if (options.bypassQueryAnalysis) {
       mongoCryptOptions.bypassQueryAnalysis = options.bypassQueryAnalysis;
+    }
+
+    if (options.keyExpirationMS) {
+      mongoCryptOptions.keyExpirationMS = options.keyExpirationMS;
     }
 
     this._bypassMongocryptdAndCryptShared = this._bypassEncryption || !!options.bypassQueryAnalysis;

--- a/src/client-side-encryption/auto_encrypter.ts
+++ b/src/client-side-encryption/auto_encrypter.ts
@@ -289,7 +289,7 @@ export class AutoEncrypter {
       mongoCryptOptions.bypassQueryAnalysis = options.bypassQueryAnalysis;
     }
 
-    if (options.keyExpirationMS) {
+    if (options.keyExpirationMS != null) {
       mongoCryptOptions.keyExpirationMS = options.keyExpirationMS;
     }
 

--- a/src/client-side-encryption/auto_encrypter.ts
+++ b/src/client-side-encryption/auto_encrypter.ts
@@ -53,7 +53,7 @@ export interface AutoEncryptionOptions {
   /** Allows users to bypass query analysis */
   bypassQueryAnalysis?: boolean;
   /**
-   * Sets the expiration time for the DEK in the cache in milliseconds. Defaults to 60000.
+   * Sets the expiration time for the DEK in the cache in milliseconds. Defaults to 60000.  0 means no timeout.
    */
   keyExpirationMS?: number;
   options?: {

--- a/src/client-side-encryption/client_encryption.ts
+++ b/src/client-side-encryption/client_encryption.ts
@@ -886,7 +886,7 @@ export interface ClientEncryptionOptions {
   tlsOptions?: CSFLEKMSTlsOptions;
 
   /**
-   * Sets the expiration time for the DEK in the cache in milliseconds. Defaults to 60000.
+   * Sets the expiration time for the DEK in the cache in milliseconds. Defaults to 60000. 0 means no timeout.
    */
   keyExpirationMS?: number;
 

--- a/src/client-side-encryption/client_encryption.ts
+++ b/src/client-side-encryption/client_encryption.ts
@@ -886,6 +886,11 @@ export interface ClientEncryptionOptions {
   tlsOptions?: CSFLEKMSTlsOptions;
 
   /**
+   * Sets the expiration time for the DEK in the cache in milliseconds. Defaults to 60000.
+   */
+  keyExpirationMS?: number;
+
+  /**
    * @experimental
    *
    * The timeout setting to be used for all the operations on ClientEncryption.

--- a/test/integration/client-side-encryption/client_side_encryption.spec.test.ts
+++ b/test/integration/client-side-encryption/client_side_encryption.spec.test.ts
@@ -109,6 +109,13 @@ describe('Client Side Encryption (Legacy)', function () {
       if (typeof result === 'string') return result;
     }
 
+    if (['Insert with deterministic encryption, then find it'].includes(description)) {
+      const result = configuration.filters.ClientSideEncryptionFilter.filter({
+        metadata: { requires: { clientSideEncryption: '>=6.4.0' } }
+      });
+
+      if (typeof result === 'string') return result;
+    }
     return true;
   });
 });
@@ -142,9 +149,16 @@ describe('Client Side Encryption (Unified)', function () {
         'rewrap from aws:name1 to aws:name2',
         'can explicitly encrypt with a named KMS provider'
       ];
+      const dekExpirationTests = ['decrypt, wait, and decrypt again'];
       if (delegatedKMIPTests.includes(description)) {
         const shouldSkip = configuration.filters.ClientSideEncryptionFilter.filter({
           metadata: { requires: { clientSideEncryption: '>=6.0.1' } }
+        });
+        if (typeof shouldSkip === 'string') return shouldSkip;
+      }
+      if (dekExpirationTests.includes(description)) {
+        const shouldSkip = configuration.filters.ClientSideEncryptionFilter.filter({
+          metadata: { requires: { clientSideEncryption: '>=6.4.0' } }
         });
         if (typeof shouldSkip === 'string') return shouldSkip;
       }

--- a/test/integration/client-side-encryption/client_side_encryption.spec.test.ts
+++ b/test/integration/client-side-encryption/client_side_encryption.spec.test.ts
@@ -107,6 +107,13 @@ describe('Client Side Encryption (Legacy)', function () {
       if (typeof result === 'string') return result;
     }
 
+    if (['Insert with deterministic encryption, then find it'].includes(description)) {
+      const result = configuration.filters.ClientSideEncryptionFilter.filter({
+        metadata: { requires: { clientSideEncryption: '>=6.4.0' } }
+      });
+
+      if (typeof result === 'string') return result;
+    }
     return true;
   });
 });

--- a/test/integration/client-side-encryption/client_side_encryption.spec.test.ts
+++ b/test/integration/client-side-encryption/client_side_encryption.spec.test.ts
@@ -15,8 +15,6 @@ const skippedAuthTests = [
   'Insert a document with auto encryption using the AWS provider with temporary credentials',
   'Insert a document with auto encryption using Azure KMS provider',
   '$rename works if target value has same encryption options',
-  'Insert with deterministic encryption, then find it',
-  'Insert with randomized encryption, then find it',
   'Bulk write with encryption',
   'Insert with bypassAutoEncryption',
   'Insert with bypassAutoEncryption for local schema',

--- a/test/integration/client-side-encryption/client_side_encryption.spec.test.ts
+++ b/test/integration/client-side-encryption/client_side_encryption.spec.test.ts
@@ -109,13 +109,6 @@ describe('Client Side Encryption (Legacy)', function () {
       if (typeof result === 'string') return result;
     }
 
-    if (['Insert with deterministic encryption, then find it'].includes(description)) {
-      const result = configuration.filters.ClientSideEncryptionFilter.filter({
-        metadata: { requires: { clientSideEncryption: '>=6.4.0' } }
-      });
-
-      if (typeof result === 'string') return result;
-    }
     return true;
   });
 });

--- a/test/spec/client-side-encryption/tests/legacy/keyCache.json
+++ b/test/spec/client-side-encryption/tests/legacy/keyCache.json
@@ -1,0 +1,270 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.1.10"
+    }
+  ],
+  "database_name": "default",
+  "collection_name": "default",
+  "data": [],
+  "json_schema": {
+    "properties": {
+      "encrypted_w_altname": {
+        "encrypt": {
+          "keyId": "/altname",
+          "bsonType": "string",
+          "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
+        }
+      },
+      "encrypted_string": {
+        "encrypt": {
+          "keyId": [
+            {
+              "$binary": {
+                "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                "subType": "04"
+              }
+            }
+          ],
+          "bsonType": "string",
+          "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+        }
+      },
+      "random": {
+        "encrypt": {
+          "keyId": [
+            {
+              "$binary": {
+                "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                "subType": "04"
+              }
+            }
+          ],
+          "bsonType": "string",
+          "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
+        }
+      },
+      "encrypted_string_equivalent": {
+        "encrypt": {
+          "keyId": [
+            {
+              "$binary": {
+                "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                "subType": "04"
+              }
+            }
+          ],
+          "bsonType": "string",
+          "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+        }
+      }
+    },
+    "bsonType": "object"
+  },
+  "key_vault_data": [
+    {
+      "status": 1,
+      "_id": {
+        "$binary": {
+          "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+          "subType": "04"
+        }
+      },
+      "masterKey": {
+        "provider": "aws",
+        "key": "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0",
+        "region": "us-east-1"
+      },
+      "updateDate": {
+        "$date": {
+          "$numberLong": "1552949630483"
+        }
+      },
+      "keyMaterial": {
+        "$binary": {
+          "base64": "AQICAHhQNmWG2CzOm1dq3kWLM+iDUZhEqnhJwH9wZVpuZ94A8gEqnsxXlR51T5EbEVezUqqKAAAAwjCBvwYJKoZIhvcNAQcGoIGxMIGuAgEAMIGoBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDHa4jo6yp0Z18KgbUgIBEIB74sKxWtV8/YHje5lv5THTl0HIbhSwM6EqRlmBiFFatmEWaeMk4tO4xBX65eq670I5TWPSLMzpp8ncGHMmvHqRajNBnmFtbYxN3E3/WjxmdbOOe+OXpnGJPcGsftc7cB2shRfA4lICPnE26+oVNXT6p0Lo20nY5XC7jyCO",
+          "subType": "00"
+        }
+      },
+      "creationDate": {
+        "$date": {
+          "$numberLong": "1552949630483"
+        }
+      },
+      "keyAltNames": [
+        "altname",
+        "another_altname"
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "Insert with deterministic encryption, then find it",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "aws": {}
+          },
+          "keyExpirationMS": 1
+        }
+      },
+      "operations": [
+        {
+          "name": "insertOne",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "encrypted_string": "string0"
+            }
+          }
+        },
+        {
+          "name": "wait",
+          "object": "testRunner",
+          "arguments": {
+            "ms": 50
+          }
+        },
+        {
+          "name": "find",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            }
+          },
+          "result": [
+            {
+              "_id": 1,
+              "encrypted_string": "string0"
+            }
+          ]
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "listCollections": 1,
+              "filter": {
+                "name": "default"
+              }
+            },
+            "command_name": "listCollections"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "find": "datakeys",
+              "filter": {
+                "$or": [
+                  {
+                    "_id": {
+                      "$in": [
+                        {
+                          "$binary": {
+                            "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                            "subType": "04"
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "keyAltNames": {
+                      "$in": []
+                    }
+                  }
+                ]
+              },
+              "$db": "keyvault",
+              "readConcern": {
+                "level": "majority"
+              }
+            },
+            "command_name": "find"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "default",
+              "documents": [
+                {
+                  "_id": 1,
+                  "encrypted_string": {
+                    "$binary": {
+                      "base64": "AQAAAAAAAAAAAAAAAAAAAAACwj+3zkv2VM+aTfk60RqhXq6a/77WlLwu/BxXFkL7EppGsju/m8f0x5kBDD3EZTtGALGXlym5jnpZAoSIkswHoA==",
+                      "subType": "06"
+                    }
+                  }
+                }
+              ],
+              "ordered": true
+            },
+            "command_name": "insert"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "find": "default",
+              "filter": {
+                "_id": 1
+              }
+            },
+            "command_name": "find"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "find": "datakeys",
+              "filter": {
+                "$or": [
+                  {
+                    "_id": {
+                      "$in": [
+                        {
+                          "$binary": {
+                            "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                            "subType": "04"
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "keyAltNames": {
+                      "$in": []
+                    }
+                  }
+                ]
+              },
+              "$db": "keyvault",
+              "readConcern": {
+                "level": "majority"
+              }
+            },
+            "command_name": "find"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "encrypted_string": {
+                "$binary": {
+                  "base64": "AQAAAAAAAAAAAAAAAAAAAAACwj+3zkv2VM+aTfk60RqhXq6a/77WlLwu/BxXFkL7EppGsju/m8f0x5kBDD3EZTtGALGXlym5jnpZAoSIkswHoA==",
+                  "subType": "06"
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/test/spec/client-side-encryption/tests/legacy/keyCache.yml
+++ b/test/spec/client-side-encryption/tests/legacy/keyCache.yml
@@ -1,0 +1,69 @@
+runOn:
+  - minServerVersion: "4.1.10"
+database_name: &database_name "default"
+collection_name: &collection_name "default"
+
+data: []
+json_schema: {'properties': {'encrypted_w_altname': {'encrypt': {'keyId': '/altname', 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Random'}}, 'encrypted_string': {'encrypt': {'keyId': [{'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}}], 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'}}, 'random': {'encrypt': {'keyId': [{'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}}], 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Random'}}, 'encrypted_string_equivalent': {'encrypt': {'keyId': [{'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}}], 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'}}}, 'bsonType': 'object'}
+key_vault_data: [{'status': 1, '_id': {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}}, 'masterKey': {'provider': 'aws', 'key': 'arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0', 'region': 'us-east-1'}, 'updateDate': {'$date': {'$numberLong': '1552949630483'}}, 'keyMaterial': {'$binary': {'base64': 'AQICAHhQNmWG2CzOm1dq3kWLM+iDUZhEqnhJwH9wZVpuZ94A8gEqnsxXlR51T5EbEVezUqqKAAAAwjCBvwYJKoZIhvcNAQcGoIGxMIGuAgEAMIGoBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDHa4jo6yp0Z18KgbUgIBEIB74sKxWtV8/YHje5lv5THTl0HIbhSwM6EqRlmBiFFatmEWaeMk4tO4xBX65eq670I5TWPSLMzpp8ncGHMmvHqRajNBnmFtbYxN3E3/WjxmdbOOe+OXpnGJPcGsftc7cB2shRfA4lICPnE26+oVNXT6p0Lo20nY5XC7jyCO', 'subType': '00'}}, 'creationDate': {'$date': {'$numberLong': '1552949630483'}}, 'keyAltNames': ['altname', 'another_altname']}]
+
+tests:
+  - description: "Insert with deterministic encryption, then find it"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          aws: {} # Credentials filled in from environment.
+        keyExpirationMS: 1
+    operations:
+      - name: insertOne
+        arguments:
+          document: &doc0 { _id: 1, encrypted_string: "string0" }
+      - name: wait
+        object: testRunner
+        arguments:
+          ms: 50 # Wait long enough to account for coarse time resolution on Windows (CDRIVER-4526).
+      - name: find
+        arguments:
+          filter: { _id: 1 }
+        result: [*doc0]
+    expectations:
+      # Auto encryption will request the collection info.
+      - command_started_event:
+          command:
+            listCollections: 1
+            filter:
+              name: *collection_name
+          command_name: listCollections
+      # Then key is fetched from the key vault.
+      - command_started_event:
+          command:
+            find: datakeys
+            filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
+            $db: keyvault
+            readConcern: { level: "majority" }
+          command_name: find
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - &doc0_encrypted { _id: 1, encrypted_string: {'$binary': {'base64': 'AQAAAAAAAAAAAAAAAAAAAAACwj+3zkv2VM+aTfk60RqhXq6a/77WlLwu/BxXFkL7EppGsju/m8f0x5kBDD3EZTtGALGXlym5jnpZAoSIkswHoA==', 'subType': '06'}} }
+            ordered: true
+          command_name: insert
+      - command_started_event:
+          command:
+            find: *collection_name
+            filter: { _id: 1 }
+          command_name: find
+      # The cache has expired and the key must be fetched again
+      - command_started_event:
+          command:
+            find: datakeys
+            filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
+            $db: keyvault
+            readConcern: { level: "majority" }
+          command_name: find
+    outcome:
+      collection:
+        # Outcome is checked using a separate MongoClient without auto encryption.
+        data:
+          - *doc0_encrypted

--- a/test/spec/client-side-encryption/tests/unified/keyCache.json
+++ b/test/spec/client-side-encryption/tests/unified/keyCache.json
@@ -1,0 +1,198 @@
+{
+  "description": "keyCache-explicit",
+  "schemaVersion": "1.22",
+  "runOnRequirements": [
+    {
+      "csfle": true
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "clientEncryption": {
+        "id": "clientEncryption0",
+        "clientEncryptionOpts": {
+          "keyVaultClient": "client0",
+          "keyVaultNamespace": "keyvault.datakeys",
+          "kmsProviders": {
+            "local": {
+              "key": "OCTP9uKPPmvuqpHlqq83gPk4U6rUPxKVRRyVtrjFmVjdoa4Xzm1SzUbr7aIhNI42czkUBmrCtZKF31eaaJnxEBkqf0RFukA9Mo3NEHQWgAQ2cn9duOcRbaFUQo2z0/rB"
+            }
+          },
+          "keyExpirationMS": 1
+        }
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "keyvault"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "datakeys"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "databaseName": "keyvault",
+      "collectionName": "datakeys",
+      "documents": [
+        {
+          "_id": {
+            "$binary": {
+              "base64": "a+YWzdygTAG62/cNUkqZiQ==",
+              "subType": "04"
+            }
+          },
+          "keyAltNames": [],
+          "keyMaterial": {
+            "$binary": {
+              "base64": "iocBkhO3YBokiJ+FtxDTS71/qKXQ7tSWhWbcnFTXBcMjarsepvALeJ5li+SdUd9ePuatjidxAdMo7vh1V2ZESLMkQWdpPJ9PaJjA67gKQKbbbB4Ik5F2uKjULvrMBnFNVRMup4JNUwWFQJpqbfMveXnUVcD06+pUpAkml/f+DSXrV3e5rxciiNVtz03dAG8wJrsKsFXWj6vTjFhsfknyBA==",
+              "subType": "00"
+            }
+          },
+          "creationDate": {
+            "$date": {
+              "$numberLong": "1552949630483"
+            }
+          },
+          "updateDate": {
+            "$date": {
+              "$numberLong": "1552949630483"
+            }
+          },
+          "status": {
+            "$numberInt": "0"
+          },
+          "masterKey": {
+            "provider": "local"
+          }
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "decrypt, wait, and decrypt again",
+      "operations": [
+        {
+          "name": "decrypt",
+          "object": "clientEncryption0",
+          "arguments": {
+            "value": {
+              "$binary": {
+                "base64": "AWvmFs3coEwButv3DVJKmYkCJ6lUzRX9R28WNlw5uyndb+8gurA+p8q14s7GZ04K2ZvghieRlAr5UwZbow3PMq27u5EIhDDczwBFcbdP1amllw==",
+                "subType": "06"
+              }
+            }
+          },
+          "expectResult": "foobar"
+        },
+        {
+          "name": "wait",
+          "object": "testRunner",
+          "arguments": {
+            "ms": 50
+          }
+        },
+        {
+          "name": "decrypt",
+          "object": "clientEncryption0",
+          "arguments": {
+            "value": {
+              "$binary": {
+                "base64": "AWvmFs3coEwButv3DVJKmYkCJ6lUzRX9R28WNlw5uyndb+8gurA+p8q14s7GZ04K2ZvghieRlAr5UwZbow3PMq27u5EIhDDczwBFcbdP1amllw==",
+                "subType": "06"
+              }
+            }
+          },
+          "expectResult": "foobar"
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "datakeys",
+                  "filter": {
+                    "$or": [
+                      {
+                        "_id": {
+                          "$in": [
+                            {
+                              "$binary": {
+                                "base64": "a+YWzdygTAG62/cNUkqZiQ==",
+                                "subType": "04"
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "keyAltNames": {
+                          "$in": []
+                        }
+                      }
+                    ]
+                  },
+                  "$db": "keyvault",
+                  "readConcern": {
+                    "level": "majority"
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "datakeys",
+                  "filter": {
+                    "$or": [
+                      {
+                        "_id": {
+                          "$in": [
+                            {
+                              "$binary": {
+                                "base64": "a+YWzdygTAG62/cNUkqZiQ==",
+                                "subType": "04"
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "keyAltNames": {
+                          "$in": []
+                        }
+                      }
+                    ]
+                  },
+                  "$db": "keyvault",
+                  "readConcern": {
+                    "level": "majority"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/client-side-encryption/tests/unified/keyCache.yml
+++ b/test/spec/client-side-encryption/tests/unified/keyCache.yml
@@ -1,0 +1,85 @@
+description: keyCache-explicit
+
+schemaVersion: "1.22"
+
+runOnRequirements:
+  - csfle: true
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents:
+        - commandStartedEvent
+  - clientEncryption:
+      id: &clientEncryption0 clientEncryption0
+      clientEncryptionOpts:
+        keyVaultClient: *client0
+        keyVaultNamespace: keyvault.datakeys
+        kmsProviders:
+          "local" : { key: "OCTP9uKPPmvuqpHlqq83gPk4U6rUPxKVRRyVtrjFmVjdoa4Xzm1SzUbr7aIhNI42czkUBmrCtZKF31eaaJnxEBkqf0RFukA9Mo3NEHQWgAQ2cn9duOcRbaFUQo2z0/rB" }
+        keyExpirationMS: 1
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name keyvault
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name datakeys
+
+initialData:
+  - databaseName: *database0Name
+    collectionName: *collection0Name
+    documents:
+      - {
+            "_id": {
+                "$binary": {
+                    "base64": "a+YWzdygTAG62/cNUkqZiQ==",
+                    "subType": "04"
+                }
+            },
+            "keyAltNames": [],
+            "keyMaterial": {
+                "$binary": {
+                    "base64": "iocBkhO3YBokiJ+FtxDTS71/qKXQ7tSWhWbcnFTXBcMjarsepvALeJ5li+SdUd9ePuatjidxAdMo7vh1V2ZESLMkQWdpPJ9PaJjA67gKQKbbbB4Ik5F2uKjULvrMBnFNVRMup4JNUwWFQJpqbfMveXnUVcD06+pUpAkml/f+DSXrV3e5rxciiNVtz03dAG8wJrsKsFXWj6vTjFhsfknyBA==",
+                    "subType": "00"
+                }
+            },
+            "creationDate": {"$date": {"$numberLong": "1552949630483"}},
+            "updateDate": {"$date": {"$numberLong": "1552949630483"}},
+            "status": {"$numberInt": "0"},
+            "masterKey": {"provider": "local"}
+        }
+
+tests:
+  - description: decrypt, wait, and decrypt again
+    operations:
+      - name: decrypt
+        object: *clientEncryption0
+        arguments:
+          value: { "$binary" : { "base64" : "AWvmFs3coEwButv3DVJKmYkCJ6lUzRX9R28WNlw5uyndb+8gurA+p8q14s7GZ04K2ZvghieRlAr5UwZbow3PMq27u5EIhDDczwBFcbdP1amllw==", "subType" : "06" } }
+        expectResult: "foobar"
+      - name: wait
+        object: testRunner
+        arguments:
+          ms: 50 # Wait long enough to account for coarse time resolution on Windows (CDRIVER-4526).
+      - name: decrypt
+        object: *clientEncryption0
+        arguments:
+          value: { "$binary" : { "base64" : "AWvmFs3coEwButv3DVJKmYkCJ6lUzRX9R28WNlw5uyndb+8gurA+p8q14s7GZ04K2ZvghieRlAr5UwZbow3PMq27u5EIhDDczwBFcbdP1amllw==", "subType" : "06" } }
+        expectResult: "foobar"
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                find: datakeys
+                filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'a+YWzdygTAG62/cNUkqZiQ==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
+                $db: keyvault
+                readConcern: { level: "majority" }
+          - commandStartedEvent:
+              command:
+                find: datakeys
+                filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'a+YWzdygTAG62/cNUkqZiQ==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
+                $db: keyvault
+                readConcern: { level: "majority" }

--- a/test/tools/unified-spec-runner/schema.ts
+++ b/test/tools/unified-spec-runner/schema.ts
@@ -221,6 +221,7 @@ export interface ClientEncryptionEntity {
         | UnnamedKMSProviders['local']
         | undefined;
     };
+    keyExpirationMS?: number;
   };
 }
 

--- a/test/tools/unified-spec-runner/unified-utils.ts
+++ b/test/tools/unified-spec-runner/unified-utils.ts
@@ -520,6 +520,7 @@ export async function createClientEncryption(
   const {
     keyVaultClient,
     keyVaultNamespace,
+    keyExpirationMS,
     kmsProviders: kmsProvidersFromTest
   } = clientEncryptionOpts;
 
@@ -571,6 +572,7 @@ export async function createClientEncryption(
     keyVaultClient: clientEntity,
     kmsProviders,
     keyVaultNamespace,
+    keyExpirationMS,
     tlsOptions: parseTLSOptions()
   };
 


### PR DESCRIPTION
### Description

Adds support to configure the DEK cache expiration time.

#### What is changing?

- Adds the option `keyTimeoutMS` to both client encryption and auto encryption options.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Support Added for Configuring the DEK cache expiration time.

Default value is 60000. Requires using mongodb-client-encryption >= 6.4.0

For `ClientEncryption`:
```ts
import { MongoClient, ClientEncryption } from 'mongodb';
const client = new MongoClient(process.env.MONGODB_URI);
const clientEncryption = new ClientEncryption(client, { keyExpirationMS: 100000, kmsProviders: ... });
```

For auto encryption:
```ts
import { MongoClient, ClientEncryption } from 'mongodb';
const client = new MongoClient(process.env.MONGODB_URI, {
  autoEncryption: {
    keyExpirationMS: 100000,
    kmsProviders: ...
  }
});
```

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
