### PR TITLE
test(NODE-7118): fix CSOT socket read failure test on latest servers

### DIFF
--- a/test/integration/client-side-operations-timeout/node_csot.test.ts
+++ b/test/integration/client-side-operations-timeout/node_csot.test.ts
@@ -1359,14 +1359,12 @@ describe('CSOT driver tests', metadata, () => {
     });
   });
 
-  // TODO(NODE-7118): Find a way to reimplement this test for latest server.
-  describe(
+  describe.only(
     'Connection after timeout',
     {
       requires: {
         // 4.4 for use of failCommands
-        // < 8.3 because of https://jira.mongodb.org/browse/SERVER-101116
-        mongodb: '>=4.4 <=8.2'
+        mongodb: '>=4.4'
       }
     },
     function () {
@@ -1374,6 +1372,11 @@ describe('CSOT driver tests', metadata, () => {
 
       beforeEach(async function () {
         client = this.configuration.newClient({ timeoutMS: 500 });
+
+        await client.db('admin').command(<FailPoint>{
+          configureFailPoint: 'maxTimeNeverTimeOut',
+          mode: 'alwaysOn'
+        });
 
         const failpoint: FailPoint = {
           configureFailPoint: 'failCommand',
@@ -1391,6 +1394,11 @@ describe('CSOT driver tests', metadata, () => {
       });
 
       afterEach(async function () {
+        await client.db('admin').command(<FailPoint>{
+          configureFailPoint: 'maxTimeNeverTimeOut',
+          mode: 'off'
+        });
+
         await client.close();
       });
 

--- a/test/tools/utils.ts
+++ b/test/tools/utils.ts
@@ -206,7 +206,7 @@ export function extractAuthFromConnectionString(connectionString: string | any[]
 }
 
 export interface FailPoint {
-  configureFailPoint: 'failCommand' | 'failGetMoreAfterCursorCheckout';
+  configureFailPoint: 'failCommand' | 'failGetMoreAfterCursorCheckout' | 'maxTimeNeverTimeOut';
   mode: { activationProbability: number } | { times: number } | 'alwaysOn' | 'off';
   data: {
     failCommands: string[];


### PR DESCRIPTION
### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
