### PR TITLE
test(NODE-6944): unskip ldap and kerberos tests

### DIFF
--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -375,6 +375,10 @@ functions:
       params:
         binary: bash
         working_dir: src
+        include_expansions_in_env:
+          - AWS_SECRET_ACCESS_KEY
+          - AWS_ACCESS_KEY_ID
+          - AWS_SESSION_TOKEN
         env:
           DRIVERS_TOOLS: ${DRIVERS_TOOLS}
         args:
@@ -387,6 +391,10 @@ functions:
       params:
         working_dir: src
         binary: bash
+        include_expansions_in_env:
+          - AWS_SECRET_ACCESS_KEY
+          - AWS_ACCESS_KEY_ID
+          - AWS_SESSION_TOKEN
         env:
           DRIVERS_TOOLS: ${DRIVERS_TOOLS}
           NODE_LTS_VERSION: ${NODE_LTS_VERSION}

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1681,6 +1681,25 @@ tasks:
       - func: start-load-balancer
       - func: run-lb-tests
       - func: stop-load-balancer
+  - name: test-auth-kerberos
+    tags:
+      - auth
+      - kerberos
+    commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: NATIVE, value: 'true'}
+      - func: install dependencies
+      - func: run kerberos tests
+  - name: test-auth-ldap
+    tags:
+      - auth
+      - ldap
+    commands:
+      - func: install dependencies
+      - func: run ldap tests
   - name: test-socks5
     tags: []
     commands:
@@ -3058,6 +3077,8 @@ buildvariants:
       - test-8.0-load-balanced
       - test-rapid-load-balanced
       - test-latest-load-balanced
+      - test-auth-kerberos
+      - test-auth-ldap
       - test-socks5
       - test-socks5-csfle
       - test-socks5-tls
@@ -3113,6 +3134,8 @@ buildvariants:
       - test-8.0-load-balanced
       - test-rapid-load-balanced
       - test-latest-load-balanced
+      - test-auth-kerberos
+      - test-auth-ldap
       - test-socks5
       - test-socks5-csfle
       - test-socks5-tls
@@ -3168,6 +3191,8 @@ buildvariants:
       - test-8.0-load-balanced
       - test-rapid-load-balanced
       - test-latest-load-balanced
+      - test-auth-kerberos
+      - test-auth-ldap
       - test-socks5
       - test-socks5-csfle
       - test-socks5-tls
@@ -3223,6 +3248,8 @@ buildvariants:
       - test-8.0-load-balanced
       - test-rapid-load-balanced
       - test-latest-load-balanced
+      - test-auth-kerberos
+      - test-auth-ldap
       - test-socks5
       - test-socks5-csfle
       - test-socks5-tls
@@ -3276,6 +3303,8 @@ buildvariants:
       - test-8.0-load-balanced
       - test-rapid-load-balanced
       - test-latest-load-balanced
+      - test-auth-kerberos
+      - test-auth-ldap
       - test-socks5-csfle
       - test-socks5-tls
       - test-snappy-compression

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -331,6 +331,10 @@ functions:
       params:
         binary: bash
         working_dir: src
+        include_expansions_in_env:
+          - AWS_SECRET_ACCESS_KEY
+          - AWS_ACCESS_KEY_ID
+          - AWS_SESSION_TOKEN
         env:
           DRIVERS_TOOLS: ${DRIVERS_TOOLS}
         args:
@@ -344,6 +348,10 @@ functions:
       params:
         working_dir: src
         binary: bash
+        include_expansions_in_env:
+          - AWS_SECRET_ACCESS_KEY
+          - AWS_ACCESS_KEY_ID
+          - AWS_SESSION_TOKEN
         env:
           DRIVERS_TOOLS: ${DRIVERS_TOOLS}
           NODE_LTS_VERSION: ${NODE_LTS_VERSION}

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1692,6 +1692,7 @@ tasks:
           updates:
             - {key: NATIVE, value: 'true'}
       - func: install dependencies
+      - func: assume secrets manager role
       - func: run kerberos tests
   - name: test-auth-ldap
     tags:
@@ -1699,6 +1700,7 @@ tasks:
       - ldap
     commands:
       - func: install dependencies
+      - func: assume secrets manager role
       - func: run ldap tests
   - name: test-socks5
     tags: []

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -159,13 +159,18 @@ TASKS.push(
           NATIVE: 'true'
         }),
         { func: 'install dependencies' },
+        { func: 'assume secrets manager role' },
         { func: 'run kerberos tests' }
       ]
     },
     {
       name: 'test-auth-ldap',
       tags: ['auth', 'ldap'],
-      commands: [{ func: 'install dependencies' }, { func: 'run ldap tests' }]
+      commands: [
+        { func: 'install dependencies' },
+        { func: 'assume secrets manager role' },
+        { func: 'run ldap tests' }
+      ]
     },
     {
       name: 'test-socks5',

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -151,23 +151,22 @@ TASKS.push(
         { func: 'stop-load-balancer' }
       ]
     })),
-    // TODO(NODE-6944): Unskip when devprod updates ldaptest servers.
-    // {
-    //   name: 'test-auth-kerberos',
-    //   tags: ['auth', 'kerberos'],
-    //   commands: [
-    //     updateExpansions({
-    //       NATIVE: 'true'
-    //     }),
-    //     { func: 'install dependencies' },
-    //     { func: 'run kerberos tests' }
-    //   ]
-    // },
-    // {
-    //   name: 'test-auth-ldap',
-    //   tags: ['auth', 'ldap'],
-    //   commands: [{ func: 'install dependencies' }, { func: 'run ldap tests' }]
-    // },
+    {
+      name: 'test-auth-kerberos',
+      tags: ['auth', 'kerberos'],
+      commands: [
+        updateExpansions({
+          NATIVE: 'true'
+        }),
+        { func: 'install dependencies' },
+        { func: 'run kerberos tests' }
+      ]
+    },
+    {
+      name: 'test-auth-ldap',
+      tags: ['auth', 'ldap'],
+      commands: [{ func: 'install dependencies' }, { func: 'run ldap tests' }]
+    },
     {
       name: 'test-socks5',
       tags: [],


### PR DESCRIPTION
### Description

Unskips the LDAP and Kerberos tests.

#### What is changing?

- Unskips the tests
- Adds assume secret manager role to the runs.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-6944

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
