### PR TITLE
refactor(NODE-7089): make AggregateOperation subclass ModernizedOperation

### DIFF
--- a/src/cmap/connection.ts
+++ b/src/cmap/connection.ts
@@ -92,7 +92,6 @@ export interface CommandOptions extends BSONSerializeOptions {
   session?: ClientSession;
   documentsReturnedIn?: string;
   noResponse?: boolean;
-  omitReadPreference?: boolean;
   omitMaxTimeMS?: boolean;
 
   // TODO(NODE-2802): Currently the CommandOptions take a property willRetryWrite which is a hint

--- a/src/cursor/aggregation_cursor.ts
+++ b/src/cursor/aggregation_cursor.ts
@@ -2,7 +2,6 @@ import type { Document } from '../bson';
 import { MongoAPIError } from '../error';
 import {
   Explain,
-  ExplainableCursor,
   type ExplainCommandOptions,
   type ExplainVerbosityLike,
   validateExplainTimeoutOptions
@@ -19,6 +18,7 @@ import {
   CursorTimeoutMode,
   type InitialCursorResponse
 } from './abstract_cursor';
+import { ExplainableCursor } from './explainable_cursor';
 
 /** @public */
 export interface AggregationCursorOptions extends AbstractCursorOptions, AggregateOptions {}

--- a/src/cursor/explainable_cursor.ts
+++ b/src/cursor/explainable_cursor.ts
@@ -1,0 +1,51 @@
+import { type Document } from '../bson';
+import { type ExplainCommandOptions, type ExplainVerbosityLike } from '../explain';
+import { AbstractCursor } from './abstract_cursor';
+
+/**
+ * @public
+ *
+ * A base class for any cursors that have `explain()` methods.
+ */
+export abstract class ExplainableCursor<TSchema> extends AbstractCursor<TSchema> {
+  /** Execute the explain for the cursor */
+  abstract explain(): Promise<Document>;
+  abstract explain(verbosity: ExplainVerbosityLike | ExplainCommandOptions): Promise<Document>;
+  abstract explain(options: { timeoutMS?: number }): Promise<Document>;
+  abstract explain(
+    verbosity: ExplainVerbosityLike | ExplainCommandOptions,
+    options: { timeoutMS?: number }
+  ): Promise<Document>;
+  abstract explain(
+    verbosity?: ExplainVerbosityLike | ExplainCommandOptions | { timeoutMS?: number },
+    options?: { timeoutMS?: number }
+  ): Promise<Document>;
+
+  protected resolveExplainTimeoutOptions(
+    verbosity?: ExplainVerbosityLike | ExplainCommandOptions | { timeoutMS?: number },
+    options?: { timeoutMS?: number }
+  ): { timeout?: { timeoutMS?: number }; explain?: ExplainVerbosityLike | ExplainCommandOptions } {
+    let explain: ExplainVerbosityLike | ExplainCommandOptions | undefined;
+    let timeout: { timeoutMS?: number } | undefined;
+
+    if (verbosity == null && options == null) {
+      explain = undefined;
+      timeout = undefined;
+    } else if (verbosity != null && options == null) {
+      explain =
+        typeof verbosity !== 'object'
+          ? verbosity
+          : 'verbosity' in verbosity
+            ? verbosity
+            : undefined;
+
+      timeout = typeof verbosity === 'object' && 'timeoutMS' in verbosity ? verbosity : undefined;
+    } else {
+      // @ts-expect-error TS isn't smart enough to determine that if both options are provided, the first is explain options
+      explain = verbosity;
+      timeout = options;
+    }
+
+    return { timeout, explain };
+  }
+}

--- a/src/cursor/find_cursor.ts
+++ b/src/cursor/find_cursor.ts
@@ -3,7 +3,6 @@ import { CursorResponse } from '../cmap/wire_protocol/responses';
 import { MongoAPIError, MongoInvalidArgumentError, MongoTailableCursorError } from '../error';
 import {
   Explain,
-  ExplainableCursor,
   type ExplainCommandOptions,
   type ExplainVerbosityLike,
   validateExplainTimeoutOptions
@@ -19,6 +18,7 @@ import type { ClientSession } from '../sessions';
 import { formatSort, type Sort, type SortDirection } from '../sort';
 import { emitWarningOnce, mergeOptions, type MongoDBNamespace, squashError } from '../utils';
 import { type InitialCursorResponse } from './abstract_cursor';
+import { ExplainableCursor } from './explainable_cursor';
 
 /** @public Flags allowed for cursor */
 export const FLAGS = [

--- a/src/explain.ts
+++ b/src/explain.ts
@@ -1,5 +1,4 @@
 import { type Document } from './bson';
-import { AbstractCursor } from './cursor/abstract_cursor';
 import { MongoAPIError } from './error';
 
 /** @public */
@@ -122,52 +121,4 @@ export function decorateWithExplain(
   }
 
   return baseCommand;
-}
-
-/**
- * @public
- *
- * A base class for any cursors that have `explain()` methods.
- */
-export abstract class ExplainableCursor<TSchema> extends AbstractCursor<TSchema> {
-  /** Execute the explain for the cursor */
-  abstract explain(): Promise<Document>;
-  abstract explain(verbosity: ExplainVerbosityLike | ExplainCommandOptions): Promise<Document>;
-  abstract explain(options: { timeoutMS?: number }): Promise<Document>;
-  abstract explain(
-    verbosity: ExplainVerbosityLike | ExplainCommandOptions,
-    options: { timeoutMS?: number }
-  ): Promise<Document>;
-  abstract explain(
-    verbosity?: ExplainVerbosityLike | ExplainCommandOptions | { timeoutMS?: number },
-    options?: { timeoutMS?: number }
-  ): Promise<Document>;
-
-  protected resolveExplainTimeoutOptions(
-    verbosity?: ExplainVerbosityLike | ExplainCommandOptions | { timeoutMS?: number },
-    options?: { timeoutMS?: number }
-  ): { timeout?: { timeoutMS?: number }; explain?: ExplainVerbosityLike | ExplainCommandOptions } {
-    let explain: ExplainVerbosityLike | ExplainCommandOptions | undefined;
-    let timeout: { timeoutMS?: number } | undefined;
-
-    if (verbosity == null && options == null) {
-      explain = undefined;
-      timeout = undefined;
-    } else if (verbosity != null && options == null) {
-      explain =
-        typeof verbosity !== 'object'
-          ? verbosity
-          : 'verbosity' in verbosity
-            ? verbosity
-            : undefined;
-
-      timeout = typeof verbosity === 'object' && 'timeoutMS' in verbosity ? verbosity : undefined;
-    } else {
-      // @ts-expect-error TS isn't smart enough to determine that if both options are provided, the first is explain options
-      explain = verbosity;
-      timeout = options;
-    }
-
-    return { timeout, explain };
-  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,6 @@ import { ListCollectionsCursor } from './cursor/list_collections_cursor';
 import { ListIndexesCursor } from './cursor/list_indexes_cursor';
 import type { RunCommandCursor } from './cursor/run_command_cursor';
 import { Db } from './db';
-import { ExplainableCursor } from './explain';
 import { GridFSBucket } from './gridfs';
 import { GridFSBucketReadStream } from './gridfs/download';
 import { GridFSBucketWriteStream } from './gridfs/upload';
@@ -44,6 +43,7 @@ export {
 } from './bulk/common';
 export { ClientEncryption } from './client-side-encryption/client_encryption';
 export { ChangeStreamCursor } from './cursor/change_stream_cursor';
+export { ExplainableCursor } from './cursor/explainable_cursor';
 export {
   MongoAPIError,
   MongoAWSError,
@@ -98,7 +98,6 @@ export {
   ClientSession,
   Collection,
   Db,
-  ExplainableCursor,
   FindCursor,
   GridFSBucket,
   GridFSBucketReadStream,
@@ -511,6 +510,7 @@ export type {
   CollationOptions,
   CommandOperation,
   CommandOperationOptions,
+  ModernizedCommandOperation,
   OperationParent
 } from './operations/command';
 export type { CountOptions } from './operations/count';

--- a/src/operations/execute_operation.ts
+++ b/src/operations/execute_operation.ts
@@ -26,6 +26,7 @@ import type { Topology } from '../sdam/topology';
 import type { ClientSession } from '../sessions';
 import { TimeoutContext } from '../timeout';
 import { abortable, supportsRetryableWrites } from '../utils';
+import { AggregateOperation } from './aggregate';
 import { AbstractOperation, Aspect, ModernizedOperation } from './operation';
 
 const MMAPv1_RETRY_WRITES_ERROR_CODE = MONGODB_ERROR_CODES.IllegalOperation;
@@ -192,7 +193,7 @@ async function tryOperation<
     // server selection to potentially force monitor checks if the server is
     // in an unknown state.
     selector = sameServerSelector(operation.server?.description);
-  } else if (operation.trySecondaryWrite) {
+  } else if (operation instanceof AggregateOperation && operation.hasWriteStage) {
     // If operation should try to write to secondary use the custom server selector
     // otherwise provide the read preference.
     selector = secondaryWritableServerSelector(topology.commonWireVersion, readPreference);

--- a/src/operations/operation.ts
+++ b/src/operations/operation.ts
@@ -33,7 +33,6 @@ export interface OperationOptions extends BSONSerializeOptions {
 
   /** @internal Hints to `executeOperation` that this operation should not unpin on an ended transaction */
   bypassPinningCheck?: boolean;
-  omitReadPreference?: boolean;
 
   /** @internal Hint to `executeOperation` to omit maxTimeMS */
   omitMaxTimeMS?: boolean;
@@ -57,7 +56,6 @@ export abstract class AbstractOperation<TResult = any> {
   readPreference: ReadPreference;
   server!: Server;
   bypassPinningCheck: boolean;
-  trySecondaryWrite: boolean;
 
   // BSON serialization options
   bsonOptions?: BSONSerializeOptions;
@@ -83,7 +81,6 @@ export abstract class AbstractOperation<TResult = any> {
 
     this.options = options;
     this.bypassPinningCheck = !!options.bypassPinningCheck;
-    this.trySecondaryWrite = false;
   }
 
   /** Must match the first key of the command object sent to the server.

--- a/test/unit/operations/aggregate.test.js
+++ b/test/unit/operations/aggregate.test.js
@@ -10,16 +10,16 @@ describe('AggregateOperation', function () {
     context('when out is in the options', function () {
       const operation = new AggregateOperation(db, [], { out: 'test', dbName: db });
 
-      it('sets trySecondaryWrite to true', function () {
-        expect(operation.trySecondaryWrite).to.be.true;
+      it('sets hasWriteStage to true', function () {
+        expect(operation.hasWriteStage).to.be.true;
       });
     });
 
     context('when $out is the last stage', function () {
       const operation = new AggregateOperation(db, [{ $out: 'test' }], { dbName: db });
 
-      it('sets trySecondaryWrite to true', function () {
-        expect(operation.trySecondaryWrite).to.be.true;
+      it('sets hasWriteStage to true', function () {
+        expect(operation.hasWriteStage).to.be.true;
       });
     });
 
@@ -28,16 +28,16 @@ describe('AggregateOperation', function () {
         dbName: db
       });
 
-      it('sets trySecondaryWrite to false', function () {
-        expect(operation.trySecondaryWrite).to.be.false;
+      it('sets hasWriteStage to false', function () {
+        expect(operation.hasWriteStage).to.be.false;
       });
     });
 
     context('when $merge is the last stage', function () {
       const operation = new AggregateOperation(db, [{ $merge: { into: 'test' } }], { dbName: db });
 
-      it('sets trySecondaryWrite to true', function () {
-        expect(operation.trySecondaryWrite).to.be.true;
+      it('sets hasWriteStage to true', function () {
+        expect(operation.hasWriteStage).to.be.true;
       });
     });
 
@@ -48,24 +48,24 @@ describe('AggregateOperation', function () {
         { dbName: db }
       );
 
-      it('sets trySecondaryWrite to false', function () {
-        expect(operation.trySecondaryWrite).to.be.false;
+      it('sets hasWriteStage to false', function () {
+        expect(operation.hasWriteStage).to.be.false;
       });
     });
 
     context('when no writable stages in empty pipeline', function () {
       const operation = new AggregateOperation(db, [], { dbName: db });
 
-      it('sets trySecondaryWrite to false', function () {
-        expect(operation.trySecondaryWrite).to.be.false;
+      it('sets hasWriteStage to false', function () {
+        expect(operation.hasWriteStage).to.be.false;
       });
     });
 
     context('when no writable stages', function () {
       const operation = new AggregateOperation(db, [{ $project: { name: 1 } }], { dbName: db });
 
-      it('sets trySecondaryWrite to false', function () {
-        expect(operation.trySecondaryWrite).to.be.false;
+      it('sets hasWriteStage to false', function () {
+        expect(operation.hasWriteStage).to.be.false;
       });
     });
   });


### PR DESCRIPTION
### Description

#### What is changing?

I broke this PR out of https://github.com/mongodb/node-mongodb-native/pull/4609 because it got kinda large.

This PR refactors AggregateOperation to subclass ModernizedOperation.  Along the way, I encountered issues with `omitReadPreference` - an option which is used by the server class to remove a read preference from a command.  To make this work with the existing design, the `buildOptions` method would need to start taking a reference to the connection to determine the maxWireVersion when attaching this option.

I didn't like this approach and this option is only used for the AggregateOperation when there is a write stage and we are using wire version <9, so I refactored to remove this option.  

After removing `omitReadPreference`, it became clear we no longer needed `trySecondaryWrite`, which is also only used for Aggregation operations but is present on all operation classes, only used to determine if we should set `omitReadPreference` to true, and is assigned the same value has AggregateOperation.hasWriteStage.

After _that_ I had a circular dependency because execute_operation now imports a reference to AggregateOperation.  I broke the circular dependency by removing ExplainableCursor from `explain.ts`.

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
