### PR TITLE
fix(NODE-7138): prevent duplicate metadata from being appended to handshake metadata

### DIFF
--- a/src/cmap/handshake/client_metadata.ts
+++ b/src/cmap/handshake/client_metadata.ts
@@ -11,10 +11,18 @@ const NODE_DRIVER_VERSION = require('../../../package.json').version;
 
 /** @internal */
 export function isDriverInfoEqual(info1: DriverInfo, info2: DriverInfo): boolean {
+  /** for equality comparison, we consider "" as unset */
+  const nonEmptyCmp = (s1: string | undefined, s2: string | undefined): boolean => {
+    s1 ||= undefined;
+    s2 ||= undefined;
+
+    return s1 === s2;
+  };
+
   return (
-    info1.name === info2.name &&
-    info1.platform === info2.platform &&
-    info1.version === info2.version
+    nonEmptyCmp(info1.name, info2.name) &&
+    nonEmptyCmp(info1.platform, info2.platform) &&
+    nonEmptyCmp(info1.version, info2.version)
   );
 }
 

--- a/src/cmap/handshake/client_metadata.ts
+++ b/src/cmap/handshake/client_metadata.ts
@@ -99,10 +99,7 @@ export class LimitedSizeDocument {
   }
 }
 
-type MakeClientMetadataOptions = Pick<
-  MongoOptions,
-  'appName' | 'driverInfo' | 'additionalDriverInfo'
->;
+type MakeClientMetadataOptions = Pick<MongoOptions, 'appName' | 'additionalDriverInfo'>;
 /**
  * From the specs:
  * Implementors SHOULD cumulatively update fields in the following order until the document is under the size limit:

--- a/src/cmap/handshake/client_metadata.ts
+++ b/src/cmap/handshake/client_metadata.ts
@@ -117,7 +117,7 @@ type MakeClientMetadataOptions = Pick<MongoOptions, 'appName'>;
  * 4. Truncate `platform`. -- special we do not truncate this field
  */
 export function makeClientMetadata(
-  driverInfos: DriverInfo[],
+  driverInfoList: DriverInfo[],
   { appName = '' }: MakeClientMetadataOptions
 ): ClientMetadata {
   const metadataDocument = new LimitedSizeDocument(512);
@@ -137,7 +137,7 @@ export function makeClientMetadata(
   };
 
   // This is where we handle additional driver info added after client construction.
-  for (const { name: n = '', version: v = '' } of driverInfos) {
+  for (const { name: n = '', version: v = '' } of driverInfoList) {
     if (n.length > 0) {
       driverInfo.name = `${driverInfo.name}|${n}`;
     }
@@ -154,7 +154,7 @@ export function makeClientMetadata(
 
   let runtimeInfo = getRuntimeInfo();
   // This is where we handle additional driver info added after client construction.
-  for (const { platform = '' } of driverInfos) {
+  for (const { platform = '' } of driverInfoList) {
     if (platform.length > 0) {
       runtimeInfo = `${runtimeInfo}|${platform}`;
     }

--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -5,7 +5,6 @@ import { URLSearchParams } from 'url';
 import type { Document } from './bson';
 import { MongoCredentials } from './cmap/auth/mongo_credentials';
 import { AUTH_MECHS_AUTH_SRC_EXTERNAL, AuthMechanism } from './cmap/auth/providers';
-import { addContainerMetadata, makeClientMetadata } from './cmap/handshake/client_metadata';
 import { Compressor, type CompressorName } from './cmap/wire_protocol/compression';
 import { Encrypter } from './encrypter';
 import {

--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -535,16 +535,6 @@ export function parseOptions(
     }
   );
 
-  // Set the default for the additional driver info.
-  mongoOptions.additionalDriverInfo = [];
-
-  mongoOptions.metadata = makeClientMetadata(mongoOptions);
-
-  mongoOptions.extendedMetadata = addContainerMetadata(mongoOptions.metadata).then(
-    undefined,
-    squashError
-  ); // rejections will be handled later
-
   return mongoOptions;
 }
 

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -431,13 +431,14 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> implements
       | 'extendedMetadata'
     >;
 
+  private driverInfos: DriverInfo[] = [];
+
   constructor(url: string, options?: MongoClientOptions) {
     super();
     this.on('error', noop);
 
     this.options = parseOptions(url, this, options);
 
-    this.options.additionalDriverInfo = [];
     this.appendMetadata(this.options.driverInfo);
 
     const shouldSetLogger = Object.values(this.options.mongoLoggerOptions.componentSeverities).some(
@@ -496,13 +497,13 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> implements
    * @param driverInfo - Information about the application or library.
    */
   appendMetadata(driverInfo: DriverInfo) {
-    const isDuplicateDriverInfo = this.options.additionalDriverInfo.some(info =>
+    const isDuplicateDriverInfo = this.driverInfos.some(info =>
       isDriverInfoEqual(info, driverInfo)
     );
     if (isDuplicateDriverInfo) return;
 
-    this.options.additionalDriverInfo.push(driverInfo);
-    this.options.metadata = makeClientMetadata(this.options);
+    this.driverInfos.push(driverInfo);
+    this.options.metadata = makeClientMetadata(this.driverInfos, this.options);
     this.options.extendedMetadata = addContainerMetadata(this.options.metadata)
       .then(undefined, squashError)
       .then(result => result ?? {}); // ensure Promise<Document>

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -431,7 +431,7 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> implements
       | 'extendedMetadata'
     >;
 
-  private driverInfos: DriverInfo[] = [];
+  private driverInfoList: DriverInfo[] = [];
 
   constructor(url: string, options?: MongoClientOptions) {
     super();
@@ -497,13 +497,13 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> implements
    * @param driverInfo - Information about the application or library.
    */
   appendMetadata(driverInfo: DriverInfo) {
-    const isDuplicateDriverInfo = this.driverInfos.some(info =>
+    const isDuplicateDriverInfo = this.driverInfoList.some(info =>
       isDriverInfoEqual(info, driverInfo)
     );
     if (isDuplicateDriverInfo) return;
 
-    this.driverInfos.push(driverInfo);
-    this.options.metadata = makeClientMetadata(this.driverInfos, this.options);
+    this.driverInfoList.push(driverInfo);
+    this.options.metadata = makeClientMetadata(this.driverInfoList, this.options);
     this.options.extendedMetadata = addContainerMetadata(this.options.metadata)
       .then(undefined, squashError)
       .then(result => result ?? {}); // ensure Promise<Document>

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -492,6 +492,11 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> implements
    * @param driverInfo - Information about the application or library.
    */
   appendMetadata(driverInfo: DriverInfo) {
+    for (const info of this.options.additionalDriverInfo) {
+      if (info.name === driverInfo.name) {
+        return;
+      }
+    }
     this.options.additionalDriverInfo.push(driverInfo);
     this.options.metadata = makeClientMetadata(this.options);
     this.options.extendedMetadata = addContainerMetadata(this.options.metadata)

--- a/test/integration/connection-monitoring-and-pooling/connection.test.ts
+++ b/test/integration/connection-monitoring-and-pooling/connection.test.ts
@@ -49,10 +49,8 @@ describe('Connection', function () {
           ...commonConnectOptions,
           connectionType: Connection,
           ...this.configuration.options,
-          metadata: makeClientMetadata({ driverInfo: {}, additionalDriverInfo: [] }),
-          extendedMetadata: addContainerMetadata(
-            makeClientMetadata({ driverInfo: {}, additionalDriverInfo: [] })
-          )
+          metadata: makeClientMetadata([], {}),
+          extendedMetadata: addContainerMetadata(makeClientMetadata([], {}))
         };
 
         let conn;
@@ -74,10 +72,8 @@ describe('Connection', function () {
           connectionType: Connection,
           ...this.configuration.options,
           monitorCommands: true,
-          metadata: makeClientMetadata({ driverInfo: {}, additionalDriverInfo: [] }),
-          extendedMetadata: addContainerMetadata(
-            makeClientMetadata({ driverInfo: {}, additionalDriverInfo: [] })
-          )
+          metadata: makeClientMetadata([], {}),
+          extendedMetadata: addContainerMetadata(makeClientMetadata([], {}))
         };
 
         let conn;
@@ -108,10 +104,8 @@ describe('Connection', function () {
           connectionType: Connection,
           ...this.configuration.options,
           monitorCommands: true,
-          metadata: makeClientMetadata({ driverInfo: {}, additionalDriverInfo: [] }),
-          extendedMetadata: addContainerMetadata(
-            makeClientMetadata({ driverInfo: {}, additionalDriverInfo: [] })
-          )
+          metadata: makeClientMetadata([], {}),
+          extendedMetadata: addContainerMetadata(makeClientMetadata([], {}))
         };
 
         let conn;

--- a/test/integration/mongodb-handshake/mongodb-handshake.prose.test.ts
+++ b/test/integration/mongodb-handshake/mongodb-handshake.prose.test.ts
@@ -412,7 +412,10 @@ describe('Client Metadata Update Prose Tests', function () {
         // 4. Save intercepted `client` document as `updatedClientMetadata`.
         // 5. Wait 5ms for the connection to become idle.
         beforeEach(async function () {
-          client = new RawMongoClient(this.configuration.url(), { maxIdleTimeMS: 1 });
+          client = new RawMongoClient(this.configuration.url(), {
+            maxIdleTimeMS: 1,
+            serverApi: this.configuration.serverApi
+          });
           client.appendMetadata(originalDriverInfo);
 
           sinon
@@ -515,6 +518,7 @@ describe('Client Metadata Update Prose Tests', function () {
       //     | platform | Library Platform |
       client = new RawMongoClient(this.configuration.url(), {
         maxIdleTimeMS: 1,
+        serverApi: this.configuration.serverApi,
         driverInfo: { name: 'library', version: '1.2', platform: 'Library Platform' }
       });
 

--- a/test/integration/mongodb-handshake/mongodb-handshake.prose.test.ts
+++ b/test/integration/mongodb-handshake/mongodb-handshake.prose.test.ts
@@ -1,10 +1,13 @@
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 
+import { type ClientMetadata } from '../../../mongodb';
+import { MongoClient as RawMongoClient } from '../../../src';
 import {
   Connection,
   getFAASEnv,
   Int32,
+  isDriverInfoEqual,
   LEGACY_HELLO_COMMAND,
   type MongoClient
 } from '../../mongodb';
@@ -364,5 +367,192 @@ describe('Client Metadata Update Prose Tests', function () {
         });
       });
     }
+  });
+
+  describe('Test 3: Multiple Successive Metadata Updates with Identical/Partially Identical `DriverInfo`', function () {
+    const originalDriverInfo = { name: 'library', version: '1.2', platform: 'Library Platform' };
+    let initialClientMetadata: ClientMetadata;
+    let updatedClientMetadata: ClientMetadata;
+    let client: RawMongoClient;
+
+    // | Case | Name      | Version | Platform           |
+    // | ---- | --------- | ------- | ------------------ |
+    // | 1    | library   | 1.2     | Library Platform   |
+    // | 2    | framework | 1.2     | Library Platform   |
+    // | 3    | library   | 2.0     | Library Platform   |
+    // | 4    | library   | 1.2     | Framework Platform |
+    // | 5    | framework | 2.0     | Library Platform   |
+    // | 6    | framework | 1.2     | Framework Platform |
+    // | 7    | library   | 2.0     | Framework Platform |
+    // | 8    | framework | 2.0     | Framework Platform |
+    const tests = [
+      { testCase: 1, name: 'library', version: '1.2', platform: 'Library Platform' },
+      { testCase: 2, name: 'framework', version: '1.2', platform: 'Library Platform' },
+      { testCase: 3, name: 'library', version: '2.0', platform: 'Library Platform' },
+      { testCase: 4, name: 'library', version: '1.2', platform: 'Framework Platform' },
+      { testCase: 5, name: 'framework', version: '2.0', platform: 'Library Platform' },
+      { testCase: 6, name: 'framework', version: '1.2', platform: 'Framework Platform' },
+      { testCase: 7, name: 'library', version: '2.0', platform: 'Framework Platform' },
+      { testCase: 8, name: 'framework', version: '2.0', platform: 'Framework Platform' }
+    ];
+
+    for (const { testCase, ...driverInfo } of tests) {
+      context(`Case ${testCase}: ${JSON.stringify(driverInfo)}`, function () {
+        // 1. Create a `MongoClient` instance with:
+        //     - `maxIdleTimeMS` set to `1ms`
+        // 2. Append the following `DriverInfoOptions` to the `MongoClient` metadata:
+        //     | Field    | Value            |
+        //     | -------- | ---------------- |
+        //     | name     | library          |
+        //     | version  | 1.2              |
+        //     | platform | Library Platform |
+        // 3. Send a `ping` command to the server and verify that the command succeeds.
+        // 4. Save intercepted `client` document as `updatedClientMetadata`.
+        // 5. Wait 5ms for the connection to become idle.
+        beforeEach(async function () {
+          client = new RawMongoClient(this.configuration.url(), { maxIdleTimeMS: 1 });
+          client.appendMetadata(originalDriverInfo);
+
+          sinon
+            .stub(Connection.prototype, 'command')
+            .callsFake(async function (ns, cmd, options, responseType) {
+              // @ts-expect-error: sinon will place wrappedMethod on the command method.
+              const command = Connection.prototype.command.wrappedMethod.bind(this);
+
+              if (cmd.hello || cmd[LEGACY_HELLO_COMMAND]) {
+                if (!initialClientMetadata) {
+                  initialClientMetadata = cmd.client;
+                } else {
+                  updatedClientMetadata = cmd.client;
+                }
+              }
+              return command(ns, cmd, options, responseType);
+            });
+
+          await client.db('test').command({ ping: 1 });
+          await sleep(5);
+        });
+
+        afterEach(async function () {
+          await client.close();
+        });
+
+        it('metadata is updated correctly, if necessary', async function () {
+          // 1. Append the `DriverInfoOptions` from the selected test case to the `MongoClient` metadata.
+          client.appendMetadata(driverInfo);
+
+          // 2. Send a `ping` command to the server and verify:
+          //     - The command succeeds.
+          await client.db('test').command({ ping: 1 });
+
+          // - The framework metadata is appended to the existing `DriverInfoOptions` in the `client.driver` fields of the `hello`
+          //     command, with values separated by a pipe `|`.  To simplify assertions in these tests, strip out the default driver info
+          //     that is automatically added by the driver (ex: `metadata.name.split('|').slice(1).join('|')`).
+
+          // - If the test case's DriverInfo is identical to the driver info from setup step 2 (test case 1):
+          //     - Assert metadata.name is equal to `library`
+          //     - Assert metadata.version is equal to `1.2`
+          //     - Assert metadata.platform is equal to `LibraryPlatform`
+          // - Otherwise:
+          //     - Assert metadata.name is equal to `library|<name>`
+          //     - Assert metadata.version is equal to `1.2|<version>`
+          //     - Assert metadata.platform is equal to `LibraryPlatform|<platform>`
+          const { driver, platform, ...updatedRest } = updatedClientMetadata;
+          const { driver: _driver, platform: _platform, ...originalRest } = initialClientMetadata;
+
+          const extractParts = (s: string) => s.split('|').slice(1).join('|');
+
+          const actual = {
+            name: extractParts(driver.name),
+            version: extractParts(driver.version),
+            platform: extractParts(platform)
+          };
+
+          const expected = isDriverInfoEqual(driverInfo, originalDriverInfo)
+            ? originalDriverInfo
+            : {
+                name: `library|${driverInfo.name}`,
+                platform: `Library Platform|${driverInfo.platform}`,
+                version: `1.2|${driverInfo.version}`
+              };
+
+          expect(actual).to.deep.equal(expected);
+
+          // All other subfields in the `client` document remain unchanged from `updatedClientMetadata`.
+          expect(updatedRest).to.deep.equal(originalRest);
+        });
+      });
+    }
+  });
+
+  describe('Test 4: Metadata is not appended if identical to initial metadata', function () {
+    let initialClientMetadata;
+    let updatedClientMetadata;
+
+    // 1. Create a `MongoClient` instance with the following:
+    //     - `maxIdleTimeMS` set to `1ms`
+    //     - Wrapping library metadata:
+    //         | Field    | Value            |
+    //         | -------- | ---------------- |
+    //         | name     | library          |
+    //         | version  | 1.2              |
+    //         | platform | Library Platform |
+    // 2. Send a `ping` command to the server and verify that the command succeeds.
+    // 3. Save intercepted `client` document as `initialClientMetadata`.
+    // 4. Wait 5ms for the connection to become idle.
+    beforeEach(async function () {
+      // 1. Create a `MongoClient` instance with:
+      //     - `maxIdleTimeMS` set to `1ms`
+      //     - `driverInfo` set to the following:
+      //     | Field    | Value            |
+      //     | -------- | ---------------- |
+      //     | name     | library          |
+      //     | version  | 1.2              |
+      //     | platform | Library Platform |
+      client = new RawMongoClient(this.configuration.url(), {
+        maxIdleTimeMS: 1,
+        driverInfo: { name: 'library', version: '1.2', platform: 'Library Platform' }
+      });
+
+      // 2. Send a `ping` command to the server and verify that the command succeeds.
+      // 3. Save intercepted `client` document as `clientMetadata`.
+      sinon
+        .stub(Connection.prototype, 'command')
+        .callsFake(async function (ns, cmd, options, responseType) {
+          // @ts-expect-error: sinon will place wrappedMethod on the command method.
+          const command = Connection.prototype.command.wrappedMethod.bind(this);
+
+          if (cmd.hello || cmd[LEGACY_HELLO_COMMAND]) {
+            if (!initialClientMetadata) {
+              initialClientMetadata = cmd.client;
+            } else {
+              updatedClientMetadata = cmd.client;
+            }
+          }
+          return command(ns, cmd, options, responseType);
+        });
+
+      await client.db('test').command({ ping: 1 });
+
+      // 4. Wait 5ms for the connection to become idle.
+      await sleep(5);
+    });
+
+    it('appends the metadata', async function () {
+      // 5. Append the following `DriverInfoOptions` to the `MongoClient` metadata:
+      //     | Field    | Value            |
+      //     | -------- | ---------------- |
+      //     | name     | library          |
+      //     | version  | 1.2              |
+      //     | platform | Library Platform |
+      client.appendMetadata({ name: 'library', version: '1.2', platform: 'Library Platform' });
+
+      // 6. Send a `ping` command to the server and verify that the command succeeds.
+      // 7. Save intercepted `client` document as `updatedClientMetadata`.
+      await client.db('test').command({ ping: 1 });
+
+      // 8. Assert that `clientMetadata` is identical to `updatedClientMetadata`.
+      expect(initialClientMetadata).to.deep.equal(updatedClientMetadata);
+    });
   });
 });

--- a/test/integration/mongodb-handshake/mongodb-handshake.prose.test.ts
+++ b/test/integration/mongodb-handshake/mongodb-handshake.prose.test.ts
@@ -355,6 +355,13 @@ describe('Client Metadata Update Prose Tests', function () {
           // (Note os is the only one getting set in these tests)
           expect(updatedClientMetadata.os).to.deep.equal(initialClientMetadata.os);
         });
+
+        it('does not append duplicate metadata for the same name', async function () {
+          client.appendMetadata({ name, version, platform });
+          client.appendMetadata({ name, version, platform });
+          await client.db('test').command({ ping: 1 });
+          expect(updatedClientMetadata.driver.name).to.not.contain('|framework|framework');
+        });
       });
     }
   });

--- a/test/integration/mongodb-handshake/mongodb-handshake.prose.test.ts
+++ b/test/integration/mongodb-handshake/mongodb-handshake.prose.test.ts
@@ -358,18 +358,11 @@ describe('Client Metadata Update Prose Tests', function () {
           // (Note os is the only one getting set in these tests)
           expect(updatedClientMetadata.os).to.deep.equal(initialClientMetadata.os);
         });
-
-        it('does not append duplicate metadata for the same name', async function () {
-          client.appendMetadata({ name, version, platform });
-          client.appendMetadata({ name, version, platform });
-          await client.db('test').command({ ping: 1 });
-          expect(updatedClientMetadata.driver.name).to.not.contain('|framework|framework');
-        });
       });
     }
   });
 
-  describe('Test 3: Multiple Successive Metadata Updates with Identical/Partially Identical `DriverInfo`', function () {
+  describe('Test 3: Multiple Successive Metadata Updates with Duplicate Data', function () {
     const originalDriverInfo = { name: 'library', version: '1.2', platform: 'Library Platform' };
     let initialClientMetadata: ClientMetadata;
     let updatedClientMetadata: ClientMetadata;
@@ -386,7 +379,6 @@ describe('Client Metadata Update Prose Tests', function () {
     // | 5    | framework | 2.0     | Library Platform   |
     // | 6    | framework | 1.2     | Framework Platform |
     // | 7    | library   | 2.0     | Framework Platform |
-    // | 8    | framework | 2.0     | Framework Platform |
     const tests = [
       { testCase: 1, name: 'library', version: '1.2', platform: 'Library Platform' },
       { testCase: 2, name: 'framework', version: '1.2', platform: 'Library Platform' },
@@ -642,7 +634,7 @@ describe('Client Metadata Update Prose Tests', function () {
       await client.close();
     });
 
-    it('appends the metadata', async function () {
+    it('does not append the duplicate metadata', async function () {
       // 5. Append the following `DriverInfoOptions` to the `MongoClient` metadata:
       //     | Field    | Value            |
       //     | -------- | ---------------- |
@@ -661,7 +653,7 @@ describe('Client Metadata Update Prose Tests', function () {
   });
 
   describe('Test 6: Metadata is not appended if identical to initial metadata (separated by non-identical metadata)', function () {
-    let initialClientMetadata: ClientMetadata;
+    let clientMetadata: ClientMetadata;
     let updatedClientMetadata: ClientMetadata;
     // TODO(NODE-6599): mongodb-legacy adds additional client metadata, breaking these prose tests
     let client: RawMongoClient;
@@ -718,8 +710,8 @@ describe('Client Metadata Update Prose Tests', function () {
           const command = Connection.prototype.command.wrappedMethod.bind(this);
 
           if (cmd.hello || cmd[LEGACY_HELLO_COMMAND]) {
-            if (!initialClientMetadata) {
-              initialClientMetadata = cmd.client;
+            if (!clientMetadata) {
+              clientMetadata = cmd.client;
             } else {
               updatedClientMetadata = cmd.client;
             }
@@ -748,7 +740,7 @@ describe('Client Metadata Update Prose Tests', function () {
       await client.db('test').command({ ping: 1 });
 
       // 11. Assert that `clientMetadata` is identical to `updatedClientMetadata`.
-      expect(updatedClientMetadata).to.deep.equal(initialClientMetadata);
+      expect(updatedClientMetadata).to.deep.equal(clientMetadata);
     });
   });
 

--- a/test/integration/mongodb-handshake/mongodb-handshake.prose.test.ts
+++ b/test/integration/mongodb-handshake/mongodb-handshake.prose.test.ts
@@ -373,6 +373,8 @@ describe('Client Metadata Update Prose Tests', function () {
     const originalDriverInfo = { name: 'library', version: '1.2', platform: 'Library Platform' };
     let initialClientMetadata: ClientMetadata;
     let updatedClientMetadata: ClientMetadata;
+
+    // TODO(NODE-6599): mongodb-legacy adds additional client metadata, breaking these prose tests
     let client: RawMongoClient;
 
     // | Case | Name      | Version | Platform           |
@@ -486,8 +488,10 @@ describe('Client Metadata Update Prose Tests', function () {
   });
 
   describe('Test 4: Metadata is not appended if identical to initial metadata', function () {
-    let initialClientMetadata;
-    let updatedClientMetadata;
+    let initialClientMetadata: ClientMetadata;
+    let updatedClientMetadata: ClientMetadata;
+    // TODO(NODE-6599): mongodb-legacy adds additional client metadata, breaking these prose tests
+    let client: RawMongoClient;
 
     // 1. Create a `MongoClient` instance with the following:
     //     - `maxIdleTimeMS` set to `1ms`
@@ -536,6 +540,10 @@ describe('Client Metadata Update Prose Tests', function () {
 
       // 4. Wait 5ms for the connection to become idle.
       await sleep(5);
+    });
+
+    afterEach(async function () {
+      await client.close();
     });
 
     it('appends the metadata', async function () {

--- a/test/tools/runner/filters/api_version_filter.ts
+++ b/test/tools/runner/filters/api_version_filter.ts
@@ -18,7 +18,11 @@ export class ApiVersionFilter extends Filter {
   constructor() {
     super();
     // Get environmental variables that are known
-    this.apiVersion = process.env.MONGODB_API_VERSION;
+    this.apiVersion =
+      typeof process.env.MONGODB_API_VERSION === 'string' &&
+      process.env.MONGODB_API_VERSION.length > 0
+        ? process.env.MONGODB_API_VERSION
+        : undefined;
   }
 
   override async initializeFilter(

--- a/test/tools/runner/filters/api_version_filter.ts
+++ b/test/tools/runner/filters/api_version_filter.ts
@@ -1,3 +1,4 @@
+import { type MongoClient } from '../../../mongodb';
 import { Filter } from './filter';
 
 /**
@@ -18,6 +19,13 @@ export class ApiVersionFilter extends Filter {
     super();
     // Get environmental variables that are known
     this.apiVersion = process.env.MONGODB_API_VERSION;
+  }
+
+  override async initializeFilter(
+    _client: MongoClient,
+    context: Record<string, any>
+  ): Promise<void> {
+    context.serverApi = this.apiVersion;
   }
 
   filter(test: { metadata?: MongoDBMetadataUI }) {

--- a/test/tools/runner/hooks/configuration.ts
+++ b/test/tools/runner/hooks/configuration.ts
@@ -40,7 +40,6 @@ process.env.MONGODB_URI =
 //  determine the connection string based on the value of process.env.AUTH
 const MONGODB_URI = process.env.MONGODB_URI;
 
-const MONGODB_API_VERSION = process.env.MONGODB_API_VERSION;
 // Load balancer fronting 1 mongos.
 const SINGLE_MONGOS_LB_URI = process.env.SINGLE_MONGOS_LB_URI;
 // Load balancer fronting 2 mongoses.
@@ -126,10 +125,6 @@ const testConfigBeforeHook = async function () {
 
   const context = await initializeFilters(client);
 
-  if (MONGODB_API_VERSION) {
-    context.serverApi = MONGODB_API_VERSION;
-  }
-
   if (SINGLE_MONGOS_LB_URI && MULTI_MONGOS_LB_URI) {
     context.singleMongosLoadBalancerUri = SINGLE_MONGOS_LB_URI;
     context.multiMongosLoadBalancerUri = MULTI_MONGOS_LB_URI;
@@ -167,7 +162,7 @@ const testConfigBeforeHook = async function () {
     },
     cryptSharedVersion: context.cryptSharedVersion,
     cryptSharedLibPath: process.env.CRYPT_SHARED_LIB_PATH,
-    serverApi: MONGODB_API_VERSION,
+    serverApi: process.env.MONGODB_API_VERSION,
     atlas: process.env.ATLAS_CONNECTIVITY != null,
     aws: MONGODB_URI.includes('authMechanism=MONGODB-AWS'),
     awsSdk: process.env.MONGODB_AWS_SDK,

--- a/test/unit/sdam/topology.test.ts
+++ b/test/unit/sdam/topology.test.ts
@@ -53,10 +53,8 @@ describe('Topology (unit)', function () {
 
     it('should correctly pass appname', function () {
       const server: Topology = topologyWithPlaceholderClient([`localhost:27017`], {
-        metadata: makeClientMetadata({
-          appName: 'My application name',
-          driverInfo: {},
-          additionalDriverInfo: []
+        metadata: makeClientMetadata([], {
+          appName: 'My application name'
         })
       });
 


### PR DESCRIPTION
### Description

#### What is changing?

This PR is a POC implementation for https://github.com/mongodb/specifications/pull/1833. 

Additionally, while working on the implementation, I decided to simplify the handshake metadata logic by using `MongoClient.appendMetadata()` to append the driverInfo provided to the MongoClient, if any was provided.  


### Double check the following

- [x] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
