### PR TITLE
chore(NODE-7123): fix flaky CSOT test

### DIFF
--- a/test/integration/change-streams/change_stream.test.ts
+++ b/test/integration/change-streams/change_stream.test.ts
@@ -24,7 +24,7 @@ import {
 } from '../../mongodb';
 import * as mock from '../../tools/mongodb-mock/index';
 import { TestBuilder, UnifiedTestSuiteBuilder } from '../../tools/unified_suite_builder';
-import { type FailPoint, sleep } from '../../tools/utils';
+import { type FailCommandFailPoint, sleep } from '../../tools/utils';
 import { delay, filterForCommands } from '../shared';
 
 const initIteratorMode = async (cs: ChangeStream) => {
@@ -1097,7 +1097,7 @@ describe('Change Streams', function () {
                 failCommands: ['getMore'],
                 errorCode: unresumableErrorCode
               }
-            } as FailPoint);
+            } as FailCommandFailPoint);
 
             await collection.insertOne({ city: 'New York City' });
             try {
@@ -1912,7 +1912,7 @@ describe('ChangeStream resumability', function () {
                 errorCode: code,
                 errmsg: message
               }
-            } as FailPoint);
+            } as FailCommandFailPoint);
 
             await collection.insertOne({ name: 'bailey' });
 
@@ -1940,7 +1940,7 @@ describe('ChangeStream resumability', function () {
                 errorCode: code,
                 errmsg: message
               }
-            } as FailPoint);
+            } as FailCommandFailPoint);
 
             // There's an inherent race condition here because we need to make sure that the `aggregates` that succeed when
             // resuming a change stream don't return the change event.  So we defer the insert until a period of time
@@ -1979,7 +1979,7 @@ describe('ChangeStream resumability', function () {
               errorCode: resumableErrorCodes[0].code,
               errmsg: resumableErrorCodes[0].message
             }
-          } as FailPoint);
+          } as FailCommandFailPoint);
 
           expect(changeStream.cursor)
             .to.have.property('changeStreamCursorOptions')
@@ -2009,7 +2009,7 @@ describe('ChangeStream resumability', function () {
               failCommands: ['getMore'],
               errorCode: unresumableErrorCode
             }
-          } as FailPoint);
+          } as FailCommandFailPoint);
 
           await initIteratorMode(changeStream);
 
@@ -2032,7 +2032,7 @@ describe('ChangeStream resumability', function () {
               failCommands: ['aggregate'],
               errorCode: resumableErrorCode
             }
-          } as FailPoint);
+          } as FailCommandFailPoint);
 
           changeStream = collection.watch([]);
 
@@ -2066,7 +2066,7 @@ describe('ChangeStream resumability', function () {
                 errorCode: code,
                 errmsg: message
               }
-            } as FailPoint);
+            } as FailCommandFailPoint);
 
             await collection.insertOne({ name: 'bailey' });
 
@@ -2094,7 +2094,7 @@ describe('ChangeStream resumability', function () {
                 errorCode: code,
                 errmsg: message
               }
-            } as FailPoint);
+            } as FailCommandFailPoint);
 
             // There's an inherent race condition here because we need to make sure that the `aggregates` that succeed when
             // resuming a change stream don't return the change event.  So we defer the insert until a period of time
@@ -2133,7 +2133,7 @@ describe('ChangeStream resumability', function () {
               errorCode: resumableErrorCodes[0].code,
               errmsg: resumableErrorCodes[0].message
             }
-          } as FailPoint);
+          } as FailCommandFailPoint);
 
           expect(changeStream.cursor)
             .to.have.property('changeStreamCursorOptions')
@@ -2163,7 +2163,7 @@ describe('ChangeStream resumability', function () {
               failCommands: ['getMore'],
               errorCode: unresumableErrorCode
             }
-          } as FailPoint);
+          } as FailCommandFailPoint);
 
           await initIteratorMode(changeStream);
 
@@ -2186,7 +2186,7 @@ describe('ChangeStream resumability', function () {
               failCommands: ['aggregate'],
               errorCode: resumableErrorCode
             }
-          } as FailPoint);
+          } as FailCommandFailPoint);
 
           changeStream = collection.watch([]);
 
