### PR TITLE
feat(NODE-3922): remove behaviour around ocsp tls options

### DIFF
--- a/src/client-side-encryption/state_machine.ts
+++ b/src/client-side-encryption/state_machine.ts
@@ -68,12 +68,7 @@ const stateToString = new Map([
 const INSECURE_TLS_OPTIONS = [
   'tlsInsecure',
   'tlsAllowInvalidCertificates',
-  'tlsAllowInvalidHostnames',
-
-  // These options are disallowed by the spec, so we explicitly filter them out if provided, even
-  // though the StateMachine does not declare support for these options.
-  'tlsDisableOCSPEndpointCheck',
-  'tlsDisableCertificateRevocationCheck'
+  'tlsAllowInvalidHostnames'
 ];
 
 /**

--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -172,11 +172,6 @@ function checkTLSOptions(allOptions: CaseInsensitiveMap): void {
   };
   check('tlsInsecure', 'tlsAllowInvalidCertificates');
   check('tlsInsecure', 'tlsAllowInvalidHostnames');
-  check('tlsInsecure', 'tlsDisableCertificateRevocationCheck');
-  check('tlsInsecure', 'tlsDisableOCSPEndpointCheck');
-  check('tlsAllowInvalidCertificates', 'tlsDisableCertificateRevocationCheck');
-  check('tlsAllowInvalidCertificates', 'tlsDisableOCSPEndpointCheck');
-  check('tlsDisableCertificateRevocationCheck', 'tlsDisableOCSPEndpointCheck');
 }
 function getBoolean(name: string, value: unknown): boolean {
   if (typeof value === 'boolean') return value;

--- a/test/unit/assorted/uri_options.spec.test.ts
+++ b/test/unit/assorted/uri_options.spec.test.ts
@@ -10,7 +10,8 @@ describe('URI option spec tests', function () {
     // Skipped because this does not apply to Node
     'Valid options specific to single-threaded drivers are parsed correctly',
 
-    // TODO(NODE-3922): have not implemented option support
+    // These options are specific to OCSP which the driver does not implement
+    // and will not be implemented in the future.
     'tlsDisableCertificateRevocationCheck can be set to true',
     'tlsDisableCertificateRevocationCheck can be set to false',
     'tlsDisableOCSPEndpointCheck can be set to true',


### PR DESCRIPTION
### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
