### PR TITLE
test(NODE-7182): migrate `integration/connection-monitoring-and-pooling` tests

### DIFF
--- a/test/integration/connection-monitoring-and-pooling/connection.test.ts
+++ b/test/integration/connection-monitoring-and-pooling/connection.test.ts
@@ -188,7 +188,7 @@ describe('Connection', function () {
 
         const db = client.db(configuration.db);
 
-        await db.collection('domainSocketCollection0').insert({ a: 1 }, { writeConcern: { w: 1 } });
+        await db.collection('domainSocketCollection0').insertOne({ a: 1 }, { writeConcern: { w: 1 } });
 
         const items = await db.collection('domainSocketCollection0').find({ a: 1 }).toArray();
         test.equal(1, items.length);

--- a/test/integration/connection-monitoring-and-pooling/connection.test.ts
+++ b/test/integration/connection-monitoring-and-pooling/connection.test.ts
@@ -5,23 +5,24 @@ import { expect } from 'chai';
 import * as sinon from 'sinon';
 
 import {
-  addContainerMetadata,
   Binary,
-  connect,
-  Connection,
   type ConnectionOptions,
-  HostAddress,
-  LEGACY_HELLO_COMMAND,
-  makeClientMetadata,
   MongoClient,
   MongoClientAuthProviders,
   type MongoClientOptions,
-  MongoDBResponse,
   MongoServerError,
-  ns,
-  ServerHeartbeatStartedEvent,
-  Topology
-} from '../../mongodb';
+  ServerHeartbeatStartedEvent
+} from '../../../src';
+import { connect } from '../../../src/cmap/connect';
+import { Connection } from '../../../src/cmap/connection';
+import {
+  addContainerMetadata,
+  makeClientMetadata
+} from '../../../src/cmap/handshake/client_metadata';
+import { MongoDBResponse } from '../../../src/cmap/wire_protocol/responses';
+import { LEGACY_HELLO_COMMAND } from '../../../src/constants';
+import { Topology } from '../../../src/sdam/topology';
+import { HostAddress, ns } from '../../../src/utils';
 import * as mock from '../../tools/mongodb-mock/index';
 import { processTick, sleep } from '../../tools/utils';
 import { assert as test, setupDatabase } from '../shared';

--- a/test/integration/connection-monitoring-and-pooling/connection.test.ts
+++ b/test/integration/connection-monitoring-and-pooling/connection.test.ts
@@ -1,7 +1,8 @@
+import { type EventEmitter, once } from 'node:events';
+import { setTimeout } from 'node:timers';
+
 import { expect } from 'chai';
-import { type EventEmitter, once } from 'events';
 import * as sinon from 'sinon';
-import { setTimeout } from 'timers';
 
 import {
   addContainerMetadata,
@@ -173,7 +174,7 @@ describe('Connection', function () {
       metadata: {
         requires: { topology: 'single', os: '!win32' }
       },
-      test: function (done) {
+      test: async function () {
         const configuration = this.configuration;
         const uri = `mongodb://${encodeURIComponent('/tmp/mongodb-27017.sock')}?w=1`;
         const options: MongoClientOptions = {
@@ -186,22 +187,10 @@ describe('Connection', function () {
 
         const db = client.db(configuration.db);
 
-        db.collection('domainSocketCollection0').insert(
-          { a: 1 },
-          { writeConcern: { w: 1 } },
-          function (err) {
-            expect(err).to.not.exist;
+        await db.collection('domainSocketCollection0').insert({ a: 1 }, { writeConcern: { w: 1 } });
 
-            db.collection('domainSocketCollection0')
-              .find({ a: 1 })
-              .toArray(function (err, items) {
-                expect(err).to.not.exist;
-                test.equal(1, items.length);
-
-                done();
-              });
-          }
-        );
+        const items = await db.collection('domainSocketCollection0').find({ a: 1 }).toArray();
+        test.equal(1, items.length);
       }
     });
 

--- a/test/integration/connection-monitoring-and-pooling/connection.test.ts
+++ b/test/integration/connection-monitoring-and-pooling/connection.test.ts
@@ -188,7 +188,9 @@ describe('Connection', function () {
 
         const db = client.db(configuration.db);
 
-        await db.collection('domainSocketCollection0').insertOne({ a: 1 }, { writeConcern: { w: 1 } });
+        await db
+          .collection('domainSocketCollection0')
+          .insertOne({ a: 1 }, { writeConcern: { w: 1 } });
 
         const items = await db.collection('domainSocketCollection0').find({ a: 1 }).toArray();
         test.equal(1, items.length);


### PR DESCRIPTION
### Description

#### Summary of Changes

This PR migrates the integration tests for `connection-monitoring-and-pooling`. The changes include:
- Replacing callbacks with `async/await` for one test.
- Import directly from the `src` folder.

##### Notes for Reviewers

To simplify the review process, this PR is split into several commits:
- The first commit converts callbacks to async/await.
- Other commits contains the remaining refactoring changes (imports).

#### What is the motivation for this change?

This work is part of a larger, ongoing initiative to convert all tests to use `async/await`, with the ultimate goal of removing the legacy driver wrapper.

### Double check the following

- [x] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
