### PR TITLE
feat(NODE-6334)!: rename PoolRequstedRetry to PoolRequestedRetry

### DIFF
--- a/src/cmap/errors.ts
+++ b/src/cmap/errors.ts
@@ -56,7 +56,7 @@ export class PoolClearedError extends MongoNetworkError {
     super(errorMessage, pool.serverError ? { cause: pool.serverError } : undefined);
     this.address = pool.address;
 
-    this.addErrorLabel(MongoErrorLabel.PoolRequstedRetry);
+    this.addErrorLabel(MongoErrorLabel.PoolRequestedRetry);
   }
 
   override get name(): string {

--- a/src/error.ts
+++ b/src/error.ts
@@ -97,7 +97,7 @@ export const MongoErrorLabel = Object.freeze({
   ResumableChangeStreamError: 'ResumableChangeStreamError',
   HandshakeError: 'HandshakeError',
   ResetPool: 'ResetPool',
-  PoolRequstedRetry: 'PoolRequstedRetry',
+  PoolRequestedRetry: 'PoolRequestedRetry',
   InterruptInUseConnections: 'InterruptInUseConnections',
   NoWritesPerformed: 'NoWritesPerformed'
 } as const);
@@ -1444,7 +1444,7 @@ export function needsRetryableWriteLabel(
 export function isRetryableWriteError(error: MongoError): boolean {
   return (
     error.hasErrorLabel(MongoErrorLabel.RetryableWriteError) ||
-    error.hasErrorLabel(MongoErrorLabel.PoolRequstedRetry)
+    error.hasErrorLabel(MongoErrorLabel.PoolRequestedRetry)
   );
 }
 

--- a/test/integration/retryable-writes/non-server-retryable_writes.test.ts
+++ b/test/integration/retryable-writes/non-server-retryable_writes.test.ts
@@ -29,7 +29,7 @@ describe('Non Server Retryable Writes', function () {
   });
 
   it(
-    'returns the original error with a PoolRequstedRetry label after encountering a WriteConcernError',
+    'returns the original error with a PoolRequestedRetry label after encountering a WriteConcernError',
     { requires: { topology: 'replicaset' } },
     async () => {
       const serverCommandStub = sinon.stub(Server.prototype, 'command');
@@ -46,7 +46,7 @@ describe('Non Server Retryable Writes', function () {
       const insertResult = await collection.insertOne({ _id: 1 }).catch(error => error);
       sinon.restore();
 
-      expect(insertResult.errorLabels).to.be.deep.equal(['PoolRequstedRetry']);
+      expect(insertResult.errorLabels).to.be.deep.equal(['PoolRequestedRetry']);
     }
   );
 });


### PR DESCRIPTION
### Description

Fixes the typo in the error name.

#### Summary of Changes

Renames the error
<!-- Please describe the changes in this PR in a high-level overview. -->

#### What is the motivation for this change?

NODE-6334
<!--
Remove this section if there is an associated Jira ticket explaining the motiviation for this change. If there is not, please fill this section out with 
information explaining why this change is valuable.
-->

<!-- 
Contributors: please leave the release notes section for the Node driver team to fill in. The following instructions are for maintainers.

For user facing changes: please provide release notes. Feel free to browse previous releases for example release highlights.

If there are no user-facing changes in this PR, please delete the release highlight section from the PR description.
-->

<!-- RELEASE_HIGHLIGHT_START -->

### 'PoolRequstedRetry' Error Label Renamed to 'PoolRequestedRetry'

The `PoolClearedError` thrown in cases where the connection pool was cleared now fixes the typo in the error label.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
