### PR TITLE
feat(NODE-7385): add experimental `os` runtime adapter 

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -276,7 +276,8 @@
             "patterns": [
               "**/../lib/**",
               "mongodb-mock-server",
-              "node:*"
+              "node:*",
+              "os"
             ],
             "paths": [
               {

--- a/src/cmap/auth/gssapi.ts
+++ b/src/cmap/auth/gssapi.ts
@@ -1,5 +1,4 @@
 import * as dns from 'dns';
-import * as os from 'os';
 
 import { getKerberos, type Kerberos, type KerberosClient } from '../../deps';
 import { MongoInvalidArgumentError, MongoMissingCredentialsError } from '../../error';
@@ -69,9 +68,13 @@ export class GSSAPI extends AuthProvider {
   }
 }
 
-async function makeKerberosClient(authContext: AuthContext): Promise<KerberosClient> {
-  const { hostAddress } = authContext.options;
-  const { credentials } = authContext;
+async function makeKerberosClient({
+  options: {
+    hostAddress,
+    runtime: { os }
+  },
+  credentials
+}: AuthContext): Promise<KerberosClient> {
   if (!hostAddress || typeof hostAddress.host !== 'string' || !credentials) {
     throw new MongoInvalidArgumentError(
       'Connection must have host and port and credentials defined.'

--- a/src/cmap/connection.ts
+++ b/src/cmap/connection.ts
@@ -35,6 +35,7 @@ import { type MongoClientAuthProviders } from '../mongo_client_auth_providers';
 import { MongoLoggableComponent, type MongoLogger, SeverityLevel } from '../mongo_logger';
 import { type Abortable, type CancellationToken, TypedEventEmitter } from '../mongo_types';
 import { ReadPreference, type ReadPreferenceLike } from '../read_preference';
+import { type Runtime } from '../runtime_adapters';
 import { ServerType } from '../sdam/common';
 import { applySession, type ClientSession, updateSessionFromResponse } from '../sessions';
 import { type TimeoutContext, TimeoutError } from '../timeout';
@@ -118,8 +119,8 @@ export interface ProxyOptions {
 /** @public */
 export interface ConnectionOptions
   extends SupportedNodeConnectionOptions,
-    StreamDescriptionOptions,
-    ProxyOptions {
+  StreamDescriptionOptions,
+  ProxyOptions {
   // Internal creation info
   id: number | '<monitor>';
   generation: number;
@@ -143,6 +144,8 @@ export interface ConnectionOptions
   metadata: Promise<ClientMetadata>;
   /** @internal */
   mongoLogger?: MongoLogger | undefined;
+  /** @internal */
+  runtime: Runtime;
 }
 
 /** @public */
@@ -526,10 +529,10 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
       options.documentsReturnedIn == null || !options.raw
         ? options
         : {
-            ...options,
-            raw: false,
-            fieldsAsRaw: { [options.documentsReturnedIn]: true }
-          };
+          ...options,
+          raw: false,
+          fieldsAsRaw: { [options.documentsReturnedIn]: true }
+        };
 
     /** MongoDBResponse instance or subclass */
     let document: MongoDBResponse | undefined = undefined;
@@ -692,9 +695,9 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
       options.agreedCompressor === 'none' || !OpCompressedRequest.canCompress(command)
         ? command
         : new OpCompressedRequest(command, {
-            agreedCompressor: options.agreedCompressor ?? 'none',
-            zlibCompressionLevel: options.zlibCompressionLevel ?? 0
-          });
+          agreedCompressor: options.agreedCompressor ?? 'none',
+          zlibCompressionLevel: options.zlibCompressionLevel ?? 0
+        });
 
     const buffer = Buffer.concat(await finalCommand.toBin());
 

--- a/src/cmap/connection.ts
+++ b/src/cmap/connection.ts
@@ -119,8 +119,8 @@ export interface ProxyOptions {
 /** @public */
 export interface ConnectionOptions
   extends SupportedNodeConnectionOptions,
-  StreamDescriptionOptions,
-  ProxyOptions {
+    StreamDescriptionOptions,
+    ProxyOptions {
   // Internal creation info
   id: number | '<monitor>';
   generation: number;
@@ -529,10 +529,10 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
       options.documentsReturnedIn == null || !options.raw
         ? options
         : {
-          ...options,
-          raw: false,
-          fieldsAsRaw: { [options.documentsReturnedIn]: true }
-        };
+            ...options,
+            raw: false,
+            fieldsAsRaw: { [options.documentsReturnedIn]: true }
+          };
 
     /** MongoDBResponse instance or subclass */
     let document: MongoDBResponse | undefined = undefined;
@@ -695,9 +695,9 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
       options.agreedCompressor === 'none' || !OpCompressedRequest.canCompress(command)
         ? command
         : new OpCompressedRequest(command, {
-          agreedCompressor: options.agreedCompressor ?? 'none',
-          zlibCompressionLevel: options.zlibCompressionLevel ?? 0
-        });
+            agreedCompressor: options.agreedCompressor ?? 'none',
+            zlibCompressionLevel: options.zlibCompressionLevel ?? 0
+          });
 
     const buffer = Buffer.concat(await finalCommand.toBin());
 

--- a/src/cmap/handshake/client_metadata.ts
+++ b/src/cmap/handshake/client_metadata.ts
@@ -1,4 +1,3 @@
-import * as os from 'os';
 import * as process from 'process';
 
 import { BSON, type Document, Int32, NumberUtils } from '../../bson';
@@ -96,7 +95,8 @@ export class LimitedSizeDocument {
   }
 }
 
-type MakeClientMetadataOptions = Pick<MongoOptions, 'appName'>;
+type MakeClientMetadataOptions = Pick<MongoOptions, 'appName' | 'runtime'>;
+
 /**
  * From the specs:
  * Implementors SHOULD cumulatively update fields in the following order until the document is under the size limit:
@@ -107,7 +107,7 @@ type MakeClientMetadataOptions = Pick<MongoOptions, 'appName'>;
  */
 export async function makeClientMetadata(
   driverInfoList: DriverInfo[],
-  { appName = '' }: MakeClientMetadataOptions
+  { appName = '', runtime: { os } }: MakeClientMetadataOptions
 ): Promise<ClientMetadata> {
   const metadataDocument = new LimitedSizeDocument(512);
 

--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -20,7 +20,7 @@ import {
 import { MongoLoggableComponent, MongoLogger, SeverityLevel } from './mongo_logger';
 import { ReadConcern, type ReadConcernLevel } from './read_concern';
 import { ReadPreference, type ReadPreferenceMode } from './read_preference';
-import { type Runtime } from './runtime_adapters';
+import { resolveRuntimeAdapters } from './runtime_adapters';
 import { ServerMonitoringMode } from './sdam/monitor';
 import type { TagSet } from './sdam/server_description';
 import {
@@ -539,12 +539,7 @@ export function parseOptions(
     }
   );
 
-  const runtime: Runtime = {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    os: options.runtimeAdapters?.os ?? require('os')
-  };
-
-  mongoOptions.runtime = runtime;
+  mongoOptions.runtime = resolveRuntimeAdapters(options);
 
   return mongoOptions;
 }

--- a/src/connection_string.ts
+++ b/src/connection_string.ts
@@ -20,6 +20,7 @@ import {
 import { MongoLoggableComponent, MongoLogger, SeverityLevel } from './mongo_logger';
 import { ReadConcern, type ReadConcernLevel } from './read_concern';
 import { ReadPreference, type ReadPreferenceMode } from './read_preference';
+import { type Runtime } from './runtime_adapters';
 import { ServerMonitoringMode } from './sdam/monitor';
 import type { TagSet } from './sdam/server_description';
 import {
@@ -537,6 +538,13 @@ export function parseOptions(
       mongodbLogMaxDocumentLength: mongoOptions.mongodbLogMaxDocumentLength
     }
   );
+
+  const runtime: Runtime = {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    os: options.runtimeAdapters?.os ?? require('os')
+  };
+
+  mongoOptions.runtime = runtime;
 
   return mongoOptions;
 }
@@ -1060,6 +1068,9 @@ export const OPTIONS = {
   retryWrites: {
     default: true,
     type: 'boolean'
+  },
+  runtimeAdapters: {
+    type: 'record'
   },
   serializeFunctions: {
     type: 'boolean'

--- a/src/index.ts
+++ b/src/index.ts
@@ -562,6 +562,7 @@ export type {
   ReadPreferenceLikeOptions,
   ReadPreferenceOptions
 } from './read_preference';
+export type { OsAdapter, Runtime, RuntimeAdapters } from './runtime_adapters';
 export type { ClusterTime } from './sdam/common';
 export type {
   Monitor,

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -319,7 +319,11 @@ export interface MongoClientOptions extends BSONSerializeOptions, SupportedNodeC
   connectionType?: typeof Connection;
   /** @internal */
   __skipPingOnConnect?: boolean;
-  /** @experimental  */
+  /**
+   * @experimental
+   *
+   * If provided, any adapters provided will be used in place of the corresponding Node.js module.
+   */
   runtimeAdapters?: RuntimeAdapters;
 }
 

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -1035,39 +1035,39 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> implements
  */
 export interface MongoOptions
   extends Required<
-    Pick<
-      MongoClientOptions,
-      | 'autoEncryption'
-      | 'connectTimeoutMS'
-      | 'directConnection'
-      | 'driverInfo'
-      | 'forceServerObjectId'
-      | 'minHeartbeatFrequencyMS'
-      | 'heartbeatFrequencyMS'
-      | 'localThresholdMS'
-      | 'maxConnecting'
-      | 'maxIdleTimeMS'
-      | 'maxPoolSize'
-      | 'minPoolSize'
-      | 'monitorCommands'
-      | 'noDelay'
-      | 'pkFactory'
-      | 'raw'
-      | 'replicaSet'
-      | 'retryReads'
-      | 'retryWrites'
-      | 'serverSelectionTimeoutMS'
-      | 'socketTimeoutMS'
-      | 'srvMaxHosts'
-      | 'srvServiceName'
-      | 'tlsAllowInvalidCertificates'
-      | 'tlsAllowInvalidHostnames'
-      | 'tlsInsecure'
-      | 'waitQueueTimeoutMS'
-      | 'zlibCompressionLevel'
-    >
-  >,
-  SupportedNodeConnectionOptions {
+      Pick<
+        MongoClientOptions,
+        | 'autoEncryption'
+        | 'connectTimeoutMS'
+        | 'directConnection'
+        | 'driverInfo'
+        | 'forceServerObjectId'
+        | 'minHeartbeatFrequencyMS'
+        | 'heartbeatFrequencyMS'
+        | 'localThresholdMS'
+        | 'maxConnecting'
+        | 'maxIdleTimeMS'
+        | 'maxPoolSize'
+        | 'minPoolSize'
+        | 'monitorCommands'
+        | 'noDelay'
+        | 'pkFactory'
+        | 'raw'
+        | 'replicaSet'
+        | 'retryReads'
+        | 'retryWrites'
+        | 'serverSelectionTimeoutMS'
+        | 'socketTimeoutMS'
+        | 'srvMaxHosts'
+        | 'srvServiceName'
+        | 'tlsAllowInvalidCertificates'
+        | 'tlsAllowInvalidHostnames'
+        | 'tlsInsecure'
+        | 'waitQueueTimeoutMS'
+        | 'zlibCompressionLevel'
+      >
+    >,
+    SupportedNodeConnectionOptions {
   appName?: string;
   hosts: HostAddress[];
   srvHost?: string;

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -46,6 +46,7 @@ import { EndSessionsOperation } from './operations/end_sessions';
 import { executeOperation } from './operations/execute_operation';
 import type { ReadConcern, ReadConcernLevel, ReadConcernLike } from './read_concern';
 import { ReadPreference, type ReadPreferenceMode } from './read_preference';
+import { type Runtime, type RuntimeAdapters } from './runtime_adapters';
 import type { ServerMonitoringMode } from './sdam/monitor';
 import type { TagSet } from './sdam/server_description';
 import { DeprioritizedServers, readPreferenceServerSelector } from './sdam/server_selection';
@@ -318,6 +319,8 @@ export interface MongoClientOptions extends BSONSerializeOptions, SupportedNodeC
   connectionType?: typeof Connection;
   /** @internal */
   __skipPingOnConnect?: boolean;
+  /** @experimental  */
+  runtimeAdapters?: RuntimeAdapters;
 }
 
 /** @public */
@@ -1032,39 +1035,39 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> implements
  */
 export interface MongoOptions
   extends Required<
-      Pick<
-        MongoClientOptions,
-        | 'autoEncryption'
-        | 'connectTimeoutMS'
-        | 'directConnection'
-        | 'driverInfo'
-        | 'forceServerObjectId'
-        | 'minHeartbeatFrequencyMS'
-        | 'heartbeatFrequencyMS'
-        | 'localThresholdMS'
-        | 'maxConnecting'
-        | 'maxIdleTimeMS'
-        | 'maxPoolSize'
-        | 'minPoolSize'
-        | 'monitorCommands'
-        | 'noDelay'
-        | 'pkFactory'
-        | 'raw'
-        | 'replicaSet'
-        | 'retryReads'
-        | 'retryWrites'
-        | 'serverSelectionTimeoutMS'
-        | 'socketTimeoutMS'
-        | 'srvMaxHosts'
-        | 'srvServiceName'
-        | 'tlsAllowInvalidCertificates'
-        | 'tlsAllowInvalidHostnames'
-        | 'tlsInsecure'
-        | 'waitQueueTimeoutMS'
-        | 'zlibCompressionLevel'
-      >
-    >,
-    SupportedNodeConnectionOptions {
+    Pick<
+      MongoClientOptions,
+      | 'autoEncryption'
+      | 'connectTimeoutMS'
+      | 'directConnection'
+      | 'driverInfo'
+      | 'forceServerObjectId'
+      | 'minHeartbeatFrequencyMS'
+      | 'heartbeatFrequencyMS'
+      | 'localThresholdMS'
+      | 'maxConnecting'
+      | 'maxIdleTimeMS'
+      | 'maxPoolSize'
+      | 'minPoolSize'
+      | 'monitorCommands'
+      | 'noDelay'
+      | 'pkFactory'
+      | 'raw'
+      | 'replicaSet'
+      | 'retryReads'
+      | 'retryWrites'
+      | 'serverSelectionTimeoutMS'
+      | 'socketTimeoutMS'
+      | 'srvMaxHosts'
+      | 'srvServiceName'
+      | 'tlsAllowInvalidCertificates'
+      | 'tlsAllowInvalidHostnames'
+      | 'tlsInsecure'
+      | 'waitQueueTimeoutMS'
+      | 'zlibCompressionLevel'
+    >
+  >,
+  SupportedNodeConnectionOptions {
   appName?: string;
   hosts: HostAddress[];
   srvHost?: string;
@@ -1152,4 +1155,7 @@ export interface MongoOptions
   timeoutMS?: number;
   /** @internal */
   __skipPingOnConnect?: boolean;
+
+  /** @internal */
+  runtime: Runtime;
 }

--- a/src/runtime_adapters.ts
+++ b/src/runtime_adapters.ts
@@ -1,14 +1,24 @@
-/**
- * @public
- * @experimental
- */
-export type OsAdapter = Pick<typeof import('os'), 'platform' | 'release' | 'arch' | 'type'>;
+/* eslint-disable no-restricted-imports */
+// We squash the restricted import errors here because we are using type-only imports, which
+// do not impact the driver's actual runtime dependencies.
+
+import type * as os from 'os';
+
+import { type MongoClientOptions } from './mongo_client';
 
 /**
  * @public
  * @experimental
  *
- * This type represents the interface that the driver needs from the runtime in order to function.
+ * Represents the set of dependencies that the driver uses from the [Node.js OS module](https://nodejs.org/api/os.html).
+ */
+export type OsAdapter = Pick<typeof os, 'release' | 'platform' | 'arch' | 'type'>;
+
+/**
+ * @public
+ * @experimental
+ *
+ * This type represents the set of dependencies that the driver needs from the Javascript runtime in order to function.
  */
 export interface RuntimeAdapters {
   os?: OsAdapter;
@@ -18,8 +28,21 @@ export interface RuntimeAdapters {
  * @internal
  *
  * Represents a complete, parsed set of runtime adapters.  After options parsing, all adapters
- * are always present (either using the user's provided adapter, or defaulting to Nodejs' module).
+ * are always present (either using the user's provided adapter, or defaulting to the Node.js module).
  */
 export interface Runtime {
   os: OsAdapter;
+}
+
+/**
+ * @internal
+ *
+ * Given a MongoClientOptions, this function resolves the set of runtime options, providing Nodejs implementations if
+ * not provided by in `options`, and returns a `Runtime`.
+ */
+export function resolveRuntimeAdapters(options: MongoClientOptions): Runtime {
+  return {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    os: options.runtimeAdapters?.os ?? require('os')
+  };
 }

--- a/src/runtime_adapters.ts
+++ b/src/runtime_adapters.ts
@@ -1,6 +1,8 @@
-/* eslint-disable no-restricted-imports */
+/* eslint-disable no-restricted-imports, @typescript-eslint/no-require-imports */
+
 // We squash the restricted import errors here because we are using type-only imports, which
 // do not impact the driver's actual runtime dependencies.
+// We also allow restricted imports in this file, because we expect this file to be the only place actually importing restricted Node APIs.
 
 import type * as os from 'os';
 
@@ -42,7 +44,6 @@ export interface Runtime {
  */
 export function resolveRuntimeAdapters(options: MongoClientOptions): Runtime {
   return {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
     os: options.runtimeAdapters?.os ?? require('os')
   };
 }

--- a/src/runtime_adapters.ts
+++ b/src/runtime_adapters.ts
@@ -1,0 +1,25 @@
+/**
+ * @public
+ * @experimental
+ */
+export type OsAdapter = Pick<typeof import('os'), 'platform' | 'release' | 'arch' | 'type'>;
+
+/**
+ * @public
+ * @experimental
+ *
+ * This type represents the interface that the driver needs from the runtime in order to function.
+ */
+export interface RuntimeAdapters {
+  os?: OsAdapter;
+}
+
+/**
+ * @internal
+ *
+ * Represents a complete, parsed set of runtime adapters.  After options parsing, all adapters
+ * are always present (either using the user's provided adapter, or defaulting to Nodejs' module).
+ */
+export interface Runtime {
+  os: OsAdapter;
+}

--- a/test/integration/connection-monitoring-and-pooling/connection.test.ts
+++ b/test/integration/connection-monitoring-and-pooling/connection.test.ts
@@ -22,7 +22,7 @@ import { LEGACY_HELLO_COMMAND } from '../../../src/constants';
 import { Topology } from '../../../src/sdam/topology';
 import { HostAddress, ns } from '../../../src/utils';
 import * as mock from '../../tools/mongodb-mock/index';
-import { processTick, sleep } from '../../tools/utils';
+import { processTick, runtime, sleep } from '../../tools/utils';
 import { assert as test, setupDatabase } from '../shared';
 
 const commonConnectOptions = {
@@ -49,7 +49,10 @@ describe('Connection', function () {
           ...commonConnectOptions,
           connectionType: Connection,
           ...this.configuration.options,
-          metadata: makeClientMetadata([], {})
+          metadata: makeClientMetadata([], {
+            runtime
+          }),
+          runtime
         };
 
         let conn;
@@ -71,7 +74,8 @@ describe('Connection', function () {
           connectionType: Connection,
           ...this.configuration.options,
           monitorCommands: true,
-          metadata: makeClientMetadata([], {})
+          runtime,
+          metadata: makeClientMetadata([], { runtime })
         };
 
         let conn;
@@ -102,7 +106,10 @@ describe('Connection', function () {
           connectionType: Connection,
           ...this.configuration.options,
           monitorCommands: true,
-          metadata: makeClientMetadata([], {})
+          runtime,
+          metadata: makeClientMetadata([], {
+            runtime
+          })
         };
 
         let conn;

--- a/test/tools/utils.ts
+++ b/test/tools/utils.ts
@@ -7,6 +7,7 @@ import * as path from 'node:path';
 import { EJSON } from 'bson';
 import * as BSON from 'bson';
 import { expect } from 'chai';
+import * as os from 'os';
 import * as process from 'process';
 import { Readable } from 'stream';
 import { setTimeout } from 'timers';
@@ -18,6 +19,7 @@ import {
   type HostAddress,
   MongoClient,
   type MongoClientOptions,
+  type Runtime,
   type ServerApiVersion,
   type TopologyOptions
 } from '../../src';
@@ -604,3 +606,7 @@ export function configureMongocryptdSpawnHooks(
     port
   };
 }
+
+export const runtime: Runtime = {
+  os
+};

--- a/test/tools/utils.ts
+++ b/test/tools/utils.ts
@@ -7,7 +7,6 @@ import * as path from 'node:path';
 import { EJSON } from 'bson';
 import * as BSON from 'bson';
 import { expect } from 'chai';
-import * as os from 'os';
 import * as process from 'process';
 import { Readable } from 'stream';
 import { setTimeout } from 'timers';
@@ -24,6 +23,7 @@ import {
   type TopologyOptions
 } from '../../src';
 import { OP_MSG } from '../../src/cmap/wire_protocol/constants';
+import { resolveRuntimeAdapters } from '../../src/runtime_adapters';
 import { Topology } from '../../src/sdam/topology';
 import { processTimeMS } from '../../src/utils';
 import { type TestConfiguration } from './runner/config';
@@ -607,6 +607,7 @@ export function configureMongocryptdSpawnHooks(
   };
 }
 
-export const runtime: Runtime = {
-  os
-};
+/**
+ * A `Runtime` that resolves to entirely Nodejs modules, useful when tests must provide a default `runtime` object to an API.
+ */
+export const runtime: Runtime = resolveRuntimeAdapters({});

--- a/test/unit/assorted/optional_require.test.ts
+++ b/test/unit/assorted/optional_require.test.ts
@@ -7,6 +7,7 @@ import { GSSAPI } from '../../../src/cmap/auth/gssapi';
 import { compress } from '../../../src/cmap/wire_protocol/compression';
 import { MongoMissingDependencyError } from '../../../src/error';
 import { HostAddress } from '../../../src/utils';
+import { runtime } from '../../tools/utils';
 
 function moduleExistsSync(moduleName) {
   return existsSync(resolve(__dirname, `../../../node_modules/${moduleName}`));
@@ -41,9 +42,13 @@ describe('optionalRequire', function () {
       const gssapi = new GSSAPI();
 
       const error = await gssapi
-        .auth(new AuthContext(null, true, {
-          hostAddress: new HostAddress('a'), credentials: true, runtime: { os: require('os') }
-        }))
+        .auth(
+          new AuthContext(null, true, {
+            hostAddress: new HostAddress('a'),
+            credentials: true,
+            runtime
+          })
+        )
         .then(
           () => null,
           e => e

--- a/test/unit/assorted/optional_require.test.ts
+++ b/test/unit/assorted/optional_require.test.ts
@@ -41,7 +41,9 @@ describe('optionalRequire', function () {
       const gssapi = new GSSAPI();
 
       const error = await gssapi
-        .auth(new AuthContext(null, true, { hostAddress: new HostAddress('a'), credentials: true }))
+        .auth(new AuthContext(null, true, {
+          hostAddress: new HostAddress('a'), credentials: true, runtime: { os: require('os') }
+        }))
         .then(
           () => null,
           e => e

--- a/test/unit/cmap/connect.test.ts
+++ b/test/unit/cmap/connect.test.ts
@@ -210,7 +210,9 @@ describe('Connect Tests', function () {
             connection: {},
             options: {
               ...CONNECT_DEFAULTS,
-              metadata: makeClientMetadata([], {})
+              metadata: makeClientMetadata([], {
+                runtime: { os: require('os') }
+              })
             }
           };
         });
@@ -239,7 +241,9 @@ describe('Connect Tests', function () {
                   name: 's'.repeat(128)
                 }
               ],
-              { appName: longAppName }
+              {
+                appName: longAppName, runtime: { os: require('os') }
+              }
             );
             const longAuthContext = {
               connection: {},
@@ -267,7 +271,9 @@ describe('Connect Tests', function () {
             connection: {},
             options: {
               ...CONNECT_DEFAULTS,
-              metadata: makeClientMetadata([], {})
+              metadata: makeClientMetadata([], {
+                runtime: { os: require('os') }
+              })
             }
           };
         });
@@ -296,7 +302,10 @@ describe('Connect Tests', function () {
                   name: 's'.repeat(128)
                 }
               ],
-              { appName: longAppName }
+              {
+                appName: longAppName,
+                runtime: { os: require('os') }
+              }
             );
             const longAuthContext = {
               connection: {},

--- a/test/unit/cmap/connect.test.ts
+++ b/test/unit/cmap/connect.test.ts
@@ -15,6 +15,7 @@ import { CancellationToken } from '../../../src/mongo_types';
 import { HostAddress, isHello } from '../../../src/utils';
 import { genClusterTime } from '../../tools/common';
 import * as mock from '../../tools/mongodb-mock/index';
+import { runtime } from '../../tools/utils';
 
 const CONNECT_DEFAULTS = {
   id: 1,
@@ -211,7 +212,7 @@ describe('Connect Tests', function () {
             options: {
               ...CONNECT_DEFAULTS,
               metadata: makeClientMetadata([], {
-                runtime: { os: require('os') }
+                runtime
               })
             }
           };
@@ -242,7 +243,8 @@ describe('Connect Tests', function () {
                 }
               ],
               {
-                appName: longAppName, runtime: { os: require('os') }
+                appName: longAppName,
+                runtime
               }
             );
             const longAuthContext = {
@@ -272,7 +274,7 @@ describe('Connect Tests', function () {
             options: {
               ...CONNECT_DEFAULTS,
               metadata: makeClientMetadata([], {
-                runtime: { os: require('os') }
+                runtime
               })
             }
           };
@@ -304,7 +306,7 @@ describe('Connect Tests', function () {
               ],
               {
                 appName: longAppName,
-                runtime: { os: require('os') }
+                runtime
               }
             );
             const longAuthContext = {

--- a/test/unit/cmap/handshake/client_metadata.test.ts
+++ b/test/unit/cmap/handshake/client_metadata.test.ts
@@ -12,11 +12,6 @@ import {
   makeClientMetadata
 } from '../../../../src/cmap/handshake/client_metadata';
 import { MongoInvalidArgumentError } from '../../../../src/error';
-import { Runtime } from '../../../../src';
-
-const runtime: Runtime = {
-  os: require('os')
-};
 
 describe('client metadata module', () => {
   afterEach(() => sinon.restore());
@@ -169,7 +164,9 @@ describe('client metadata module', () => {
 
     context('when driverInfo.platform is provided', () => {
       it('throws an error if driverInfo.platform is too large', async () => {
-        const error = await makeClientMetadata([{ platform: 'a'.repeat(512) }], { runtime }).catch(e => e);
+        const error = await makeClientMetadata([{ platform: 'a'.repeat(512) }], { runtime }).catch(
+          e => e
+        );
         expect(error)
           .to.be.instanceOf(MongoInvalidArgumentError)
           .to.match(/platform/);
@@ -195,7 +192,9 @@ describe('client metadata module', () => {
 
     context('when driverInfo.name is provided', () => {
       it('throws an error if driverInfo.name is too large', async () => {
-        const error = await makeClientMetadata([{ name: 'a'.repeat(512) }], { runtime }).catch(e => e);
+        const error = await makeClientMetadata([{ name: 'a'.repeat(512) }], { runtime }).catch(
+          e => e
+        );
         expect(error).to.be.instanceOf(MongoInvalidArgumentError).to.match(/name/);
       });
 
@@ -219,7 +218,9 @@ describe('client metadata module', () => {
 
     context('when driverInfo.version is provided', () => {
       it('throws an error if driverInfo.version is too large', async () => {
-        const error = await makeClientMetadata([{ version: 'a'.repeat(512) }], { runtime }).catch(e => e);
+        const error = await makeClientMetadata([{ version: 'a'.repeat(512) }], { runtime }).catch(
+          e => e
+        );
         expect(error)
           .to.be.instanceOf(MongoInvalidArgumentError)
           .to.match(/version/);
@@ -540,7 +541,9 @@ describe('client metadata module', () => {
       });
 
       it('does not attach it to the metadata', async () => {
-        expect(await makeClientMetadata([], { runtime })).not.to.have.nested.property('aws.memory_mb');
+        expect(await makeClientMetadata([], { runtime })).not.to.have.nested.property(
+          'aws.memory_mb'
+        );
       });
     });
   });

--- a/test/unit/cmap/handshake/client_metadata.test.ts
+++ b/test/unit/cmap/handshake/client_metadata.test.ts
@@ -12,6 +12,7 @@ import {
   makeClientMetadata
 } from '../../../../src/cmap/handshake/client_metadata';
 import { MongoInvalidArgumentError } from '../../../../src/error';
+import { runtime } from '../../../tools/utils';
 
 describe('client metadata module', () => {
   afterEach(() => sinon.restore());

--- a/test/unit/cmap/handshake/client_metadata.test.ts
+++ b/test/unit/cmap/handshake/client_metadata.test.ts
@@ -12,6 +12,11 @@ import {
   makeClientMetadata
 } from '../../../../src/cmap/handshake/client_metadata';
 import { MongoInvalidArgumentError } from '../../../../src/error';
+import { Runtime } from '../../../../src';
+
+const runtime: Runtime = {
+  os: require('os')
+};
 
 describe('client metadata module', () => {
   afterEach(() => sinon.restore());
@@ -141,7 +146,7 @@ describe('client metadata module', () => {
   describe('makeClientMetadata()', () => {
     context('when no FAAS environment is detected', () => {
       it('does not append FAAS metadata', async () => {
-        const metadata = await makeClientMetadata([], {});
+        const metadata = await makeClientMetadata([], { runtime });
         expect(metadata).not.to.have.property(
           'env',
           'faas metadata applied in a non-faas environment'
@@ -164,14 +169,14 @@ describe('client metadata module', () => {
 
     context('when driverInfo.platform is provided', () => {
       it('throws an error if driverInfo.platform is too large', async () => {
-        const error = await makeClientMetadata([{ platform: 'a'.repeat(512) }], {}).catch(e => e);
+        const error = await makeClientMetadata([{ platform: 'a'.repeat(512) }], { runtime }).catch(e => e);
         expect(error)
           .to.be.instanceOf(MongoInvalidArgumentError)
           .to.match(/platform/);
       });
 
       it('appends driverInfo.platform to the platform field', async () => {
-        const metadata = await makeClientMetadata([{ platform: 'myPlatform' }], {});
+        const metadata = await makeClientMetadata([{ platform: 'myPlatform' }], { runtime });
         expect(metadata).to.deep.equal({
           driver: {
             name: 'nodejs',
@@ -190,12 +195,12 @@ describe('client metadata module', () => {
 
     context('when driverInfo.name is provided', () => {
       it('throws an error if driverInfo.name is too large', async () => {
-        const error = await makeClientMetadata([{ name: 'a'.repeat(512) }], {}).catch(e => e);
+        const error = await makeClientMetadata([{ name: 'a'.repeat(512) }], { runtime }).catch(e => e);
         expect(error).to.be.instanceOf(MongoInvalidArgumentError).to.match(/name/);
       });
 
       it('appends driverInfo.name to the driver.name field', async () => {
-        const metadata = await makeClientMetadata([{ name: 'myName' }], {});
+        const metadata = await makeClientMetadata([{ name: 'myName' }], { runtime });
         expect(metadata).to.deep.equal({
           driver: {
             name: 'nodejs|myName',
@@ -214,14 +219,14 @@ describe('client metadata module', () => {
 
     context('when driverInfo.version is provided', () => {
       it('throws an error if driverInfo.version is too large', async () => {
-        const error = await makeClientMetadata([{ version: 'a'.repeat(512) }], {}).catch(e => e);
+        const error = await makeClientMetadata([{ version: 'a'.repeat(512) }], { runtime }).catch(e => e);
         expect(error)
           .to.be.instanceOf(MongoInvalidArgumentError)
           .to.match(/version/);
       });
 
       it('appends driverInfo.version to the version field', async () => {
-        const metadata = await makeClientMetadata([{ version: 'myVersion' }], {});
+        const metadata = await makeClientMetadata([{ version: 'myVersion' }], { runtime });
         expect(metadata).to.deep.equal({
           driver: {
             name: 'nodejs',
@@ -240,7 +245,7 @@ describe('client metadata module', () => {
 
     context('when no custom driverInto is provided', () => {
       it('does not append the driver info to the metadata', async () => {
-        const metadata = await makeClientMetadata([], {});
+        const metadata = await makeClientMetadata([], { runtime });
         expect(metadata).to.deep.equal({
           driver: {
             name: 'nodejs',
@@ -257,7 +262,7 @@ describe('client metadata module', () => {
       });
 
       it('does not set the application field', async () => {
-        const metadata = await makeClientMetadata([], {});
+        const metadata = await makeClientMetadata([], { runtime });
         expect(metadata).not.to.have.property('application');
       });
     });
@@ -267,6 +272,7 @@ describe('client metadata module', () => {
         it('truncates the application name to <=128 bytes', async () => {
           const longString = 'a'.repeat(300);
           const metadata = await makeClientMetadata([], {
+            runtime,
             appName: longString
           });
           expect(metadata.application?.name).to.be.a('string');
@@ -283,6 +289,7 @@ describe('client metadata module', () => {
           it('truncates the application name to 129 bytes', async () => {
             const longString = '€'.repeat(300);
             const metadata = await makeClientMetadata([], {
+              runtime,
               appName: longString
             });
 
@@ -298,6 +305,7 @@ describe('client metadata module', () => {
       context('when the app name is under 128 bytes', () => {
         it('sets the application name to the value', async () => {
           const metadata = await makeClientMetadata([], {
+            runtime,
             appName: 'myApplication'
           });
           expect(metadata.application?.name).to.equal('myApplication');
@@ -313,37 +321,37 @@ describe('client metadata module', () => {
 
         it('sets platform to Deno', async () => {
           globalThis.Deno = { version: { deno: '1.2.3' } };
-          const metadata = await makeClientMetadata([], {});
+          const metadata = await makeClientMetadata([], { runtime });
           expect(metadata.platform).to.equal('Deno v1.2.3, LE');
         });
 
         it('sets platform to Deno with driverInfo.platform', async () => {
           globalThis.Deno = { version: { deno: '1.2.3' } };
-          const metadata = await makeClientMetadata([{ platform: 'myPlatform' }], {});
+          const metadata = await makeClientMetadata([{ platform: 'myPlatform' }], { runtime });
           expect(metadata.platform).to.equal('Deno v1.2.3, LE|myPlatform');
         });
 
         it('ignores version if Deno.version.deno is not a string', async () => {
           globalThis.Deno = { version: { deno: 1 } };
-          const metadata = await makeClientMetadata([], {});
+          const metadata = await makeClientMetadata([], { runtime });
           expect(metadata.platform).to.equal('Deno v0.0.0-unknown, LE');
         });
 
         it('ignores version if Deno.version does not have a deno property', async () => {
           globalThis.Deno = { version: { somethingElse: '1.2.3' } };
-          const metadata = await makeClientMetadata([], {});
+          const metadata = await makeClientMetadata([], { runtime });
           expect(metadata.platform).to.equal('Deno v0.0.0-unknown, LE');
         });
 
         it('ignores version if Deno.version is null', async () => {
           globalThis.Deno = { version: null };
-          const metadata = await makeClientMetadata([], {});
+          const metadata = await makeClientMetadata([], { runtime });
           expect(metadata.platform).to.equal('Deno v0.0.0-unknown, LE');
         });
 
         it('ignores version if Deno is nullish', async () => {
           globalThis.Deno = null;
-          const metadata = await makeClientMetadata([], {});
+          const metadata = await makeClientMetadata([], { runtime });
           expect(metadata.platform).to.equal('Deno v0.0.0-unknown, LE');
         });
       });
@@ -357,7 +365,7 @@ describe('client metadata module', () => {
           globalThis.Bun = class {
             static version = '1.2.3';
           };
-          const metadata = await makeClientMetadata([], {});
+          const metadata = await makeClientMetadata([], { runtime });
           expect(metadata.platform).to.equal('Bun v1.2.3, LE');
         });
 
@@ -365,7 +373,7 @@ describe('client metadata module', () => {
           globalThis.Bun = class {
             static version = '1.2.3';
           };
-          const metadata = await makeClientMetadata([{ platform: 'myPlatform' }], {});
+          const metadata = await makeClientMetadata([{ platform: 'myPlatform' }], { runtime });
           expect(metadata.platform).to.equal('Bun v1.2.3, LE|myPlatform');
         });
 
@@ -373,7 +381,7 @@ describe('client metadata module', () => {
           globalThis.Bun = class {
             static version = 1;
           };
-          const metadata = await makeClientMetadata([], {});
+          const metadata = await makeClientMetadata([], { runtime });
           expect(metadata.platform).to.equal('Bun v0.0.0-unknown, LE');
         });
 
@@ -381,13 +389,13 @@ describe('client metadata module', () => {
           globalThis.Bun = class {
             static version = 1;
           };
-          const metadata = await makeClientMetadata([{ platform: 'myPlatform' }], {});
+          const metadata = await makeClientMetadata([{ platform: 'myPlatform' }], { runtime });
           expect(metadata.platform).to.equal('Bun v0.0.0-unknown, LE|myPlatform');
         });
 
         it('ignores version if Bun is nullish', async () => {
           globalThis.Bun = null;
-          const metadata = await makeClientMetadata([{ platform: 'myPlatform' }], {});
+          const metadata = await makeClientMetadata([{ platform: 'myPlatform' }], { runtime });
           expect(metadata.platform).to.equal('Bun v0.0.0-unknown, LE|myPlatform');
         });
       });
@@ -508,7 +516,7 @@ describe('client metadata module', () => {
           });
 
           it(`returns ${inspect(outcome)} under env property`, async () => {
-            const { env } = await makeClientMetadata([], {});
+            const { env } = await makeClientMetadata([], { runtime });
             expect(env).to.deep.equal(outcome);
           });
 
@@ -532,7 +540,7 @@ describe('client metadata module', () => {
       });
 
       it('does not attach it to the metadata', async () => {
-        expect(await makeClientMetadata([], {})).not.to.have.nested.property('aws.memory_mb');
+        expect(await makeClientMetadata([], { runtime })).not.to.have.nested.property('aws.memory_mb');
       });
     });
   });
@@ -547,7 +555,7 @@ describe('client metadata module', () => {
       });
 
       it('only includes env.name', async () => {
-        const metadata = await makeClientMetadata([], {});
+        const metadata = await makeClientMetadata([], { runtime });
         expect(metadata).to.not.have.nested.property('env.region');
         expect(metadata).to.have.nested.property('env.name', 'aws.lambda');
         expect(metadata.env).to.have.all.keys('name');
@@ -565,7 +573,7 @@ describe('client metadata module', () => {
         });
 
         it('only includes env.name', async () => {
-          const metadata = await makeClientMetadata([], {});
+          const metadata = await makeClientMetadata([], { runtime });
           expect(metadata).to.have.property('env');
           expect(metadata).to.have.nested.property('env.region', 'abc');
           expect(metadata.os).to.have.all.keys('type');
@@ -582,7 +590,7 @@ describe('client metadata module', () => {
         });
 
         it('omits os information', async () => {
-          const metadata = await makeClientMetadata([], {});
+          const metadata = await makeClientMetadata([], { runtime });
           expect(metadata).to.not.have.property('os');
         });
       });
@@ -598,7 +606,7 @@ describe('client metadata module', () => {
       });
 
       it('omits the faas env', async () => {
-        const metadata = await makeClientMetadata([{ name: 'a'.repeat(350) }], {});
+        const metadata = await makeClientMetadata([{ name: 'a'.repeat(350) }], { runtime });
         expect(metadata).to.not.have.property('env');
       });
     });

--- a/test/unit/runtime_adapters.test.ts
+++ b/test/unit/runtime_adapters.test.ts
@@ -1,30 +1,31 @@
-import { expect } from "chai"
-import { MongoClient, OsAdapter } from "../../src"
+import { expect } from 'chai';
 import * as os from 'os';
 
+import { MongoClient, type OsAdapter } from '../../src';
+
 describe('Runtime Adapters tests', function () {
-    describe('`os`', function () {
-        describe('when no os adapter is provided', function () {
-            it(`defaults to Node's os module`, function () {
-                const client = new MongoClient('mongodb://localhost:27017');
+  describe('`os`', function () {
+    describe('when no os adapter is provided', function () {
+      it(`defaults to Node's os module`, function () {
+        const client = new MongoClient('mongodb://localhost:27017');
 
-                expect(client.options.runtime.os).to.equal(os);
-            })
-        })
+        expect(client.options.runtime.os).to.equal(os);
+      });
+    });
 
-        describe('when an os adapter is provided', function () {
-            it(`uses the user provided adapter`, function () {
-                const osAdapter: OsAdapter = {
-                    ...os
-                };
-                const client = new MongoClient('mongodb://localhost:27017', {
-                    runtimeAdapters: {
-                        os: osAdapter
-                    }
-                });
+    describe('when an os adapter is provided', function () {
+      it(`uses the user provided adapter`, function () {
+        const osAdapter: OsAdapter = {
+          ...os
+        };
+        const client = new MongoClient('mongodb://localhost:27017', {
+          runtimeAdapters: {
+            os: osAdapter
+          }
+        });
 
-                expect(client.options.runtime.os).to.equal(osAdapter);
-            })
-        })
-    })
-})
+        expect(client.options.runtime.os).to.equal(osAdapter);
+      });
+    });
+  });
+});

--- a/test/unit/runtime_adapters.test.ts
+++ b/test/unit/runtime_adapters.test.ts
@@ -1,0 +1,30 @@
+import { expect } from "chai"
+import { MongoClient, OsAdapter } from "../../src"
+import * as os from 'os';
+
+describe('Runtime Adapters tests', function () {
+    describe('`os`', function () {
+        describe('when no os adapter is provided', function () {
+            it(`defaults to Node's os module`, function () {
+                const client = new MongoClient('mongodb://localhost:27017');
+
+                expect(client.options.runtime.os).to.equal(os);
+            })
+        })
+
+        describe('when an os adapter is provided', function () {
+            it(`uses the user provided adapter`, function () {
+                const osAdapter: OsAdapter = {
+                    ...os
+                };
+                const client = new MongoClient('mongodb://localhost:27017', {
+                    runtimeAdapters: {
+                        os: osAdapter
+                    }
+                });
+
+                expect(client.options.runtime.os).to.equal(osAdapter);
+            })
+        })
+    })
+})

--- a/test/unit/sdam/topology.test.ts
+++ b/test/unit/sdam/topology.test.ts
@@ -29,6 +29,11 @@ import { TimeoutContext } from '../../../src/timeout';
 import { isHello, ns } from '../../../src/utils';
 import * as mock from '../../tools/mongodb-mock/index';
 import { topologyWithPlaceholderClient } from '../../tools/utils';
+import { Runtime } from '../../../src';
+
+const runtime: Runtime = {
+  os: require('os')
+};
 
 describe('Topology (unit)', function () {
   let client, topology;
@@ -56,6 +61,7 @@ describe('Topology (unit)', function () {
     it('should correctly pass appname', async function () {
       const topology: Topology = topologyWithPlaceholderClient([`localhost:27017`], {
         metadata: makeClientMetadata([], {
+          runtime,
           appName: 'My application name'
         })
       });
@@ -120,7 +126,7 @@ describe('Topology (unit)', function () {
       });
       const server = await topology.selectServer('primary', {
         timeoutContext: ctx,
-        operationName: 'none'
+        operationName: 'none',
       });
       const err = await server
         .command(new RunCursorCommandOperation(ns('admin.$cmd'), { ping: 1 }, {}), ctx)

--- a/test/unit/sdam/topology.test.ts
+++ b/test/unit/sdam/topology.test.ts
@@ -28,12 +28,7 @@ import { TopologyDescription } from '../../../src/sdam/topology_description';
 import { TimeoutContext } from '../../../src/timeout';
 import { isHello, ns } from '../../../src/utils';
 import * as mock from '../../tools/mongodb-mock/index';
-import { topologyWithPlaceholderClient } from '../../tools/utils';
-import { Runtime } from '../../../src';
-
-const runtime: Runtime = {
-  os: require('os')
-};
+import { runtime, topologyWithPlaceholderClient } from '../../tools/utils';
 
 describe('Topology (unit)', function () {
   let client, topology;
@@ -126,7 +121,7 @@ describe('Topology (unit)', function () {
       });
       const server = await topology.selectServer('primary', {
         timeoutContext: ctx,
-        operationName: 'none',
+        operationName: 'none'
       });
       const err = await server
         .command(new RunCursorCommandOperation(ns('admin.$cmd'), { ping: 1 }, {}), ctx)


### PR DESCRIPTION
### Description

#### Summary of Changes

This PR adds support for an experimental runtimeAdapters.

##### Notes for Reviewers

<!-- 
If there is any additional context on the changes in the PR that reviewers might find helpful, feel free to make notes in this section.

Otherwise, feel free to remove this section.
-->

#### What is the motivation for this change?

<!--
Remove this section if there is an associated Jira ticket explaining the motivation for this change. If there is not, please fill this section out with
information explaining why this change is valuable.
-->

### Release Highlight

<!-- 
Contributors: please leave the release notes section for the Node driver team to fill in. The following instructions are for maintainers.

For user facing changes: please provide release notes. Feel free to browse previous releases for example release highlights.

If there are no user-facing changes in this PR, please delete the release highlight section from the PR description.
-->

<!-- RELEASE_HIGHLIGHT_START -->

### Experimental Support for Dependency Injection of Nodejs Runtime Dependencies

This release introduces a new MongoClient option, `runtimeAdapters`. `runtimeAdapters` allows injection of core Nodejs APIs, to allow users of the driver to use alternative runtimes that don't support Nodejs compatibility or work in restricted environments.

`runtimeAdapters` is experimental and the actual interface of each dependency might change at any time.

Notes about usage of `runtimeAdapters`:

1. If no `runtimeAdapter` is provided for a core Nodejs module that the driver uses, the driver will import the corresponding module from Nodejs.
2. Adapters are per-client.
3. Each adapter specifies the required APIs as a part of its Typescript API definition. There are no runtime checks to ensure all required functions are provided; the onus is on users to ensure that all required module dependencies are provided.
4. The `runtimeAdapters` Typescript types currently rely on Nodejs' type definitions (`@types/node`). To use `runtimeAdapters` in a Typescript project, `@types/node` must be installed as well.
5. When providing a module in `runtimeAdapters`, all required functions inside that module must be provided. For example, when injecting the `os` module, the `platform()` function cannot be omitted.

### `runtimeAdapters` supports injecting Nodejs' `os` module

The `os` module is pluggable using `runtimeAdapters`:

```typescript
const os: OsAdapter = {
  // implement the required OSAdapter interface
}

// `client` will never import or make use of the `os` module and instead only rely on the `os` adapter specified above.
const client = new MongoClient(<uri>, {
  runtimeAdapters: { os }
});
```

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Lint is passing (`npm run check:lint`)
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
