### PR TITLE
ci: test against pinned driver commit

### DIFF
--- a/.evergreen/install-mongodb-client-encryption.sh
+++ b/.evergreen/install-mongodb-client-encryption.sh
@@ -12,6 +12,9 @@ rm -rf mongodb-client-encryption
 git clone https://github.com/mongodb-js/mongodb-client-encryption.git
 pushd mongodb-client-encryption
 
+# TODO(NODE-7218): test against latest mongodb-client-encryption
+git checkout aa61a35f5e174cd1c1e247e036093e18c88268c6
+
 node --version
 npm --version
 


### PR DESCRIPTION
### Description

#### Summary of Changes

To avoid driver CI breakages once breaking changes start merging into mongodb-client-encryption's main branch, the custom dependency tests now test against a pinned commit.  These tests will be updated to test against `main` again in https://jira.mongodb.org/browse/NODE-7218.

##### Notes for Reviewers

<!-- 
If there is any additional context on the changes in the PR that reviewers might find helpful, feel free to make notes in this section.

Otherwise, feel free to remove this section.
-->

#### What is the motivation for this change?

<!--
Remove this section if there is an associated Jira ticket explaining the motiviation for this change. If there is not, please fill this section out with 
information explaining why this change is valuable.
-->

### Release Highlight

<!-- 
Contributors: please leave the release notes section for the Node driver team to fill in. The following instructions are for maintainers.

For user facing changes: please provide release notes. Feel free to browse previous releases for example release highlights.

If there are no user-facing changes in this PR, please delete the release highlight section from the PR description.
-->

<!-- RELEASE_HIGHLIGHT_START -->

### Release notes highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Lint is passing (`npm run check:lint`)
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