@@ -2220,7 +2220,7 @@ describe('ChangeStream resumability', function () {
                 errorCode: code,
                 errmsg: message
               }
-            } as FailPoint);
+            } as FailCommandFailPoint);
 
             try {
               // tryNext is not blocking and on sharded clusters we don't have control of when
@@ -2255,7 +2255,7 @@ describe('ChangeStream resumability', function () {
                 errorCode: code,
                 errmsg: message
               }
-            } as FailPoint);
+            } as FailCommandFailPoint);
 
             try {
               // tryNext is not blocking and on sharded clusters we don't have control of when
@@ -2294,7 +2294,7 @@ describe('ChangeStream resumability', function () {
               errorCode: resumableErrorCodes[0].code,
               errmsg: resumableErrorCodes[0].message
             }
-          } as FailPoint);
+          } as FailCommandFailPoint);
 
           expect(changeStream.cursor)
             .to.have.property('changeStreamCursorOptions')
@@ -2324,7 +2324,7 @@ describe('ChangeStream resumability', function () {
               failCommands: ['getMore'],
               errorCode: unresumableErrorCode
             }
-          } as FailPoint);
+          } as FailCommandFailPoint);
 
           await initIteratorMode(changeStream);
 
@@ -2345,7 +2345,7 @@ describe('ChangeStream resumability', function () {
               failCommands: ['aggregate'],
               errorCode: resumableErrorCode
             }
-          } as FailPoint);
+          } as FailCommandFailPoint);
 
           changeStream = collection.watch([]);
 
@@ -2382,7 +2382,7 @@ describe('ChangeStream resumability', function () {
                 errorCode: code,
                 errmsg: message
               }
-            } as FailPoint);
+            } as FailCommandFailPoint);
 
             for await (const change of changeStream) {
               const { fullDocument } = change;
@@ -2417,7 +2417,7 @@ describe('ChangeStream resumability', function () {
               errorCode: resumableErrorCodes[0].code,
               errmsg: resumableErrorCodes[0].message
             }
-          } as FailPoint);
+          } as FailCommandFailPoint);
 
           expect(changeStream.cursor)
             .to.have.property('changeStreamCursorOptions')
@@ -2450,7 +2450,7 @@ describe('ChangeStream resumability', function () {
               failCommands: ['getMore'],
               errorCode: unresumableErrorCode
             }
-          } as FailPoint);
+          } as FailCommandFailPoint);
 
           try {
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -2479,7 +2479,7 @@ describe('ChangeStream resumability', function () {
               failCommands: ['aggregate'],
               errorCode: resumableErrorCode
             }
-          } as FailPoint);
+          } as FailCommandFailPoint);
 
           try {
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -2515,7 +2515,7 @@ describe('ChangeStream resumability', function () {
               errorCode: code,
               errmsg: message
             }
-          } as FailPoint);
+          } as FailCommandFailPoint);
 
           const changes = once(changeStream, 'change');
           await once(changeStream.cursor, 'init');
@@ -2545,7 +2545,7 @@ describe('ChangeStream resumability', function () {
               errorCode: code,
               errmsg: message
             }
-          } as FailPoint);
+          } as FailCommandFailPoint);
 
           const changes = once(changeStream, 'change');
           await once(changeStream.cursor, 'init');
@@ -2585,7 +2585,7 @@ describe('ChangeStream resumability', function () {
             errorCode: resumableErrorCodes[0].code,
             errmsg: resumableErrorCodes[0].message
           }
-        } as FailPoint);
+        } as FailCommandFailPoint);
 
         expect(changeStream.cursor)
           .to.have.property('changeStreamCursorOptions')
@@ -2618,7 +2618,7 @@ describe('ChangeStream resumability', function () {
             failCommands: ['getMore'],
             errorCode: unresumableErrorCode
           }
-        } as FailPoint);
+        } as FailCommandFailPoint);
 
         const willBeError = once(changeStream, 'change').catch(error => error);
         await once(changeStream.cursor, 'init');
