### PR TITLE
fix(NODE-7411): closeCheckedOutConnections iterates all servers and fixes test regression

### DIFF
--- a/src/sdam/topology.ts
+++ b/src/sdam/topology.ts
@@ -494,7 +494,7 @@ export class Topology extends TypedEventEmitter<TopologyEvents> {
 
   closeCheckedOutConnections() {
     for (const server of this.s.servers.values()) {
-      return server.closeCheckedOutConnections();
+      server.closeCheckedOutConnections();
     }
   }
 

--- a/test/integration/connection-monitoring-and-pooling/connection_pool.test.ts
+++ b/test/integration/connection-monitoring-and-pooling/connection_pool.test.ts
@@ -95,7 +95,7 @@ describe('Connection Pool', function () {
           }
         });
 
-        client = this.configuration.newClient({}, { readPreference: 'secondaryPreferred' });
+        client = this.configuration.newClient({}, {});
         await client.connect();
         await Promise.all(Array.from({ length: 100 }, () => client.db().command({ ping: 1 })));
       });

--- a/test/integration/node-specific/client_close.test.ts
+++ b/test/integration/node-specific/client_close.test.ts
@@ -10,7 +10,12 @@ import {
   type FindCursor,
   type MongoClient
 } from '../../mongodb';
-import { configureMongocryptdSpawnHooks } from '../../tools/utils';
+import {
+  clearFailPoint,
+  configureFailPoint,
+  configureMongocryptdSpawnHooks,
+  sleep
+} from '../../tools/utils';
 import { filterForCommands } from '../shared';
 import { runScriptAndGetProcessInfo } from './resource_tracking_script_builder';
 
@@ -714,6 +719,78 @@ describe('MongoClient.close() Integration', () => {
         it.skip('no sockets remain after client.close()', metadata, async () => null);
       });
     });
+  });
+
+  describe('closeCheckedOutConnections', () => {
+    const metadata: MongoDBMetadataUI = { requires: { mongodb: '>=4.4' } };
+    let client: MongoClient;
+
+    beforeEach(async function () {
+      await configureFailPoint(this.configuration, {
+        configureFailPoint: 'failCommand',
+        mode: 'alwaysOn',
+        data: {
+          failCommands: ['find'],
+          blockConnection: true,
+          blockTimeMS: 500
+        }
+      });
+      client = this.configuration.newClient({}, {});
+      await client.connect();
+    });
+
+    afterEach(async function () {
+      await clearFailPoint(this.configuration);
+      await client?.close();
+    });
+
+    it(
+      'emits connectionCheckedIn immediately followed by connectionClosed for each in-flight connection',
+      metadata,
+      async function () {
+        const allEvents: Array<{ name: string; address: string; connectionId: number }> = [];
+        const push = e => allEvents.push(e);
+
+        client
+          .on('connectionCheckedOut', push)
+          .on('connectionCheckedIn', push)
+          .on('connectionClosed', push);
+
+        const finds = Promise.allSettled([
+          client.db('test').collection('test').findOne({ a: 1 }),
+          client.db('test').collection('test').findOne({ a: 1 }),
+          client.db('test').collection('test').findOne({ a: 1 })
+        ]);
+
+        // wait until all three finds have checked out a connection
+        while (allEvents.filter(e => e.name === 'connectionCheckedOut').length < 3) {
+          await sleep(1);
+        }
+
+        const findConnectionIds = new Set(
+          allEvents
+            .filter(e => e.name === 'connectionCheckedOut')
+            .map(({ address, connectionId }) => `${address}+${connectionId}`)
+        );
+
+        await client.close();
+
+        const findEvents = allEvents
+          .filter(e => e.name === 'connectionCheckedIn' || e.name === 'connectionClosed')
+          .filter(({ address, connectionId }) =>
+            findConnectionIds.has(`${address}+${connectionId}`)
+          );
+
+        expect(findEvents).to.have.lengthOf(6);
+
+        // spec requires each connectionCheckedIn to be immediately followed by connectionClosed
+        expect(findEvents.map(e => e.name)).to.deep.equal(
+          Array.from({ length: 3 }, () => ['connectionCheckedIn', 'connectionClosed']).flat()
+        );
+
+        await finds;
+      }
+    );
   });
 
   describe('Server resource: Cursor', () => {


### PR DESCRIPTION
### Description
#### Summary of Changes
Fixes a bug in `closeCheckedOutConnections()` in `topology.ts` where a premature `return` caused cleanup to stop after the first server, skipping checked-out connections on remaining servers in multi-server topologies such as replica sets and sharded clusters.

#### Notes for Reviewers
- The premature `return` has been replaced so the loop iterates all servers
- The existing `ConnectionCheckedInEvent` test in `connection_pool.test.ts` has been fixed — it previously used `readPreference: 'secondaryPreferred'` which could route to secondaries where no failpoint was configured, making the test ineffective
- A dedicated `closeCheckedOutConnections` test has been added in `client_close.test.ts` to verify the CMAP requirement that each `connectionCheckedIn` event is immediately followed by `connectionClosed` for in-flight connections during `client.close()`

This PR includes Nepomuk's original fix commit. Relates to #4847.

### Double check the following
- [x] Lint is passing (`npm run check:lint`)
- [x] Self-review completed
- [x] PR title follows the correct format: `fix(NODE-7411): closeCheckedOutConnections iterates all servers and fixes test regression`
- [x] Changes are covered by tests
- [x] No new TODOs