### PR TITLE
refactor(NODE-7060): move QE collection creation/deletion out of operations classes

### DIFF
--- a/src/collection.ts
+++ b/src/collection.ts
@@ -37,7 +37,7 @@ import {
   type DeleteResult
 } from './operations/delete';
 import { DistinctOperation, type DistinctOptions } from './operations/distinct';
-import { DropCollectionOperation, type DropCollectionOptions } from './operations/drop';
+import { type DropCollectionOptions } from './operations/drop';
 import {
   EstimatedDocumentCountOperation,
   type EstimatedDocumentCountOptions
@@ -523,10 +523,7 @@ export class Collection<TSchema extends Document = Document> {
    * @param options - Optional settings for the command
    */
   async drop(options?: DropCollectionOptions): Promise<boolean> {
-    return await executeOperation(
-      this.client,
-      new DropCollectionOperation(this.s.db, this.collectionName, options)
-    );
+    return await this.s.db.dropCollection(this.collectionName, options);
   }
 
   /**

--- a/src/db.ts
+++ b/src/db.ts
@@ -10,13 +10,10 @@ import { MongoInvalidArgumentError } from './error';
 import type { MongoClient, PkFactory } from './mongo_client';
 import type { Abortable, TODO_NODE_3286 } from './mongo_types';
 import type { AggregateOptions } from './operations/aggregate';
+import { type CreateCollectionOptions, createCollections } from './operations/create_collection';
 import {
-  CreateCollectionOperation,
-  type CreateCollectionOptions
-} from './operations/create_collection';
-import {
-  DropCollectionOperation,
   type DropCollectionOptions,
+  dropCollections,
   DropDatabaseOperation,
   type DropDatabaseOptions
 } from './operations/drop';
@@ -241,10 +238,8 @@ export class Db {
     name: string,
     options?: CreateCollectionOptions
   ): Promise<Collection<TSchema>> {
-    return await executeOperation(
-      this.client,
-      new CreateCollectionOperation(this, name, resolveOptions(this, options)) as TODO_NODE_3286
-    );
+    options = resolveOptions(this, options);
+    return await createCollections<TSchema>(this, name, options);
   }
 
   /**
@@ -410,10 +405,8 @@ export class Db {
    * @param options - Optional settings for the command
    */
   async dropCollection(name: string, options?: DropCollectionOptions): Promise<boolean> {
-    return await executeOperation(
-      this.client,
-      new DropCollectionOperation(this, name, resolveOptions(this, options))
-    );
+    options = resolveOptions(this, options);
+    return await dropCollections(this, name, options);
   }
 
   /**

--- a/src/operations/drop.ts
+++ b/src/operations/drop.ts
@@ -1,10 +1,12 @@
 import type { Document } from '../bson';
+import { CursorTimeoutContext } from '../cursor/abstract_cursor';
 import type { Db } from '../db';
 import { MONGODB_ERROR_CODES, MongoServerError } from '../error';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
-import { type TimeoutContext } from '../timeout';
+import { TimeoutContext } from '../timeout';
 import { CommandOperation, type CommandOperationOptions } from './command';
+import { executeOperation } from './execute_operation';
 import { Aspect, defineAspects } from './operation';
 
 /** @public */
@@ -16,12 +18,10 @@ export interface DropCollectionOptions extends CommandOperationOptions {
 /** @internal */
 export class DropCollectionOperation extends CommandOperation<boolean> {
   override options: DropCollectionOptions;
-  db: Db;
   name: string;
 
   constructor(db: Db, name: string, options: DropCollectionOptions = {}) {
     super(db, options);
-    this.db = db;
     this.options = options;
     this.name = name;
   }
@@ -35,56 +35,70 @@ export class DropCollectionOperation extends CommandOperation<boolean> {
     session: ClientSession | undefined,
     timeoutContext: TimeoutContext
   ): Promise<boolean> {
-    const db = this.db;
-    const options = this.options;
-    const name = this.name;
-
-    const encryptedFieldsMap = db.client.s.options.autoEncryption?.encryptedFieldsMap;
-    let encryptedFields: Document | undefined =
-      options.encryptedFields ?? encryptedFieldsMap?.[`${db.databaseName}.${name}`];
-
-    if (!encryptedFields && encryptedFieldsMap) {
-      // If the MongoClient was configured with an encryptedFieldsMap,
-      // and no encryptedFields config was available in it or explicitly
-      // passed as an argument, the spec tells us to look one up using
-      // listCollections().
-      const listCollectionsResult = await db
-        .listCollections({ name }, { nameOnly: false })
-        .toArray();
-      encryptedFields = listCollectionsResult?.[0]?.options?.encryptedFields;
-    }
-
-    if (encryptedFields) {
-      const escCollection = encryptedFields.escCollection || `enxcol_.${name}.esc`;
-      const ecocCollection = encryptedFields.ecocCollection || `enxcol_.${name}.ecoc`;
-
-      for (const collectionName of [escCollection, ecocCollection]) {
-        // Drop auxilliary collections, ignoring potential NamespaceNotFound errors.
-        const dropOp = new DropCollectionOperation(db, collectionName);
-        try {
-          await dropOp.executeWithoutEncryptedFieldsCheck(server, session, timeoutContext);
-        } catch (err) {
-          if (
-            !(err instanceof MongoServerError) ||
-            err.code !== MONGODB_ERROR_CODES.NamespaceNotFound
-          ) {
-            throw err;
-          }
-        }
-      }
-    }
-
-    return await this.executeWithoutEncryptedFieldsCheck(server, session, timeoutContext);
-  }
-
-  private async executeWithoutEncryptedFieldsCheck(
-    server: Server,
-    session: ClientSession | undefined,
-    timeoutContext: TimeoutContext
-  ): Promise<boolean> {
     await super.executeCommand(server, session, { drop: this.name }, timeoutContext);
     return true;
   }
+}
+
+export async function dropCollections(
+  db: Db,
+  name: string,
+  options: DropCollectionOptions
+): Promise<boolean> {
+  const timeoutContext = TimeoutContext.create({
+    session: options.session,
+    serverSelectionTimeoutMS: db.client.s.options.serverSelectionTimeoutMS,
+    waitQueueTimeoutMS: db.client.s.options.waitQueueTimeoutMS,
+    timeoutMS: options.timeoutMS
+  });
+
+  const encryptedFieldsMap = db.client.s.options.autoEncryption?.encryptedFieldsMap;
+  let encryptedFields: Document | undefined =
+    options.encryptedFields ?? encryptedFieldsMap?.[`${db.databaseName}.${name}`];
+
+  if (!encryptedFields && encryptedFieldsMap) {
+    // If the MongoClient was configured with an encryptedFieldsMap,
+    // and no encryptedFields config was available in it or explicitly
+    // passed as an argument, the spec tells us to look one up using
+    // listCollections().
+    const listCollectionsResult = await db
+      .listCollections(
+        { name },
+        {
+          nameOnly: false,
+          session: options.session,
+          timeoutContext: new CursorTimeoutContext(timeoutContext, Symbol())
+        }
+      )
+      .toArray();
+    encryptedFields = listCollectionsResult?.[0]?.options?.encryptedFields;
+  }
+
+  if (encryptedFields) {
+    const escCollection = encryptedFields.escCollection || `enxcol_.${name}.esc`;
+    const ecocCollection = encryptedFields.ecocCollection || `enxcol_.${name}.ecoc`;
+
+    for (const collectionName of [escCollection, ecocCollection]) {
+      // Drop auxilliary collections, ignoring potential NamespaceNotFound errors.
+      const dropOp = new DropCollectionOperation(db, collectionName, options);
+      try {
+        await executeOperation(db.client, dropOp, timeoutContext);
+      } catch (err) {
+        if (
+          !(err instanceof MongoServerError) ||
+          err.code !== MONGODB_ERROR_CODES.NamespaceNotFound
+        ) {
+          throw err;
+        }
+      }
+    }
+  }
+
+  return await executeOperation(
+    db.client,
+    new DropCollectionOperation(db, name, options),
+    timeoutContext
+  );
 }
 
 /** @public */

--- a/test/integration/collection-management/collection_db_management.test.ts
+++ b/test/integration/collection-management/collection_db_management.test.ts
@@ -6,9 +6,10 @@ describe('Collection Management and Db Management', function () {
   let client: MongoClient;
   let db: Db;
 
-  beforeEach(function () {
+  beforeEach(async function () {
     client = this.configuration.newClient();
     db = client.db();
+    await db.dropDatabase();
   });
 
   afterEach(async function () {


### PR DESCRIPTION
### Description

#### What is changing?

This PR moves esc and esoc create/drop support out of operation's `execute()` method.

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
