### PR TITLE
feat(NODE-7134): allow hint with unacknowledged writes for delete, update and findAndModify commands

### DIFF
--- a/src/operations/update.ts
+++ b/src/operations/update.ts
@@ -1,13 +1,12 @@
 import type { Document } from '../bson';
 import { type Connection } from '../cmap/connection';
 import { MongoDBResponse } from '../cmap/wire_protocol/responses';
-import { MongoCompatibilityError, MongoInvalidArgumentError, MongoServerError } from '../error';
+import { MongoInvalidArgumentError, MongoServerError } from '../error';
 import type { InferIdType } from '../mongo_types';
 import type { ClientSession } from '../sessions';
 import { formatSort, type Sort, type SortForCmd } from '../sort';
 import {
   hasAtomicOperators,
-  maxWireVersion,
   type MongoDBCollectionNamespace,
   type MongoDBNamespace
 } from '../utils';

--- a/src/operations/update.ts
+++ b/src/operations/update.ts
@@ -7,6 +7,7 @@ import type { ClientSession } from '../sessions';
 import { formatSort, type Sort, type SortForCmd } from '../sort';
 import {
   hasAtomicOperators,
+  maxWireVersion,
   type MongoDBCollectionNamespace,
   type MongoDBNamespace
 } from '../utils';
@@ -119,14 +120,6 @@ export class UpdateOperation extends CommandOperation<Document> {
     // eslint-disable-next-line no-restricted-syntax
     if (options.comment !== undefined) {
       command.comment = options.comment;
-    }
-
-    const unacknowledgedWrite = this.writeConcern?.w === 0;
-    if (unacknowledgedWrite) {
-      if (this.statements.find((o: Document) => o.hint)) {
-        // TODO(NODE-3541): fix error for hint with unacknowledged writes
-        throw new MongoCompatibilityError(`hint is not supported with unacknowledged writes`);
-      }
     }
 
     return command;

--- a/test/integration/crud/crud.spec.test.ts
+++ b/test/integration/crud/crud.spec.test.ts
@@ -3,35 +3,6 @@ import * as path from 'path';
 import { loadSpecTests } from '../../spec/index';
 import { runUnifiedSuite } from '../../tools/unified-spec-runner/runner';
 
-const unacknowledgedHintTests = [
-  'Unacknowledged updateOne with hint document on 4.2+ server',
-  'Unacknowledged updateOne with hint string on 4.2+ server',
-  'Unacknowledged updateMany with hint document on 4.2+ server',
-  'Unacknowledged updateMany with hint string on 4.2+ server',
-  'Unacknowledged replaceOne with hint document on 4.2+ server',
-  'Unacknowledged replaceOne with hint string on 4.2+ server',
-  'Unacknowledged updateOne with hint document on 4.2+ server',
-  'Unacknowledged updateOne with hint string on 4.2+ server',
-  'Unacknowledged updateMany with hint document on 4.2+ server',
-  'Unacknowledged updateMany with hint string on 4.2+ server',
-  'Unacknowledged replaceOne with hint document on 4.2+ server',
-  'Unacknowledged replaceOne with hint string on 4.2+ server',
-  'Unacknowledged findOneAndUpdate with hint document on 4.4+ server',
-  'Unacknowledged findOneAndUpdate with hint string on 4.4+ server',
-  'Unacknowledged findOneAndReplace with hint document on 4.4+ server',
-  'Unacknowledged findOneAndReplace with hint string on 4.4+ server',
-  'Unacknowledged findOneAndDelete with hint document on 4.4+ server',
-  'Unacknowledged findOneAndDelete with hint string on 4.4+ server',
-  'Unacknowledged deleteOne with hint document on 4.4+ server',
-  'Unacknowledged deleteOne with hint string on 4.4+ server',
-  'Unacknowledged deleteMany with hint document on 4.4+ server',
-  'Unacknowledged deleteMany with hint string on 4.4+ server',
-  'Unacknowledged deleteOne with hint document on 4.4+ server',
-  'Unacknowledged deleteOne with hint string on 4.4+ server',
-  'Unacknowledged deleteMany with hint document on 4.4+ server',
-  'Unacknowledged deleteMany with hint string on 4.4+ server'
-];
-
 const loadBalancedCollationTests = [
   'FindOneAndUpdate when many documents match with collation returning the document before modification',
   'FindOneAndReplace when one document matches with collation returning the document after modification',
@@ -70,13 +41,10 @@ describe('CRUD unified', function () {
   runUnifiedSuite(
     loadSpecTests(path.join('crud', 'unified')),
     ({ description }, { isLoadBalanced }) => {
-      return unacknowledgedHintTests.includes(description)
-        ? `TODO(NODE-3541)`
-        : isLoadBalanced && loadBalancedCollationTests.includes(description)
-          ? `TODO(NODE-6280): fix collation for find and modify commands on load balanced mode`
-          : description in unimplementedCrudTests
-            ? unimplementedCrudTests[description]
-            : false;
+      if (isLoadBalanced && loadBalancedCollationTests.includes(description)) {
+        return `TODO(NODE-6280): fix collation for find and modify commands on load balanced mode`;
+      }
+      return unimplementedCrudTests[description] ?? false;
     }
   );
 });


### PR DESCRIPTION
### Description

#### What is changing?

With these changes, the driver only throws errors when an unacknowledged write is used with a hint when the server does not support `hint`.  This occurs in the following scenarios:

- update commands: **never** (this is supported 4.2+, 4.2 is our minimum supported server version)
- findAndModify and delete commands: 4.4+

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Hint is supported with unacknowledged writes for delete, update and findAndModify commands on servers that support hint

The driver no longer throws errors when `hint` is provided to unacknowledged writes for delete, update and findOneModify commands in the following circumstances:

- No error is thrown for update commands.
- No errors are thrown for delete and findAndModify commands on servers >=4.4.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
