### PR TITLE
chore(NODE-7562): use npm trusted publisher for nightly release

### DIFF
--- a/.github/scripts/dispatch-and-wait.mjs
+++ b/.github/scripts/dispatch-and-wait.mjs
@@ -1,0 +1,70 @@
+// @ts-check
+// Dispatch a workflow_dispatch-triggered GitHub Actions workflow and wait for
+// the resulting run to complete (propagating its exit status).
+//
+// `gh workflow run` prints the created workflow run URL on stdout when the
+// server returns it (current github.com API version does); we parse the run
+// id out of the URL and pass it to `gh run watch`.
+//
+// Usage:
+//   node dispatch-and-wait.mjs <workflow.yml> [key=value ...]
+//
+//   For npm-publish.yml specifically:
+//   node dispatch-and-wait.mjs npm-publish.yml tag=<tag> version=<v> ref=<sha>
+//
+// Arguments:
+//   <workflow.yml>    Filename of the target workflow under .github/workflows/
+//                     in the same repo. Must declare `on: workflow_dispatch:`.
+//   key=value ...     Inputs forwarded to the dispatched workflow. Valid keys
+//                     and which of them are required are determined by the
+//                     target workflow's `on.workflow_dispatch.inputs`; the
+//                     dispatch fails if any required input is missing or any
+//                     unknown input is passed. For `npm-publish.yml`, all of
+//                     `tag`, `version`, and `ref` are required.
+//                     Example: tag=nightly version=1.2.3 ref=abc1234
+//
+// Environment:
+//   GH_TOKEN              (required) used by the gh CLI; in a workflow set
+//                         this to ${{ github.token }}.
+//   DISPATCH_WORKFLOW_REF (optional, default `main`) git ref the target
+//                         workflow file is loaded from. Hardcoded to main by
+//                         default so callers on backport branches don't have
+//                         to keep a copy of the target workflow on their
+//                         branch.
+import * as child_process from 'node:child_process';
+import * as process from 'node:process';
+
+const [, , workflow, ...inputArgs] = process.argv;
+if (!workflow) {
+  console.error('usage: dispatch-and-wait.mjs <workflow.yml> [key=value ...]');
+  process.exit(2);
+}
+
+const dispatchRef = process.env.DISPATCH_WORKFLOW_REF || 'main';
+
+const ghArgs = [
+  'workflow', 'run', workflow,
+  '--ref', dispatchRef,
+  ...inputArgs.flatMap(kv => ['-f', kv])
+];
+console.log(`Dispatching ${workflow} from ref ${dispatchRef}`);
+
+const dispatch = child_process.spawnSync('gh', ghArgs, {
+  encoding: 'utf8',
+  stdio: ['inherit', 'pipe', 'inherit']
+});
+if (dispatch.status !== 0) process.exit(dispatch.status ?? 1);
+
+// gh prints e.g. "https://github.com/owner/repo/actions/runs/<id>"
+const match = dispatch.stdout.match(/\/actions\/runs\/(\d+)/);
+if (!match) {
+  console.error('Could not extract run id from gh workflow run output:', dispatch.stdout);
+  process.exit(1);
+}
+const runId = match[1];
+console.log(`Dispatched run ${runId}`);
+
+const watch = child_process.spawnSync('gh', ['run', 'watch', runId, '--exit-status'], {
+  stdio: 'inherit'
+});
+process.exit(watch.status ?? 1);

--- a/.github/scripts/dispatch-and-wait.mjs
+++ b/.github/scripts/dispatch-and-wait.mjs
@@ -1,4 +1,7 @@
 // @ts-check
