### PR TITLE
test(NODE-7508): Fix inconsistent wording for prose retryable writes test 6, case 3

### DIFF
--- a/test/integration/crud/find.test.ts
+++ b/test/integration/crud/find.test.ts
@@ -8,8 +8,7 @@ import {
   type MongoClient,
   MongoServerError,
   ObjectId,
-  ReturnDocument,
-  runNodelessTests
+  ReturnDocument
 } from '../../mongodb';
 import { assert as test, filterForCommands } from '../shared';
 
@@ -1079,11 +1078,6 @@ describe('Find', function () {
     'regression test (NODE-6878): CursorResponse.emptyGetMore contains all CursorResponse fields',
     { requires: { topology: 'sharded' } },
     async function () {
-      if (runNodelessTests) {
-        // This test relies on sinon spying on an internal method, but this doesn't work in nodeless due to the way sinon is bundled.
-        this.skip();
-      }
-
       const collection = client.db('rewind-regression').collection('bar');
 
       await collection.deleteMany({});

--- a/test/integration/crud/find.test.ts
+++ b/test/integration/crud/find.test.ts
@@ -8,7 +8,8 @@ import {
   type MongoClient,
   MongoServerError,
   ObjectId,
-  ReturnDocument
+  ReturnDocument,
+  runNodelessTests
 } from '../../mongodb';
 import { assert as test, filterForCommands } from '../shared';
 
@@ -1078,6 +1079,11 @@ describe('Find', function () {
     'regression test (NODE-6878): CursorResponse.emptyGetMore contains all CursorResponse fields',
     { requires: { topology: 'sharded' } },
     async function () {
+      if (runNodelessTests) {
+        // This test relies on sinon spying on an internal method, but this doesn't work in nodeless due to the way sinon is bundled.
+        this.skip();
+      }
+
       const collection = client.db('rewind-regression').collection('bar');
 
       await collection.deleteMany({});

--- a/test/integration/retryable-writes/retryable_writes.spec.prose.test.ts
+++ b/test/integration/retryable-writes/retryable_writes.spec.prose.test.ts
@@ -239,38 +239,40 @@ describe('Retryable Writes Spec Prose', () => {
      * Additionally, this test requires drivers to set a fail point after an insertOne operation but before the subsequent retry.
      * Drivers that are unable to set a failCommand after the CommandSucceededEvent SHOULD use mocking or write a unit test to cover the same sequence of events.
      *
-     * Create a client with retryWrites=true.
+     * 1. Create a client with retryWrites=true.
      *
-     * Configure a fail point with error code 91 (ShutdownInProgress):
+     * 2. Configure a fail point with error code `91` (ShutdownInProgress) with the `RetryableError` and
+     *     `SystemOverloadedError` error labels:
      * ```js
      * db.adminCommand({
      *   configureFailPoint: 'failCommand',
      *   mode: { times: 1 },
      *   data: {
-     *     writeConcernError: {
-     *       code: 91,
-     *       errorLabels: ['RetryableWriteError']
-     *     },
      *     failCommands: ['insert']
+     *     errorLabels: ['RetryableError', 'SystemOverloadedError'],
+     *     errorCode: 91,
      *   }
      * });
      * ```
-     * Via the command monitoring CommandSucceededEvent, configure a fail point with error code 10107 (NotWritablePrimary) and a NoWritesPerformed label:
+     * 
+     * 3. Via the command monitoring CommandSucceededEvent, configure a fail point with error code `91` (ShutdownInProgress) and
+     *     the `NoWritesPerformed`, `RetryableError` and `SystemOverloadedError` labels:
      *
      * ```js
      * db.adminCommand({
      *   configureFailPoint: 'failCommand',
-     *   mode: { times: 1 },
+     *   mode: 'alwaysOn',
      *   data: {
-     *     errorCode: 10107,
-     *     errorLabels: ['RetryableWriteError', 'NoWritesPerformed'],
      *     failCommands: ['insert']
+     *     errorLabels: [ 'RetryableError', 'SystemOverloadedError', 'NoWritesPerformed'],
+     *     errorCode: 91,
      *   }
      * });
      * ```
-     * Drivers SHOULD only configure the 10107 fail point command if the the succeeded event is for the 91 error configured in step 2.
+     * 
+     * Drivers SHOULD configure the second fail point command only if the event is for the first error configured in step 2.
      *
-     * Attempt an insertOne operation on any record for any database and collection. For the resulting error, assert that the associated error code is 91.
+     * 4. Attempt an insertOne operation on any record for any database and collection. For the resulting error, assert that the associated error code is 91.
      */
     it(
       'when a retry attempt fails with an error labeled NoWritesPerformed, drivers MUST return the original error',
@@ -279,7 +281,8 @@ describe('Retryable Writes Spec Prose', () => {
         const serverCommandStub = sinon.stub(Server.prototype, 'command');
         serverCommandStub.onCall(0).rejects(
           new MongoWriteConcernError({
-            errorLabels: ['RetryableWriteError'],
+            // errorLabels: ['RetryableError', 'SystemOverloadedError'], // expected changes, tests fail
+            errorLabels: ['RetryableWriteError'], // original, tests pass
             writeConcernError: { errmsg: 'ShutdownInProgress error', code: 91 },
             ok: 1
           })
@@ -287,8 +290,10 @@ describe('Retryable Writes Spec Prose', () => {
         serverCommandStub.onCall(1).returns(
           Promise.reject(
             new MongoWriteConcernError({
-              errorLabels: ['RetryableWriteError', 'NoWritesPerformed'],
-              writeConcernError: { errmsg: 'NotWritablePrimary error', errorCode: 10107 }
+              errorLabels: ['RetryableWriteError', 'NoWritesPerformed'], // original, tests pass
+              // errorLabels: ['RetryableError', 'SystemOverloadedError', 'NoWritesPerformed'], // expected changes, tests fail
+              writeConcernError: { errmsg: 'NotWritablePrimary error', code: 91 }, // my changes
+              ok: 1
             })
           )
         );
@@ -526,10 +531,10 @@ describe('Retryable Writes Spec Prose', () => {
               serverCommandStub.callCount === 1
                 ? [MongoErrorLabel.RetryableError, MongoErrorLabel.SystemOverloadedError]
                 : [
-                    MongoErrorLabel.RetryableError,
-                    MongoErrorLabel.SystemOverloadedError,
-                    MongoErrorLabel.NoWritesPerformed
-                  ];
+                  MongoErrorLabel.RetryableError,
+                  MongoErrorLabel.SystemOverloadedError,
+                  MongoErrorLabel.NoWritesPerformed
+                ];
 
             throw new MongoServerError({
               message: 'Server Error',

--- a/test/integration/retryable-writes/retryable_writes.spec.prose.test.ts
+++ b/test/integration/retryable-writes/retryable_writes.spec.prose.test.ts
@@ -239,40 +239,38 @@ describe('Retryable Writes Spec Prose', () => {
      * Additionally, this test requires drivers to set a fail point after an insertOne operation but before the subsequent retry.
      * Drivers that are unable to set a failCommand after the CommandSucceededEvent SHOULD use mocking or write a unit test to cover the same sequence of events.
      *
-     * 1. Create a client with retryWrites=true.
+     * Create a client with retryWrites=true.
      *
-     * 2. Configure a fail point with error code `91` (ShutdownInProgress) with the `RetryableError` and
-     *     `SystemOverloadedError` error labels:
+     * Configure a fail point with error code 91 (ShutdownInProgress):
      * ```js
      * db.adminCommand({
      *   configureFailPoint: 'failCommand',
      *   mode: { times: 1 },
      *   data: {
+     *     writeConcernError: {
+     *       code: 91,
+     *       errorLabels: ['RetryableWriteError']
+     *     },
      *     failCommands: ['insert']
-     *     errorLabels: ['RetryableError', 'SystemOverloadedError'],
-     *     errorCode: 91,
      *   }
      * });
      * ```
-     *
-     * 3. Via the command monitoring CommandSucceededEvent, configure a fail point with error code `91` (ShutdownInProgress) and
-     *     the `NoWritesPerformed`, `RetryableError` and `SystemOverloadedError` labels:
+     * Via the command monitoring CommandSucceededEvent, configure a fail point with error code 10107 (NotWritablePrimary) and a NoWritesPerformed label:
      *
      * ```js
      * db.adminCommand({
      *   configureFailPoint: 'failCommand',
-     *   mode: 'alwaysOn',
+     *   mode: { times: 1 },
      *   data: {
+     *     errorCode: 10107,
+     *     errorLabels: ['RetryableWriteError', 'NoWritesPerformed'],
      *     failCommands: ['insert']
-     *     errorLabels: [ 'RetryableError', 'SystemOverloadedError', 'NoWritesPerformed'],
-     *     errorCode: 91,
      *   }
      * });
      * ```
+     * Drivers SHOULD only configure the 10107 fail point command if the the succeeded event is for the 91 error configured in step 2.
      *
-     * Drivers SHOULD configure the second fail point command only if the event is for the first error configured in step 2.
-     *
-     * 4. Attempt an insertOne operation on any record for any database and collection. For the resulting error, assert that the associated error code is 91.
+     * Attempt an insertOne operation on any record for any database and collection. For the resulting error, assert that the associated error code is 91.
      */
     it(
       'when a retry attempt fails with an error labeled NoWritesPerformed, drivers MUST return the original error',
@@ -281,8 +279,7 @@ describe('Retryable Writes Spec Prose', () => {
         const serverCommandStub = sinon.stub(Server.prototype, 'command');
         serverCommandStub.onCall(0).rejects(
           new MongoWriteConcernError({
-            // errorLabels: ['RetryableError', 'SystemOverloadedError'], // expected changes, tests fail
-            errorLabels: ['RetryableWriteError'], // original, tests pass
+            errorLabels: ['RetryableWriteError'],
             writeConcernError: { errmsg: 'ShutdownInProgress error', code: 91 },
             ok: 1
           })
@@ -290,10 +287,8 @@ describe('Retryable Writes Spec Prose', () => {
         serverCommandStub.onCall(1).returns(
           Promise.reject(
             new MongoWriteConcernError({
-              errorLabels: ['RetryableWriteError', 'NoWritesPerformed'], // original, tests pass
-              // errorLabels: ['RetryableError', 'SystemOverloadedError', 'NoWritesPerformed'], // expected changes, tests fail
-              writeConcernError: { errmsg: 'NotWritablePrimary error', code: 91 }, // my changes
-              ok: 1
+              errorLabels: ['RetryableWriteError', 'NoWritesPerformed'],
+              writeConcernError: { errmsg: 'NotWritablePrimary error', errorCode: 10107 }
             })
           )
         );

--- a/test/integration/retryable-writes/retryable_writes.spec.prose.test.ts
+++ b/test/integration/retryable-writes/retryable_writes.spec.prose.test.ts
@@ -254,7 +254,7 @@ describe('Retryable Writes Spec Prose', () => {
      *   }
      * });
      * ```
-     * 
+     *
      * 3. Via the command monitoring CommandSucceededEvent, configure a fail point with error code `91` (ShutdownInProgress) and
      *     the `NoWritesPerformed`, `RetryableError` and `SystemOverloadedError` labels:
      *
@@ -269,7 +269,7 @@ describe('Retryable Writes Spec Prose', () => {
      *   }
      * });
      * ```
-     * 
+     *
      * Drivers SHOULD configure the second fail point command only if the event is for the first error configured in step 2.
      *
      * 4. Attempt an insertOne operation on any record for any database and collection. For the resulting error, assert that the associated error code is 91.
@@ -531,10 +531,10 @@ describe('Retryable Writes Spec Prose', () => {
               serverCommandStub.callCount === 1
                 ? [MongoErrorLabel.RetryableError, MongoErrorLabel.SystemOverloadedError]
                 : [
-                  MongoErrorLabel.RetryableError,
-                  MongoErrorLabel.SystemOverloadedError,
-                  MongoErrorLabel.NoWritesPerformed
-                ];
+                    MongoErrorLabel.RetryableError,
+                    MongoErrorLabel.SystemOverloadedError,
+                    MongoErrorLabel.NoWritesPerformed
+                  ];
 
             throw new MongoServerError({
               message: 'Server Error',

--- a/test/integration/retryable-writes/retryable_writes.spec.prose.test.ts
+++ b/test/integration/retryable-writes/retryable_writes.spec.prose.test.ts
@@ -490,22 +490,8 @@ describe('Retryable Writes Spec Prose', () => {
       'Case 3: Test that drivers return the correct error when receiving some errors with NoWritesPerformed and some without NoWritesPerformed',
       { requires: { topology: 'replicaset', mongodb: '>=6.0' } },
       async () => {
-        // 2. Configure the client to listen to CommandFailedEvents. In the attached listener, configure a fail point with error
-        //     code `91` (NotWritablePrimary) and the `NoWritesPerformed`, `RetryableError` and `SystemOverloadedError` labels:
-        //     ```javascript
-        //     {
-        //         configureFailPoint: "failCommand",
-        //         mode: "alwaysOn",
-        //         data: {
-        //             failCommands: ["insert"],
-        //             errorLabels: ["RetryableError", "SystemOverloadedError", "NoWritesPerformed"],
-        //             errorCode: 91
-        //         }
-        //     }
-        //     ```
-
-        // 3. Configure a fail point with error code `91` (ShutdownInProgress) with the `RetryableError` and
-        //     `SystemOverloadedError` error labels but without the `NoWritesPerformed` error label:
+        // 2. Configure a fail point with error code `91` (ShutdownInProgress) with the `RetryableError` and
+        //     `SystemOverloadedError` error labels:
         //     ```javascript
         //     {
         //         configureFailPoint: "failCommand",
@@ -517,6 +503,22 @@ describe('Retryable Writes Spec Prose', () => {
         //         }
         //     }
         //     ```
+
+        // 3. Via the command monitoring CommandFailedEvent, configure a fail point with error code `91` (ShutdownInProgress) and
+        //     the `NoWritesPerformed`, `RetryableError` and `SystemOverloadedError` labels:
+        //     ```javascript
+        //     {
+        //         configureFailPoint: "failCommand",
+        //         mode: "alwaysOn",
+        //         data: {
+        //             failCommands: ["insert"],
+        //             errorLabels: ["RetryableError", "SystemOverloadedError", "NoWritesPerformed"],
+        //             errorCode: 91
+        //         }
+        //     }
+        //     ```
+        //     Configure the second fail point command only if the failed event is for the first error configured in step 2.
+
         const serverCommandStub = sinon
           .stub(Server.prototype, 'command')
           .callsFake(async function () {


### PR DESCRIPTION
### Description

#### Summary of Changes

<!-- Please describe the changes in this PR in a high-level overview. -->

##### Notes for Reviewers

<!-- 
If there is any additional context on the changes in the PR that reviewers might find helpful, feel free to make notes in this section.

Otherwise, feel free to remove this section.
-->

#### What is the motivation for this change?

<!--
Remove this section if there is an associated Jira ticket explaining the motivation for this change. If there is not, please fill this section out with
information explaining why this change is valuable.
-->

### Release Highlight

<!-- 
Contributors: please leave the release notes section for the Node driver team to fill in. The following instructions are for maintainers.

For user facing changes: please provide release notes. Feel free to browse previous releases for example release highlights.

If there are no user-facing changes in this PR, please delete the release highlight section from the PR description.
-->

<!-- RELEASE_HIGHLIGHT_START -->

### Release notes highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Lint is passing (`npm run check:lint`)
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
