### PR TITLE
refactor(NODE-7148): make rawData internal

### DIFF
--- a/src/operations/command.ts
+++ b/src/operations/command.ts
@@ -67,8 +67,8 @@ export interface CommandOperationOptions
 
   /**
    * Used when the command needs to grant access to the underlying namespaces for time series collections.
-   * Only available on server versions 8.2 and above.
-   * @public
+   * Only available on server versions 8.2 and above and is not meant for public use.
+   * @internal
    * @sinceServerVersion 8.2
    **/
   rawData?: boolean;

--- a/src/operations/indexes.ts
+++ b/src/operations/indexes.ts
@@ -356,6 +356,8 @@ export class DropIndexOperation extends CommandOperation<Document> {
 export type ListIndexesOptions = AbstractCursorOptions & {
   /** @internal */
   omitMaxTimeMS?: boolean;
+  /** @internal */
+  rawData?: boolean;
 };
 
 /** @internal */
@@ -368,7 +370,7 @@ export class ListIndexesOperation extends CommandOperation<CursorResponse> {
    * This allows typescript to delete the key but will
    * not allow a writeConcern to be assigned as a property on options.
    */
-  override options: ListIndexesOptions & { writeConcern?: never; rawData?: boolean };
+  override options: ListIndexesOptions & { writeConcern?: never };
   collectionNamespace: MongoDBNamespace;
 
   constructor(collection: Collection, options?: ListIndexesOptions) {


### PR DESCRIPTION
### Description

Makes raw data internal.

### Double check the following

- [x] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
