### PR TITLE
docs(NODE-6589): update maxIdleTimeMS API docs

### DIFF
--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -186,8 +186,8 @@ export interface MongoClientOptions extends BSONSerializeOptions, SupportedNodeC
   maxConnecting?: number;
   /**
    * The maximum amount of time a connection should remain idle in the connection pool before being marked idle, in milliseconds.
-   * If specified, this must be a number >= 0, where 0 means there is no limit. Defaults to 0. After this time passes, the idle
-   * collection can be automatically cleaned up in the background.
+   * If specified, this must be a number greater than or equal to 0, where 0 means there is no limit. Defaults to 0. After this
+   * time passes, the idle collection can be automatically cleaned up in the background.
    */
   maxIdleTimeMS?: number;
   /** The maximum time in milliseconds that a thread can wait for a connection to become available. */


### PR DESCRIPTION
### Description

Updates the API docs for the `maxIdleTimeMS` option.

#### What is changing?

Updates the API docs.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-6589

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
