### PR TITLE
chore: pin npm for kerberos tests

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1699,6 +1699,7 @@ tasks:
         params:
           updates:
             - {key: NATIVE, value: 'true'}
+            - {key: NPM_VERSION, value: 11.4.2}
       - func: install dependencies
       - func: assume secrets manager role
       - func: run kerberos tests

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1699,7 +1699,7 @@ tasks:
         params:
           updates:
             - {key: NATIVE, value: 'true'}
-            - {key: NPM_VERSION, value: 11.4.2}
+            - {key: NPM_VERSION, value: 8.19.4}
       - func: install dependencies
       - func: assume secrets manager role
       - func: run kerberos tests

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -156,7 +156,8 @@ TASKS.push(
       tags: ['auth', 'kerberos'],
       commands: [
         updateExpansions({
-          NATIVE: 'true'
+          NATIVE: 'true',
+          NPM_VERSION: '11.4.2'
         }),
         { func: 'install dependencies' },
         { func: 'assume secrets manager role' },

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -157,7 +157,7 @@ TASKS.push(
       commands: [
         updateExpansions({
           NATIVE: 'true',
-          NPM_VERSION: '11.4.2'
+          NPM_VERSION: '8.19.4'
         }),
         { func: 'install dependencies' },
         { func: 'assume secrets manager role' },


### PR DESCRIPTION
### Description

Pin npm for kerberos tests

#### What is changing?

Pins npm for kerberos tests only. See: https://github.com/mongodb/node-mongodb-native/pull/4599

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

Kerberos build failures

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
