### PR TITLE
refactor(NODE-7083): index operations to modernized operation

### DIFF
--- a/src/cmap/wire_protocol/responses.ts
+++ b/src/cmap/wire_protocol/responses.ts
@@ -391,9 +391,3 @@ export class ClientBulkWriteCursorResponse extends CursorResponse {
     return this.get('writeConcernError', BSONType.object, false);
   }
 }
-
-export class CreateSearchIndexesResponse extends MongoDBResponse {
-  get indexesCreated() {
-    return this.get('indexesCreated', BSONType.array);
-  }
-}

--- a/src/cmap/wire_protocol/responses.ts
+++ b/src/cmap/wire_protocol/responses.ts
@@ -391,3 +391,9 @@ export class ClientBulkWriteCursorResponse extends CursorResponse {
     return this.get('writeConcernError', BSONType.object, false);
   }
 }
+
+export class CreateSearchIndexesResponse extends MongoDBResponse {
+  get indexesCreated() {
+    return this.get('indexesCreated', BSONType.array);
+  }
+}

--- a/src/operations/search_indexes/create.ts
+++ b/src/operations/search_indexes/create.ts
@@ -47,7 +47,7 @@ export class CreateSearchIndexesOperation extends ModernizedOperation<Document> 
   }
 
   override handleOk(response: InstanceType<typeof this.SERVER_COMMAND_RESPONSE_TYPE>): string[] {
-    return super.handleOk(response).indexesCreated.map((val: { name: any }) => val.name);
+    return super.handleOk(response).indexesCreated.map((val: { name: string }) => val.name);
   }
 
   override buildOptions(timeoutContext: TimeoutContext): ServerCommandOptions {

--- a/src/operations/search_indexes/create.ts
+++ b/src/operations/search_indexes/create.ts
@@ -22,7 +22,7 @@ export interface SearchIndexDescription extends Document {
 }
 
 /** @internal */
-export class CreateSearchIndexesOperation extends ModernizedOperation<string[]> {
+export class CreateSearchIndexesOperation extends ModernizedOperation<Document> {
   override SERVER_COMMAND_RESPONSE_TYPE = MongoDBResponse;
   private readonly collection: Collection;
   private readonly descriptions: ReadonlyArray<SearchIndexDescription>;
@@ -47,7 +47,7 @@ export class CreateSearchIndexesOperation extends ModernizedOperation<string[]> 
   }
 
   override handleOk(response: InstanceType<typeof this.SERVER_COMMAND_RESPONSE_TYPE>): string[] {
-    return response.toObject(this.bsonOptions).indexesCreated.map((val: { name: any }) => val.name);
+    return super.handleOk(response).indexesCreated.map((val: { name: any }) => val.name);
   }
 
   override buildOptions(timeoutContext: TimeoutContext): ServerCommandOptions {

--- a/src/operations/search_indexes/update.ts
+++ b/src/operations/search_indexes/update.ts
@@ -1,12 +1,15 @@
 import type { Document } from '../../bson';
+import { type Connection } from '../../cmap/connection';
+import { MongoDBResponse } from '../../cmap/wire_protocol/responses';
 import type { Collection } from '../../collection';
-import type { Server } from '../../sdam/server';
+import type { ServerCommandOptions } from '../../sdam/server';
 import type { ClientSession } from '../../sessions';
 import { type TimeoutContext } from '../../timeout';
-import { AbstractOperation } from '../operation';
+import { ModernizedOperation } from '../operation';
 
 /** @internal */
-export class UpdateSearchIndexOperation extends AbstractOperation<void> {
+export class UpdateSearchIndexOperation extends ModernizedOperation<void> {
+  override SERVER_COMMAND_RESPONSE_TYPE = MongoDBResponse;
   private readonly collection: Collection;
   private readonly name: string;
   private readonly definition: Document;
@@ -16,25 +19,27 @@ export class UpdateSearchIndexOperation extends AbstractOperation<void> {
     this.collection = collection;
     this.name = name;
     this.definition = definition;
+    this.ns = collection.fullNamespace;
   }
 
   override get commandName() {
     return 'updateSearchIndex' as const;
   }
 
-  override async execute(
-    server: Server,
-    session: ClientSession | undefined,
-    timeoutContext: TimeoutContext
-  ): Promise<void> {
+  override buildCommand(_connection: Connection, _session?: ClientSession): Document {
     const namespace = this.collection.fullNamespace;
-    const command = {
+    return {
       updateSearchIndex: namespace.collection,
       name: this.name,
       definition: this.definition
     };
+  }
 
-    await server.command(namespace, command, { session, timeoutContext });
-    return;
+  override handleOk(_response: MongoDBResponse): void {
+    // no response.
+  }
+
+  override buildOptions(timeoutContext: TimeoutContext): ServerCommandOptions {
+    return { session: this.session, timeoutContext };
   }
 }


### PR DESCRIPTION
### Description

Refactors index related operations to use the modernized operations.

#### What is changing?

Refactor index operations.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-7083

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
