### PR TITLE
chore(NODE-6783): document keeping UTR loop and events as entities

### DIFF
--- a/test/tools/unified-spec-runner/operations.ts
+++ b/test/tools/unified-spec-runner/operations.ts
@@ -456,6 +456,10 @@ operations.set('listIndexNames', async ({ entities, operation }) => {
   return indexes.map(index => index.name);
 });
 
+/**
+ * This function was scheduled to be removed in NODE-6783, but we've decideded to keep it
+ * as the removal is optional and has utility for testing and debugging.
+ */
 operations.set('loop', async ({ entities, operation, client, testConfig }) => {
   const controller = new AbortController();
   // We always want the process to exit on SIGINT last, so all other

--- a/test/tools/unified-spec-runner/schema.ts
+++ b/test/tools/unified-spec-runner/schema.ts
@@ -150,6 +150,7 @@ export interface ClientEntity {
   ignoreCommandMonitoringEvents?: string[];
   serverApi?: ServerApi;
   observeSensitiveCommands?: boolean;
+  // Was optionally scheduled for removal in NODE-6783, but opted to keep it for potential future use.
   storeEventsAsEntities?: StoreEventsAsEntity[];
 }
 export interface DatabaseEntity {


### PR DESCRIPTION
### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
