### PR TITLE
feat(NODE-4179): allow secureContext in KMS TLS options

### DIFF
--- a/src/client-side-encryption/state_machine.ts
+++ b/src/client-side-encryption/state_machine.ts
@@ -103,6 +103,8 @@ declare module 'mongodb-client-encryption' {
  *  - tlsInsecure
  *
  * These options are not included in the type, and are ignored if provided.
+ *
+ * Note that if a secureContext option is provided, all other TLS options will be ignored.
  */
 export type ClientEncryptionTlsOptions = Pick<
   MongoClientOptions,

--- a/src/client-side-encryption/state_machine.ts
+++ b/src/client-side-encryption/state_machine.ts
@@ -106,7 +106,7 @@ declare module 'mongodb-client-encryption' {
  */
 export type ClientEncryptionTlsOptions = Pick<
   MongoClientOptions,
-  'tlsCAFile' | 'tlsCertificateKeyFile' | 'tlsCertificateKeyFilePassword'
+  'tlsCAFile' | 'tlsCertificateKeyFile' | 'tlsCertificateKeyFilePassword' | 'secureContext'
 >;
 
 /** @public */
@@ -521,15 +521,20 @@ export class StateMachine {
     tlsOptions: ClientEncryptionTlsOptions,
     options: tls.ConnectionOptions
   ): Promise<void> {
-    if (tlsOptions.tlsCertificateKeyFile) {
-      const cert = await fs.readFile(tlsOptions.tlsCertificateKeyFile);
-      options.cert = options.key = cert;
-    }
-    if (tlsOptions.tlsCAFile) {
-      options.ca = await fs.readFile(tlsOptions.tlsCAFile);
-    }
-    if (tlsOptions.tlsCertificateKeyFilePassword) {
-      options.passphrase = tlsOptions.tlsCertificateKeyFilePassword;
+    // If a secureContext is provided, it takes precedence over the other options.
+    if (tlsOptions.secureContext) {
+      options.secureContext = tlsOptions.secureContext;
+    } else {
+      if (tlsOptions.tlsCertificateKeyFile) {
+        const cert = await fs.readFile(tlsOptions.tlsCertificateKeyFile);
+        options.cert = options.key = cert;
+      }
+      if (tlsOptions.tlsCAFile) {
+        options.ca = await fs.readFile(tlsOptions.tlsCAFile);
+      }
+      if (tlsOptions.tlsCertificateKeyFilePassword) {
+        options.passphrase = tlsOptions.tlsCertificateKeyFilePassword;
+      }
     }
   }
 

--- a/src/client-side-encryption/state_machine.ts
+++ b/src/client-side-encryption/state_machine.ts
@@ -103,8 +103,6 @@ declare module 'mongodb-client-encryption' {
  *  - tlsInsecure
  *
  * These options are not included in the type, and are ignored if provided.
- *
- * Note that if a secureContext option is provided, all other TLS options will be ignored.
  */
 export type ClientEncryptionTlsOptions = Pick<
   MongoClientOptions,
@@ -523,20 +521,19 @@ export class StateMachine {
     tlsOptions: ClientEncryptionTlsOptions,
     options: tls.ConnectionOptions
   ): Promise<void> {
-    // If a secureContext is provided, it takes precedence over the other options.
+    // If a secureContext is provided, ensure it is set.
     if (tlsOptions.secureContext) {
       options.secureContext = tlsOptions.secureContext;
-    } else {
-      if (tlsOptions.tlsCertificateKeyFile) {
-        const cert = await fs.readFile(tlsOptions.tlsCertificateKeyFile);
-        options.cert = options.key = cert;
-      }
-      if (tlsOptions.tlsCAFile) {
-        options.ca = await fs.readFile(tlsOptions.tlsCAFile);
-      }
-      if (tlsOptions.tlsCertificateKeyFilePassword) {
-        options.passphrase = tlsOptions.tlsCertificateKeyFilePassword;
-      }
+    }
+    if (tlsOptions.tlsCertificateKeyFile) {
+      const cert = await fs.readFile(tlsOptions.tlsCertificateKeyFile);
+      options.cert = options.key = cert;
+    }
+    if (tlsOptions.tlsCAFile) {
+      options.ca = await fs.readFile(tlsOptions.tlsCAFile);
+    }
+    if (tlsOptions.tlsCertificateKeyFilePassword) {
+      options.passphrase = tlsOptions.tlsCertificateKeyFilePassword;
     }
   }
 

--- a/test/integration/client-side-encryption/client_side_encryption.prose.test.ts
+++ b/test/integration/client-side-encryption/client_side_encryption.prose.test.ts
@@ -40,15 +40,14 @@ export const getKmsProviders = (localKey, kmipEndpoint, azureEndpoint, gcpEndpoi
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const noop = () => {};
-/** @type { MongoDBMetadataUI } */
-const metadata = {
+const metadata: MongoDBMetadataUI = {
   requires: {
     clientSideEncryption: true,
     topology: '!load-balanced'
   }
 };
 
-const eeMetadata = {
+const eeMetadata: MongoDBMetadataUI = {
   requires: {
     clientSideEncryption: true,
     mongodb: '>=7.0.0',

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -3,7 +3,8 @@
     "compilerOptions": {
         "strict": false,
         "allowJs": true,
-        "checkJs": false
+        "checkJs": false,
+        "resolveJsonModule": true
     },
     "include": [
         "../node_modules/@types/mocha/index.d.ts",

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -3,8 +3,7 @@
     "compilerOptions": {
         "strict": false,
         "allowJs": true,
-        "checkJs": false,
-        "resolveJsonModule": true
+        "checkJs": false
     },
     "include": [
         "../node_modules/@types/mocha/index.d.ts",


### PR DESCRIPTION
### Description

Allows users to pass a `secureContext` option to the TLS options in client encryption and auto encryption.

#### What is changing?
- Allows a `secureContext` option to the `tlsOptions:<provider>` option in `autoEncryption` options on the `MongoClient` or the options for `ClientEncryption`.
- Adds tests that ensure a `secureContext` option takes precedence over the driver tls* options, that the tls* options aren't attempted to be read from the file, and that it works end-to-end.

##### Is there new documentation needed for these changes?

Yes, update the MongoDB manual to show the precedence of the options.

#### What is the motivation for this change?

NODE-4179

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Allow a `secureContext` for Auto Encryption and Client Encryption TLS options

This can be provided in the `tlsOptions` option both both objects.

```ts
import * as tls from 'tls';
import { ClientEncryption, MongoClient } from 'mongodb';

const caFile = await fs.readFile(process.env.CSFLE_TLS_CA_FILE);
const certFile = await fs.readFile(process.env.CSFLE_TLS_CLIENT_CERT_FILE);
const secureContextOptions = {
  ca: caFile,
  key: certFile,
  cert: certFile
};
const options = {
  keyVaultNamespace: 'db.coll',
  kmsProviders: {
    aws: {}
    }
  },
  tlsOptions: {
    aws: {
      secureContext: tls.createSecureContext(secureContextOptions),
    }
  }
};

const client = this.configuration.newClient({}, { autoEncryption: { ...options, schemaMap } });
const clientEncryption = new ClientEncryption(client, options);
```

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
