### PR TITLE
fix(NODE-7459): explicitly call setKeepAlive and setNoDelay on socket

### DIFF
--- a/src/cmap/connect.ts
+++ b/src/cmap/connect.ts
@@ -396,6 +396,8 @@ export async function makeSocket(options: MakeConnectionOptions): Promise<Stream
     socket = net.createConnection(parseConnectOptions(options));
   }
 
+  socket.setKeepAlive(true, options.keepAliveInitialDelay ?? 120_000);
+  socket.setNoDelay(options.noDelay ?? true);
   socket.setTimeout(connectTimeoutMS);
 
   let cancellationHandler: ((err: Error) => void) | null = null;

--- a/src/cmap/connect.ts
+++ b/src/cmap/connect.ts
@@ -281,6 +281,15 @@ export async function prepareHandshakeDocument(
   return handshakeDoc;
 }
 
+/**
+ * @internal
+ * Default TCP keepAlive initial delay in milliseconds.
+ * Set to half the Azure load balancer idle timeout (240s) to ensure
+ * probes fire well before cloud LBs (Azure, AWS PrivateLink/NLB)
+ * drop idle connections.
+ */
+export const DEFAULT_KEEP_ALIVE_INITIAL_DELAY_MS = 120_000;
+
 /** @public */
 export const LEGAL_TLS_SOCKET_OPTIONS = [
   'allowPartialTrustChain',
@@ -324,7 +333,7 @@ function parseConnectOptions(options: ConnectionOptions): SocketConnectOpts {
       (result as Document)[name] = options[name];
     }
   }
-  result.keepAliveInitialDelay ??= 120000;
+  result.keepAliveInitialDelay ??= DEFAULT_KEEP_ALIVE_INITIAL_DELAY_MS;
   result.keepAlive = true;
   result.noDelay = options.noDelay ?? true;
 
@@ -370,6 +379,9 @@ export async function makeSocket(options: MakeConnectionOptions): Promise<Stream
   const useTLS = options.tls ?? false;
   const connectTimeoutMS = options.connectTimeoutMS ?? 30000;
   const existingSocket = options.existingSocket;
+  const keepAliveInitialDelay =
+    options.keepAliveInitialDelay ?? DEFAULT_KEEP_ALIVE_INITIAL_DELAY_MS;
+  const noDelay = options.noDelay ?? true;
 
   let socket: Stream;
 
@@ -396,8 +408,11 @@ export async function makeSocket(options: MakeConnectionOptions): Promise<Stream
     socket = net.createConnection(parseConnectOptions(options));
   }
 
-  socket.setKeepAlive(true, options.keepAliveInitialDelay ?? 120_000);
-  socket.setNoDelay(options.noDelay ?? true);
+  // Explicit setKeepAlive/setNoDelay are required because tls.connect() silently
+  // ignores these constructor options due to a Node.js bug.
+  // See: https://github.com/nodejs/node/issues/62003
+  socket.setKeepAlive(true, keepAliveInitialDelay);
+  socket.setNoDelay(noDelay);
   socket.setTimeout(connectTimeoutMS);
 
   let cancellationHandler: ((err: Error) => void) | null = null;

--- a/src/cmap/connect.ts
+++ b/src/cmap/connect.ts
@@ -411,6 +411,7 @@ export async function makeSocket(options: MakeConnectionOptions): Promise<Stream
   // Explicit setKeepAlive/setNoDelay are required because tls.connect() silently
   // ignores these constructor options due to a Node.js bug.
   // See: https://github.com/nodejs/node/issues/62003
+  // TODO(NODE-7474): remove this fix once the underlying Node.js issue is resolved.
   socket.setKeepAlive(true, keepAliveInitialDelay);
   socket.setNoDelay(noDelay);
   socket.setTimeout(connectTimeoutMS);

--- a/test/unit/cmap/connect.test.ts
+++ b/test/unit/cmap/connect.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
-import { execSync } from 'child_process';
-import * as crypto from 'crypto';
+import * as fs from 'fs';
 import * as net from 'net';
+import * as path from 'path';
 import * as process from 'process';
 import * as sinon from 'sinon';
 import * as tls from 'tls';