@@ -2646,7 +2646,7 @@ describe('ChangeStream resumability', function () {
             errorCode: unresumableErrorCode,
             errmsg: 'operation was interrupted'
           }
-        } as FailPoint);
+        } as FailCommandFailPoint);
 
         const willBeError = once(changeStream, 'change').catch(error => error);
         await once(changeStream.cursor, 'init');
@@ -2671,7 +2671,7 @@ describe('ChangeStream resumability', function () {
             failCommands: ['aggregate'],
             errorCode: resumableErrorCode
           }
-        } as FailPoint);
+        } as FailCommandFailPoint);
 
         const willBeError = once(changeStream, 'change').catch(error => error);
         await collection.insertOne({ name: 'bailey' });

--- a/test/integration/client-side-encryption/driver.test.ts
+++ b/test/integration/client-side-encryption/driver.test.ts
@@ -26,7 +26,7 @@ import {
 import {
   clearFailPoint,
   configureFailPoint,
-  type FailPoint,
+  type FailCommandFailPoint,
   getEncryptExtraOptions,
   measureDuration,
   sleep
@@ -399,6 +399,10 @@ describe('Client Side Encryption Functional', function () {
     function makeBlockingFailFor(command: string | string[], blockTimeMS: number) {
       beforeEach(async function () {
         await configureFailPoint(this.configuration, {
+          configureFailPoint: 'maxTimeNeverTimeOut',
+          mode: 'alwaysOn'
+        });
+        await configureFailPoint(this.configuration, {
           configureFailPoint: 'failCommand',
           mode: { times: 2 },
           data: {
@@ -412,6 +416,7 @@ describe('Client Side Encryption Functional', function () {
 
       afterEach(async function () {
         sinon.restore();
+        await clearFailPoint(this.configuration, 'maxTimeNeverTimeOut');
         await clearFailPoint(this.configuration);
       });
     }
@@ -681,7 +686,7 @@ describe('CSOT', function () {
             blockConnection: true,
             blockTimeMS: 2000
           }
-        } as FailPoint);
+        } as FailCommandFailPoint);
     });
 
     afterEach(async function () {
@@ -692,7 +697,7 @@ describe('CSOT', function () {
         .command({
           configureFailPoint: 'failCommand',
           mode: 'off'
-        } as FailPoint);
+        } as FailCommandFailPoint);
       await setupClient.close();
     });
 
@@ -863,7 +868,7 @@ describe('CSOT', function () {
               blockConnection: true,
               blockTimeMS: 2000
             }
-          } as FailPoint);
+          } as FailCommandFailPoint);
       });
 
       afterEach(async function () {
@@ -873,7 +878,7 @@ describe('CSOT', function () {
           .command({
             configureFailPoint: 'failCommand',
             mode: 'off'
-          } as FailPoint);
+          } as FailCommandFailPoint);
         await setupClient.close();
       });
 
@@ -1004,7 +1009,7 @@ describe('CSOT', function () {
               blockConnection: true,
               blockTimeMS: 2000
             }
-          } as FailPoint);
+          } as FailCommandFailPoint);
       });
 
       afterEach(async function () {
@@ -1014,7 +1019,7 @@ describe('CSOT', function () {
           .command({
             configureFailPoint: 'failCommand',
             mode: 'off'
-          } as FailPoint);
+          } as FailCommandFailPoint);
         await setupClient.close();
       });
 
@@ -1116,7 +1121,7 @@ describe('CSOT', function () {
           .command({
             configureFailPoint: 'failCommand',
             mode: 'off'
-          } as FailPoint);
+          } as FailCommandFailPoint);
         await client
           .db('db')
           .collection('newnew')
@@ -1168,7 +1173,7 @@ describe('CSOT', function () {
                     blockConnection: true,
                     blockTimeMS: timeoutMS * 1.2
                   }
-                } as FailPoint);
+                } as FailCommandFailPoint);
 
               const { duration, result: err } = await runCreateEncryptedCollection();
               expect(err).to.be.instanceOf(MongoCryptCreateDataKeyError);
