### PR TITLE
feat(NODE-4184): do not throw with explain and write conceern

### DIFF
--- a/src/operations/aggregate.ts
+++ b/src/operations/aggregate.ts
@@ -85,12 +85,6 @@ export class AggregateOperation extends CommandOperation<CursorResponse> {
       delete this.options.writeConcern;
     }
 
-    if (this.explain && this.writeConcern) {
-      throw new MongoInvalidArgumentError(
-        'Option "explain" cannot be used on an aggregate call with writeConcern'
-      );
-    }
-
     if (options?.cursor != null && typeof options.cursor !== 'object') {
       throw new MongoInvalidArgumentError('Cursor options must be an object');
     }

--- a/test/integration/crud/aggregation.test.ts
+++ b/test/integration/crud/aggregation.test.ts
@@ -640,31 +640,29 @@ describe('Aggregation', function () {
     expect(error).to.be.instanceOf(MongoInvalidArgumentError);
   });
 
-  it(`should fail if you try to use explain flag with { readConcern: { level: 'local' }, writeConcern: { j: true } }`, async function () {
+  it(`should succeed if you try to use explain flag with { readConcern: { level: 'local' }, writeConcern: { j: true } }`, async function () {
     const db = client.db();
 
     const collection = db.collection('foo');
     Object.assign(collection.s, { writeConcern: { j: true } });
-    const error = await collection
+    const result = await collection
       .aggregate([{ $project: { _id: 0 } }, { $out: 'bar' }], { explain: true })
-      .toArray()
-      .catch(error => error);
+      .toArray();
 
-    expect(error).to.be.instanceOf(MongoInvalidArgumentError);
+    expect(result).to.not.be.null;
   });
 
-  it('should fail if you try to use explain flag with { writeConcern: { j: true } }', async function () {
+  it('should succeed if you try to use explain flag with { writeConcern: { j: true } }', async function () {
     const db = client.db();
 
     const collection = db.collection('foo');
     Object.assign(collection.s, { writeConcern: { j: true } });
 
-    const error = await collection
+    const result = await collection
       .aggregate([{ $project: { _id: 0 } }, { $out: 'bar' }], { explain: true })
-      .toArray()
-      .catch(error => error);
+      .toArray();
 
-    expect(error).to.be.instanceOf(MongoInvalidArgumentError);
+    expect(result).to.not.be.null;
   });
 
   it('should ensure MaxTimeMS is correctly passed down into command execution when using a cursor', function (done) {

--- a/test/integration/crud/aggregation.test.ts
+++ b/test/integration/crud/aggregation.test.ts
@@ -640,29 +640,31 @@ describe('Aggregation', function () {
     expect(error).to.be.instanceOf(MongoInvalidArgumentError);
   });
 
-  it(`should succeed if you try to use explain flag with { readConcern: { level: 'local' }, writeConcern: { j: true } }`, async function () {
+  it(`should fail if you try to use explain flag with { readConcern: { level: 'local' }, writeConcern: { j: true } }`, async function () {
     const db = client.db();
 
     const collection = db.collection('foo');
     Object.assign(collection.s, { writeConcern: { j: true } });
-    const result = await collection
+    const error = await collection
       .aggregate([{ $project: { _id: 0 } }, { $out: 'bar' }], { explain: true })
-      .toArray();
+      .toArray()
+      .catch(error => error);
 
-    expect(result).to.not.be.null;
+    expect(error).to.be.instanceOf(MongoInvalidArgumentError);
   });
 
-  it('should succeed if you try to use explain flag with { writeConcern: { j: true } }', async function () {
+  it('should fail if you try to use explain flag with { writeConcern: { j: true } }', async function () {
     const db = client.db();
 
     const collection = db.collection('foo');
     Object.assign(collection.s, { writeConcern: { j: true } });
 
-    const result = await collection
+    const error = await collection
       .aggregate([{ $project: { _id: 0 } }, { $out: 'bar' }], { explain: true })
-      .toArray();
+      .toArray()
+      .catch(error => error);
 
-    expect(result).to.not.be.null;
+    expect(error).to.be.instanceOf(MongoInvalidArgumentError);
   });
 
   it('should ensure MaxTimeMS is correctly passed down into command execution when using a cursor', function (done) {

--- a/test/unit/operations/aggregate.test.js
+++ b/test/unit/operations/aggregate.test.js
@@ -7,6 +7,23 @@ describe('AggregateOperation', function () {
   const db = 'test';
 
   describe('#constructor', function () {
+    context('when explain is in the options', function () {
+      context('when writeConcern is set', function () {
+        const operation = new AggregateOperation(db, [], {
+          explain: 'verbose',
+          writeConcern: { w: 1 }
+        });
+
+        it('sets explain on the operation', function () {
+          expect(operation.explain.verbosity).to.equal('verbose');
+        });
+
+        it('sets the write concern on the operation', function () {
+          expect(operation.writeConcern.w).to.equal(1);
+        });
+      });
+    });
+
     context('when out is in the options', function () {
       const operation = new AggregateOperation(db, [], { out: 'test', dbName: db });
 


### PR DESCRIPTION
### Description

The driver will no longer throw an error if aggregate is used with explain and write concern. The server simply ignores the write concern in this case.

#### What is changing?
- Removes the check and throw from the aggregation operation.
- Adds a unit test to protect from regressions.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-4184

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Explain + Write Concern on an aggregation no longer throws.

The server will silently ignore the write concern.

```ts
// Previously this would throw a MongoInvalidArgumentError, now it will return explain results.
collection.aggregate([{ $match: { n: 1 }}], { writeConcern: { w: 1 }, explain: 'verbose' });
```

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
