### PR TITLE
feat(NODE-5055): Add databaseName property to command monitoring events

### DIFF
--- a/src/cmap/command_monitoring_events.ts
+++ b/src/cmap/command_monitoring_events.ts
@@ -96,6 +96,7 @@ export class CommandSucceededEvent {
   commandName: string;
   reply: unknown;
   serviceId?: ObjectId;
+  databaseName: string;
   /** @internal */
   name = COMMAND_SUCCEEDED;
 
@@ -127,6 +128,7 @@ export class CommandSucceededEvent {
     this.duration = calculateDurationInMs(started);
     this.reply = maybeRedact(commandName, cmd, extractReply(reply));
     this.serverConnectionId = serverConnectionId;
+    this.databaseName = command.databaseName;
   }
 
   /* @internal */
@@ -154,6 +156,7 @@ export class CommandFailedEvent {
   commandName: string;
   failure: Error;
   serviceId?: ObjectId;
+  databaseName: string;
   /** @internal */
   name = COMMAND_FAILED;
 
@@ -186,6 +189,7 @@ export class CommandFailedEvent {
     this.duration = calculateDurationInMs(started);
     this.failure = maybeRedact(commandName, cmd, error) as Error;
     this.serverConnectionId = serverConnectionId;
+    this.databaseName = command.databaseName;
   }
 
   /* @internal */

--- a/test/spec/unified-test-format/invalid/expectedCommandEvent-commandFailedEvent-databaseName-type.json
+++ b/test/spec/unified-test-format/invalid/expectedCommandEvent-commandFailedEvent-databaseName-type.json
@@ -1,0 +1,29 @@
+{
+  "description": "expectedCommandEvent-commandFailedEvent-databaseName-type",
+  "schemaVersion": "1.15",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandFailedEvent": {
+                "databaseName": 0
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/expectedCommandEvent-commandFailedEvent-databaseName-type.yml
+++ b/test/spec/unified-test-format/invalid/expectedCommandEvent-commandFailedEvent-databaseName-type.yml
@@ -1,0 +1,16 @@
+description: "expectedCommandEvent-commandFailedEvent-databaseName-type"
+
+schemaVersion: "1.15"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+
+tests:
+  - description: "foo"
+    operations: []
+    expectEvents:
+      - client: *client0
+        events:
+          - commandFailedEvent:
+              databaseName: 0

--- a/test/spec/unified-test-format/invalid/expectedCommandEvent-commandSucceededEvent-databaseName-type.json
+++ b/test/spec/unified-test-format/invalid/expectedCommandEvent-commandSucceededEvent-databaseName-type.json
@@ -1,0 +1,29 @@
+{
+  "description": "expectedCommandEvent-commandSucceededEvent-databaseName-type",
+  "schemaVersion": "1.15",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandSucceededEvent": {
+                "databaseName": 0
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/unified-test-format/invalid/expectedCommandEvent-commandSucceededEvent-databaseName-type.yml
+++ b/test/spec/unified-test-format/invalid/expectedCommandEvent-commandSucceededEvent-databaseName-type.yml
@@ -1,0 +1,16 @@
+description: "expectedCommandEvent-commandSucceededEvent-databaseName-type"
+
+schemaVersion: "1.15"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+
+tests:
+  - description: "foo"
+    operations: []
+    expectEvents:
+      - client: *client0
+        events:
+          - commandSucceededEvent:
+              databaseName: 0

--- a/test/tools/unified-spec-runner/match.ts
+++ b/test/tools/unified-spec-runner/match.ts
@@ -461,16 +461,14 @@ function compareCommandStartedEvents(
   if (expected!.commandName) {
     expect(
       expected!.commandName,
-      `expected ${prefix}.commandName to equal ${expected!.commandName} but received ${
-        actual.commandName
+      `expected ${prefix}.commandName to equal ${expected!.commandName} but received ${actual.commandName
       }`
     ).to.equal(actual.commandName);
   }
   if (expected!.databaseName) {
     expect(
       expected!.databaseName,
-      `expected ${prefix}.databaseName to equal ${expected!.databaseName} but received ${
-        actual.databaseName
+      `expected ${prefix}.databaseName to equal ${expected!.databaseName} but received ${actual.databaseName
       }`
     ).to.equal(actual.databaseName);
   }
@@ -478,36 +476,48 @@ function compareCommandStartedEvents(
 
 function compareCommandSucceededEvents(
   actual: CommandSucceededEvent,
-  expected: ExpectedCommandEvent['commandSucceededEvent'],
+  expected: NonNullable<ExpectedCommandEvent['commandSucceededEvent']>,
   entities: EntitiesMap,
   prefix: string
 ) {
-  if (expected!.reply) {
-    resultCheck(actual.reply as Document, expected!.reply, entities, [prefix]);
+  if (expected.reply) {
+    resultCheck(actual.reply as Document, expected.reply, entities, [prefix]);
   }
-  if (expected!.commandName) {
+  if (expected.commandName) {
     expect(
-      expected!.commandName,
-      `expected ${prefix}.commandName to equal ${expected!.commandName} but received ${
-        actual.commandName
+      expected.commandName,
+      `expected ${prefix}.commandName to equal ${expected.commandName} but received ${actual.commandName
       }`
     ).to.equal(actual.commandName);
+  }
+  if (expected.databaseName) {
+    expect(
+      expected.databaseName,
+      `expected ${prefix}.databaseName to equal ${expected.databaseName} but received ${actual.databaseName
+      }`
+    ).to.equal(actual.databaseName);
   }
 }
 
 function compareCommandFailedEvents(
   actual: CommandFailedEvent,
-  expected: ExpectedCommandEvent['commandFailedEvent'],
-  entities: EntitiesMap,
+  expected: NonNullable<ExpectedCommandEvent['commandFailedEvent']>,
+  _entities: EntitiesMap,
   prefix: string
 ) {
-  if (expected!.commandName) {
+  if (expected.commandName) {
     expect(
-      expected!.commandName,
-      `expected ${prefix}.commandName to equal ${expected!.commandName} but received ${
-        actual.commandName
+      expected.commandName,
+      `expected ${prefix}.commandName to equal ${expected.commandName} but received ${actual.commandName
       }`
     ).to.equal(actual.commandName);
+  }
+  if (expected.databaseName) {
+    expect(
+      expected.databaseName,
+      `expected ${prefix}.databaseName to equal ${expected.databaseName} but received ${actual.databaseName
+      }`
+    ).to.equal(actual.databaseName);
   }
 }
 

--- a/test/tools/unified-spec-runner/schema.ts
+++ b/test/tools/unified-spec-runner/schema.ts
@@ -312,10 +312,12 @@ export interface ExpectedCommandEvent {
   commandSucceededEvent?: {
     reply?: Document;
     commandName?: string;
+    databaseName?: string;
     hasServerConnectionId?: boolean;
   };
   commandFailedEvent?: {
     commandName?: string;
+    databaseName?: string;
     hasServerConnectionId?: boolean;
   };
 }


### PR DESCRIPTION
### Description

#### What is changing?

CommandSucceeded and CommandFailed events now have a database name property.

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### `CommandSucceededEvent` and `CommandFailedEvent` events now have a database name property

`CommandSucceededEvent` and `CommandFailedEvent` now report which database the executed command was executed against.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
