### PR TITLE
fix(NODE-4763): tryNext not updating resumeToken for a returned update

### DIFF
--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -809,7 +809,8 @@ export class ChangeStream<
       while (true) {
         try {
           const change = await this.cursor.tryNext();
-          return change ?? null;
+          const processedChange = this._processChange(change ?? null);
+          return processedChange;
         } catch (error) {
           try {
             await this._processErrorIteratorMode(error, this.cursor.id != null);


### PR DESCRIPTION
### Description
This PR attempts to fix an issue noticed when using `tryNext` in which it does not correctly update the resumeToken when updates are received, meaning that if the change stream is resumed it can end up resuming in the past, causing issues.

#### What is changing?
The change is small and involves changing the `tryNext` function to use the internal `_processChange` function which handles updating the resume token before returning the given change. This is used by `next` already, so seems to be a good solution overall. 

#### What is the motivation for this change?

To prevent issues where resuming the change-stream using `tryNext` causes the client to go backwards in time, potentially causing issues on systems that use this functionality 

#### NOTE FOR REVIEWERS
I wasn't sure where to add test coverage for this, or what exactly I should call in terms of testing, Happy to add some tests for this functionality if someone can point me in the right direction of the "where and how" to test this. 

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
