### PR TITLE
feat(NODE-7100): make MONGODB_ERROR_CODES public

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -34,7 +34,7 @@ export const LEGACY_NOT_PRIMARY_OR_SECONDARY_ERROR_MESSAGE = new RegExp(
  */
 export const NODE_IS_RECOVERING_ERROR_MESSAGE = new RegExp('node is recovering', 'i');
 
-/** @internal MongoDB Error Codes */
+/** @public */
 export const MONGODB_ERROR_CODES = Object.freeze({
   HostUnreachable: 6,
   HostNotFound: 7,


### PR DESCRIPTION
### Description

Made MONGODB_ERROR_CODES public

#### What is the motivation for this change?

We have a use case where accessing the error code definition is useful for error checking. Checking `e.code === MONGODB_ERROR_CODES.Something` seems pretty useful. The object is already frozen so we can't just accidentally modify this.

This is a small type change so I haven't run any tests / compilation yet. But would be happy to do so if still required! Thanks, mongodb team

