### PR TITLE
chore: fix docs action

### DIFF
--- a/.github/workflows/build_and_commit_docs.yml
+++ b/.github/workflows/build_and_commit_docs.yml
@@ -1,0 +1,28 @@
+on:
+  push:
+    branches: ['main']
+  workflow_dispatch: {}
+
+name: Build and commit documentation
+
+jobs:
+  build-docs:
+    # prevent subsequent commits from triggering the job multiple times
+    concurrency:
+      group: ci-${{ github.ref }}
+      cancel-in-progress: true
+    name: "Build documentation."
+    uses: ./.github/workflows/build.yml
+
+  commit-docs:
+    needs: [build-docs]
+    permissions:
+        contents: write
+        pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+        - name: Open Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+        title: 'docs: generate docs from latest main [skip-ci]'
+        delete-branch: true

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -1,31 +1,30 @@
-name: Build and commit docs
+name: Build documentation
 
 on:
   push:
     branches: ['main']
+  workflow_dispatch: {}
+  workflow_call: {}
 
-permissions:
-  contents: write
-  pull-requests: write
+  pull_request:
+    branches: [ "main" ]
 
 jobs:
   build:
-    # prevent subsequent commits from triggering the job multiple times
-    concurrency:
-      group: ci-${{ github.ref }}
-      cancel-in-progress: true
-
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v5
+
+      - name: Install Hugo
+        run: |
+          mkdir hugo 
+          curl -L https://github.com/gohugoio/hugo/releases/download/v0.150.0/hugo_0.150.0_linux-amd64.tar.gz | tar -xzf - -C hugo
+          echo "$(pwd)/hugo" >> $GITHUB_PATH
+
       - name: Install Node and dependencies
         uses: mongodb-labs/drivers-github-tools/node/setup@v2
-      - run: sudo apt update && sudo apt-get install hugo
+
       - name: Build Docs
         run: npm run build:docs -- --yes
-      - name: Open Pull Request
-        uses: peter-evans/create-pull-request@v6
-        with:
-          title: 'docs: generate docs from latest main [skip-ci]'
-          delete-branch: true
+


### PR DESCRIPTION
### Description

#### Summary of Changes

It seems like apt doesn't have hugo 150 available, which is what we've standardized on for our documentation.  It also seems like apt and other package managers on linux can lag behind (https://github.com/gohugoio/hugo/issues/13105).

This PR updates the documentation GHA to instead install hugo from Github.  Additionally, I added a GHA that runs on each PR that just builds docs, to confirm that documentation generation is not broken by changes in the PR.

##### Notes for Reviewers


#### What is the motivation for this change?

<!--
Remove this section if there is an associated Jira ticket explaining the motiviation for this change. If there is not, please fill this section out with 
information explaining why this change is valuable.
-->

### Release Highlight

<!-- 
Contributors: please leave the release notes section for the Node driver team to fill in. The following instructions are for maintainers.

For user facing changes: please provide release notes. Feel free to browse previous releases for example release highlights.

If there are no user-facing changes in this PR, please delete the release highlight section from the PR description.
-->

<!-- RELEASE_HIGHLIGHT_START -->

### Release notes highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Lint is passing (`npm run check:lint`)
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
