### PR TITLE
chore: fix yargs import in docs build

### DIFF
--- a/etc/docs/utils.ts
+++ b/etc/docs/utils.ts
@@ -1,6 +1,6 @@
 import { createInterface } from 'readline';
 import * as util from 'util';
-import yargs from 'yargs';
+import * as yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 
 export const LATEST_TAG = 'Next';


### PR DESCRIPTION
### Description

#### What is changing?

Updates import of `yargs` in our documentation tooling to work with `yargs@11`.  Docs build locally for me:

```
bailey.pearson:node-mongodb-native (fix-yargs) % npm run build:docs -- --yes   

> mongodb@6.19.0 build:docs
> ./etc/docs/build.ts --yes

[ 'Installing dependencies...' ]
[ 'Building docs for current branch' ]
[ 'Generating new static site...' ]
[ 'Successfully generated api documentation and updated the doc site.' ]
```

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
