### PR TITLE
fix(NODE-6955): add missing `wallTime` property to `ChangeStreamDocumentCommon`

### DIFF
--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -184,6 +184,14 @@ export interface ChangeStreamDocumentCommon {
   clusterTime?: Timestamp;
 
   /**
+   * The server date and time of the database operation. 
+   * wallTime differs from clusterTime in that clusterTime is a timestamp taken from the oplog entry associated with the database operation event.
+   * The format is "YYYY-MM-DD HH:MM.SS.millis".
+   */
+  wallTime?: string;
+
+
+  /**
    * The transaction number.
    * Only present if the operation is part of a multi-document transaction.
    *


### PR DESCRIPTION


### Description

#### What is changing?

Adds missing `wallTime: string` property to `ChangeStreamDocumentCommon` type.

##### Is there new documentation needed for these changes?

I don't think so?

#### What is the motivation for this change?

I needed to use the `wallTime` property from my change stream messages, but noticed that the property is missing from `mongodb` built-in types.

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->


<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
