### PR TITLE
fix(NODE-4845): allocate sessions lazily in cursors

### DIFF
--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -905,7 +905,7 @@ export abstract class AbstractCursor<
       );
     }
 
-    if (!this.cursorSession) {
+    if (this.cursorSession == null) {
       throw new MongoRuntimeError(
         'Unexpected null session. A cursor creating command should have set this'
       );
@@ -1081,7 +1081,7 @@ export abstract class AbstractCursor<
         if (session.owner === this) {
           await session.endSession({ error });
         }
-        if (!session?.inTransaction()) {
+        if (!session.inTransaction()) {
           maybeClearPinnedConnection(session, { error });
         }
       }

--- a/src/cursor/run_command_cursor.ts
+++ b/src/cursor/run_command_cursor.ts
@@ -1,7 +1,7 @@
 import type { BSONSerializeOptions, Document } from '../bson';
 import { CursorResponse } from '../cmap/wire_protocol/responses';
 import type { Db } from '../db';
-import { MongoAPIError } from '../error';
+import { MongoAPIError, MongoRuntimeError } from '../error';
 import { executeOperation } from '../operations/execute_operation';
 import { GetMoreOperation } from '../operations/get_more';
 import { RunCommandOperation } from '../operations/run_command';
@@ -161,6 +161,12 @@ export class RunCommandCursor extends AbstractCursor {
 
   /** @internal */
   override async getMore(_batchSize: number): Promise<CursorResponse> {
+    if (!this.session) {
+      throw new MongoRuntimeError(
+        'Unexpected null session. A cursor creating command should have set this'
+      );
+    }
+
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const getMoreOperation = new GetMoreOperation(this.namespace, this.id!, this.server!, {
       ...this.cursorOptions,

--- a/test/unit/cursor/abstract_cursor.test.ts
+++ b/test/unit/cursor/abstract_cursor.test.ts
@@ -32,9 +32,9 @@ describe('class AbstractCursor', () => {
   });
 
   context('#constructor', () => {
-    it('creates a session if none passed in', () => {
+    it('does not create a session if none passed in', () => {
       const cursor = new ConcreteCursor(client);
-      expect(cursor).to.have.property('session').that.is.instanceOf(ClientSession);
+      expect(cursor).to.have.property('session').that.is.null;
     });
 
     it('uses the passed in session', async () => {

--- a/test/unit/cursor/abstract_cursor.test.ts
+++ b/test/unit/cursor/abstract_cursor.test.ts
@@ -4,7 +4,7 @@ import {
   AbstractCursor,
   type AbstractCursorOptions,
   type Callback,
-  ClientSession,
+  type ClientSession,
   type ExecutionResult,
   MongoClient,
   ns,

--- a/test/unit/cursor/aggregation_cursor.test.ts
+++ b/test/unit/cursor/aggregation_cursor.test.ts
@@ -29,10 +29,9 @@ describe('class AggregationCursor', () => {
   });
 
   context('clone()', () => {
-    it('returns a new cursor with a different session', () => {
+    it('returns a new cursor', () => {
       const cloned = cursor.clone();
       expect(cursor).to.not.equal(cloned);
-      expect(cursor.session).to.not.equal(cloned.session);
     });
   });
 


### PR DESCRIPTION
### Description

#### What is changing?

When no explicit session is provided to a cursor, we now instantiate an implicit session when initializing the cursor, instead of in the cursor's constructor.

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Cursors lazily instantiate sessions

In previous versions, sessions were eagerly allocated whenever a cursor was created, regardless of whether or not a cursor was actually iterated (and the session was actually needed).  Some driver APIs (`FindCursor.count()`, `AggregationCursor.explain()` and `FindCursor.explain()`) don't actually iterate the cursor they are executed on.  This can lead to client sessions being created and never being cleaned up.

With this update, sessions are not allocated until the cursor is iterated.
<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
