### PR TITLE
test(NODE-7147): Revert field presence changes from server 8.2.0

### DIFF
--- a/test/spec/change-streams/unified/change-streams-disambiguatedPaths.json
+++ b/test/spec/change-streams/unified/change-streams-disambiguatedPaths.json
@@ -43,6 +43,91 @@
   ],
   "tests": [
     {
+      "description": "disambiguatedPaths is not present when showExpandedEvents is false/unset",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "6.1.0",
+          "maxServerVersion": "8.1.99",
+          "topologies": [
+            "replicaset",
+            "load-balanced",
+            "sharded"
+          ],
+          "serverless": "forbid"
+        },
+        {
+          "minServerVersion": "8.2.1",
+          "topologies": [
+            "replicaset",
+            "load-balanced",
+            "sharded"
+          ],
+          "serverless": "forbid"
+        }
+      ],
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "a": {
+                "1": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": []
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "a.1": 2
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "update",
+            "ns": {
+              "db": "database0",
+              "coll": "collection0"
+            },
+            "updateDescription": {
+              "updatedFields": {
+                "$$exists": true
+              },
+              "removedFields": {
+                "$$exists": true
+              },
+              "truncatedArrays": {
+                "$$exists": true
+              },
+              "disambiguatedPaths": {
+                "$$exists": false
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
       "description": "disambiguatedPaths is present on updateDescription when an ambiguous path is present",
       "operations": [
         {

--- a/test/spec/change-streams/unified/change-streams-disambiguatedPaths.yml
+++ b/test/spec/change-streams/unified/change-streams-disambiguatedPaths.yml
@@ -15,7 +15,7 @@ createEntities:
 
 runOnRequirements:
   - minServerVersion: "6.1.0"
-    topologies: [ replicaset, sharded-replicaset, load-balanced, sharded ]
+    topologies: [ replicaset, load-balanced, sharded ]
     serverless: forbid
 
 initialData:
@@ -24,6 +24,41 @@ initialData:
     documents: []
 
 tests:
+  - description: "disambiguatedPaths is not present when showExpandedEvents is false/unset"
+    # skip server version 8.2.0, which emits disambiguatedPaths unconditionally
+    runOnRequirements:
+      - minServerVersion: "6.1.0"
+        maxServerVersion: "8.1.99"
+        topologies: [ replicaset, load-balanced, sharded ]
+        serverless: forbid
+      - minServerVersion: "8.2.1"
+        topologies: [ replicaset, load-balanced, sharded ]
+        serverless: forbid
+    operations:
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: { _id: 1, 'a': { '1': 1 } }
+      - name: createChangeStream
+        object: *collection0
+        arguments: { pipeline: [] }
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { 'a.1': 2 } }
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "update"
+          ns: { db: *database0, coll: *collection0 }
+          updateDescription:
+            updatedFields: { $$exists: true }
+            removedFields: { $$exists: true }
+            truncatedArrays: { $$exists: true }
+            disambiguatedPaths: { $$exists: false }
+
   - description: "disambiguatedPaths is present on updateDescription when an ambiguous path is present"
     operations:
       - name: insertOne


### PR DESCRIPTION
### Description

#### Summary of Changes

Updated spec tests for change stream. All affected files pass tests, failures unrelated (even though they are also about change streams).

### Double check the following

- [x] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
