### PR TITLE
feat(NODE-4184)!: don't throw on aggregate with write concern and explain

### DIFF
--- a/src/operations/aggregate.ts
+++ b/src/operations/aggregate.ts
@@ -80,12 +80,6 @@ export class AggregateOperation extends CommandOperation<CursorResponse> {
       delete this.options.writeConcern;
     }
 
-    if (this.explain && this.writeConcern) {
-      throw new MongoInvalidArgumentError(
-        'Option "explain" cannot be used on an aggregate call with writeConcern'
-      );
-    }
-
     if (options?.cursor != null && typeof options.cursor !== 'object') {
       throw new MongoInvalidArgumentError('Cursor options must be an object');
     }

--- a/test/integration/crud/aggregation.test.ts
+++ b/test/integration/crud/aggregation.test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 
-import { MongoInvalidArgumentError } from '../../../src/error';
+import { MongoInvalidArgumentError, MongoServerError } from '../../../src/error';
 import { type MongoClient } from '../../../src/mongo_client';
 import { filterForCommands } from '../shared';
 
@@ -601,7 +601,7 @@ describe('Aggregation', function () {
       .toArray()
       .catch(error => error);
 
-    expect(error).to.be.instanceOf(MongoInvalidArgumentError);
+    expect(error).to.be.instanceOf(MongoServerError);
   });
 
   it('should fail if you try to use explain flag with { writeConcern: { j: true } }', async function () {
@@ -615,7 +615,7 @@ describe('Aggregation', function () {
       .toArray()
       .catch(error => error);
 
-    expect(error).to.be.instanceOf(MongoInvalidArgumentError);
+    expect(error).to.be.instanceOf(MongoServerError);
   });
 
   it('should ensure MaxTimeMS is correctly passed down into command execution when using a cursor', async function () {


### PR DESCRIPTION
### Description

Driver no longer throws on an aggregation when write concern and explain are provided. Server will now error.

#### Summary of Changes

Removes the check in the driver and updates tests.

<!-- Please describe the changes in this PR in a high-level overview. -->

#### What is the motivation for this change?

NODE-4184
<!--
Remove this section if there is an associated Jira ticket explaining the motiviation for this change. If there is not, please fill this section out with 
information explaining why this change is valuable.
-->

### Release Highlight

<!-- 
Contributors: please leave the release notes section for the Node driver team to fill in. The following instructions are for maintainers.

For user facing changes: please provide release notes. Feel free to browse previous releases for example release highlights.

If there are no user-facing changes in this PR, please delete the release highlight section from the PR description.
-->

<!-- RELEASE_HIGHLIGHT_START -->

### Aggregate with Write Concern + Explain No Longer Throws Client Side

This will now throw a `MongoServerError`

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
