### PR TITLE
test(NODE-7129): sync CRUD spec tests to latest

### DIFF
--- a/test/integration/crud/crud.spec.test.ts
+++ b/test/integration/crud/crud.spec.test.ts
@@ -39,6 +39,33 @@ const loadBalancedCollationTests = [
   'Distinct with a collation'
 ];
 
+const unimplementedCrudTests = {
+  'inserting _id with type null via clientBulkWrite':
+    'TODO(NODE-6468): Test that inserts and upserts respect null _id values (DRIVERS-2124)',
+  'inserting _id with type null via insertOne':
+    'TODO(NODE-6468): Test that inserts and upserts respect null _id values (DRIVERS-2124)',
+  'inserting _id with type null via insertMany':
+    'TODO(NODE-6468): Test that inserts and upserts respect null _id values (DRIVERS-2124)',
+  'inserting _id with type null via bulkWrite':
+    'TODO(NODE-6468): Test that inserts and upserts respect null _id values (DRIVERS-2124)',
+  'partialResult is unset when all operations fail during an unordered bulk write':
+    'TODO(NODE-6384): do not set partialResult when using unacknowledged writes',
+  'partialResult is unset when first operation fails during an ordered bulk write (summary)':
+    'TODO(NODE-6384): do not set partialResult when using unacknowledged writes',
+  'partialResult is unset when first operation fails during an ordered bulk write (verbose)':
+    'TODO(NODE-6384): do not set partialResult when using unacknowledged writes',
+  'InsertMany passes bypassDocumentValidation: false':
+    'TODO(NODE-6484): Allow drivers to set bypassDocumentValidation: false on write commands (DRIVERS-2865)',
+  'FindOneAndUpdate passes bypassDocumentValidation: false':
+    'TODO(NODE-6484): Allow drivers to set bypassDocumentValidation: false on write commands (DRIVERS-2865)',
+  'FindOneAndReplace passes bypassDocumentValidation: false':
+    'TODO(NODE-6484): Allow drivers to set bypassDocumentValidation: false on write commands (DRIVERS-2865)',
+  'BulkWrite passes bypassDocumentValidation: false':
+    'TODO(NODE-6484): Allow drivers to set bypassDocumentValidation: false on write commands (DRIVERS-2865)',
+  'Aggregate with $out passes bypassDocumentValidation: false':
+    'TODO(NODE-6484): Allow drivers to set bypassDocumentValidation: false on write commands (DRIVERS-2865)'
+};
+
 describe('CRUD unified', function () {
   runUnifiedSuite(
     loadSpecTests(path.join('crud', 'unified')),
@@ -47,7 +74,9 @@ describe('CRUD unified', function () {
         ? `TODO(NODE-3541)`
         : isLoadBalanced && loadBalancedCollationTests.includes(description)
           ? `TODO(NODE-6280): fix collation for find and modify commands on load balanced mode`
-          : false;
+          : description in unimplementedCrudTests
+            ? unimplementedCrudTests[description]
+            : false;
     }
   );
 });

--- a/test/spec/crud/unified/bulkWrite-updateMany-pipeline.json
+++ b/test/spec/crud/unified/bulkWrite-updateMany-pipeline.json
@@ -1,0 +1,148 @@
+{
+  "description": "bulkWrite-updateMany-pipeline",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "4.1.11"
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "test",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 1,
+          "y": 1,
+          "t": {
+            "u": {
+              "v": 1
+            }
+          }
+        },
+        {
+          "_id": 2,
+          "x": 2,
+          "y": 1
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "UpdateMany in bulk write using pipelines",
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "bulkWrite",
+          "arguments": {
+            "requests": [
+              {
+                "updateMany": {
+                  "filter": {},
+                  "update": [
+                    {
+                      "$project": {
+                        "x": 1
+                      }
+                    },
+                    {
+                      "$addFields": {
+                        "foo": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "matchedCount": 2,
+            "modifiedCount": 2,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "test",
+                  "updates": [
+                    {
+                      "q": {},
+                      "u": [
+                        {
+                          "$project": {
+                            "x": 1
+                          }
+                        },
+                        {
+                          "$addFields": {
+                            "foo": 1
+                          }
+                        }
+                      ],
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                },
+                "commandName": "update",
+                "databaseName": "crud-tests"
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "test",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 1,
+              "foo": 1
+            },
+            {
+              "_id": 2,
+              "x": 2,
+              "foo": 1
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/crud/unified/bulkWrite-updateMany-pipeline.yml
+++ b/test/spec/crud/unified/bulkWrite-updateMany-pipeline.yml
@@ -1,0 +1,67 @@
+description: bulkWrite-updateMany-pipeline
+
+schemaVersion: '1.0'
+
+runOnRequirements:
+  - minServerVersion: 4.1.11
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents:
+        - commandStartedEvent
+  - database:
+      id: &database0 database0
+      client: client0
+      databaseName: &database_name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: database0
+      collectionName: &collection_name test
+
+initialData:
+  - collectionName: *collection_name
+    databaseName: *database_name
+    documents:
+      - { _id: 1, x: 1, y: 1, t: { u: { v: 1 } } }
+      - { _id: 2, x: 2, y: 1 }
+
+tests:
+  -
+    description: 'UpdateMany in bulk write using pipelines'
+    operations:
+      - object: *collection0
+        name: bulkWrite
+        arguments:
+          requests:
+            - updateMany:
+                filter: {  }
+                update:
+                  - { $project: { x: 1 } }
+                  - { $addFields: { foo: 1 } }
+        expectResult:
+          matchedCount: 2
+          modifiedCount: 2
+          upsertedCount: 0
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection_name
+                updates:
+                  - q: {  }
+                    u:
+                      - { $project: { x: 1 } }
+                      - { $addFields: { foo: 1 } }
+                    multi: true
+                    upsert: { $$unsetOrMatches: false }
+              commandName: update
+              databaseName: *database_name
+    outcome:
+      -
+        collectionName: *collection_name
+        databaseName: *database_name
+        documents:
+          - { _id: 1, x: 1, foo: 1 }
+          - { _id: 2, x: 2, foo: 1 }

--- a/test/spec/crud/unified/bulkWrite-updateOne-pipeline.json
+++ b/test/spec/crud/unified/bulkWrite-updateOne-pipeline.json
@@ -1,0 +1,156 @@
+{
+  "description": "bulkWrite-updateOne-pipeline",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "4.1.11"
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "test",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 1,
+          "y": 1,
+          "t": {
+            "u": {
+              "v": 1
+            }
+          }
+        },
+        {
+          "_id": 2,
+          "x": 2,
+          "y": 1
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "UpdateOne in bulk write using pipelines",
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "bulkWrite",
+          "arguments": {
+            "requests": [
+              {
+                "updateOne": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "update": [
+                    {
+                      "$replaceRoot": {
+                        "newRoot": "$t"
+                      }
+                    },
+                    {
+                      "$addFields": {
+                        "foo": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "test",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": [
+                        {
+                          "$replaceRoot": {
+                            "newRoot": "$t"
+                          }
+                        },
+                        {
+                          "$addFields": {
+                            "foo": 1
+                          }
+                        }
+                      ],
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                },
+                "commandName": "update",
+                "databaseName": "crud-tests"
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "test",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "u": {
+                "v": 1
+              },
+              "foo": 1
+            },
+            {
+              "_id": 2,
+              "x": 2,
+              "y": 1
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/crud/unified/bulkWrite-updateOne-pipeline.yml
+++ b/test/spec/crud/unified/bulkWrite-updateOne-pipeline.yml
@@ -1,0 +1,66 @@
+description: bulkWrite-updateOne-pipeline
+
+schemaVersion: '1.0'
+
+runOnRequirements:
+  - minServerVersion: 4.1.11
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents:
+        - commandStartedEvent
+  - database:
+      id: &database0 database0
+      client: client0
+      databaseName: &database_name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: database0
+      collectionName: &collection_name test
+
+initialData:
+  - collectionName: *collection_name
+    databaseName: *database_name
+    documents:
+      - { _id: 1, x: 1, y: 1, t: { u: { v: 1 } } }
+      - { _id: 2, x: 2, y: 1 }
+
+tests:
+  -
+    description: 'UpdateOne in bulk write using pipelines'
+    operations:
+      - object: *collection0
+        name: bulkWrite
+        arguments:
+          requests:
+            - updateOne:
+                filter: { _id: 1 }
+                update:
+                  - { $replaceRoot: { newRoot: $t } }
+                  - { $addFields: { foo: 1 } }
+        expectResult:
+          matchedCount: 1
+          modifiedCount: 1
+          upsertedCount: 0
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection_name
+                updates:
+                  - q: { _id: 1 }
+                    u:
+                      - { $replaceRoot: { newRoot: $t } }
+                      - { $addFields: { foo: 1 } }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+              commandName: update
+              databaseName: *database_name
+    outcome:
+      - collectionName: *collection_name
+        databaseName: *database_name
+        documents:
+          - { _id: 1, u: { v: 1 }, foo: 1 }
+          - { _id: 2, x: 2, y: 1 }

--- a/test/spec/crud/unified/bypassDocumentValidation.json
+++ b/test/spec/crud/unified/bypassDocumentValidation.json
@@ -1,0 +1,493 @@
+{
+  "description": "bypassDocumentValidation",
+  "schemaVersion": "1.4",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "3.2",
+      "serverless": "forbid"
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll",
+      "databaseName": "crud",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        },
+        {
+          "_id": 2,
+          "x": 22
+        },
+        {
+          "_id": 3,
+          "x": 33
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "Aggregate with $out passes bypassDocumentValidation: false",
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "aggregate",
+          "arguments": {
+            "pipeline": [
+              {
+                "$sort": {
+                  "x": 1
+                }
+              },
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$out": "other_test_collection"
+              }
+            ],
+            "bypassDocumentValidation": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "coll",
+                  "pipeline": [
+                    {
+                      "$sort": {
+                        "x": 1
+                      }
+                    },
+                    {
+                      "$match": {
+                        "_id": {
+                          "$gt": 1
+                        }
+                      }
+                    },
+                    {
+                      "$out": "other_test_collection"
+                    }
+                  ],
+                  "bypassDocumentValidation": false
+                },
+                "commandName": "aggregate",
+                "databaseName": "crud"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "BulkWrite passes bypassDocumentValidation: false",
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "bulkWrite",
+          "arguments": {
+            "requests": [
+              {
+                "insertOne": {
+                  "document": {
+                    "_id": 4,
+                    "x": 44
+                  }
+                }
+              }
+            ],
+            "bypassDocumentValidation": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll",
+                  "documents": [
+                    {
+                      "_id": 4,
+                      "x": 44
+                    }
+                  ],
+                  "bypassDocumentValidation": false
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "FindOneAndReplace passes bypassDocumentValidation: false",
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "findOneAndReplace",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
+            },
+            "replacement": {
+              "x": 32
+            },
+            "bypassDocumentValidation": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "findAndModify": "coll",
+                  "query": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  },
+                  "update": {
+                    "x": 32
+                  },
+                  "bypassDocumentValidation": false
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "FindOneAndUpdate passes bypassDocumentValidation: false",
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "findOneAndUpdate",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "bypassDocumentValidation": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "findAndModify": "coll",
+                  "query": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  },
+                  "update": {
+                    "$inc": {
+                      "x": 1
+                    }
+                  },
+                  "bypassDocumentValidation": false
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "InsertMany passes bypassDocumentValidation: false",
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "insertMany",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 4,
+                "x": 44
+              }
+            ],
+            "bypassDocumentValidation": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll",
+                  "documents": [
+                    {
+                      "_id": 4,
+                      "x": 44
+                    }
+                  ],
+                  "bypassDocumentValidation": false
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "InsertOne passes bypassDocumentValidation: false",
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "insertOne",
+          "arguments": {
+            "document": {
+              "_id": 4,
+              "x": 44
+            },
+            "bypassDocumentValidation": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll",
+                  "documents": [
+                    {
+                      "_id": 4,
+                      "x": 44
+                    }
+                  ],
+                  "bypassDocumentValidation": false
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "ReplaceOne passes bypassDocumentValidation: false",
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "replaceOne",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
+            },
+            "replacement": {
+              "x": 32
+            },
+            "bypassDocumentValidation": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": {
+                          "$gt": 1
+                        }
+                      },
+                      "u": {
+                        "x": 32
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ],
+                  "bypassDocumentValidation": false
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "UpdateMany passes bypassDocumentValidation: false",
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "updateMany",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "bypassDocumentValidation": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": {
+                          "$gt": 1
+                        }
+                      },
+                      "u": {
+                        "$inc": {
+                          "x": 1
+                        }
+                      },
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ],
+                  "bypassDocumentValidation": false
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "UpdateOne passes bypassDocumentValidation: false",
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "updateOne",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "bypassDocumentValidation": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": {
+                          "$gt": 1
+                        }
+                      },
+                      "u": {
+                        "$inc": {
+                          "x": 1
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ],
+                  "bypassDocumentValidation": false
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/crud/unified/bypassDocumentValidation.yml
+++ b/test/spec/crud/unified/bypassDocumentValidation.yml
@@ -1,0 +1,222 @@
+description: bypassDocumentValidation
+
+schemaVersion: '1.4'
+
+runOnRequirements:
+  -
+    minServerVersion: '3.2'
+    serverless: forbid
+
+createEntities:
+  -
+    client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  -
+    database:
+      id: &database0 database0
+      client: client0
+      databaseName: &database_name crud
+  -
+    collection:
+      id: &collection0 collection0
+      database: database0
+      collectionName: &collection_name coll
+
+initialData:
+  -
+    collectionName: *collection_name
+    databaseName: *database_name
+    documents:
+      - { _id: 1, x: 11 }
+      - { _id: 2, x: 22 }
+      - { _id: 3, x: 33 }
+
+tests:
+  -
+    description: 'Aggregate with $out passes bypassDocumentValidation: false'
+    operations:
+      -
+        object: *collection0
+        name: aggregate
+        arguments:
+          pipeline: &pipeline
+            - { $sort: { x: 1 } }
+            - { $match: { _id: { $gt: 1 } } }
+            - { $out: other_test_collection }
+          bypassDocumentValidation: false
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection_name
+                pipeline: *pipeline
+                bypassDocumentValidation: false
+              commandName: aggregate
+              databaseName: *database_name
+  -
+    description: 'BulkWrite passes bypassDocumentValidation: false'
+    operations:
+      -
+        object: *collection0
+        name: bulkWrite
+        arguments:
+          requests:
+            -
+              insertOne:
+                document: &inserted_document { _id: 4, x: 44 }
+          bypassDocumentValidation: false
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                insert: *collection_name
+                documents:
+                  - *inserted_document
+                bypassDocumentValidation: false
+  -
+    description: 'FindOneAndReplace passes bypassDocumentValidation: false'
+    operations:
+      -
+        object: *collection0
+        name: findOneAndReplace
+        arguments:
+          filter: &filter { _id: { $gt: 1 } }
+          replacement: &replacement { x: 32 }
+          bypassDocumentValidation: false
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                findAndModify: *collection_name
+                query: *filter
+                update: *replacement
+                bypassDocumentValidation: false
+  -
+    description: 'FindOneAndUpdate passes bypassDocumentValidation: false'
+    operations:
+      -
+        object: *collection0
+        name: findOneAndUpdate
+        arguments:
+          filter: *filter
+          update: &update { $inc: { x: 1 } }
+          bypassDocumentValidation: false
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                findAndModify: *collection_name
+                query: *filter
+                update: *update
+                bypassDocumentValidation: false
+  -
+    description: 'InsertMany passes bypassDocumentValidation: false'
+    operations:
+      -
+        object: *collection0
+        name: insertMany
+        arguments:
+          documents:
+            - *inserted_document
+          bypassDocumentValidation: false
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                insert: *collection_name
+                documents:
+                  - *inserted_document
+                bypassDocumentValidation: false
+  -
+    description: 'InsertOne passes bypassDocumentValidation: false'
+    operations:
+      -
+        object: *collection0
+        name: insertOne
+        arguments:
+          document: *inserted_document
+          bypassDocumentValidation: false
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                insert: *collection_name
+                documents:
+                  - *inserted_document
+                bypassDocumentValidation: false
+  -
+    description: 'ReplaceOne passes bypassDocumentValidation: false'
+    operations:
+      -
+        object: *collection0
+        name: replaceOne
+        arguments:
+          filter: *filter
+          replacement: *replacement
+          bypassDocumentValidation: false
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection_name
+                updates:
+                  -
+                    q: *filter
+                    u: *replacement
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                bypassDocumentValidation: false
+  -
+    description: 'UpdateMany passes bypassDocumentValidation: false'
+    operations:
+      -
+        object: *collection0
+        name: updateMany
+        arguments:
+          filter: *filter
+          update: *update
+          bypassDocumentValidation: false
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection_name
+                updates:
+                  -
+                    q: *filter
+                    u: *update
+                    multi: true
+                    upsert: { $$unsetOrMatches: false }
+                bypassDocumentValidation: false
+  -
+    description: 'UpdateOne passes bypassDocumentValidation: false'
+    operations:
+      -
+        object: *collection0
+        name: updateOne
+        arguments:
+          filter: *filter
+          update: *update
+          bypassDocumentValidation: false
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection_name
+                updates:
+                  -
+                    q: *filter
+                    u: *update
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                bypassDocumentValidation: false

--- a/test/spec/crud/unified/client-bulkWrite-partialResults.json
+++ b/test/spec/crud/unified/client-bulkWrite-partialResults.json
@@ -1,0 +1,540 @@
+{
+  "description": "client bulkWrite partial results",
+  "schemaVersion": "1.4",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "8.0",
+      "serverless": "forbid"
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        }
+      ]
+    }
+  ],
+  "_yamlAnchors": {
+    "namespace": "crud-tests.coll0",
+    "newDocument": {
+      "_id": 2,
+      "x": 22
+    }
+  },
+  "tests": [
+    {
+      "description": "partialResult is unset when first operation fails during an ordered bulk write (verbose)",
+      "operations": [
+        {
+          "object": "client0",
+          "name": "clientBulkWrite",
+          "arguments": {
+            "models": [
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 1,
+                    "x": 11
+                  }
+                }
+              },
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 2,
+                    "x": 22
+                  }
+                }
+              }
+            ],
+            "ordered": true,
+            "verboseResults": true
+          },
+          "expectError": {
+            "expectResult": {
+              "$$unsetOrMatches": {
+                "insertedCount": {
+                  "$$exists": false
+                },
+                "upsertedCount": {
+                  "$$exists": false
+                },
+                "matchedCount": {
+                  "$$exists": false
+                },
+                "modifiedCount": {
+                  "$$exists": false
+                },
+                "deletedCount": {
+                  "$$exists": false
+                },
+                "insertResults": {
+                  "$$exists": false
+                },
+                "updateResults": {
+                  "$$exists": false
+                },
+                "deleteResults": {
+                  "$$exists": false
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "partialResult is unset when first operation fails during an ordered bulk write (summary)",
+      "operations": [
+        {
+          "object": "client0",
+          "name": "clientBulkWrite",
+          "arguments": {
+            "models": [
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 1,
+                    "x": 11
+                  }
+                }
+              },
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 2,
+                    "x": 22
+                  }
+                }
+              }
+            ],
+            "ordered": true,
+            "verboseResults": false
+          },
+          "expectError": {
+            "expectResult": {
+              "$$unsetOrMatches": {
+                "insertedCount": {
+                  "$$exists": false
+                },
+                "upsertedCount": {
+                  "$$exists": false
+                },
+                "matchedCount": {
+                  "$$exists": false
+                },
+                "modifiedCount": {
+                  "$$exists": false
+                },
+                "deletedCount": {
+                  "$$exists": false
+                },
+                "insertResults": {
+                  "$$exists": false
+                },
+                "updateResults": {
+                  "$$exists": false
+                },
+                "deleteResults": {
+                  "$$exists": false
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "partialResult is set when second operation fails during an ordered bulk write (verbose)",
+      "operations": [
+        {
+          "object": "client0",
+          "name": "clientBulkWrite",
+          "arguments": {
+            "models": [
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 2,
+                    "x": 22
+                  }
+                }
+              },
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 1,
+                    "x": 11
+                  }
+                }
+              }
+            ],
+            "ordered": true,
+            "verboseResults": true
+          },
+          "expectError": {
+            "expectResult": {
+              "insertedCount": 1,
+              "upsertedCount": 0,
+              "matchedCount": 0,
+              "modifiedCount": 0,
+              "deletedCount": 0,
+              "insertResults": {
+                "0": {
+                  "insertedId": 2
+                }
+              },
+              "updateResults": {},
+              "deleteResults": {}
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "partialResult is set when second operation fails during an ordered bulk write (summary)",
+      "operations": [
+        {
+          "object": "client0",
+          "name": "clientBulkWrite",
+          "arguments": {
+            "models": [
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 2,
+                    "x": 22
+                  }
+                }
+              },
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 1,
+                    "x": 11
+                  }
+                }
+              }
+            ],
+            "ordered": true,
+            "verboseResults": false
+          },
+          "expectError": {
+            "expectResult": {
+              "insertedCount": 1,
+              "upsertedCount": 0,
+              "matchedCount": 0,
+              "modifiedCount": 0,
+              "deletedCount": 0,
+              "insertResults": {
+                "$$unsetOrMatches": {}
+              },
+              "updateResults": {
+                "$$unsetOrMatches": {}
+              },
+              "deleteResults": {
+                "$$unsetOrMatches": {}
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "partialResult is unset when all operations fail during an unordered bulk write",
+      "operations": [
+        {
+          "object": "client0",
+          "name": "clientBulkWrite",
+          "arguments": {
+            "models": [
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 1,
+                    "x": 11
+                  }
+                }
+              },
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 1,
+                    "x": 11
+                  }
+                }
+              }
+            ],
+            "ordered": false
+          },
+          "expectError": {
+            "expectResult": {
+              "$$unsetOrMatches": {
+                "insertedCount": {
+                  "$$exists": false
+                },
+                "upsertedCount": {
+                  "$$exists": false
+                },
+                "matchedCount": {
+                  "$$exists": false
+                },
+                "modifiedCount": {
+                  "$$exists": false
+                },
+                "deletedCount": {
+                  "$$exists": false
+                },
+                "insertResults": {
+                  "$$exists": false
+                },
+                "updateResults": {
+                  "$$exists": false
+                },
+                "deleteResults": {
+                  "$$exists": false
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "partialResult is set when first operation fails during an unordered bulk write (verbose)",
+      "operations": [
+        {
+          "object": "client0",
+          "name": "clientBulkWrite",
+          "arguments": {
+            "models": [
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 1,
+                    "x": 11
+                  }
+                }
+              },
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 2,
+                    "x": 22
+                  }
+                }
+              }
+            ],
+            "ordered": false,
+            "verboseResults": true
+          },
+          "expectError": {
+            "expectResult": {
+              "insertedCount": 1,
+              "upsertedCount": 0,
+              "matchedCount": 0,
+              "modifiedCount": 0,
+              "deletedCount": 0,
+              "insertResults": {
+                "1": {
+                  "insertedId": 2
+                }
+              },
+              "updateResults": {},
+              "deleteResults": {}
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "partialResult is set when first operation fails during an unordered bulk write (summary)",
+      "operations": [
+        {
+          "object": "client0",
+          "name": "clientBulkWrite",
+          "arguments": {
+            "models": [
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 1,
+                    "x": 11
+                  }
+                }
+              },
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 2,
+                    "x": 22
+                  }
+                }
+              }
+            ],
+            "ordered": false,
+            "verboseResults": false
+          },
+          "expectError": {
+            "expectResult": {
+              "insertedCount": 1,
+              "upsertedCount": 0,
+              "matchedCount": 0,
+              "modifiedCount": 0,
+              "deletedCount": 0,
+              "insertResults": {
+                "$$unsetOrMatches": {}
+              },
+              "updateResults": {
+                "$$unsetOrMatches": {}
+              },
+              "deleteResults": {
+                "$$unsetOrMatches": {}
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "partialResult is set when second operation fails during an unordered bulk write (verbose)",
+      "operations": [
+        {
+          "object": "client0",
+          "name": "clientBulkWrite",
+          "arguments": {
+            "models": [
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 2,
+                    "x": 22
+                  }
+                }
+              },
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 1,
+                    "x": 11
+                  }
+                }
+              }
+            ],
+            "ordered": false,
+            "verboseResults": true
+          },
+          "expectError": {
+            "expectResult": {
+              "insertedCount": 1,
+              "upsertedCount": 0,
+              "matchedCount": 0,
+              "modifiedCount": 0,
+              "deletedCount": 0,
+              "insertResults": {
+                "0": {
+                  "insertedId": 2
+                }
+              },
+              "updateResults": {},
+              "deleteResults": {}
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "partialResult is set when second operation fails during an unordered bulk write (summary)",
+      "operations": [
+        {
+          "object": "client0",
+          "name": "clientBulkWrite",
+          "arguments": {
+            "models": [
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 2,
+                    "x": 22
+                  }
+                }
+              },
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 1,
+                    "x": 11
+                  }
+                }
+              }
+            ],
+            "ordered": false,
+            "verboseResults": false
+          },
+          "expectError": {
+            "expectResult": {
+              "insertedCount": 1,
+              "upsertedCount": 0,
+              "matchedCount": 0,
+              "modifiedCount": 0,
+              "deletedCount": 0,
+              "insertResults": {
+                "$$unsetOrMatches": {}
+              },
+              "updateResults": {
+                "$$unsetOrMatches": {}
+              },
+              "deleteResults": {
+                "$$unsetOrMatches": {}
+              }
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/crud/unified/client-bulkWrite-partialResults.yml
+++ b/test/spec/crud/unified/client-bulkWrite-partialResults.yml
@@ -1,0 +1,262 @@
+description: "client bulkWrite partial results"
+schemaVersion: "1.4" # To support `serverless: forbid`
+runOnRequirements:
+  - minServerVersion: "8.0"
+    serverless: forbid
+
+createEntities:
+  - client:
+      id: &client0 client0
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - &existingDocument { _id: 1, x: 11 }
+
+_yamlAnchors:
+  namespace: &namespace "crud-tests.coll0"
+  newDocument: &newDocument { _id: 2, x: 22 }
+
+tests:
+  - description: "partialResult is unset when first operation fails during an ordered bulk write (verbose)"
+    operations:
+      - object: *client0
+        name: clientBulkWrite
+        arguments:
+          models:
+            - insertOne:
+                namespace: *namespace
+                document: *existingDocument
+            - insertOne:
+                namespace: *namespace
+                document: *newDocument
+          ordered: true
+          verboseResults: true
+        expectError:
+          expectResult:
+            $$unsetOrMatches:
+              insertedCount: { $$exists: false }
+              upsertedCount: { $$exists: false }
+              matchedCount: { $$exists: false }
+              modifiedCount: { $$exists: false }
+              deletedCount: { $$exists: false }
+              insertResults: { $$exists: false }
+              updateResults: { $$exists: false }
+              deleteResults: { $$exists: false }
+  - description: "partialResult is unset when first operation fails during an ordered bulk write (summary)"
+    operations:
+      - object: *client0
+        name: clientBulkWrite
+        arguments:
+          models:
+            - insertOne:
+                namespace: *namespace
+                document: *existingDocument
+            - insertOne:
+                namespace: *namespace
+                document: *newDocument
+          ordered: true
+          verboseResults: false
+        expectError:
+          expectResult:
+            $$unsetOrMatches:
+              insertedCount: { $$exists: false }
+              upsertedCount: { $$exists: false }
+              matchedCount: { $$exists: false }
+              modifiedCount: { $$exists: false }
+              deletedCount: { $$exists: false }
+              insertResults: { $$exists: false }
+              updateResults: { $$exists: false }
+              deleteResults: { $$exists: false }
+  - description: "partialResult is set when second operation fails during an ordered bulk write (verbose)"
+    operations:
+      - object: *client0
+        name: clientBulkWrite
+        arguments:
+          models:
+            - insertOne:
+                namespace: *namespace
+                document: *newDocument
+            - insertOne:
+                namespace: *namespace
+                document: *existingDocument
+          ordered: true
+          verboseResults: true
+        expectError:
+          expectResult:
+            insertedCount: 1
+            upsertedCount: 0
+            matchedCount: 0
+            modifiedCount: 0
+            deletedCount: 0
+            insertResults:
+              0:
+                insertedId: 2
+            updateResults: {}
+            deleteResults: {}
+  - description: "partialResult is set when second operation fails during an ordered bulk write (summary)"
+    operations:
+      - object: *client0
+        name: clientBulkWrite
+        arguments:
+          models:
+            - insertOne:
+                namespace: *namespace
+                document: *newDocument
+            - insertOne:
+                namespace: *namespace
+                document: *existingDocument
+          ordered: true
+          verboseResults: false
+        expectError:
+          expectResult:
+            insertedCount: 1
+            upsertedCount: 0
+            matchedCount: 0
+            modifiedCount: 0
+            deletedCount: 0
+            insertResults:
+              $$unsetOrMatches: {}
+            updateResults:
+              $$unsetOrMatches: {}
+            deleteResults:
+              $$unsetOrMatches: {}
+  - description: "partialResult is unset when all operations fail during an unordered bulk write"
+    operations:
+      - object: *client0
+        name: clientBulkWrite
+        arguments:
+          models:
+            - insertOne:
+                namespace: *namespace
+                document: *existingDocument
+            - insertOne:
+                namespace: *namespace
+                document: *existingDocument
+          ordered: false
+        expectError:
+          expectResult:
+            $$unsetOrMatches:
+              insertedCount: { $$exists: false }
+              upsertedCount: { $$exists: false }
+              matchedCount: { $$exists: false }
+              modifiedCount: { $$exists: false }
+              deletedCount: { $$exists: false }
+              insertResults: { $$exists: false }
+              updateResults: { $$exists: false }
+              deleteResults: { $$exists: false }
+  - description: "partialResult is set when first operation fails during an unordered bulk write (verbose)"
+    operations:
+      - object: *client0
+        name: clientBulkWrite
+        arguments:
+          models:
+            - insertOne:
+                namespace: *namespace
+                document: *existingDocument
+            - insertOne:
+                namespace: *namespace
+                document: *newDocument
+          ordered: false
+          verboseResults: true
+        expectError:
+          expectResult:
+            insertedCount: 1
+            upsertedCount: 0
+            matchedCount: 0
+            modifiedCount: 0
+            deletedCount: 0
+            insertResults:
+              1:
+                insertedId: 2
+            updateResults: {}
+            deleteResults: {}
+  - description: "partialResult is set when first operation fails during an unordered bulk write (summary)"
+    operations:
+      - object: *client0
+        name: clientBulkWrite
+        arguments:
+          models:
+            - insertOne:
+                namespace: *namespace
+                document: *existingDocument
+            - insertOne:
+                namespace: *namespace
+                document: *newDocument
+          ordered: false
+          verboseResults: false
+        expectError:
+          expectResult:
+            insertedCount: 1
+            upsertedCount: 0
+            matchedCount: 0
+            modifiedCount: 0
+            deletedCount: 0
+            insertResults:
+              $$unsetOrMatches: {}
+            updateResults:
+              $$unsetOrMatches: {}
+            deleteResults:
+              $$unsetOrMatches: {}
+  - description: "partialResult is set when second operation fails during an unordered bulk write (verbose)"
+    operations:
+      - object: *client0
+        name: clientBulkWrite
+        arguments:
+          models:
+            - insertOne:
+                namespace: *namespace
+                document: *newDocument
+            - insertOne:
+                namespace: *namespace
+                document: *existingDocument
+          ordered: false
+          verboseResults: true
+        expectError:
+          expectResult:
+            insertedCount: 1
+            upsertedCount: 0
+            matchedCount: 0
+            modifiedCount: 0
+            deletedCount: 0
+            insertResults:
+              0:
+                insertedId: 2
+            updateResults: {}
+            deleteResults: {}
+  - description: "partialResult is set when second operation fails during an unordered bulk write (summary)"
+    operations:
+      - object: *client0
+        name: clientBulkWrite
+        arguments:
+          models:
+            - insertOne:
+                namespace: *namespace
+                document: *newDocument
+            - insertOne:
+                namespace: *namespace
+                document: *existingDocument
+          ordered: false
+          verboseResults: false
+        expectError:
+          expectResult:
+            insertedCount: 1
+            upsertedCount: 0
+            matchedCount: 0
+            modifiedCount: 0
+            deletedCount: 0
+            insertResults:
+              $$unsetOrMatches: {}
+            updateResults:
+              $$unsetOrMatches: {}
+            deleteResults:
+              $$unsetOrMatches: {}

--- a/test/spec/crud/unified/create-null-ids.json
+++ b/test/spec/crud/unified/create-null-ids.json
@@ -1,0 +1,253 @@
+{
+  "description": "create-null-ids",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database",
+        "client": "client",
+        "databaseName": "crud_id"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection",
+        "database": "database",
+        "collectionName": "type_tests"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "type_tests",
+      "databaseName": "crud_id",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "inserting _id with type null via insertOne",
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "document": {
+              "_id": null
+            }
+          }
+        },
+        {
+          "name": "countDocuments",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$type": "null"
+              }
+            }
+          },
+          "expectResult": 1
+        }
+      ]
+    },
+    {
+      "description": "inserting _id with type null via insertMany",
+      "operations": [
+        {
+          "name": "insertMany",
+          "object": "collection",
+          "arguments": {
+            "documents": [
+              {
+                "_id": null
+              }
+            ]
+          }
+        },
+        {
+          "name": "countDocuments",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$type": "null"
+              }
+            }
+          },
+          "expectResult": 1
+        }
+      ]
+    },
+    {
+      "description": "inserting _id with type null via updateOne",
+      "operations": [
+        {
+          "name": "updateOne",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": null
+            },
+            "update": {
+              "$unset": {
+                "a": ""
+              }
+            },
+            "upsert": true
+          }
+        },
+        {
+          "name": "countDocuments",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$type": "null"
+              }
+            }
+          },
+          "expectResult": 1
+        }
+      ]
+    },
+    {
+      "description": "inserting _id with type null via updateMany",
+      "operations": [
+        {
+          "name": "updateMany",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": null
+            },
+            "update": {
+              "$unset": {
+                "a": ""
+              }
+            },
+            "upsert": true
+          }
+        },
+        {
+          "name": "countDocuments",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$type": "null"
+              }
+            }
+          },
+          "expectResult": 1
+        }
+      ]
+    },
+    {
+      "description": "inserting _id with type null via replaceOne",
+      "operations": [
+        {
+          "name": "replaceOne",
+          "object": "collection",
+          "arguments": {
+            "filter": {},
+            "replacement": {
+              "_id": null
+            },
+            "upsert": true
+          }
+        },
+        {
+          "name": "countDocuments",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$type": "null"
+              }
+            }
+          },
+          "expectResult": 1
+        }
+      ]
+    },
+    {
+      "description": "inserting _id with type null via bulkWrite",
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection",
+          "arguments": {
+            "requests": [
+              {
+                "insertOne": {
+                  "document": {
+                    "_id": null
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "countDocuments",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$type": "null"
+              }
+            }
+          },
+          "expectResult": 1
+        }
+      ]
+    },
+    {
+      "description": "inserting _id with type null via clientBulkWrite",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "8.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "clientBulkWrite",
+          "object": "client",
+          "arguments": {
+            "models": [
+              {
+                "insertOne": {
+                  "namespace": "crud_id.type_tests",
+                  "document": {
+                    "_id": null
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "countDocuments",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$type": "null"
+              }
+            }
+          },
+          "expectResult": 1
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/crud/unified/create-null-ids.yml
+++ b/test/spec/crud/unified/create-null-ids.yml
@@ -1,0 +1,97 @@
+description: create-null-ids
+schemaVersion: '1.0'
+
+createEntities:
+  - client:
+      id: client
+      observeEvents:
+        - commandStartedEvent
+  - database:
+      id: &database database
+      client: client
+      databaseName: crud_id
+  - collection:
+      id: &collection collection
+      database: *database
+      collectionName: type_tests
+
+initialData:
+  - collectionName: type_tests
+    databaseName: crud_id
+    documents: []
+
+tests:
+
+  - description: inserting _id with type null via insertOne
+    operations:
+      - name: insertOne
+        object: *collection
+        arguments: {document: &null_id {_id: null}}
+      # We use countDocuments with a $type query to verify the insert of the correct BSON type
+      # this is to avoid client side type conversions (potentially common: undefined -> null)
+      - name: countDocuments
+        object: *collection
+        arguments: {filter: &null_id_filter {_id: {$type: 'null'}}}
+        expectResult: 1
+
+  - description: inserting _id with type null via insertMany
+    operations:
+      - name: insertMany
+        object: *collection
+        arguments: {documents: [*null_id]}
+      - name: countDocuments
+        object: *collection
+        arguments: {filter: *null_id_filter}
+        expectResult: 1
+
+  - description: inserting _id with type null via updateOne
+    operations:
+      - name: updateOne
+        object: *collection
+        arguments: {filter: *null_id, update: {$unset: {a: ''}}, upsert: true}
+      - name: countDocuments
+        object: *collection
+        arguments: {filter: *null_id_filter}
+        expectResult: 1
+
+  - description: inserting _id with type null via updateMany
+    operations:
+      - name: updateMany
+        object: *collection
+        arguments: {filter: *null_id, update: {$unset: {a: ''}}, upsert: true}
+      - name: countDocuments
+        object: *collection
+        arguments: {filter: *null_id_filter}
+        expectResult: 1
+
+  - description: inserting _id with type null via replaceOne
+    operations:
+      - name: replaceOne
+        object: *collection
+        arguments: {filter: {}, replacement: *null_id, upsert: true}
+      - name: countDocuments
+        object: *collection
+        arguments: {filter: *null_id_filter}
+        expectResult: 1
+
+  - description: inserting _id with type null via bulkWrite
+    operations:
+      - name: bulkWrite
+        object: *collection
+        arguments: {requests: [{insertOne: {document: *null_id}}]}
+      - name: countDocuments
+        object: *collection
+        arguments: {filter: *null_id_filter}
+        expectResult: 1
+
+  - description: inserting _id with type null via clientBulkWrite
+    runOnRequirements:
+      - minServerVersion: '8.0'
+    operations:
+      - name: clientBulkWrite
+        object: client
+        arguments: {models: [{insertOne: {namespace: crud_id.type_tests, document: *null_id}}]}
+      - name: countDocuments
+        object: *collection
+        arguments: {filter: *null_id_filter}
+        expectResult: 1

--- a/test/spec/crud/unified/findOneAndUpdate-pipeline.json
+++ b/test/spec/crud/unified/findOneAndUpdate-pipeline.json
@@ -1,0 +1,130 @@
+{
+  "description": "findOneAndUpdate-pipeline",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "4.1.11"
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "test",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 1,
+          "y": 1,
+          "t": {
+            "u": {
+              "v": 1
+            }
+          }
+        },
+        {
+          "_id": 2,
+          "x": 2,
+          "y": 1
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "FindOneAndUpdate using pipelines",
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "findOneAndUpdate",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": [
+              {
+                "$project": {
+                  "x": 1
+                }
+              },
+              {
+                "$addFields": {
+                  "foo": 1
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "findAndModify": "test",
+                  "update": [
+                    {
+                      "$project": {
+                        "x": 1
+                      }
+                    },
+                    {
+                      "$addFields": {
+                        "foo": 1
+                      }
+                    }
+                  ]
+                },
+                "commandName": "findAndModify",
+                "databaseName": "crud-tests"
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "test",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 1,
+              "foo": 1
+            },
+            {
+              "_id": 2,
+              "x": 2,
+              "y": 1
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/crud/unified/findOneAndUpdate-pipeline.yml
+++ b/test/spec/crud/unified/findOneAndUpdate-pipeline.yml
@@ -1,0 +1,56 @@
+description: findOneAndUpdate-pipeline
+
+schemaVersion: '1.0'
+
+runOnRequirements:
+  - minServerVersion: 4.1.11
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents:
+        - commandStartedEvent
+  - database:
+      id: &database0 database0
+      client: client0
+      databaseName: &database_name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: database0
+      collectionName: &collection_name test
+
+initialData:
+  - collectionName: *collection_name
+    databaseName: *database_name
+    documents:
+      - { _id: 1, x: 1, y: 1, t: { u: { v: 1 } } }
+      - { _id: 2, x: 2, y: 1 }
+
+tests:
+  -
+    description: 'FindOneAndUpdate using pipelines'
+    operations:
+      - object: *collection0
+        name: findOneAndUpdate
+        arguments:
+          filter: { _id: 1 }
+          update:
+            - { $project: { x: 1 } }
+            - { $addFields: { foo: 1 } }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                findAndModify: *collection_name
+                update:
+                  - { $project: { x: 1 } }
+                  - { $addFields: { foo: 1 } }
+              commandName: findAndModify
+              databaseName: *database_name
+    outcome:
+      - collectionName: *collection_name
+        databaseName: *database_name
+        documents:
+          - { _id: 1, x: 1, foo: 1 }
+          - { _id: 2, x: 2, y: 1 }

--- a/test/spec/crud/unified/insertOne-dots_and_dollars.yml
+++ b/test/spec/crud/unified/insertOne-dots_and_dollars.yml
@@ -198,7 +198,7 @@ tests:
           # Using "$db" here works for libmongoc so long as it's a string type;
           # however, neither $ref nor $id would be accepted on their own.
           #
-          # See https://github.com/mongodb/specifications/blob/master/source/extended-json.rst#parsers
+          # See https://github.com/mongodb/specifications/blob/master/source/extended-json.md#parsers
           document: &dbrefLikeKey { _id: 1, a: { $db: "foo" } }
         expectResult: *insertResult
     expectEvents:

--- a/test/spec/crud/unified/updateMany-pipeline.json
+++ b/test/spec/crud/unified/updateMany-pipeline.json
@@ -1,0 +1,142 @@
+{
+  "description": "updateMany-pipeline",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "4.1.11"
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "test",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 1,
+          "y": 1,
+          "t": {
+            "u": {
+              "v": 1
+            }
+          }
+        },
+        {
+          "_id": 2,
+          "x": 2,
+          "y": 1
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "UpdateMany using pipelines",
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "updateMany",
+          "arguments": {
+            "filter": {},
+            "update": [
+              {
+                "$project": {
+                  "x": 1
+                }
+              },
+              {
+                "$addFields": {
+                  "foo": 1
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "matchedCount": 2,
+            "modifiedCount": 2,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "test",
+                  "updates": [
+                    {
+                      "q": {},
+                      "u": [
+                        {
+                          "$project": {
+                            "x": 1
+                          }
+                        },
+                        {
+                          "$addFields": {
+                            "foo": 1
+                          }
+                        }
+                      ],
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                },
+                "commandName": "update",
+                "databaseName": "crud-tests"
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "test",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 1,
+              "foo": 1
+            },
+            {
+              "_id": 2,
+              "x": 2,
+              "foo": 1
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/crud/unified/updateMany-pipeline.yml
+++ b/test/spec/crud/unified/updateMany-pipeline.yml
@@ -1,0 +1,64 @@
+description: updateMany-pipeline
+
+schemaVersion: '1.0'
+
+runOnRequirements:
+  - minServerVersion: 4.1.11
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents:
+        - commandStartedEvent
+  - database:
+      id: &database0 database0
+      client: client0
+      databaseName: &database_name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: database0
+      collectionName: &collection_name test
+
+initialData:
+  - collectionName: *collection_name
+    databaseName: *database_name
+    documents:
+      - { _id: 1, x: 1, y: 1, t: { u: { v: 1 } } }
+      - { _id: 2, x: 2, y: 1 }
+
+tests:
+  -
+    description: 'UpdateMany using pipelines'
+    operations:
+      - object: *collection0
+        name: updateMany
+        arguments:
+          filter: {  }
+          update:
+            - { $project: { x: 1 } }
+            - { $addFields: { foo: 1 } }
+        expectResult:
+          matchedCount: 2
+          modifiedCount: 2
+          upsertedCount: 0
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection_name
+                updates:
+                  - q: {  }
+                    u:
+                      - { $project: { x: 1 } }
+                      - { $addFields: { foo: 1 } }
+                    multi: true
+                    upsert: { $$unsetOrMatches: false }
+              commandName: update
+              databaseName: *database_name
+    outcome:
+      - collectionName: *collection_name
+        databaseName: *database_name
+        documents:
+          - { _id: 1, x: 1, foo: 1 }
+          - { _id: 2, x: 2, foo: 1 }

--- a/test/spec/crud/unified/updateOne-pipeline.json
+++ b/test/spec/crud/unified/updateOne-pipeline.json
@@ -1,0 +1,150 @@
+{
+  "description": "updateOne-pipeline",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "4.1.11"
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "test",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 1,
+          "y": 1,
+          "t": {
+            "u": {
+              "v": 1
+            }
+          }
+        },
+        {
+          "_id": 2,
+          "x": 2,
+          "y": 1
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "UpdateOne using pipelines",
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "updateOne",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": [
+              {
+                "$replaceRoot": {
+                  "newRoot": "$t"
+                }
+              },
+              {
+                "$addFields": {
+                  "foo": 1
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "test",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": [
+                        {
+                          "$replaceRoot": {
+                            "newRoot": "$t"
+                          }
+                        },
+                        {
+                          "$addFields": {
+                            "foo": 1
+                          }
+                        }
+                      ],
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                },
+                "commandName": "update",
+                "databaseName": "crud-tests"
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "test",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "u": {
+                "v": 1
+              },
+              "foo": 1
+            },
+            {
+              "_id": 2,
+              "x": 2,
+              "y": 1
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/spec/crud/unified/updateOne-pipeline.yml
+++ b/test/spec/crud/unified/updateOne-pipeline.yml
@@ -1,0 +1,64 @@
+description: updateOne-pipeline
+
+schemaVersion: '1.0'
+
+runOnRequirements:
+  - minServerVersion: 4.1.11
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents:
+        - commandStartedEvent
+  - database:
+      id: &database0 database0
+      client: client0
+      databaseName: &database_name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: database0
+      collectionName: &collection_name test
+
+initialData:
+  - collectionName: *collection_name
+    databaseName: *database_name
+    documents:
+      - { _id: 1, x: 1, y: 1, t: { u: { v: 1 } } }
+      - { _id: 2, x: 2, y: 1 }
+
+tests:
+  -
+    description: 'UpdateOne using pipelines'
+    operations:
+      - object: *collection0
+        name: updateOne
+        arguments:
+          filter: { _id: 1 }
+          update:
+            - { $replaceRoot: { newRoot: $t } }
+            - { $addFields: { foo: 1 } }
+        expectResult:
+          matchedCount: 1
+          modifiedCount: 1
+          upsertedCount: 0
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection_name
+                updates:
+                  - q: { _id: 1 }
+                    u:
+                      - { $replaceRoot: { newRoot: $t } }
+                      - { $addFields: { foo: 1 } }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+              commandName: update
+              databaseName: *database_name
+    outcome:
+      - collectionName: *collection_name
+        databaseName: *database_name
+        documents:
+          - { _id: 1, u: { v: 1 }, foo: 1 }
+          - { _id: 2, x: 2, y: 1 }


### PR DESCRIPTION
### Description

#### What is changing?

This PR syncs all CRUD unified tests to latest and skips any tests for features we have not implemented.

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
