### PR TITLE
refactor(NODE-7085): refactor db collection management APIs to use modernized operation

### DIFF
--- a/src/operations/drop.ts
+++ b/src/operations/drop.ts
@@ -1,12 +1,17 @@
-import { MongoServerError } from '..';
+import { type Connection, MongoServerError } from '..';
 import type { Document } from '../bson';
+import { MongoDBResponse } from '../cmap/wire_protocol/responses';
 import { CursorTimeoutContext } from '../cursor/abstract_cursor';
 import type { Db } from '../db';
 import { MONGODB_ERROR_CODES } from '../error';
 import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
 import { TimeoutContext } from '../timeout';
-import { CommandOperation, type CommandOperationOptions } from './command';
+import {
+  CommandOperation,
+  type CommandOperationOptions,
+  ModernizedCommandOperation
+} from './command';
 import { executeOperation } from './execute_operation';
 import { Aspect, defineAspects } from './operation';
 
@@ -17,7 +22,9 @@ export interface DropCollectionOptions extends CommandOperationOptions {
 }
 
 /** @internal */
-export class DropCollectionOperation extends CommandOperation<boolean> {
+export class DropCollectionOperation extends ModernizedCommandOperation<boolean> {
+  override SERVER_COMMAND_RESPONSE_TYPE = MongoDBResponse;
+
   override options: DropCollectionOptions;
   name: string;
 
@@ -31,12 +38,11 @@ export class DropCollectionOperation extends CommandOperation<boolean> {
     return 'drop' as const;
   }
 
-  override async execute(
-    server: Server,
-    session: ClientSession | undefined,
-    timeoutContext: TimeoutContext
-  ): Promise<boolean> {
-    await super.executeCommand(server, session, { drop: this.name }, timeoutContext);
+  override buildCommandDocument(_connection: Connection, _session?: ClientSession): Document {
+    return { drop: this.name };
+  }
+
+  override handleOk(_response: InstanceType<typeof this.SERVER_COMMAND_RESPONSE_TYPE>): boolean {
     return true;
   }
 }

--- a/src/operations/rename.ts
+++ b/src/operations/rename.ts
@@ -1,10 +1,10 @@
+import { type Connection } from '..';
 import type { Document } from '../bson';
+import { MongoDBResponse } from '../cmap/wire_protocol/responses';
 import { Collection } from '../collection';
-import type { Server } from '../sdam/server';
 import type { ClientSession } from '../sessions';
-import { type TimeoutContext } from '../timeout';
 import { MongoDBNamespace } from '../utils';
-import { CommandOperation, type CommandOperationOptions } from './command';
+import { type CommandOperationOptions, ModernizedCommandOperation } from './command';
 import { Aspect, defineAspects } from './operation';
 
 /** @public */
@@ -16,7 +16,8 @@ export interface RenameOptions extends CommandOperationOptions {
 }
 
 /** @internal */
-export class RenameOperation extends CommandOperation<Document> {
+export class RenameOperation extends ModernizedCommandOperation<Document> {
+  override SERVER_COMMAND_RESPONSE_TYPE = MongoDBResponse;
   collection: Collection;
   newName: string;
   override options: RenameOptions;
@@ -33,24 +34,20 @@ export class RenameOperation extends CommandOperation<Document> {
     return 'renameCollection' as const;
   }
 
-  override async execute(
-    server: Server,
-    session: ClientSession | undefined,
-    timeoutContext: TimeoutContext
-  ): Promise<Collection> {
-    // Build the command
+  override buildCommandDocument(_connection: Connection, _session?: ClientSession): Document {
     const renameCollection = this.collection.namespace;
-    const toCollection = this.collection.s.namespace.withCollection(this.newName).toString();
+    const to = this.collection.s.namespace.withCollection(this.newName).toString();
     const dropTarget =
       typeof this.options.dropTarget === 'boolean' ? this.options.dropTarget : false;
 
-    const command = {
-      renameCollection: renameCollection,
-      to: toCollection,
-      dropTarget: dropTarget
+    return {
+      renameCollection,
+      to,
+      dropTarget
     };
+  }
 
-    await super.executeCommand(server, session, command, timeoutContext);
+  override handleOk(_response: InstanceType<typeof this.SERVER_COMMAND_RESPONSE_TYPE>): Document {
     return new Collection(this.collection.s.db, this.newName, this.collection.s.options);
   }
 }

--- a/test/integration/node-specific/bson-options/use_bigint_64.test.ts
+++ b/test/integration/node-specific/bson-options/use_bigint_64.test.ts
@@ -171,10 +171,20 @@ describe('useBigInt64 option', function () {
       beforeEach(async function () {
         client = await this.configuration.newClient().connect();
         db = client.db('bsonOptions', { promoteLongs: false, useBigInt64: true });
+
+        await db.createCollection('foo');
+        await db.createCollection('bar');
+      });
+
+      afterEach(async function () {
+        await db.dropDatabase();
       });
 
       it('throws a BSONError', async function () {
-        const e = await db.createCollection('bsonError').catch(e => e);
+        const e = await db
+          .listCollections()
+          .toArray()
+          .catch(e => e);
         expect(e).to.be.instanceOf(BSON.BSONError);
       });
     });
@@ -186,8 +196,11 @@ describe('useBigInt64 option', function () {
       });
 
       it('throws a BSONError', async function () {
-        const e = await db
-          .createCollection('bsonError', { promoteLongs: false, useBigInt64: true })
+        const collection = db.collection('bsonError', { promoteLongs: false, useBigInt64: true });
+
+        const e = await collection
+          .insertOne({ name: 'bailey ' })
+          .then(() => null)
           .catch(e => e);
         expect(e).to.be.instanceOf(BSON.BSONError);
       });
@@ -229,11 +242,21 @@ describe('useBigInt64 option', function () {
     describe('when set at DB level', function () {
       beforeEach(async function () {
         client = await this.configuration.newClient().connect();
-        db = client.db('bsonOptions', { promoteValues: false, useBigInt64: true });
+        db = client.db('bsonOptions', { promoteLongs: false, useBigInt64: true });
+
+        await db.createCollection('foo');
+        await db.createCollection('bar');
+      });
+
+      afterEach(async function () {
+        await db.dropDatabase();
       });
 
       it('throws a BSONError', async function () {
-        const e = await db.createCollection('bsonError').catch(e => e);
+        const e = await db
+          .listCollections()
+          .toArray()
+          .catch(e => e);
         expect(e).to.be.instanceOf(BSON.BSONError);
       });
     });
@@ -245,8 +268,11 @@ describe('useBigInt64 option', function () {
       });
 
       it('throws a BSONError', async function () {
-        const e = await db
-          .createCollection('bsonError', { promoteValues: false, useBigInt64: true })
+        const collection = db.collection('bsonError', { promoteValues: false, useBigInt64: true });
+
+        const e = await collection
+          .insertOne({ name: 'bailey ' })
+          .then(() => null)
           .catch(e => e);
         expect(e).to.be.instanceOf(BSON.BSONError);
       });

--- a/test/integration/node-specific/validate_collection.test.ts
+++ b/test/integration/node-specific/validate_collection.test.ts
@@ -1,0 +1,84 @@
+import { expect } from 'chai';
+
+import { ValidateCollectionOperation } from '../../mongodb';
+
+describe('ValidateCollectionOperation', function () {
+  let client;
+
+  beforeEach(function () {
+    client = this.configuration.newClient();
+  });
+
+  afterEach(async function () {
+    await client.close();
+  });
+
+  describe('buildCommandDocument()', function () {
+    it('builds the base command when no options are provided', function () {
+      client = this.configuration.newClient();
+      const op = new ValidateCollectionOperation(client.db('foo').admin(), 'bar', {});
+
+      const doc = op.buildCommandDocument({} as any, {} as any);
+      expect(doc).to.deep.equal({
+        validate: 'bar'
+      });
+    });
+
+    it('supports background=true', function () {
+      client = this.configuration.newClient();
+      const op = new ValidateCollectionOperation(client.db('foo').admin(), 'bar', {
+        background: true
+      });
+
+      const doc = op.buildCommandDocument({} as any, {} as any);
+      expect(doc).to.deep.equal({
+        validate: 'bar',
+        background: true
+      });
+    });
+
+    it('supports background=false', function () {
+      client = this.configuration.newClient();
+      const op = new ValidateCollectionOperation(client.db('foo').admin(), 'bar', {
+        background: false
+      });
+
+      const doc = op.buildCommandDocument({} as any, {} as any);
+      expect(doc).to.deep.equal({
+        validate: 'bar',
+        background: false
+      });
+    });
+
+    it('attaches all options to the command document', function () {
+      client = this.configuration.newClient();
+      const op = new ValidateCollectionOperation(client.db('foo').admin(), 'bar', {
+        background: false,
+        a: 1,
+        b: 2,
+        c: 3
+      });
+
+      const doc = op.buildCommandDocument({} as any, {} as any);
+      expect(doc).to.deep.equal({
+        validate: 'bar',
+        background: false,
+        a: 1,
+        b: 2,
+        c: 3
+      });
+    });
+
+    it('does not attach session command document', function () {
+      client = this.configuration.newClient();
+      const op = new ValidateCollectionOperation(client.db('foo').admin(), 'bar', {
+        session: client.startSession()
+      });
+
+      const doc = op.buildCommandDocument({} as any, {} as any);
+      expect(doc).to.deep.equal({
+        validate: 'bar'
+      });
+    });
+  });
+});


### PR DESCRIPTION
### Description

#### What is changing?

This PR refactors db/collection management APIs to use ModernizedOperation.

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