@@ -1199,7 +1204,7 @@ describe('CSOT', function () {
                     blockConnection: true,
                     blockTimeMS: timeoutMS * 1.2
                   }
-                } as FailPoint);
+                } as FailCommandFailPoint);
 
               const { duration, result: err } = await runCreateEncryptedCollection();
               expect(err).to.be.instanceOf(MongoCryptCreateEncryptedCollectionError);
@@ -1230,7 +1235,7 @@ describe('CSOT', function () {
                     blockConnection: true,
                     blockTimeMS: timeoutMS * 0.6
                   }
-                } as FailPoint);
+                } as FailCommandFailPoint);
 
               const { duration, result: err } = await runCreateEncryptedCollection();
               expect(err).to.be.instanceOf(MongoCryptCreateEncryptedCollectionError);

--- a/test/integration/client-side-operations-timeout/client_side_operations_timeout.prose.test.ts
+++ b/test/integration/client-side-operations-timeout/client_side_operations_timeout.prose.test.ts
@@ -27,7 +27,7 @@ import {
 import {
   clearFailPoint,
   configureFailPoint,
-  type FailPoint,
+  type FailCommandFailPoint,
   makeMultiBatchWrite,
   measureDuration
 } from '../../tools/utils';
@@ -74,7 +74,7 @@ describe('CSOT spec prose tests', function () {
      * 1. Verify that two `insert` commands were executed against `db.coll` as part of the `insertMany` call.
      */
 
-    const failpoint: FailPoint = {
+    const failpoint: FailCommandFailPoint = {
       configureFailPoint: 'failCommand',
       mode: {
         times: 2
@@ -219,7 +219,7 @@ describe('CSOT spec prose tests', function () {
         .command({
           configureFailPoint: 'failCommand',
           mode: 'off'
-        } as FailPoint);
+        } as FailCommandFailPoint);
       await keyVaultClient.close();
       await internalClient.close();
     });
@@ -259,7 +259,7 @@ describe('CSOT spec prose tests', function () {
               blockConnection: true,
               blockTimeMS: 150
             }
-          } as FailPoint);
+          } as FailCommandFailPoint);
         const commandStarted: CommandStartedEvent[] = [];
         keyVaultClient.on('commandStarted', ev => commandStarted.push(ev));
 
@@ -314,7 +314,7 @@ describe('CSOT spec prose tests', function () {
               blockConnection: true,
               blockTimeMS: 150
             }
-          } as FailPoint);
+          } as FailCommandFailPoint);
 
         const commandStarted: CommandStartedEvent[] = [];
         keyVaultClient.on('commandStarted', ev => commandStarted.push(ev));
@@ -386,7 +386,7 @@ describe('CSOT spec prose tests', function () {
               blockConnection: true,
               blockTimeMS: 150
             }
-          } as FailPoint);
+          } as FailCommandFailPoint);
 
         const commandStarted: CommandStartedEvent[] = [];
         keyVaultClient.on('commandStarted', ev => commandStarted.push(ev));
