### PR TITLE
feat(NODE-7452): restrict server deprioritization on replica sets to overload errors

### DIFF
--- a/src/operations/execute_operation.ts
+++ b/src/operations/execute_operation.ts
@@ -19,6 +19,7 @@ import {
 } from '../error';
 import type { MongoClient } from '../mongo_client';
 import { ReadPreference } from '../read_preference';
+import { TopologyType } from '../sdam/common';
 import {
   DeprioritizedServers,
   sameServerSelector,
@@ -342,7 +343,12 @@ async function executeOperationWithRetries<
         session.unpin({ force: true, forceClear: true });
       }
 
-      deprioritizedServers.add(server.description);
+      if (
+        topology.description.type === TopologyType.Sharded ||
+        operationError.hasErrorLabel(MongoErrorLabel.SystemOverloadedError)
+      ) {
+        deprioritizedServers.add(server.description);
+      }
 
       server = await topology.selectServer(selector, {
         session,

--- a/test/integration/retryable-reads/retryable_reads.spec.prose.test.ts
+++ b/test/integration/retryable-reads/retryable_reads.spec.prose.test.ts
@@ -148,10 +148,10 @@ describe('Retryable Reads Spec Prose', () => {
     // for SystemOverloadedError errors.
 
     const TEST_METADATA: MongoDBMetadataUI = {
-      requires: { mongodb: '>=4.2', topology: 'replicaset' }
+      requires: { mongodb: '>=4.4', topology: 'replicaset' }
     };
 
-    describe.only('Retryable Reads Caused by Overload Errors Are Retried on a Different Server', () => {
+    describe('Retryable Reads Caused by Overload Errors Are Retried on a Different Server', () => {
       let client: MongoClient;
       const commandFailedEvents: CommandFailedEvent[] = [];
       const commandSucceededEvents: CommandSucceededEvent[] = [];
@@ -189,15 +189,6 @@ describe('Retryable Reads Spec Prose', () => {
 
       it('retries on a different server when SystemOverloadedError', TEST_METADATA, async () => {
         await client.db('test').collection('test').find().toArray();
-
-        console.log('failed event:', {
-          address: commandFailedEvents[0].address,
-          failure: {
-            name: commandFailedEvents[0].failure.name,
-            code: (commandFailedEvents[0].failure as any).code,
-            labels: (commandFailedEvents[0].failure as any).errorLabels
-          }
-        });
 
         expect(commandFailedEvents).to.have.lengthOf(1);
         expect(commandSucceededEvents).to.have.lengthOf(1);

--- a/test/integration/retryable-reads/retryable_reads.spec.prose.test.ts
+++ b/test/integration/retryable-reads/retryable_reads.spec.prose.test.ts
@@ -190,7 +190,14 @@ describe('Retryable Reads Spec Prose', () => {
       it('retries on a different server when SystemOverloadedError', TEST_METADATA, async () => {
         await client.db('test').collection('test').find().toArray();
 
-        console.log('failed event:', JSON.stringify(commandFailedEvents[0]));
+        console.log('failed event:', {
+          address: commandFailedEvents[0].address,
+          failure: {
+            name: commandFailedEvents[0].failure.name,
+            code: (commandFailedEvents[0].failure as any).code,
+            labels: (commandFailedEvents[0].failure as any).errorLabels
+          }
+        });
 
         expect(commandFailedEvents).to.have.lengthOf(1);
         expect(commandSucceededEvents).to.have.lengthOf(1);

--- a/test/integration/retryable-reads/retryable_reads.spec.prose.test.ts
+++ b/test/integration/retryable-reads/retryable_reads.spec.prose.test.ts
@@ -151,7 +151,7 @@ describe('Retryable Reads Spec Prose', () => {
       requires: { mongodb: '>=4.2', topology: 'replicaset' }
     };
 
-    describe('Retryable Reads Caused by Overload Errors Are Retried on a Different Server', () => {
+    describe.only('Retryable Reads Caused by Overload Errors Are Retried on a Different Server', () => {
       let client: MongoClient;
       const commandFailedEvents: CommandFailedEvent[] = [];
       const commandSucceededEvents: CommandSucceededEvent[] = [];
@@ -165,6 +165,8 @@ describe('Retryable Reads Spec Prose', () => {
 
         client.on('commandFailed', filterForCommands('find', commandFailedEvents));
         client.on('commandSucceeded', filterForCommands('find', commandSucceededEvents));
+
+        await client.connect();
 
         await client.db('admin').command({
           configureFailPoint: 'failCommand',
@@ -188,6 +190,8 @@ describe('Retryable Reads Spec Prose', () => {
       it('retries on a different server when SystemOverloadedError', TEST_METADATA, async () => {
         await client.db('test').collection('test').find().toArray();
 
+        console.log('failed event:', JSON.stringify(commandFailedEvents[0]));
+
         expect(commandFailedEvents).to.have.lengthOf(1);
         expect(commandSucceededEvents).to.have.lengthOf(1);
         expect(commandFailedEvents[0].address).to.not.equal(commandSucceededEvents[0].address);
@@ -208,6 +212,8 @@ describe('Retryable Reads Spec Prose', () => {
 
         client.on('commandFailed', filterForCommands('find', commandFailedEvents));
         client.on('commandSucceeded', filterForCommands('find', commandSucceededEvents));
+
+        await client.connect();
 
         await client.db('admin').command({
           configureFailPoint: 'failCommand',

--- a/test/integration/retryable-reads/retryable_reads.spec.prose.test.ts
+++ b/test/integration/retryable-reads/retryable_reads.spec.prose.test.ts
@@ -157,6 +157,8 @@ describe('Retryable Reads Spec Prose', () => {
       const commandSucceededEvents: CommandSucceededEvent[] = [];
 
       beforeEach(async function () {
+        // 1. Create a client `client` with `retryReads=true`, `readPreference=primaryPreferred`, and command event monitoring
+        //     enabled.
         client = this.configuration.newClient({
           retryReads: true,
           readPreference: 'primaryPreferred',
@@ -168,6 +170,18 @@ describe('Retryable Reads Spec Prose', () => {
 
         await client.connect();
 
+        /*
+        * 2. Configure the following fail point for `client`:
+            {
+                configureFailPoint: "failCommand",
+                mode: { times: 1 },
+                data: {
+                    failCommands: ["find"],
+                    errorLabels: ["RetryableError", "SystemOverloadedError"]
+                    errorCode: 6
+                }
+            }
+        * */
         await client.db('admin').command({
           configureFailPoint: 'failCommand',
           mode: { times: 1 },
@@ -178,6 +192,7 @@ describe('Retryable Reads Spec Prose', () => {
           }
         });
 
+        // 3. Reset the command event monitor to clear the failpoint command from its stored events.
         commandFailedEvents.length = 0;
         commandSucceededEvents.length = 0;
       });
@@ -188,10 +203,14 @@ describe('Retryable Reads Spec Prose', () => {
       });
 
       it('retries on a different server when SystemOverloadedError', TEST_METADATA, async () => {
+        // 4. Execute a `find` command with `client`.
         await client.db('test').collection('test').find().toArray();
 
+        // 5. Assert that one failed command event and one successful command event occurred.
         expect(commandFailedEvents).to.have.lengthOf(1);
         expect(commandSucceededEvents).to.have.lengthOf(1);
+
+        // 6. Assert that both events occurred on different servers.
         expect(commandFailedEvents[0].address).to.not.equal(commandSucceededEvents[0].address);
       });
     });
@@ -202,6 +221,8 @@ describe('Retryable Reads Spec Prose', () => {
       const commandSucceededEvents: CommandSucceededEvent[] = [];
 
       beforeEach(async function () {
+        // 1. Create a client `client` with `retryReads=true`, `readPreference=primaryPreferred`, and command event monitoring
+        //     enabled.
         client = this.configuration.newClient({
           retryReads: true,
           readPreference: 'primaryPreferred',
@@ -213,6 +234,18 @@ describe('Retryable Reads Spec Prose', () => {
 
         await client.connect();
 
+        /*
+        * 2. Configure the following fail point for `client`:
+            {
+                configureFailPoint: "failCommand",
+                mode: { times: 1 },
+                data: {
+                    failCommands: ["find"],
+                    errorLabels: ["RetryableError"]
+                    errorCode: 6
+                }
+            }
+        * */
         await client.db('admin').command({
           configureFailPoint: 'failCommand',
           mode: { times: 1 },
@@ -223,6 +256,7 @@ describe('Retryable Reads Spec Prose', () => {
           }
         });
 
+        // 3. Reset the command event monitor to clear the failpoint command from its stored events.
         commandFailedEvents.length = 0;
         commandSucceededEvents.length = 0;
       });
@@ -233,10 +267,14 @@ describe('Retryable Reads Spec Prose', () => {
       });
 
       it('retries on the same server when no SystemOverloadedError', TEST_METADATA, async () => {
+        // 4. Execute a `find` command with `client`.
         await client.db('test').collection('test').find().toArray();
 
+        // 5. Assert that one failed command event and one successful command event occurred.
         expect(commandFailedEvents).to.have.lengthOf(1);
         expect(commandSucceededEvents).to.have.lengthOf(1);
+
+        // 6. Assert that both events occurred on the same server.
         expect(commandFailedEvents[0].address).to.equal(commandSucceededEvents[0].address);
       });
     });


### PR DESCRIPTION
### Description

#### Summary of Changes

- Restrict server deprioritization during retryable operations so that on replica sets, only `SystemOverloadedError` triggers deprioritization. For non-overload transient errors, the retry goes back to the same server since it was selected for a reason and is still the best candidate.
- New prose tests are implemented.

Second implementation of [DRIVERS-3404](https://jira.mongodb.org/browse/DRIVERS-3404).

<!-- Please describe the changes in this PR in a high-level overview. -->

##### Notes for Reviewers

<!-- 
If there is any additional context on the changes in the PR that reviewers might find helpful, feel free to make notes in this section.

Otherwise, feel free to remove this section.
-->

#### What is the motivation for this change?

<!--
Remove this section if there is an associated Jira ticket explaining the motivation for this change. If there is not, please fill this section out with
information explaining why this change is valuable.
-->



### Double check the following

- [x] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
