### PR TITLE
feat(NODE-7157): deprecate `retryWrites` in `CommandOperationOptions`

### DIFF
--- a/src/operations/command.ts
+++ b/src/operations/command.ts
@@ -53,7 +53,11 @@ export interface CommandOperationOptions
    * In server versions 4.4 and above, 'comment' can be any valid BSON type.
    */
   comment?: unknown;
-  /** Should retry failed writes */
+  /**
+   * @deprecated
+   * This option is deprecated and will be removed in a future release as it is not used
+   * in the driver. Use MongoClientOptions or connection string parameters instead.
+   * */
   retryWrites?: boolean;
 
   // Admin command overrides.


### PR DESCRIPTION
### Description

#### Summary of Changes

Deprecate option `retryWrites` in `CommandOperationOptions`.

### Release Highlight

<!-- 
Contributors: please leave the release notes section for the Node driver team to fill in. The following instructions are for maintainers.

For user facing changes: please provide release notes. Feel free to browse previous releases for example release highlights.

If there are no user-facing changes in this PR, please delete the release highlight section from the PR description.
-->

<!-- RELEASE_HIGHLIGHT_START -->

### `CommandOperationOptions.retryWrites` is deprecated

`CommandOperationOptions.retryWrites` is deprecated. This per‑command option has no effect; the Node.js driver only honors `retryWrites` when configured at the client level (MongoClient options) or via the connection string. Do not use this option on individual commands. There is no runtime behavior change because it was already ignored, but it will be removed in an upcoming major release and may cause type or build errors in code that references it. To control retryable writes, set `retryWrites` in MongoClient options or include `retryWrites=true|false` in the connection string.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