@@ -12,6 +12,7 @@ import {
   connect,
   type Connection,
   type ConnectionOptions,
+  DEFAULT_KEEP_ALIVE_INITIAL_DELAY_MS,
   HostAddress,
   isHello,
   LEGACY_HELLO_COMMAND,
@@ -456,27 +457,24 @@ describe('Connect Tests', function () {
   });
 
   describe('makeSocket', function () {
-    // TLS sockets created by tls.connect() do not honor keepAlive/noDelay constructor
-    // options due to a Node.js bug (options are not forwarded to the net.Socket constructor).
-    // The driver must call setKeepAlive/setNoDelay explicitly on all sockets.
-    // See: https://github.com/nodejs/node/issues/...
-
     let tlsServer: tls.Server;
     let tlsPort: number;
     let setKeepAliveSpy: sinon.SinonSpy;
     let setNoDelaySpy: sinon.SinonSpy;
 
-    before(function (done) {
-      const { privateKey } = crypto.generateKeyPairSync('rsa', { modulusLength: 2048 });
-      const key = privateKey.export({ type: 'pkcs8', format: 'pem' });
-      const cert = execSync(
-        'openssl req -new -x509 -key /dev/stdin -out /dev/stdout -days 1 -subj /CN=localhost -batch 2>/dev/null',
-        { input: key }
-      ).toString();
+    const serverPem = fs.readFileSync(
+      path.join(__dirname, '../../integration/auth/ssl/server.pem')
+    );
 
-      tlsServer = tls.createServer({ key, cert }, () => {
-        /* empty */
-      });
+    before(function (done) {
+      // @SECLEVEL=0 allows the legacy test certificate (signed with SHA-1/1024-bit RSA)
+      // to be accepted by OpenSSL 3.x, which rejects at the default security level.
+      tlsServer = tls.createServer(
+        { key: serverPem, cert: serverPem, ciphers: 'DEFAULT:@SECLEVEL=0' },
+        () => {
+          /* empty */
+        }
+      );
       tlsServer.listen(0, '127.0.0.1', () => {
         tlsPort = (tlsServer.address() as net.AddressInfo).port;
         done();
@@ -501,14 +499,12 @@ describe('Connect Tests', function () {
         const socket = await makeSocket({
           hostAddress: new HostAddress(`127.0.0.1:${tlsPort}`),
           tls: true,
-          rejectUnauthorized: false
+          rejectUnauthorized: false,
+          ciphers: 'DEFAULT:@SECLEVEL=0'
         } as ConnectionOptions);
+        socket.destroy();
 
-        try {
-          expect(setKeepAliveSpy).to.have.been.calledWith(true, 120000);
-        } finally {
-          socket.destroy();
-        }
+        expect(setKeepAliveSpy).to.have.been.calledWith(true, DEFAULT_KEEP_ALIVE_INITIAL_DELAY_MS);
       });
 
       it('calls setKeepAlive with custom keepAliveInitialDelay', async function () {
@@ -516,28 +512,24 @@ describe('Connect Tests', function () {
           hostAddress: new HostAddress(`127.0.0.1:${tlsPort}`),
           tls: true,
           rejectUnauthorized: false,
+          ciphers: 'DEFAULT:@SECLEVEL=0',
           keepAliveInitialDelay: 5000
         } as ConnectionOptions);
+        socket.destroy();
 
-        try {
-          expect(setKeepAliveSpy).to.have.been.calledWith(true, 5000);
-        } finally {
-          socket.destroy();
-        }
+        expect(setKeepAliveSpy).to.have.been.calledWith(true, 5000);
       });
 
       it('calls setNoDelay with true by default', async function () {
         const socket = await makeSocket({
           hostAddress: new HostAddress(`127.0.0.1:${tlsPort}`),
           tls: true,
-          rejectUnauthorized: false
+          rejectUnauthorized: false,
+          ciphers: 'DEFAULT:@SECLEVEL=0'
         } as ConnectionOptions);
+        socket.destroy();
 
-        try {
-          expect(setNoDelaySpy).to.have.been.calledWith(true);
-        } finally {
-          socket.destroy();
-        }
+        expect(setNoDelaySpy).to.have.been.calledWith(true);
       });
     });
 
@@ -547,12 +539,9 @@ describe('Connect Tests', function () {
           hostAddress: new HostAddress(`127.0.0.1:${tlsPort}`),
           tls: false
         } as ConnectionOptions);
+        socket.destroy();
 
-        try {
-          expect(setKeepAliveSpy).to.have.been.calledWith(true, 120000);
-        } finally {
-          socket.destroy();
-        }
+        expect(setKeepAliveSpy).to.have.been.calledWith(true, DEFAULT_KEEP_ALIVE_INITIAL_DELAY_MS);
       });
 
       it('calls setNoDelay with true by default', async function () {
@@ -560,12 +549,9 @@ describe('Connect Tests', function () {
           hostAddress: new HostAddress(`127.0.0.1:${tlsPort}`),
           tls: false
         } as ConnectionOptions);
+        socket.destroy();
 
-        try {
-          expect(setNoDelaySpy).to.have.been.calledWith(true);
-        } finally {
-          socket.destroy();
-        }
+        expect(setNoDelaySpy).to.have.been.calledWith(true);
       });
     });
   });

--- a/test/unit/cmap/connect.test.ts
+++ b/test/unit/cmap/connect.test.ts
@@ -1,5 +1,10 @@
 import { expect } from 'chai';
+import { execSync } from 'child_process';
+import * as crypto from 'crypto';
+import * as net from 'net';
 import * as process from 'process';
+import * as sinon from 'sinon';
+import * as tls from 'tls';
 
 import {
   CancellationToken,
@@ -11,6 +16,7 @@ import {
   isHello,
   LEGACY_HELLO_COMMAND,
   makeClientMetadata,
+  makeSocket,
   MongoClientAuthProviders,
   MongoCredentials,
   MongoNetworkError,
@@ -445,6 +451,121 @@ describe('Connect Tests', function () {
           const handshakeDocument = await prepareHandshakeDocument(authContext);
           expect(handshakeDocument).not.have.property(LEGACY_HELLO_COMMAND, 1);
         });
+      });
+    });
+  });
+
+  describe('makeSocket', function () {
+    // TLS sockets created by tls.connect() do not honor keepAlive/noDelay constructor
+    // options due to a Node.js bug (options are not forwarded to the net.Socket constructor).
+    // The driver must call setKeepAlive/setNoDelay explicitly on all sockets.
+    // See: https://github.com/nodejs/node/issues/...
+
+    let tlsServer: tls.Server;
+    let tlsPort: number;
+    let setKeepAliveSpy: sinon.SinonSpy;
+    let setNoDelaySpy: sinon.SinonSpy;
+
+    before(function (done) {
+      const { privateKey } = crypto.generateKeyPairSync('rsa', { modulusLength: 2048 });
+      const key = privateKey.export({ type: 'pkcs8', format: 'pem' });
+      const cert = execSync(
+        'openssl req -new -x509 -key /dev/stdin -out /dev/stdout -days 1 -subj /CN=localhost -batch 2>/dev/null',
+        { input: key }
+      ).toString();
+
+      tlsServer = tls.createServer({ key, cert }, () => {
+        /* empty */
+      });
+      tlsServer.listen(0, '127.0.0.1', () => {
+        tlsPort = (tlsServer.address() as net.AddressInfo).port;
+        done();
+      });
+    });
+
+    after(function () {
+      tlsServer?.close();
+    });
+
+    beforeEach(function () {
+      setKeepAliveSpy = sinon.spy(net.Socket.prototype, 'setKeepAlive');
+      setNoDelaySpy = sinon.spy(net.Socket.prototype, 'setNoDelay');
+    });
+
+    afterEach(function () {
+      sinon.restore();
+    });
+
+    context('when tls is enabled', function () {
+      it('calls setKeepAlive with default keepAliveInitialDelay', async function () {
+        const socket = await makeSocket({
+          hostAddress: new HostAddress(`127.0.0.1:${tlsPort}`),
+          tls: true,
+          rejectUnauthorized: false
+        } as ConnectionOptions);
+
+        try {
+          expect(setKeepAliveSpy).to.have.been.calledWith(true, 120000);
+        } finally {
+          socket.destroy();
+        }
+      });
+
+      it('calls setKeepAlive with custom keepAliveInitialDelay', async function () {
+        const socket = await makeSocket({
+          hostAddress: new HostAddress(`127.0.0.1:${tlsPort}`),
+          tls: true,
+          rejectUnauthorized: false,
+          keepAliveInitialDelay: 5000
+        } as ConnectionOptions);
+
+        try {
+          expect(setKeepAliveSpy).to.have.been.calledWith(true, 5000);
+        } finally {
+          socket.destroy();
+        }
+      });
+
+      it('calls setNoDelay with true by default', async function () {
+        const socket = await makeSocket({
+          hostAddress: new HostAddress(`127.0.0.1:${tlsPort}`),
+          tls: true,
+          rejectUnauthorized: false
+        } as ConnectionOptions);
+
+        try {
+          expect(setNoDelaySpy).to.have.been.calledWith(true);
+        } finally {
+          socket.destroy();
+        }
+      });
+    });
+
+    context('when tls is disabled', function () {
+      it('calls setKeepAlive with default keepAliveInitialDelay', async function () {
+        const socket = await makeSocket({
+          hostAddress: new HostAddress(`127.0.0.1:${tlsPort}`),
+          tls: false
+        } as ConnectionOptions);
+
+        try {
+          expect(setKeepAliveSpy).to.have.been.calledWith(true, 120000);
+        } finally {
+          socket.destroy();
+        }
+      });
+
+      it('calls setNoDelay with true by default', async function () {
+        const socket = await makeSocket({
+          hostAddress: new HostAddress(`127.0.0.1:${tlsPort}`),
+          tls: false
+        } as ConnectionOptions);
+
+        try {
+          expect(setNoDelaySpy).to.have.been.calledWith(true);
+        } finally {
+          socket.destroy();
+        }
       });
     });
   });


### PR DESCRIPTION
### Description

#### Summary of Changes

<!-- Please describe the changes in this PR in a high-level overview. -->

Revert [previous behaviour](https://github.com/mongodb/node-mongodb-native/pull/4510/changes#diff-7cc25e5d3247913cdf1fe1e7788e951e4435bb1091d6b8aef135c4b171c7c997) of explicitly calling setKeepAlive and setNoDelay on the socket due to the Node.js bug: https://github.com/nodejs/node/pull/62004

##### Notes for Reviewers

<!-- 
If there is any additional context on the changes in the PR that reviewers might find helpful, feel free to make notes in this section.

Otherwise, feel free to remove this section.
-->

#### What is the motivation for this change?

<!--
Remove this section if there is an associated Jira ticket explaining the motivation for this change. If there is not, please fill this section out with
information explaining why this change is valuable.
-->

### Double check the following

- [x] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
