### PR TITLE
test(NODE-7192): Migrate `test/integration/crud/aggregation` tests

### DIFF
--- a/test/integration/crud/aggregation.test.ts
+++ b/test/integration/crud/aggregation.test.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 
-import { type MongoClient, MongoInvalidArgumentError } from '../../mongodb';
+import { MongoInvalidArgumentError } from '../../../src/error';
+import { type MongoClient } from '../../../src/mongo_client';
 import { filterForCommands } from '../shared';
 
 describe('Aggregation', function () {
@@ -14,7 +15,7 @@ describe('Aggregation', function () {
     await client.close();
   });
 
-  it('should correctly execute simple aggregation pipeline using array', function (done) {
+  it('should correctly execute simple aggregation pipeline using array', async function () {
     const client = this.configuration.newClient({ w: 1 }, { maxPoolSize: 1 }),
       databaseName = this.configuration.db;
 
@@ -38,60 +39,54 @@ describe('Aggregation', function () {
     // Create a collection
     const collection = db.collection('shouldCorrectlyExecuteSimpleAggregationPipelineUsingArray');
     // Insert the docs
-    collection.insertMany(docs, { writeConcern: { w: 1 } }, function (err, result) {
-      expect(result).to.exist;
-      expect(err).to.not.exist;
+    const res = await collection.insertMany(docs, { writeConcern: { w: 1 } });
+    expect(res).to.exist;
 
-      // Execute aggregate, notice the pipeline is expressed as an Array
-      const cursor = collection.aggregate([
-        {
-          $project: {
-            author: 1,
-            tags: 1
-          }
-        },
-        { $unwind: '$tags' },
-        {
-          $group: {
-            _id: { tags: '$tags' },
-            authors: { $addToSet: '$author' }
-          }
-        },
-        { $sort: { _id: -1 } }
-      ]);
+    // Execute aggregate, notice the pipeline is expressed as an Array
+    const cursor = collection.aggregate([
+      {
+        $project: {
+          author: 1,
+          tags: 1
+        }
+      },
+      { $unwind: '$tags' },
+      {
+        $group: {
+          _id: { tags: '$tags' },
+          authors: { $addToSet: '$author' }
+        }
+      },
+      { $sort: { _id: -1 } }
+    ]);
 
-      cursor.toArray(function (err, result) {
-        expect(err).to.not.exist;
-        expect(result[0]._id.tags).to.equal('good');
-        expect(result[0].authors).to.eql(['bob']);
-        expect(result[1]._id.tags).to.equal('fun');
-        expect(result[1].authors).to.eql(['bob']);
+    const result = await cursor.toArray();
+    expect(result[0]._id.tags).to.equal('good');
+    expect(result[0].authors).to.eql(['bob']);
+    expect(result[1]._id.tags).to.equal('fun');
+    expect(result[1].authors).to.eql(['bob']);
 
-        client.close(done);
-      });
-    });
+    await client.close();
   });
 
-  it('should correctly execute db.aggregate() with $currentOp', function (done) {
+  it('should correctly execute db.aggregate() with $currentOp', async function () {
     const client = this.configuration.newClient({ w: 1 }, { maxPoolSize: 1 });
 
     const db = client.db('admin');
     const cursor = db.aggregate([{ $currentOp: { localOps: true } }]);
 
-    cursor.toArray((err, result) => {
-      expect(err).to.not.exist;
+    const result = await cursor.toArray();
 
-      const aggregateOperation = result.filter(op => op.command && op.command.aggregate)[0];
-      expect(aggregateOperation.command.aggregate).to.equal(1);
-      expect(aggregateOperation.command.pipeline).to.eql([{ $currentOp: { localOps: true } }]);
-      expect(aggregateOperation.command.cursor).to.deep.equal({});
-      expect(aggregateOperation.command['$db']).to.equal('admin');
+    const aggregateOperation = result.filter(op => op.command && op.command.aggregate)[0];
+    expect(aggregateOperation.command.aggregate).to.equal(1);
+    expect(aggregateOperation.command.pipeline).to.eql([{ $currentOp: { localOps: true } }]);
+    expect(aggregateOperation.command.cursor).to.deep.equal({});
+    expect(aggregateOperation.command['$db']).to.equal('admin');
 
-      client.close(done);
-    });
+    await client.close();
   });
 
-  it('should fail when executing simple aggregation pipeline using arguments not an array', function (done) {
+  it('should fail when executing simple aggregation pipeline using arguments not an array', async function () {
     const client = this.configuration.newClient({ w: 1 }, { maxPoolSize: 1 }),
       databaseName = this.configuration.db;
 
@@ -117,42 +112,38 @@ describe('Aggregation', function () {
       'shouldCorrectlyExecuteSimpleAggregationPipelineUsingArguments'
     );
     // Insert the docs
-    collection.insertMany(docs, { writeConcern: { w: 1 } }, function (err, result) {
-      expect(result).to.exist;
-      expect(err).to.not.exist;
+    const res = await collection.insertMany(docs, { writeConcern: { w: 1 } });
+    expect(res).to.exist;
 
-      // Execute aggregate, notice the pipeline is expressed as function call parameters
-      // instead of an Array.
-      const cursor = collection.aggregate([
-        {
-          $project: {
-            author: 1,
-            tags: 1
-          }
-        },
-        { $unwind: '$tags' },
-        {
-          $group: {
-            _id: { tags: '$tags' },
-            authors: { $addToSet: '$author' }
-          }
-        },
-        { $sort: { _id: -1 } }
-      ]);
+    // Execute aggregate, notice the pipeline is expressed as function call parameters
+    // instead of an Array.
+    const cursor = collection.aggregate([
+      {
+        $project: {
+          author: 1,
+          tags: 1
+        }
+      },
+      { $unwind: '$tags' },
+      {
+        $group: {
+          _id: { tags: '$tags' },
+          authors: { $addToSet: '$author' }
+        }
+      },
+      { $sort: { _id: -1 } }
+    ]);
 
-      cursor.toArray(function (err, result) {
-        expect(err).to.not.exist;
-        expect(result[0]._id.tags).to.equal('good');
-        expect(result[0].authors).to.eql(['bob']);
-        expect(result[1]._id.tags).to.equal('fun');
-        expect(result[1].authors).to.eql(['bob']);
+    const result = await cursor.toArray();
+    expect(result[0]._id.tags).to.equal('good');
+    expect(result[0].authors).to.eql(['bob']);
+    expect(result[1]._id.tags).to.equal('fun');
+    expect(result[1].authors).to.eql(['bob']);
 
-        client.close(done);
-      });
-    });
+    await client.close();
   });
 
-  it('should fail when executing simple aggregation pipeline using arguments using single object', function (done) {
+  it('should fail when executing simple aggregation pipeline using arguments using single object', async function () {
     const client = this.configuration.newClient({ w: 1 }, { maxPoolSize: 1 }),
       databaseName = this.configuration.db;
 
@@ -178,42 +169,38 @@ describe('Aggregation', function () {
       'shouldCorrectlyExecuteSimpleAggregationPipelineUsingArguments'
     );
     // Insert the docs
-    collection.insertMany(docs, { writeConcern: { w: 1 } }, function (err, result) {
-      expect(result).to.exist;
-      expect(err).to.not.exist;
+    const res = await collection.insertMany(docs, { writeConcern: { w: 1 } });
+    expect(res).to.exist;
 
-      // Execute aggregate, notice the pipeline is expressed as function call parameters
-      // instead of an Array.
-      const cursor = collection.aggregate([
-        {
-          $project: {
-            author: 1,
-            tags: 1
-          }
-        },
-        { $unwind: '$tags' },
-        {
-          $group: {
-            _id: { tags: '$tags' },
-            authors: { $addToSet: '$author' }
-          }
-        },
-        { $sort: { _id: -1 } }
-      ]);
+    // Execute aggregate, notice the pipeline is expressed as function call parameters
+    // instead of an Array.
+    const cursor = collection.aggregate([
+      {
+        $project: {
+          author: 1,
+          tags: 1
+        }
+      },
+      { $unwind: '$tags' },
+      {
+        $group: {
+          _id: { tags: '$tags' },
+          authors: { $addToSet: '$author' }
+        }
+      },
+      { $sort: { _id: -1 } }
+    ]);
 
-      cursor.toArray(function (err, result) {
-        expect(err).to.not.exist;
-        expect(result[0]._id.tags).to.equal('good');
-        expect(result[0].authors).to.eql(['bob']);
-        expect(result[1]._id.tags).to.equal('fun');
-        expect(result[1].authors).to.eql(['bob']);
+    const result = await cursor.toArray();
+    expect(result[0]._id.tags).to.equal('good');
+    expect(result[0].authors).to.eql(['bob']);
+    expect(result[1]._id.tags).to.equal('fun');
+    expect(result[1].authors).to.eql(['bob']);
 
-        client.close(done);
-      });
-    });
+    await client.close();
   });
 
-  it('should correctly return and iterate over all the cursor results', function (done) {
+  it('should correctly return and iterate over all the cursor results', async function () {
     const client = this.configuration.newClient({ w: 1 }, { maxPoolSize: 1 }),
       databaseName = this.configuration.db;
 
@@ -237,41 +224,37 @@ describe('Aggregation', function () {
     // Create a collection
     const collection = db.collection('shouldCorrectlyDoAggWithCursorGet');
     // Insert the docs
-    collection.insertMany(docs, { writeConcern: { w: 1 } }, function (err, result) {
-      expect(err).to.not.exist;
-      expect(result).to.exist;
+    const res = await collection.insertMany(docs, { writeConcern: { w: 1 } });
+    expect(res).to.exist;
 
-      // Execute aggregate, notice the pipeline is expressed as an Array
-      const cursor = collection.aggregate([
-        {
-          $project: {
-            author: 1,
-            tags: 1
-          }
-        },
-        { $unwind: '$tags' },
-        {
-          $group: {
-            _id: { tags: '$tags' },
-            authors: { $addToSet: '$author' }
-          }
+    // Execute aggregate, notice the pipeline is expressed as an Array
+    const cursor = collection.aggregate([
+      {
+        $project: {
+          author: 1,
+          tags: 1
         }
-      ]);
+      },
+      { $unwind: '$tags' },
+      {
+        $group: {
+          _id: { tags: '$tags' },
+          authors: { $addToSet: '$author' }
+        }
+      }
+    ]);
 
-      // Iterate over all the items in the cursor
-      cursor.toArray(function (err, result) {
-        expect(err).to.not.exist;
-        expect(result).to.exist;
+    // Iterate over all the items in the cursor
+    const result = await cursor.toArray();
+    expect(result).to.exist;
 
-        client.close(done);
-      });
-    });
+    await client.close();
   });
 
   it(
     'should correctly return a cursor and call explain',
     { requires: { mongodb: '<7.1.0' } },
-    function (done) {
+    async function () {
       const client = this.configuration.newClient({ maxPoolSize: 1 }),
         databaseName = this.configuration.db;
 
@@ -295,43 +278,39 @@ describe('Aggregation', function () {
       // Create a collection
       const collection = db.collection('shouldCorrectlyDoAggWithCursorGet');
       // Insert the docs
-      collection.insertMany(docs, { writeConcern: { w: 1 } }, function (err, result) {
-        expect(result).to.exist;
-        expect(err).to.not.exist;
+      const res = await collection.insertMany(docs, { writeConcern: { w: 1 } });
+      expect(res).to.exist;
 
-        // Execute aggregate, notice the pipeline is expressed as an Array
-        const cursor = collection.aggregate(
-          [
-            {
-              $project: {
-                author: 1,
-                tags: 1
-              }
-            },
-            { $unwind: '$tags' },
-            {
-              $group: {
-                _id: { tags: '$tags' },
-                authors: { $addToSet: '$author' }
-              }
-            }
-          ],
+      // Execute aggregate, notice the pipeline is expressed as an Array
+      const cursor = collection.aggregate(
+        [
           {
-            cursor: { batchSize: 100 }
+            $project: {
+              author: 1,
+              tags: 1
+            }
+          },
+          { $unwind: '$tags' },
+          {
+            $group: {
+              _id: { tags: '$tags' },
+              authors: { $addToSet: '$author' }
+            }
           }
-        );
+        ],
+        {
+          cursor: { batchSize: 100 }
+        }
+      );
 
-        // Iterate over all the items in the cursor
-        cursor.explain(function (err, result) {
-          expect(err).to.not.exist;
-          expect(JSON.stringify(result)).to.include('$cursor');
-          client.close(done);
-        });
-      });
+      // Iterate over all the items in the cursor
+      const result = await cursor.explain();
+      expect(JSON.stringify(result)).to.include('$cursor');
+      await client.close();
     }
   );
 
-  it('should correctly return a cursor with batchSize 1 and call next', function (done) {
+  it('should correctly return a cursor with batchSize 1 and call next', async function () {
     const client = this.configuration.newClient({ w: 1 }, { maxPoolSize: 1 }),
       databaseName = this.configuration.db;
 
@@ -357,103 +336,40 @@ describe('Aggregation', function () {
     // Create a collection
     const collection = db.collection('shouldCorrectlyDoAggWithCursorGet');
     // Insert the docs
-    collection.insertMany(docs, { writeConcern: { w: 1 } }, (err, result) => {
-      expect(result).to.exist;
-      expect(err).to.not.exist;
+    const res = await collection.insertMany(docs, { writeConcern: { w: 1 } });
+    expect(res).to.exist;
 
-      // Execute aggregate, notice the pipeline is expressed as an Array
-      const cursor = collection.aggregate(
-        [
-          {
-            $project: {
-              author: 1,
-              tags: 1
-            }
-          },
-          { $unwind: '$tags' },
-          {
-            $group: {
-              _id: { tags: '$tags' },
-              authors: { $addToSet: '$author' }
-            }
-          },
-          { $sort: { _id: -1 } }
-        ],
+    // Execute aggregate, notice the pipeline is expressed as an Array
+    const cursor = collection.aggregate(
+      [
         {
-          cursor: { batchSize: 1 }
-        }
-      );
-      this.defer(() => cursor.close());
-
-      // Iterate over all the items in the cursor
-      cursor.next((err, result) => {
-        expect(err).to.not.exist;
-        expect(result._id.tags).to.equal('good');
-        expect(result.authors).to.eql(['bob']);
-        done();
-      });
-    });
-  });
-
-  it('should correctly write the results out to a new collection', function (done) {
-    const client = this.configuration.newClient({ w: 1 }, { maxPoolSize: 1 }),
-      databaseName = this.configuration.db;
-
-    const db = client.db(databaseName);
-    // Some docs for insertion
-    const docs = [
-      {
-        title: 'this is my title',
-        author: 'bob',
-        posted: new Date(),
-        pageViews: 5,
-        tags: ['fun', 'good', 'fun'],
-        other: { foo: 5 },
-        comments: [
-          { author: 'joe', text: 'this is cool' },
-          { author: 'sam', text: 'this is bad' }
-        ]
-      }
-    ];
-
-    // Create a collection
-    const collection = db.collection('shouldCorrectlyDoAggWithCursorGet');
-    // Insert the docs
-    collection.insertMany(docs, { writeConcern: { w: 1 } }, function (err, result) {
-      expect(result).to.exist;
-      expect(err).to.not.exist;
-
-      // Execute aggregate, notice the pipeline is expressed as an Array
-      const cursor = collection.aggregate(
-        [
-          {
-            $project: {
-              author: 1,
-              tags: 1
-            }
-          },
-          { $unwind: '$tags' },
-          {
-            $group: {
-              _id: { tags: '$tags' },
-              authors: { $addToSet: '$author' }
-            }
+          $project: {
+            author: 1,
+            tags: 1
           }
-        ],
+        },
+        { $unwind: '$tags' },
         {
-          out: 'testingOutCollectionForAggregation'
-        }
-      );
-      cursor.toArray(function (err, results) {
-        expect(err).to.not.exist;
-        expect(results).to.be.empty;
+          $group: {
+            _id: { tags: '$tags' },
+            authors: { $addToSet: '$author' }
+          }
+        },
+        { $sort: { _id: -1 } }
+      ],
+      {
+        cursor: { batchSize: 1 }
+      }
+    );
 
-        client.close(done);
-      });
-    });
+    // Iterate over all the items in the cursor
+    const result = await cursor.next();
+    expect(result._id.tags).to.equal('good');
+    expect(result.authors).to.eql(['bob']);
+    await client.close();
   });
 
-  it('should correctly use allowDiskUse when performing an aggregation', function (done) {
+  it('should correctly write the results out to a new collection', async function () {
     const client = this.configuration.newClient({ w: 1 }, { maxPoolSize: 1 }),
       databaseName = this.configuration.db;
 
@@ -477,45 +393,95 @@ describe('Aggregation', function () {
     // Create a collection
     const collection = db.collection('shouldCorrectlyDoAggWithCursorGet');
     // Insert the docs
-    collection.insertMany(docs, { writeConcern: { w: 1 } }, function (err, result) {
-      expect(result).to.exist;
-      expect(err).to.not.exist;
+    const res = await collection.insertMany(docs, { writeConcern: { w: 1 } });
+    expect(res).to.exist;
 
-      // Execute aggregate, notice the pipeline is expressed as an Array
-      const cursor = collection.aggregate(
-        [
-          {
-            $project: {
-              author: 1,
-              tags: 1
-            }
-          },
-          { $unwind: '$tags' },
-          {
-            $group: {
-              _id: { tags: '$tags' },
-              authors: { $addToSet: '$author' }
-            }
-          },
-          { $sort: { _id: -1 } }
-        ],
+    // Execute aggregate, notice the pipeline is expressed as an Array
+    const cursor = collection.aggregate(
+      [
         {
-          allowDiskUse: true
+          $project: {
+            author: 1,
+            tags: 1
+          }
+        },
+        { $unwind: '$tags' },
+        {
+          $group: {
+            _id: { tags: '$tags' },
+            authors: { $addToSet: '$author' }
+          }
         }
-      );
-      cursor.toArray(function (err, results) {
-        expect(err).to.not.exist;
-        expect(results[0]._id.tags).to.equal('good');
-        expect(results[0].authors).to.eql(['bob']);
-        expect(results[1]._id.tags).to.equal('fun');
-        expect(results[1].authors).to.eql(['bob']);
+      ],
+      {
+        out: 'testingOutCollectionForAggregation'
+      }
+    );
+    const results = await cursor.toArray();
+    expect(results).to.be.empty;
 
-        client.close(done);
-      });
-    });
+    await client.close();
   });
 
-  it('should perform a simple group aggregation', function (done) {
+  it('should correctly use allowDiskUse when performing an aggregation', async function () {
+    const client = this.configuration.newClient({ w: 1 }, { maxPoolSize: 1 }),
+      databaseName = this.configuration.db;
+
+    const db = client.db(databaseName);
+    // Some docs for insertion
+    const docs = [
+      {
+        title: 'this is my title',
+        author: 'bob',
+        posted: new Date(),
+        pageViews: 5,
+        tags: ['fun', 'good', 'fun'],
+        other: { foo: 5 },
+        comments: [
+          { author: 'joe', text: 'this is cool' },
+          { author: 'sam', text: 'this is bad' }
+        ]
+      }
+    ];
+
+    // Create a collection
+    const collection = db.collection('shouldCorrectlyDoAggWithCursorGet');
+    // Insert the docs
+    const res = await collection.insertMany(docs, { writeConcern: { w: 1 } });
+    expect(res).to.exist;
+
+    // Execute aggregate, notice the pipeline is expressed as an Array
+    const cursor = collection.aggregate(
+      [
+        {
+          $project: {
+            author: 1,
+            tags: 1
+          }
+        },
+        { $unwind: '$tags' },
+        {
+          $group: {
+            _id: { tags: '$tags' },
+            authors: { $addToSet: '$author' }
+          }
+        },
+        { $sort: { _id: -1 } }
+      ],
+      {
+        allowDiskUse: true
+      }
+    );
+    const results = await cursor.toArray();
+    expect(results[0]._id.tags).to.equal('good');
+    expect(results[0].authors).to.eql(['bob']);
+    expect(results[1]._id.tags).to.equal('fun');
+    expect(results[1].authors).to.eql(['bob']);
+
+    await client.close();
+  });
+
+  it('should perform a simple group aggregation', async function () {
     const databaseName = this.configuration.db;
     const client = this.configuration.newClient(this.configuration.writeConcernMax(), {
       maxPoolSize: 1
@@ -524,33 +490,27 @@ describe('Aggregation', function () {
     const db = client.db(databaseName);
     // Create a collection
     const col = db.collection('shouldPerformSimpleGroupAggregation');
-    col.deleteMany({}, function (err) {
-      expect(err).to.not.exist;
+    await col.deleteMany({});
 
-      // Insert a single document
-      col.insertMany([{ a: 1 }, { a: 1 }, { a: 1 }], function (err, r) {
-        expect(err).to.not.exist;
-        expect(r).property('insertedCount').to.equal(3);
+    // Insert a single document
+    const r = await col.insertMany([{ a: 1 }, { a: 1 }, { a: 1 }]);
+    expect(r).property('insertedCount').to.equal(3);
 
-        // Get first two documents that match the query
-        col
-          .aggregate([
-            { $match: {} },
-            {
-              $group: { _id: '$a', total: { $sum: '$a' } }
-            }
-          ])
-          .toArray(function (err, docs) {
-            expect(err).to.not.exist;
-            expect(docs[0].total).to.equal(3);
+    // Get first two documents that match the query
+    const docs = await col
+      .aggregate([
+        { $match: {} },
+        {
+          $group: { _id: '$a', total: { $sum: '$a' } }
+        }
+      ])
+      .toArray();
+    expect(docs[0].total).to.equal(3);
 
-            client.close(done);
-          });
-      });
-    });
+    await client.close();
   });
 
-  it('should correctly perform an aggregation using a collection name with dot in it', function (done) {
+  it('should correctly perform an aggregation using a collection name with dot in it', async function () {
     const databaseName = this.configuration.db;
     const client = this.configuration.newClient(this.configuration.writeConcernMax(), {
       maxPoolSize: 1
@@ -560,34 +520,25 @@ describe('Aggregation', function () {
     const col = db.collection('te.st');
     let count = 0;
 
-    col.insertMany([{ a: 1 }, { a: 1 }, { a: 1 }], function (err, r) {
-      expect(err).to.not.exist;
-      expect(r).property('insertedCount').to.equal(3);
+    const r = await col.insertMany([{ a: 1 }, { a: 1 }, { a: 1 }]);
+    expect(r).property('insertedCount').to.equal(3);
 
-      const cursor = col.aggregate([{ $project: { a: 1 } }]);
+    const cursor = col.aggregate([{ $project: { a: 1 } }]);
 
-      cursor.toArray(function (err, docs) {
-        expect(err).to.not.exist;
-        expect(docs.length).to.be.greaterThan(0);
+    const docs = await cursor.toArray();
+    expect(docs.length).to.be.greaterThan(0);
 
-        //Using cursor - KO
-        col
-          .aggregate([{ $project: { a: 1 } }], {
-            cursor: { batchSize: 10000 }
-          })
-          .forEach(
-            function () {
-              count = count + 1;
-            },
-            function (err) {
-              expect(err).to.not.exist;
-              expect(count).to.be.greaterThan(0);
-
-              client.close(done);
-            }
-          );
+    //Using cursor - KO
+    await col
+      .aggregate([{ $project: { a: 1 } }], {
+        cursor: { batchSize: 10000 }
+      })
+      .forEach(function () {
+        count = count + 1;
       });
-    });
+    expect(count).to.be.greaterThan(0);
+
+    await client.close();
   });
 
   it('should fail aggregation due to illegal cursor option and streams', async function () {
@@ -667,11 +618,9 @@ describe('Aggregation', function () {
     expect(error).to.be.instanceOf(MongoInvalidArgumentError);
   });
 
-  it('should ensure MaxTimeMS is correctly passed down into command execution when using a cursor', function (done) {
+  it('should ensure MaxTimeMS is correctly passed down into command execution when using a cursor', async function () {
     const client = this.configuration.newClient({ w: 1 }, { maxPoolSize: 1 }),
       databaseName = this.configuration.db;
-
-    this.defer(() => client.close());
 
     const db = client.db(databaseName);
     const docs = [
@@ -692,93 +641,86 @@ describe('Aggregation', function () {
     // Create a collection
     const collection = db.collection('shouldCorrectlyDoAggWithCursorMaxTimeMSSet');
     // Insert the docs
-    collection.insertMany(docs, { writeConcern: { w: 1 } }, (err, result) => {
-      expect(result).to.exist;
-      expect(err).to.not.exist;
+    const res = await collection.insertMany(docs, { writeConcern: { w: 1 } });
+    expect(res).to.exist;
 
-      // Execute aggregate, notice the pipeline is expressed as an Array
-      const cursor = collection.aggregate(
-        [
-          {
-            $project: {
-              author: 1,
-              tags: 1
-            }
-          },
-          { $unwind: '$tags' },
-          {
-            $group: {
-              _id: { tags: '$tags' },
-              authors: { $addToSet: '$author' }
-            }
-          },
-          { $sort: { _id: -1 } }
-        ],
+    // Execute aggregate, notice the pipeline is expressed as an Array
+    const cursor = collection.aggregate(
+      [
         {
-          cursor: { batchSize: 1 },
-          maxTimeMS: 1000
-        }
-      );
-      this.defer(() => cursor.close());
-
-      // Override the db.command to validate the correct command
-      // is executed
-      const command = db.command.bind(db);
-      // Validate the command
-      db.command = function (...args: Parameters<(typeof db)['command']>) {
-        const c = args[0];
-        expect(err).to.not.exist;
-        expect(c.maxTimeMS).to.equal(1000);
-
-        // Apply to existing command
-        command(...args);
-      };
-
-      // Iterate over all the items in the cursor
-      cursor.next((err, result) => {
-        expect(err).to.not.exist;
-        expect(result._id.tags).to.equal('good');
-        expect(result.authors).to.eql(['bob']);
-
-        // Validate the command
-        db.command = function (...args: Parameters<(typeof db)['command']>) {
-          const c = args[0];
-          expect(err).to.not.exist;
-          expect(c.maxTimeMS).to.equal(1000);
-
-          // Apply to existing command
-          command(...args);
-        };
-
-        // Execute aggregate, notice the pipeline is expressed as an Array
-        const secondCursor = collection.aggregate(
-          [
-            {
-              $project: {
-                author: 1,
-                tags: 1
-              }
-            },
-            { $unwind: '$tags' },
-            {
-              $group: {
-                _id: { tags: '$tags' },
-                authors: { $addToSet: '$author' }
-              }
-            }
-          ],
-          {
-            maxTimeMS: 1000
+          $project: {
+            author: 1,
+            tags: 1
           }
-        );
-        this.defer(() => secondCursor.close());
-        expect(secondCursor).to.exist;
+        },
+        { $unwind: '$tags' },
+        {
+          $group: {
+            _id: { tags: '$tags' },
+            authors: { $addToSet: '$author' }
+          }
+        },
+        { $sort: { _id: -1 } }
+      ],
+      {
+        cursor: { batchSize: 1 },
+        maxTimeMS: 1000
+      }
+    );
 
-        // Return the command
-        db.command = command;
-        done();
-      });
-    });
+    // Override the db.command to validate the correct command
+    // is executed
+    const command = db.command.bind(db);
+    // Validate the command
+    db.command = function (...args: Parameters<(typeof db)['command']>) {
+      const c = args[0];
+      expect(c.maxTimeMS).to.equal(1000);
+
+      // Apply to existing command
+      return command(...args);
+    };
+
+    // Iterate over all the items in the cursor
+    const result = await cursor.next();
+    expect(result._id.tags).to.equal('good');
+    expect(result.authors).to.eql(['bob']);
+
+    // Validate the command
+    db.command = function (...args: Parameters<(typeof db)['command']>) {
+      const c = args[0];
+      expect(c.maxTimeMS).to.equal(1000);
+      // Apply to existing command
+      return command(...args);
+    };
+
+    // Execute aggregate, notice the pipeline is expressed as an Array
+    const secondCursor = collection.aggregate(
+      [
+        {
+          $project: {
+            author: 1,
+            tags: 1
+          }
+        },
+        { $unwind: '$tags' },
+        {
+          $group: {
+            _id: { tags: '$tags' },
+            authors: { $addToSet: '$author' }
+          }
+        }
+      ],
+      {
+        maxTimeMS: 1000
+      }
+    );
+    // this.defer(() => secondCursor.close());
+    expect(secondCursor).to.exist;
+
+    // Return the command
+    db.command = command;
+    await client.close();
+    await secondCursor.close();
   });
 
   it('should pass a comment down via the aggregation command', async function () {
@@ -806,7 +748,7 @@ describe('Aggregation', function () {
     await client.close();
   });
 
-  it('should correctly handle ISODate date matches in aggregation framework', function (done) {
+  it('should correctly handle ISODate date matches in aggregation framework', async function () {
     const databaseName = this.configuration.db;
     const client = this.configuration.newClient(this.configuration.writeConcernMax(), {
       maxPoolSize: 1
@@ -831,30 +773,26 @@ describe('Aggregation', function () {
     // Create a collection
     const collection = db.collection('shouldCorrectlyQueryUsingISODate');
     // Insert the docs
-    collection.insertMany(docs, { writeConcern: { w: 1 } }, function (err, result) {
-      expect(result).to.exist;
-      expect(err).to.not.exist;
+    const res = await collection.insertMany(docs, { writeConcern: { w: 1 } });
+    expect(res).to.exist;
 
-      // Execute aggregate, notice the pipeline is expressed as an Array
-      const cursor = collection.aggregate([
-        {
-          $match: {
-            a: new Date(date1.toISOString())
-          }
+    // Execute aggregate, notice the pipeline is expressed as an Array
+    const cursor = collection.aggregate([
+      {
+        $match: {
+          a: new Date(date1.toISOString())
         }
-      ]);
+      }
+    ]);
 
-      // Iterate over all the items in the cursor
-      cursor.next(function (err, result) {
-        expect(err).to.not.exist;
-        expect(result.b).to.equal(1);
+    // Iterate over all the items in the cursor
+    const result = await cursor.next();
+    expect(result.b).to.equal(1);
 
-        client.close(done);
-      });
-    });
+    await client.close();
   });
 
-  it('should correctly exercise hasNext function on aggregation cursor', function (done) {
+  it('should correctly exercise hasNext function on aggregation cursor', async function () {
     const databaseName = this.configuration.db;
     const client = this.configuration.newClient(this.configuration.writeConcernMax(), {
       maxPoolSize: 1
@@ -863,25 +801,21 @@ describe('Aggregation', function () {
     // Create a collection
     const collection = db.collection('shouldCorrectlyQueryUsingISODate3');
     // Insert the docs
-    collection.insertMany([{ a: 1 }, { b: 1 }], { writeConcern: { w: 1 } }, function (err, result) {
-      expect(result).to.exist;
-      expect(err).to.not.exist;
+    const res = await collection.insertMany([{ a: 1 }, { b: 1 }], { writeConcern: { w: 1 } });
+    expect(res).to.exist;
 
-      // Execute aggregate, notice the pipeline is expressed as an Array
-      const cursor = collection.aggregate([
-        {
-          $match: {}
-        }
-      ]);
+    // Execute aggregate, notice the pipeline is expressed as an Array
+    const cursor = collection.aggregate([
+      {
+        $match: {}
+      }
+    ]);
 
-      // Iterate over all the items in the cursor
-      cursor.hasNext(function (err, result) {
-        expect(err).to.not.exist;
-        expect(result).to.equal(true);
+    // Iterate over all the items in the cursor
+    const result = await cursor.hasNext();
+    expect(result).to.equal(true);
 
-        client.close(done);
-      });
-    });
+    await client.close();
   });
 
   it('should not send a batchSize for aggregations with an out stage', {


### PR DESCRIPTION
### Description

#### Summary of Changes

Migrating `test/integration/crud/aggregation` driver callback API style tests to promises.

#### What is the motivation for this change?

https://jira.mongodb.org/browse/NODE-4979
> We want to modify all tests to no longer use callbacks as the driver is a promise only API now. This is a requirement for deprecating the legacy driver.

### Double check the following

- [x] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
- [x] Changes are covered by tests