+// TODO(NODE-7570): replace with workflow_call once GitHub/npm resolve the OIDC
+// workflow_ref mismatch (https://github.com/npm/documentation/issues/1755).
+//
 // Dispatch a workflow_dispatch-triggered GitHub Actions workflow and wait for
 // the resulting run to complete (propagating its exit status).
 //

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,3 +1,8 @@
+# This workflow is invoked by callers via `workflow_dispatch` (the GitHub
+# Actions API), NOT as a reusable workflow (`on: workflow_call:`). With
+# workflow_call, the OIDC token's workflow_ref claim points to the caller's
+# filename rather than this file, which breaks npm Trusted Publishing's
+# workflow-filename matching. See npm/documentation#1755.
 name: npm-publish
 
 run-name: 'npm-publish ${{ inputs.tag }}@${{ inputs.version }}'

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,35 @@
+name: npm-publish
+
+run-name: 'npm-publish ${{ inputs.tag }}@${{ inputs.version }}'
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'npm dist-tag (e.g. nightly, latest, alpha)'
+        required: true
+        type: string
+      version:
+        description: 'Package version to publish'
+        required: true
+        type: string
+      ref:
+        description: 'Git ref (commit SHA preferred) to publish from'
+        required: true
+        type: string
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref }}
+      - name: Install Node and dependencies
+        uses: mongodb-labs/drivers-github-tools/node/setup@v3
+      - run: npm version "${{ inputs.version }}" --git-tag-version=false --allow-same-version
+      - run: npm publish --provenance --tag="${{ inputs.tag }}"

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -30,8 +30,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh workflow run npm-publish.yml \
-            --ref "${{ github.ref_name }}" \
-            -f tag=nightly \
-            -f version="$(node -p "require('./package.json').version")" \
-            -f ref="${{ github.sha }}"
+          node ./.github/scripts/dispatch-and-wait.mjs npm-publish.yml \
+            tag=nightly \
+            version="$(node -p "require('./package.json').version")" \
+            ref="${{ github.sha }}"

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -29,6 +29,7 @@ jobs:
         name: Dispatch npm-publish workflow
         env:
           GH_TOKEN: ${{ github.token }}
+          DISPATCH_WORKFLOW_REF: ${{ github.sha }}
         run: |
           node ./.github/scripts/dispatch-and-wait.mjs npm-publish.yml \
             tag=nightly \

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -11,7 +11,8 @@ on:
   workflow_dispatch: {}
 
 permissions:
-  id-token: write
+  contents: read
+  actions: write
 
 name: release-nightly
 
@@ -25,6 +26,12 @@ jobs:
       - id: build_nightly
         run: npm run build:nightly
       - if: ${{ steps.build_nightly.outputs.publish == 'yes' }}
-        run: npm publish --provenance --tag=nightly
+        name: Dispatch npm-publish workflow
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run npm-publish.yml \
+            --ref "${{ github.ref_name }}" \
+            -f tag=nightly \
+            -f version="$(node -p "require('./package.json').version")" \
+            -f ref="${{ github.sha }}"

--- a/etc/notes/releasing.md
+++ b/etc/notes/releasing.md
@@ -104,6 +104,12 @@ The github action is able to publish with the repository secret `NPM_TOKEN`.
 This is a granular API key that is unique to each package and has to be rotated on a regular basis.
 The `dbx-node@mongodb.com` npm account is the author of the automated release.
 
+The nightly release flow is an exception: `release-nightly.yml` dispatches
+`.github/workflows/npm-publish.yml`, which authenticates to the npm registry
+via [npm Trusted Publishing](https://docs.npmjs.com/trusted-publishers) (OIDC)
+rather than `NPM_TOKEN`. The `mongodb` package's trusted publisher entry on
+npmjs.com points at `npm-publish.yml`.
+
 ### Prebuilds
 
 Our native packages offer pre built binaries using [`prebuild`](https://github.com/prebuild/prebuild).


### PR DESCRIPTION
### Description

Merge this PR only after configuration on NPM for trusted publisher is complete! Workflow name for NPM - `npm-publish.yml`.

#### Summary of Changes

Migrates the nightly release flow off `NPM_TOKEN` and onto npm Trusted Publishing (OIDC). The pattern routes publishing through a dedicated, single-purpose workflow that we can register once on npmjs.com as the trusted publisher for the `mongodb` package.

npm Trusted Publishing currently allows **one trusted publisher entry per package**, and the OIDC validation matches against the top-level caller workflow's filename - so [`workflow_call` does not work around this](https://github.com/npm/documentation/issues/1755) (that's because with `workflow_call` the caller name appears, so it won't be npm_publish.yml but release.yml, release-nightly.yml, -alpha.yml, etc.). Dispatching the publish workflow via the `workflow_dispatch` API lets us register a single publisher entry and eventually route every release flow (nightly, latest, alpha, backports) through it.

Test on nightly build first, before promoting to the rest.

### Double check the following

- [x] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
