### PR TITLE
test(NODE-7538): ignore unknown fields in `listIndexes`

### DIFF
--- a/test/integration/index_management.test.ts
+++ b/test/integration/index_management.test.ts
@@ -820,10 +820,9 @@ describe('Indexes', function () {
       const indexName = await collection.createIndex('a', { hidden: true });
       expect(indexName).to.equal('a_1');
       const indexes = await collection.listIndexes().toArray();
-      expect(indexes).to.deep.equal([
-        { v: 2, key: { _id: 1 }, name: '_id_' },
-        { v: 2, key: { a: 1 }, name: 'a_1', hidden: true }
-      ]);
+      expect(indexes).to.have.lengthOf(2);
+      expect(indexes[0]).to.containSubset({ v: 2, key: { _id: 1 }, name: '_id_' });
+      expect(indexes[1]).to.containSubset({ v: 2, key: { a: 1 }, name: 'a_1', hidden: true });
     }
   );
 });


### PR DESCRIPTION
### Description

#### Summary of Changes

<!-- Please describe the changes in this PR in a high-level overview. -->

Only test known fields in the `listIndexes` response. Latest server returns more fields (collation is included).

##### Notes for Reviewers

<!-- 
If there is any additional context on the changes in the PR that reviewers might find helpful, feel free to make notes in this section.

Otherwise, feel free to remove this section.
-->

#### What is the motivation for this change?

<!--
Remove this section if there is an associated Jira ticket explaining the motivation for this change. If there is not, please fill this section out with
information explaining why this change is valuable.
-->

Failing test on latest server.

### Double check the following

- [x] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