@@ -471,7 +471,7 @@ describe('CSOT spec prose tests', function () {
      * blocking method for cursor iteration that executes `getMore` commands in a loop until a document is available or an
      * error occurs.
      */
-    const failpoint: FailPoint = {
+    const failpoint: FailCommandFailPoint = {
       configureFailPoint: 'failCommand',
       mode: 'alwaysOn',
       data: {
@@ -659,8 +659,10 @@ describe('CSOT spec prose tests', function () {
     afterEach(async function () {
       await clearFailPoint(
         this.configuration,
+        'failCommand',
         this.configuration.url({ useMultipleMongoses: false })
       );
+
       await client?.close();
     });
 
@@ -855,7 +857,7 @@ describe('CSOT spec prose tests', function () {
       const bucket = new GridFSBucket(client.db('db'));
       const downloadStream = bucket.openDownloadStream(new ObjectId('000000000000000000000005'));
 
-      const failpoint: FailPoint = {
+      const failpoint: FailCommandFailPoint = {
         configureFailPoint: 'failCommand',
         mode: { times: 1 },
         data: {
@@ -1152,7 +1154,7 @@ describe('CSOT spec prose tests', function () {
     //     ```
     // 5. Using `session`, execute `session.end_session`
     //     - Expect this to fail with a timeout error after no more than 150ms.
-    const failpoint: FailPoint = {
+    const failpoint: FailCommandFailPoint = {
       configureFailPoint: 'failCommand',
       mode: { times: 1 },
       data: {
@@ -1264,7 +1266,7 @@ describe('CSOT spec prose tests', function () {
       // 6. Verify that the following events were published during the `withTransaction` call:
       //     1. `command_started` and `command_failed` events for an `insert` command.
       //     2. `command_started` and `command_failed` events for an `abortTransaction` command.
-      const failpoint: FailPoint = {
+      const failpoint: FailCommandFailPoint = {
         configureFailPoint: 'failCommand',
         mode: { times: 2 },
         data: {
@@ -1390,7 +1392,7 @@ describe('CSOT spec prose tests', function () {
        *
        * 7. Verify that two `bulkWrite` commands were executed as part of the `MongoClient.bulkWrite` call.
        */
-      const failpoint: FailPoint = {
+      const failpoint: FailCommandFailPoint = {
         configureFailPoint: 'failCommand',
         mode: {
           times: 2

--- a/test/integration/client-side-operations-timeout/node_csot.test.ts
+++ b/test/integration/client-side-operations-timeout/node_csot.test.ts
@@ -31,7 +31,7 @@ import {
   promiseWithResolvers,
   TopologyType
 } from '../../mongodb';
-import { type FailPoint, waitUntilPoolsFilled } from '../../tools/utils';
+import { type FailCommandFailPoint, type FailPoint, waitUntilPoolsFilled } from '../../tools/utils';
 
 const metadata = { requires: { mongodb: '>=4.4' } };
 
@@ -223,7 +223,7 @@ describe('CSOT driver tests', metadata, () => {
 
     describe('when a maxTimeExpired error is returned at the top-level', () => {
       // {ok: 0, code: 50, codeName: "MaxTimeMSExpired", errmsg: "operation time limit exceeded"}
-      const failpoint: FailPoint = {
+      const failpoint: FailCommandFailPoint = {
         configureFailPoint: 'failCommand',
         mode: { times: 1 },
         data: {
@@ -320,7 +320,7 @@ describe('CSOT driver tests', metadata, () => {
 
     describe('when a maxTimeExpired error is returned inside a writeConcernError embedded document', () => {
       // {ok: 1, writeConcernError: {code: 50, codeName: "MaxTimeMSExpired"}}
-      const failpoint: FailPoint = {
+      const failpoint: FailCommandFailPoint = {
         configureFailPoint: 'failCommand',
         mode: { times: 1 },
         data: {
@@ -368,7 +368,7 @@ describe('CSOT driver tests', metadata, () => {
     let internalClient: MongoClient;
     let commandStarted: (CommandStartedEvent & { command: { maxTimeMS?: number } })[];
     let commandSucceeded: CommandSucceededEvent[];
-    const failpoint: FailPoint = {
+    const failpoint: FailCommandFailPoint = {
       configureFailPoint: 'failCommand',
       mode: 'alwaysOn',
       data: {
@@ -491,7 +491,7 @@ describe('CSOT driver tests', metadata, () => {
       let internalClient: MongoClient;
       let commandStarted: CommandStartedEvent[];
       let commandSucceeded: CommandSucceededEvent[];
-      const failpoint: FailPoint = {
+      const failpoint: FailCommandFailPoint = {
         configureFailPoint: 'failCommand',
         mode: 'alwaysOn',
         data: {
@@ -621,7 +621,7 @@ describe('CSOT driver tests', metadata, () => {
       requires: { mongodb: '>=4.4' }
     };
 
-    const failpoint: FailPoint = {
+    const failpoint: FailCommandFailPoint = {
       configureFailPoint: 'failCommand',
       mode: 'alwaysOn',
       data: {
@@ -862,7 +862,7 @@ describe('CSOT driver tests', metadata, () => {
       context('when the initial aggregate times out', function () {
         beforeEach(async function () {
           data = [];
-          const failpoint: FailPoint = {
+          const failpoint: FailCommandFailPoint = {
             configureFailPoint: 'failCommand',
             mode: { times: 1 }, // fail twice to account for executeOperation's retry attempt
             data: {
@@ -901,7 +901,7 @@ describe('CSOT driver tests', metadata, () => {
             this.configuration.topologyType === TopologyType.LoadBalanced ||
             this.configuration.topologyType === TopologyType.Sharded;
           data = [];
-          const failpoint: FailPoint = {
+          const failpoint: FailCommandFailPoint = {
             configureFailPoint: 'failCommand',
             mode: { times: 1 },
             data: {
@@ -940,7 +940,7 @@ describe('CSOT driver tests', metadata, () => {
           async function () {
             // NOTE: duplicating setup code here so its particular configuration requirements don't
             // affect other tests.
-            const failpoint: FailPoint = {
+            const failpoint: FailCommandFailPoint = {
               configureFailPoint: 'failCommand',
               mode: { times: 1 },
               data: {
@@ -1011,7 +1011,7 @@ describe('CSOT driver tests', metadata, () => {
       });
 
       context('when the resume attempt times out', function () {
-        const failpoint: FailPoint = {
+        const failpoint: FailCommandFailPoint = {
           configureFailPoint: 'failCommand',
           mode: { times: 2 }, // timeout the getMore, and the aggregate
           data: {
@@ -1064,7 +1064,7 @@ describe('CSOT driver tests', metadata, () => {
     });
 
     context('upload', function () {
-      const failpoint: FailPoint = {
+      const failpoint: FailCommandFailPoint = {
         configureFailPoint: 'failCommand',
         mode: { times: 1 },
         data: {
@@ -1143,7 +1143,7 @@ describe('CSOT driver tests', metadata, () => {
     });
 
     context('download', function () {
-      const failpoint: FailPoint = {
+      const failpoint: FailCommandFailPoint = {
         configureFailPoint: 'failCommand',
         mode: { times: 1 },
         data: {
@@ -1281,7 +1281,7 @@ describe('CSOT driver tests', metadata, () => {
     };
 
     describe('when an operation fails inside withTransaction callback', () => {
-      const failpoint: FailPoint = {
+      const failpoint: FailCommandFailPoint = {
         configureFailPoint: 'failCommand',
         mode: { times: 2 },
         data: {
@@ -1378,7 +1378,7 @@ describe('CSOT driver tests', metadata, () => {
           mode: 'alwaysOn'
         });
 
-        const failpoint: FailPoint = {
+        const failpoint: FailCommandFailPoint = {
           configureFailPoint: 'failCommand',
           mode: {
             times: 1

--- a/test/integration/collection-management/collection.test.ts
+++ b/test/integration/collection-management/collection.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 
 import { Collection, type Db, type MongoClient, MongoServerError } from '../../mongodb';
-import { type FailPoint } from '../../tools/utils';
+import { type FailCommandFailPoint } from '../../tools/utils';
 import { setupDatabase } from '../shared';
 
 describe('Collection', function () {
@@ -483,7 +483,7 @@ describe('Collection', function () {
             configureFailPoint: 'failCommand',
             mode: 'alwaysOn',
             data: { failCommands: ['aggregate'], errorCode: 1 }
-          } as FailPoint);
+          } as FailCommandFailPoint);
       });
 
       afterEach(async function () {
@@ -494,7 +494,7 @@ describe('Collection', function () {
             configureFailPoint: 'failCommand',
             mode: 'off',
             data: { failCommands: ['aggregate'] }
-          } as FailPoint);
+          } as FailCommandFailPoint);
       });
 
       it('rejects the countDocuments API', async () => {

--- a/test/integration/connections-survive-step-down/connections_survive_step_down.prose.test.ts
+++ b/test/integration/connections-survive-step-down/connections_survive_step_down.prose.test.ts
@@ -9,7 +9,7 @@ import {
   MongoServerError,
   ReadPreference
 } from '../../mongodb';
-import { type FailPoint } from '../../tools/utils';
+import { type FailCommandFailPoint } from '../../tools/utils';
 
 describe('Connections Survive Primary Step Down - prose', function () {
   let client: MongoClient;
@@ -94,7 +94,7 @@ describe('Connections Survive Primary Step Down - prose', function () {
     // This test requires a replica set with server version 4.2 or higher.
 
     // - Set the following fail point: ``{configureFailPoint: "failCommand", mode: {times: 1}, data: {failCommands: ["insert"], errorCode: 10107}}``
-    const failPoint: FailPoint = {
+    const failPoint: FailCommandFailPoint = {
       configureFailPoint: 'failCommand',
       mode: { times: 1 },
       data: { failCommands: ['insert'], errorCode: 10107 }
@@ -121,7 +121,7 @@ describe('Connections Survive Primary Step Down - prose', function () {
       // This test should be run on all server versions >= 4.0.
 
       // - Set the following fail point: ``{configureFailPoint: "failCommand", mode: {times: 1}, data: {failCommands: ["insert"], errorCode: 91}}``
-      const failPoint: FailPoint = {
+      const failPoint: FailCommandFailPoint = {
         configureFailPoint: 'failCommand',
         mode: { times: 1 },
         data: { failCommands: ['insert'], errorCode: 91 }
@@ -149,7 +149,7 @@ describe('Connections Survive Primary Step Down - prose', function () {
       // This test should be run on all server versions >= 4.0.
 
       // - Set the following fail point: ``{configureFailPoint: "failCommand", mode: {times: 1}, data: {failCommands: ["insert"], errorCode: 11600}}``
-      const failPoint: FailPoint = {
+      const failPoint: FailCommandFailPoint = {
         configureFailPoint: 'failCommand',
         mode: { times: 1 },
         data: { failCommands: ['insert'], errorCode: 11600 }

--- a/test/integration/crud/crud_api.test.ts
+++ b/test/integration/crud/crud_api.test.ts
@@ -13,7 +13,7 @@ import {
   ObjectId,
   ReturnDocument
 } from '../../mongodb';
-import { type FailPoint } from '../../tools/utils';
+import { type FailCommandFailPoint } from '../../tools/utils';
 import { assert as test } from '../shared';
 // instanceof cannot be use reliably to detect the new models in js due to scoping and new
 // contexts killing class info find/distinct/count thus cannot be overloaded without breaking
@@ -112,7 +112,7 @@ describe('CRUD API', function () {
 
     describe('when the find operation fails', () => {
       beforeEach(async function () {
-        const failPoint: FailPoint = {
+        const failPoint: FailCommandFailPoint = {
           configureFailPoint: 'failCommand',
           mode: 'alwaysOn',
           data: {
@@ -125,7 +125,7 @@ describe('CRUD API', function () {
       });
 
       afterEach(async function () {
-        const failPoint: FailPoint = {
+        const failPoint: FailCommandFailPoint = {
           configureFailPoint: 'failCommand',
           mode: 'off',
           data: { failCommands: ['find'] }
@@ -182,7 +182,7 @@ describe('CRUD API', function () {
 
     describe('when the aggregation operation fails', () => {
       beforeEach(async function () {
-        const failPoint: FailPoint = {
+        const failPoint: FailCommandFailPoint = {
           configureFailPoint: 'failCommand',
           mode: 'alwaysOn',
           data: {
@@ -195,7 +195,7 @@ describe('CRUD API', function () {
       });
 
       afterEach(async function () {
-        const failPoint: FailPoint = {
+        const failPoint: FailCommandFailPoint = {
           configureFailPoint: 'failCommand',
           mode: 'off',
           data: { failCommands: ['aggregate'] }

--- a/test/integration/crud/explain.test.ts
+++ b/test/integration/crud/explain.test.ts
@@ -310,6 +310,7 @@ describe('CRUD API explain option', function () {
     afterEach(async function () {
       await clearFailPoint(
         this.configuration,
+        'failCommand',
         this.configuration.url({ useMultipleMongoses: false })
       );
     });

--- a/test/integration/index_management.test.ts
+++ b/test/integration/index_management.test.ts
@@ -8,7 +8,7 @@ import {
   type MongoClient,
   MongoServerError
 } from '../mongodb';
-import { type FailPoint } from '../tools/utils';
+import { type FailCommandFailPoint } from '../tools/utils';
 import { assert as test, filterForCommands, setupDatabase } from './shared';
 
 describe('Indexes', function () {
@@ -38,7 +38,7 @@ describe('Indexes', function () {
   });
 
   it('createIndex() throws an error error when createIndex fails', async function () {
-    await client.db('admin').command(<FailPoint>{
+    await client.db('admin').command(<FailCommandFailPoint>{
       configureFailPoint: 'failCommand',
       mode: { times: 1 },
       data: {

--- a/test/integration/node-specific/abstract_cursor.test.ts
+++ b/test/integration/node-specific/abstract_cursor.test.ts
@@ -560,7 +560,7 @@ describe('class AbstractCursor', function () {
       });
 
       afterEach(async function () {
-        await clearFailPoint(this.configuration, uri);
+        await clearFailPoint(this.configuration, 'failCommand', uri);
       });
 
       it(

--- a/test/integration/server-selection/operation_count.test.ts
+++ b/test/integration/server-selection/operation_count.test.ts
@@ -7,7 +7,7 @@ import {
   ConnectionPool,
   type MongoClient
 } from '../../mongodb';
-import { type FailPoint } from '../../tools/utils';
+import { type FailCommandFailPoint } from '../../tools/utils';
 
 const testMetadata: MongoDBMetadataUI = {
   requires: {
@@ -21,7 +21,7 @@ const loadBalancedTestMetadata: MongoDBMetadataUI = {
   }
 };
 
-const enableFailPointCommand: FailPoint = {
+const enableFailPointCommand: FailCommandFailPoint = {
   configureFailPoint: 'failCommand',
   mode: 'alwaysOn',
   data: {
@@ -30,7 +30,7 @@ const enableFailPointCommand: FailPoint = {
   }
 };
 
-const disableFailPointCommand: FailPoint = {
+const disableFailPointCommand: FailCommandFailPoint = {
   configureFailPoint: 'failCommand',
   mode: 'off',
   data: {

--- a/test/integration/transactions/transactions.test.ts
+++ b/test/integration/transactions/transactions.test.ts
@@ -9,7 +9,7 @@ import {
   MongoNetworkError,
   type ServerSessionPool
 } from '../../mongodb';
-import { type FailPoint } from '../../tools/utils';
+import { type FailCommandFailPoint } from '../../tools/utils';
 
 describe('Transactions', function () {
   describe('withTransaction', function () {
@@ -149,7 +149,7 @@ describe('Transactions', function () {
             errorLabels: ['TransientTransactionError'],
             closeConnection: false
           }
-        } as FailPoint);
+        } as FailCommandFailPoint);
 
         collection = await client.db('withTransaction').createCollection('withTransactionRetry');
       });

--- a/test/tools/cmap_spec_runner.ts
+++ b/test/tools/cmap_spec_runner.ts
@@ -15,7 +15,7 @@ import {
   TimeoutContext
 } from '../mongodb';
 import { isAnyRequirementSatisfied } from './unified-spec-runner/unified-utils';
-import { type FailPoint, sleep } from './utils';
+import { type FailCommandFailPoint, sleep } from './utils';
 
 type CmapOperation =
   | { name: 'start' | 'waitForThread'; target: string }
@@ -86,7 +86,7 @@ export type CmapTest = {
     minServerVersion?: string;
     maxServerVersion?: string;
   }[];
-  failPoint?: FailPoint;
+  failPoint?: FailCommandFailPoint;
 };
 
 const ALL_POOL_EVENTS = new Set(CMAP_EVENTS);


### PR DESCRIPTION
### Description

#### What is changing?

This PR fixes the flaky test mentioned in the ticket.  Additionally, because we are now creating the `maxTimeNeverTimeOut` in multiple tests, I updated the `FailCommand` interface to support `maxTimeNeverTimeOut` (a `failCommand` is a subset of `failPoint).

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
