### PR TITLE
fix(NODE-7411): iterate all servers in closeCheckedOutConnections()

### DIFF
--- a/src/sdam/topology.ts
+++ b/src/sdam/topology.ts
@@ -495,7 +495,7 @@ export class Topology extends TypedEventEmitter<TopologyEvents> {
 
   closeCheckedOutConnections() {
     for (const server of this.s.servers.values()) {
-      return server.closeCheckedOutConnections();
+      server.closeCheckedOutConnections();
     }
   }
 


### PR DESCRIPTION
## Summary

Fix a bug in `Topology.closeCheckedOutConnections()` where only the first server's checked-out connections were being closed.

## The Bug

The method had a premature `return` statement inside the `for` loop:

```typescript
closeCheckedOutConnections() {
  for (const server of this.s.servers.values()) {
    return server.closeCheckedOutConnections();  // Returns on first iteration!
  }
}
```

This caused the method to:
1. Get the first server from the servers Map
2. Call `closeCheckedOutConnections()` on it
3. Immediately return, skipping all remaining servers

## The Fix

Remove the `return` statement so all servers are iterated:

```typescript
closeCheckedOutConnections() {
  for (const server of this.s.servers.values()) {
    server.closeCheckedOutConnections();
  }
}
```

## Impact

This bug affects multi-server topologies (replica sets, sharded clusters) where only the first server's connections would be properly closed when `MongoClient.close()` is called. This could lead to:
- Connection leaks on servers other than the first one
- Resources not being properly cleaned up during client shutdown