### PR TITLE
feat(NODE-7053): deprecate noResponse option

### DIFF
--- a/src/operations/command.ts
+++ b/src/operations/command.ts
@@ -34,8 +34,8 @@ export interface CollationOptions {
 /** @public */
 export interface CommandOperationOptions
   extends OperationOptions,
-  WriteConcernOptions,
-  ExplainOptions {
+    WriteConcernOptions,
+    ExplainOptions {
   /** Specify a read concern and level for the collection. (only MongoDB 3.2 or higher supported) */
   readConcern?: ReadConcernLike;
   /** Collation */
@@ -59,8 +59,8 @@ export interface CommandOperationOptions
   // Admin command overrides.
   dbName?: string;
   authdb?: string;
-  /** 
-   * @deprecated 
+  /**
+   * @deprecated
    * This option is deprecated and will be removed in an upcoming major version.
    */
   noResponse?: boolean;

--- a/src/operations/command.ts
+++ b/src/operations/command.ts
@@ -34,8 +34,8 @@ export interface CollationOptions {
 /** @public */
 export interface CommandOperationOptions
   extends OperationOptions,
-    WriteConcernOptions,
-    ExplainOptions {
+  WriteConcernOptions,
+  ExplainOptions {
   /** Specify a read concern and level for the collection. (only MongoDB 3.2 or higher supported) */
   readConcern?: ReadConcernLike;
   /** Collation */
@@ -59,6 +59,10 @@ export interface CommandOperationOptions
   // Admin command overrides.
   dbName?: string;
   authdb?: string;
+  /** 
+   * @deprecated 
+   * This option is deprecated and will be removed in an upcoming major version.
+   */
   noResponse?: boolean;
 }
 


### PR DESCRIPTION
### Description

#### What is changing?

`CommandOptions.noResponse` is deprecated.

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### `CommandOptions.noResponse` is deprecated

> [!CAUTION]
> `noResponse` is not intended for use outside of `MongoClient.close()`.  Do not use this option.

The Node driver has historically supported an option, `noResponse`, that is used internally when a MongoClient is closed.  This option was accidentally public.  This option will be removed in an upcoming major release.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
