### PR TITLE
fix(NODE-7131): dont add duplicate metadata

### DIFF
--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -493,7 +493,7 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> implements
    */
   appendMetadata(driverInfo: DriverInfo) {
     for (const info of this.options.additionalDriverInfo) {
-      if (info.name === driverInfo.name) {
+      if (info.name === driverInfo.name && info.version === driverInfo.version) {
         return;
       }
     }

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -492,6 +492,11 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> implements
    * @param driverInfo - Information about the application or library.
    */
   appendMetadata(driverInfo: DriverInfo) {
+    for (const info of this.options.additionalDriverInfo) {
+      if (info.name === driverInfo.name) {
+        return;
+      }
+    }
     this.options.additionalDriverInfo.push(driverInfo);
     this.options.metadata = makeClientMetadata(this.options);
     this.options.extendedMetadata = addContainerMetadata(this.options.metadata)

--- a/test/integration/mongodb-handshake/mongodb-handshake.prose.test.ts
+++ b/test/integration/mongodb-handshake/mongodb-handshake.prose.test.ts
@@ -355,6 +355,13 @@ describe('Client Metadata Update Prose Tests', function () {
           // (Note os is the only one getting set in these tests)
           expect(updatedClientMetadata.os).to.deep.equal(initialClientMetadata.os);
         });
+
+        it('does not append duplicate metadata for the same name', async function () {
+          client.appendMetadata({ name, version, platform });
+          client.appendMetadata({ name, version, platform });
+          await client.db('test').command({ ping: 1 });
+          expect(updatedClientMetadata.driver.name).to.not.contain('|framework|framework');
+        });
       });
     }
   });

--- a/test/integration/mongodb-handshake/mongodb-handshake.prose.test.ts
+++ b/test/integration/mongodb-handshake/mongodb-handshake.prose.test.ts
@@ -356,11 +356,17 @@ describe('Client Metadata Update Prose Tests', function () {
           expect(updatedClientMetadata.os).to.deep.equal(initialClientMetadata.os);
         });
 
-        it('does not append duplicate metadata for the same name', async function () {
+        it('does not append duplicate metadata for the same name and version', async function () {
           client.appendMetadata({ name, version, platform });
           client.appendMetadata({ name, version, platform });
           await client.db('test').command({ ping: 1 });
           expect(updatedClientMetadata.driver.name).to.not.contain('|framework|framework');
+        });
+
+        it('appends metadata when the version differs', async function () {
+          client.appendMetadata({ name, version: '0.0', platform });
+          await client.db('test').command({ ping: 1 });
+          expect(updatedClientMetadata.driver.name).to.not.contain('0.0');
         });
       });
     }


### PR DESCRIPTION
### Description

Prevents duplicate metadata for the same driver info name to be appended.

#### What is changing?

Checks the name of the driver info being appended. If it exists, it does not get added.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-7073

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
