### PR TITLE
fix(NODE-7548): SCRAM authentication fails on non-Node runtimes

### DIFF
--- a/etc/bundle-driver.mjs
+++ b/etc/bundle-driver.mjs
@@ -19,7 +19,7 @@ await esbuild.build({
   outfile: outputBundleFile,
   platform: 'browser',
   format: 'cjs',
-  target: 'node20',
+  target: 'chrome112',
   external: [
     '@aws-sdk/credential-providers',
     '@mongodb-js/saslprep',

--- a/etc/bundle-driver.mjs
+++ b/etc/bundle-driver.mjs
@@ -17,7 +17,7 @@ await esbuild.build({
   entryPoints: [path.join(rootDir, 'test/mongodb_all.ts')],
   bundle: true,
   outfile: outputBundleFile,
-  platform: 'node',
+  platform: 'browser',
   format: 'cjs',
   target: 'node20',
   external: [
@@ -25,7 +25,6 @@ await esbuild.build({
     '@mongodb-js/saslprep',
     '@mongodb-js/zstd',
     '@napi-rs/snappy*',
-    'bson',
     'gcp-metadata',
     'kerberos',
     'mongodb-client-encryption',

--- a/src/bson.ts
+++ b/src/bson.ts
@@ -78,15 +78,15 @@ export const setUint32LE = (destination: Uint8Array, offset: number, value: numb
  */
 export interface BSONSerializeOptions
   extends Omit<SerializeOptions, 'index'>,
-  Omit<
-    DeserializeOptions,
-    | 'evalFunctions'
-    | 'cacheFunctions'
-    | 'cacheFunctionsCrc32'
-    | 'allowObjectSmallerThanBufferSize'
-    | 'index'
-    | 'validation'
-  > {
+    Omit<
+      DeserializeOptions,
+      | 'evalFunctions'
+      | 'cacheFunctions'
+      | 'cacheFunctionsCrc32'
+      | 'allowObjectSmallerThanBufferSize'
+      | 'index'
+      | 'validation'
+    > {
   /**
    * Enabling the raw option will return a [Node.js Buffer](https://nodejs.org/api/buffer.html)
    * which is allocated using [allocUnsafe API](https://nodejs.org/api/buffer.html#static-method-bufferallocunsafesize).

--- a/src/bson.ts
+++ b/src/bson.ts
@@ -57,6 +57,7 @@ export const readInt32LE = (buffer: Uint8Array, offset: number): number => {
 
 // readUint8, reads a single unsigned byte from buffer at given offset
 export const readUint8 = (buffer: Uint8Array, offset: number): number => {
+  validateBufferInputs(buffer, offset, 1);
   return buffer[offset];
 };
 
@@ -77,15 +78,15 @@ export const setUint32LE = (destination: Uint8Array, offset: number, value: numb
  */
 export interface BSONSerializeOptions
   extends Omit<SerializeOptions, 'index'>,
-    Omit<
-      DeserializeOptions,
-      | 'evalFunctions'
-      | 'cacheFunctions'
-      | 'cacheFunctionsCrc32'
-      | 'allowObjectSmallerThanBufferSize'
-      | 'index'
-      | 'validation'
-    > {
+  Omit<
+    DeserializeOptions,
+    | 'evalFunctions'
+    | 'cacheFunctions'
+    | 'cacheFunctionsCrc32'
+    | 'allowObjectSmallerThanBufferSize'
+    | 'index'
+    | 'validation'
+  > {
   /**
    * Enabling the raw option will return a [Node.js Buffer](https://nodejs.org/api/buffer.html)
    * which is allocated using [allocUnsafe API](https://nodejs.org/api/buffer.html#static-method-bufferallocunsafesize).

--- a/src/bson.ts
+++ b/src/bson.ts
@@ -55,6 +55,11 @@ export const readInt32LE = (buffer: Uint8Array, offset: number): number => {
   return NumberUtils.getInt32LE(buffer, offset);
 };
 
+// readUint8, reads a single unsigned byte from buffer at given offset
+export const readUint8 = (buffer: Uint8Array, offset: number): number => {
+  return buffer[offset];
+};
+
 export const setUint32LE = (destination: Uint8Array, offset: number, value: number): 4 => {
   destination[offset] = value;
   value >>>= 8;
@@ -72,15 +77,15 @@ export const setUint32LE = (destination: Uint8Array, offset: number, value: numb
  */
 export interface BSONSerializeOptions
   extends Omit<SerializeOptions, 'index'>,
-    Omit<
-      DeserializeOptions,
-      | 'evalFunctions'
-      | 'cacheFunctions'
-      | 'cacheFunctionsCrc32'
-      | 'allowObjectSmallerThanBufferSize'
-      | 'index'
-      | 'validation'
-    > {
+  Omit<
+    DeserializeOptions,
+    | 'evalFunctions'
+    | 'cacheFunctions'
+    | 'cacheFunctionsCrc32'
+    | 'allowObjectSmallerThanBufferSize'
+    | 'index'
+    | 'validation'
+  > {
   /**
    * Enabling the raw option will return a [Node.js Buffer](https://nodejs.org/api/buffer.html)
    * which is allocated using [allocUnsafe API](https://nodejs.org/api/buffer.html#static-method-bufferallocunsafesize).

--- a/src/bson.ts
+++ b/src/bson.ts
@@ -77,15 +77,15 @@ export const setUint32LE = (destination: Uint8Array, offset: number, value: numb
  */
 export interface BSONSerializeOptions
   extends Omit<SerializeOptions, 'index'>,
-  Omit<
-    DeserializeOptions,
-    | 'evalFunctions'
-    | 'cacheFunctions'
-    | 'cacheFunctionsCrc32'
-    | 'allowObjectSmallerThanBufferSize'
-    | 'index'
-    | 'validation'
-  > {
+    Omit<
+      DeserializeOptions,
+      | 'evalFunctions'
+      | 'cacheFunctions'
+      | 'cacheFunctionsCrc32'
+      | 'allowObjectSmallerThanBufferSize'
+      | 'index'
+      | 'validation'
+    > {
   /**
    * Enabling the raw option will return a [Node.js Buffer](https://nodejs.org/api/buffer.html)
    * which is allocated using [allocUnsafe API](https://nodejs.org/api/buffer.html#static-method-bufferallocunsafesize).

--- a/src/cmap/auth/scram.ts
+++ b/src/cmap/auth/scram.ts
@@ -204,7 +204,7 @@ async function continueScramConversation(
 }
 
 function parsePayload(payload: Binary) {
-  const payloadStr = ByteUtils.toUTF8(payload.buffer, 0, payload.buffer.length, true);
+  const payloadStr = ByteUtils.toUTF8(payload.buffer, 0, payload.position, true);
   const dict: Document = {};
   const parts = payloadStr.split(',');
   for (let i = 0; i < parts.length; i++) {

--- a/src/cmap/auth/scram.ts
+++ b/src/cmap/auth/scram.ts
@@ -168,17 +168,8 @@ async function continueScramConversation(
   const storedKey = await H(cryptoMethod, clientKey);
   const firstMessageBytes = clientFirstMessageBare(username, nonce);
   const firstMessage = ByteUtils.toUTF8(firstMessageBytes, 0, firstMessageBytes.length, true);
-  const payloadString = ByteUtils.toUTF8(
-    payload.buffer,
-    0,
-    payload.buffer.length,
-    true
-  );
-  const authMessage = [
-    firstMessage,
-    payloadString,
-    withoutProof
-  ].join(',');
+  const payloadString = ByteUtils.toUTF8(payload.buffer, 0, payload.buffer.length, true);
+  const authMessage = [firstMessage, payloadString, withoutProof].join(',');
 
   const clientSignature = await HMAC(cryptoMethod, storedKey, authMessage);
   const clientProof = `p=${xor(clientKey, clientSignature)}`;

--- a/src/cmap/auth/scram.ts
+++ b/src/cmap/auth/scram.ts
@@ -166,8 +166,10 @@ async function continueScramConversation(
   const clientKey = await HMAC(cryptoMethod, saltedPassword, 'Client Key');
   const serverKey = await HMAC(cryptoMethod, saltedPassword, 'Server Key');
   const storedKey = await H(cryptoMethod, clientKey);
+  const firstMessageBytes = clientFirstMessageBare(username, nonce);
+  const firstMessage = ByteUtils.toUTF8(firstMessageBytes, 0, firstMessageBytes.length, true);
   const authMessage = [
-    clientFirstMessageBare(username, nonce),
+    firstMessage,
     payload.toString('utf8'),
     withoutProof
   ].join(',');

--- a/src/cmap/auth/scram.ts
+++ b/src/cmap/auth/scram.ts
@@ -168,7 +168,7 @@ async function continueScramConversation(
   const storedKey = await H(cryptoMethod, clientKey);
   const firstMessageBytes = clientFirstMessageBare(username, nonce);
   const firstMessage = ByteUtils.toUTF8(firstMessageBytes, 0, firstMessageBytes.length, true);
-  const payloadString = ByteUtils.toUTF8(payload.buffer, 0, payload.buffer.length, true);
+  const payloadString = ByteUtils.toUTF8(payload.buffer, 0, payload.position, true);
   const authMessage = [firstMessage, payloadString, withoutProof].join(',');
 
   const clientSignature = await HMAC(cryptoMethod, storedKey, authMessage);

--- a/src/cmap/auth/scram.ts
+++ b/src/cmap/auth/scram.ts
@@ -168,9 +168,15 @@ async function continueScramConversation(
   const storedKey = await H(cryptoMethod, clientKey);
   const firstMessageBytes = clientFirstMessageBare(username, nonce);
   const firstMessage = ByteUtils.toUTF8(firstMessageBytes, 0, firstMessageBytes.length, true);
+  const payloadString = ByteUtils.toUTF8(
+    payload.buffer,
+    0,
+    payload.buffer.length,
+    true
+  );
   const authMessage = [
     firstMessage,
-    payload.toString('utf8'),
+    payloadString,
     withoutProof
   ].join(',');
 
@@ -207,7 +213,7 @@ async function continueScramConversation(
 }
 
 function parsePayload(payload: Binary) {
-  const payloadStr = payload.toString('utf8');
+  const payloadStr = ByteUtils.toUTF8(payload.buffer, 0, payload.buffer.length, true);
   const dict: Document = {};
   const parts = payloadStr.split(',');
   for (let i = 0; i < parts.length; i++) {

--- a/src/cmap/auth/scram.ts
+++ b/src/cmap/auth/scram.ts
@@ -167,8 +167,8 @@ async function continueScramConversation(
   const serverKey = await HMAC(cryptoMethod, saltedPassword, 'Server Key');
   const storedKey = await H(cryptoMethod, clientKey);
   const firstMessageBytes = clientFirstMessageBare(username, nonce);
-  const firstMessage = ByteUtils.toUTF8(firstMessageBytes, 0, firstMessageBytes.length, true);
-  const payloadString = ByteUtils.toUTF8(payload.buffer, 0, payload.position, true);
+  const firstMessage = ByteUtils.toUTF8(firstMessageBytes, 0, firstMessageBytes.length, false);
+  const payloadString = ByteUtils.toUTF8(payload.buffer, 0, payload.position, false);
   const authMessage = [firstMessage, payloadString, withoutProof].join(',');
 
   const clientSignature = await HMAC(cryptoMethod, storedKey, authMessage);
@@ -204,7 +204,7 @@ async function continueScramConversation(
 }
 
 function parsePayload(payload: Binary) {
-  const payloadStr = ByteUtils.toUTF8(payload.buffer, 0, payload.position, true);
+  const payloadStr = ByteUtils.toUTF8(payload.buffer, 0, payload.position, false);
   const dict: Document = {};
   const parts = payloadStr.split(',');
   for (let i = 0; i < parts.length; i++) {

--- a/test/integration/change-streams/change_stream.test.ts
+++ b/test/integration/change-streams/change_stream.test.ts
@@ -21,11 +21,12 @@ import {
   type MongoClient,
   MongoServerError,
   ReadPreference,
-  type ResumeToken
+  type ResumeToken,
+  runNodelessTests
 } from '../../mongodb';
 import * as mock from '../../tools/mongodb-mock/index';
 import { TestBuilder, UnifiedTestSuiteBuilder } from '../../tools/unified_suite_builder';
-import { type FailCommandFailPoint, sleep } from '../../tools/utils';
+import { ensureTypeByName, type FailCommandFailPoint, sleep } from '../../tools/utils';
 import { delay, filterForCommands } from '../shared';
 
 const initIteratorMode = async (cs: ChangeStream) => {
@@ -1826,7 +1827,11 @@ describe('Change Streams', function () {
             expect(result).to.exist;
 
             const change = await willBeChange;
-            expect(change).to.have.nested.property('fullDocument.a').that.is.instanceOf(Long);
+            if (runNodelessTests) {
+              ensureTypeByName(change?.fullDocument?.a, '_Long');
+            } else {
+              expect(change).to.have.nested.property('fullDocument.a').that.is.instanceOf(Long);
+            }
           }
         });
       });

--- a/test/integration/client-side-encryption/driver.test.ts
+++ b/test/integration/client-side-encryption/driver.test.ts
@@ -725,14 +725,14 @@ describe('CSOT', function () {
                   'test.test': {
                     bsonType: 'object',
                     encryptMetadata: {
-                      keyId: [new UUID(dataKey)]
+                      keyId: [new UUID(dataKey.toHexString(true))]
                     },
                     properties: {
                       a: {
                         encrypt: {
                           bsonType: 'int',
                           algorithm: 'AEAD_AES_256_CBC_HMAC_SHA_512-Random',
-                          keyId: [new UUID(dataKey)]
+                          keyId: [new UUID(dataKey.toHexString(true))]
                         }
                       }
                     }

--- a/test/integration/client-side-encryption/driver.test.ts
+++ b/test/integration/client-side-encryption/driver.test.ts
@@ -725,6 +725,7 @@ describe('CSOT', function () {
                   'test.test': {
                     bsonType: 'object',
                     encryptMetadata: {
+                      // NODE-7581: should be able to pass dataKey as-is, as UUID, w/o needing toHexString
                       keyId: [new UUID(dataKey.toHexString(true))]
                     },
                     properties: {
@@ -732,6 +733,7 @@ describe('CSOT', function () {
                         encrypt: {
                           bsonType: 'int',
                           algorithm: 'AEAD_AES_256_CBC_HMAC_SHA_512-Random',
+                          // NODE-7581: should be able to pass dataKey as-is, as UUID, w/o needing toHexString
                           keyId: [new UUID(dataKey.toHexString(true))]
                         }
                       }

--- a/test/integration/crud/insert.test.ts
+++ b/test/integration/crud/insert.test.ts
@@ -25,6 +25,7 @@ import {
   Timestamp
 } from '../../mongodb';
 import { assert as test, setupDatabase } from '../shared';
+import { ByteUtils } from 'bson';
 
 describe('crud - insert', function () {
   let client: MongoClient;
@@ -180,7 +181,7 @@ describe('crud - insert', function () {
       test.equal(date.toString(), doc.date.toString());
       test.equal(date.getTime(), doc.date.getTime());
       test.equal(motherOfAllDocuments.oid.toHexString(), doc.oid.toHexString());
-      test.equal(motherOfAllDocuments.binary.toString('hex'), doc.binary.value().toString('hex'));
+      test.equal(motherOfAllDocuments.binary.toString('hex'), ByteUtils.toHex(doc.binary.value()));
 
       test.equal(motherOfAllDocuments.int, doc.int);
       test.equal(motherOfAllDocuments.long, doc.long);
@@ -281,8 +282,8 @@ describe('crud - insert', function () {
       test.equal(date.getTime(), doc.date.getTime());
       test.equal(motherOfAllDocuments.oid.toHexString(), doc.oid.toHexString());
       test.equal(
-        motherOfAllDocuments.binary.value().toString('hex'),
-        doc.binary.value().toString('hex')
+        ByteUtils.toHex(motherOfAllDocuments.binary.value()),
+        ByteUtils.toHex(doc.binary.value())
       );
 
       test.equal(motherOfAllDocuments.int, doc.int);

--- a/test/integration/crud/insert.test.ts
+++ b/test/integration/crud/insert.test.ts
@@ -1,5 +1,6 @@
 import * as Script from 'node:vm';
 
+import { ByteUtils } from 'bson';
 import { expect } from 'chai';
 import * as process from 'process';
 import { satisfies } from 'semver';
@@ -25,7 +26,6 @@ import {
   Timestamp
 } from '../../mongodb';
 import { assert as test, setupDatabase } from '../shared';
-import { ByteUtils } from 'bson';
 
 describe('crud - insert', function () {
   let client: MongoClient;

--- a/test/integration/node-specific/bson-options/promote_buffers.test.ts
+++ b/test/integration/node-specific/bson-options/promote_buffers.test.ts
@@ -1,8 +1,9 @@
 import { expect } from 'chai';
 
+import { runOnlyInNodeMetadata } from '../../../tools/utils';
 import { setupDatabase } from '../../shared';
 
-describe('Promote Buffers', function () {
+describe('Promote Buffers', runOnlyInNodeMetadata, function () {
   before(function () {
     return setupDatabase(this.configuration);
   });

--- a/test/integration/node-specific/bson-options/raw.test.ts
+++ b/test/integration/node-specific/bson-options/raw.test.ts
@@ -1,8 +1,9 @@
 import { expect } from 'chai';
 
 import { type Collection, type MongoClient, ObjectId } from '../../../mongodb';
+import { runOnlyInNodeMetadata } from '../../../tools/utils';
 
-describe('raw bson support', () => {
+describe('raw bson support', runOnlyInNodeMetadata, () => {
   describe('raw', () => {
     describe('option inheritance', () => {
       // define client and option for tests to use

--- a/test/integration/node-specific/bson-options/utf8_validation.test.ts
+++ b/test/integration/node-specific/bson-options/utf8_validation.test.ts
@@ -11,7 +11,9 @@ import {
   MongoServerError,
   OpMsgResponse
 } from '../../../mongodb';
-describe('class MongoDBResponse', () => {
+import { runOnlyInNodeMetadata } from '../../../tools/utils';
+
+describe('class MongoDBResponse', runOnlyInNodeMetadata, () => {
   let client;
 
   afterEach(async () => {

--- a/test/integration/node-specific/bson-options/utf8_validation.test.ts
+++ b/test/integration/node-specific/bson-options/utf8_validation.test.ts
@@ -74,7 +74,7 @@ describe('class MongoDBResponse', runOnlyInNodeMetadata, () => {
   );
 });
 
-describe('parsing of utf8-invalid documents with cursors', function () {
+describe('parsing of utf8-invalid documents with cursors', runOnlyInNodeMetadata, function () {
   let client: MongoClient;
   let collection: Collection;
   const compressionPredicate = () =>

--- a/test/mongodb_bundled.ts
+++ b/test/mongodb_bundled.ts
@@ -176,6 +176,7 @@ export const {
   ListIndexesOperation,
   Long,
   makeClientMetadata,
+  makeSocket,
   MAX_SUPPORTED_SERVER_VERSION,
   MAX_SUPPORTED_WIRE_VERSION,
   MaxKey,

--- a/test/mongodb_bundled.ts
+++ b/test/mongodb_bundled.ts
@@ -423,6 +423,7 @@ export type {
 import type {
   AbstractCursor as _AbstractCursor,
   AuthMechanism as _AuthMechanism,
+  Binary as _Binary,
   ChangeStream as _ChangeStream,
   ClientEncryption as _ClientEncryption,
   ClientSession as _ClientSession,
@@ -484,6 +485,7 @@ import type {
 // To re-sort: Highlight the list and use VSCode's "Sort Lines Ascending" command
 export type AbstractCursor = _AbstractCursor;
 export type AuthMechanism = _AuthMechanism;
+export type Binary = _Binary;
 export type ChangeStream = _ChangeStream;
 export type ClientEncryption = _ClientEncryption;
 export type ClientSession = _ClientSession;

--- a/test/mongodb_bundled.ts
+++ b/test/mongodb_bundled.ts
@@ -109,6 +109,7 @@ export const {
   decompress,
   decorateWithExplain,
   DEFAULT_ALLOWED_HOSTS,
+  DEFAULT_KEEP_ALIVE_INITIAL_DELAY_MS,
   DEFAULT_MAX_DOCUMENT_LENGTH,
   DEFAULT_PK_FACTORY,
   DeleteManyOperation,

--- a/test/tools/runner/metadata_ui.js
+++ b/test/tools/runner/metadata_ui.js
@@ -102,7 +102,8 @@ module.exports = Mocha.interfaces.metadata_ui = function (suite) {
         newSuite.parent._onlySuites = newSuite.parent._onlySuites.concat(newSuite);
         mocha.options.hasOnly = true;
       }
-      newSuite.metadata = testData.metadata || {};
+      // Inherit parent metadata if metadata is not explicitly provided
+      newSuite.metadata = testData.metadata || suites[1]?.metadata || {};
       if (typeof testData.fn === 'function') {
         testData.fn.call(newSuite);
         suites.shift();

--- a/test/tools/runner/vm_context_helper.ts
+++ b/test/tools/runner/vm_context_helper.ts
@@ -50,7 +50,6 @@ const exposedGlobals = new Set([
   'console',
   'crypto',
   'performance',
-  'process',
 
   'atob',
   'btoa',
@@ -95,8 +94,11 @@ const context = {
   global: undefined as any,
   globalThis: undefined as any,
 
-  // Block Buffer from being accessible in the context
-  Buffer: undefined,
+  TextEncoder: undefined,
+  TextDecoder: undefined,
+
+  atob: undefined,
+  btoa: undefined,
 };
 
 // Expose allowed globals in the context
@@ -127,6 +129,8 @@ const sandbox = vm.createContext(context);
 
 // Make globalThis point to the sandbox
 sandbox.globalThis = sandbox;
+
+export { sandbox };
 
 // Diagnostic: Check if Buffer is accessible in the VM context
 if (process.env.MONGODB_BUNDLE_DEBUG) {

--- a/test/tools/runner/vm_context_helper.ts
+++ b/test/tools/runner/vm_context_helper.ts
@@ -5,8 +5,6 @@ import { isBuiltin } from 'node:module';
 import * as path from 'node:path';
 import * as vm from 'node:vm';
 
-import * as process from 'process';
-
 import { ALLOWED_DRIVER_REQUIRE_PROPERTY_NAME } from '../../mongodb_all';
 
 const allowedModules = new Set([
@@ -89,7 +87,7 @@ const context = {
   atob: undefined,
   btoa: undefined,
   TextEncoder: undefined,
-  TextDecoder: undefined,
+  TextDecoder: undefined
 };
 
 // Expose allowed globals in the context

--- a/test/tools/runner/vm_context_helper.ts
+++ b/test/tools/runner/vm_context_helper.ts
@@ -9,15 +9,6 @@ import * as process from 'process';
 
 import { ALLOWED_DRIVER_REQUIRE_PROPERTY_NAME } from '../../mongodb_all';
 
-/**
- * Debug logging for bundled test environment issues
- */
-function debug(msg: unknown) {
-  if (process.env.MONGODB_BUNDLE_DEBUG) {
-    console.log(`[BUNDLE_DEBUG] ${msg}`);
-  }
-}
-
 const allowedModules = new Set([
   '@aws-sdk/credential-providers',
   '@mongodb-js/saslprep',
@@ -95,11 +86,11 @@ const context = {
   global: undefined as any,
   globalThis: undefined as any,
 
+  // These are needed for webByteUtils and are not available in the browser.
+  atob: undefined,
+  btoa: undefined,
   TextEncoder: undefined,
   TextDecoder: undefined,
-
-  atob: undefined,
-  btoa: undefined
 };
 
 // Expose allowed globals in the context
@@ -131,18 +122,8 @@ const sandbox = vm.createContext(context);
 // Make globalThis point to the sandbox
 sandbox.globalThis = sandbox;
 
+// Export the sandbox for use in tests
 export { sandbox };
-
-// Diagnostic: Check if Buffer is accessible in the VM context
-if (process.env.MONGODB_BUNDLE_DEBUG) {
-  try {
-    const testScript = new vm.Script('typeof Buffer');
-    const bufferType = testScript.runInContext(sandbox);
-    debug(`In VM context, typeof Buffer = ${bufferType}`);
-  } catch (e) {
-    debug(`Error checking Buffer in context: ${(e as Error).message}`);
-  }
-}
 
 /**
  * Load the bundled MongoDB driver module in a VM context

--- a/test/tools/runner/vm_context_helper.ts
+++ b/test/tools/runner/vm_context_helper.ts
@@ -7,11 +7,20 @@ import * as vm from 'node:vm';
 
 import { ALLOWED_DRIVER_REQUIRE_PROPERTY_NAME } from '../../mongodb_all';
 
+/**
+ * Debug logging for bundled test environment issues
+ */
+function debug(msg: unknown) {
+  if (process.env.MONGODB_BUNDLE_DEBUG) {
+    // eslint-disable-next-line no-console
+    console.log(`[BUNDLE_DEBUG] ${msg}`);
+  }
+}
+
 const allowedModules = new Set([
   '@aws-sdk/credential-providers',
   '@mongodb-js/saslprep',
   '@mongodb-js/zstd',
-  'bson',
   'gcp-metadata',
   'kerberos',
   'mongodb-client-encryption',
@@ -27,7 +36,6 @@ const exposedGlobals = new Set([
   'AbortController',
   'AbortSignal',
   'BigInt',
-  'Buffer',
   'Date',
   'Error',
   'Headers',
@@ -44,13 +52,15 @@ const exposedGlobals = new Set([
   'performance',
   'process',
 
+  'atob',
+  'btoa',
   'clearImmediate',
   'clearInterval',
   'clearTimeout',
   'setImmediate',
   'setInterval',
   'setTimeout',
-  'queueMicrotask'
+  'queueMicrotask',
 ]);
 
 /**
@@ -68,7 +78,10 @@ function createRestrictedRequire() {
     if (shouldBlock) {
       throw new Error(`Access to core module '${moduleName}' is restricted in this context`);
     }
-    return require(moduleName);
+
+    const required = require(moduleName);
+    debug(`Loaded external module: ${moduleName}`);
+    return required;
   } as NodeJS.Require;
 }
 
@@ -80,7 +93,10 @@ const context = {
 
   // Needed for some modules
   global: undefined as any,
-  globalThis: undefined as any
+  globalThis: undefined as any,
+
+  // Block Buffer from being accessible in the context
+  Buffer: undefined,
 };
 
 // Expose allowed globals in the context
@@ -90,11 +106,38 @@ for (const globalName of exposedGlobals) {
   }
 }
 
+// Ensure TextEncoder/TextDecoder are always available (needed for webByteUtils)
+if (!context.TextEncoder && typeof TextEncoder !== 'undefined') {
+  context.TextEncoder = TextEncoder;
+}
+if (!context.TextDecoder && typeof TextDecoder !== 'undefined') {
+  context.TextDecoder = TextDecoder;
+}
+
+// Ensure btoa/atob are available (needed for webByteUtils base64 encoding)
+if (!context.btoa && typeof btoa !== 'undefined') {
+  context.btoa = btoa;
+}
+if (!context.atob && typeof atob !== 'undefined') {
+  context.atob = atob;
+}
+
 // Create a sandbox context with necessary globals
 const sandbox = vm.createContext(context);
 
 // Make globalThis point to the sandbox
 sandbox.globalThis = sandbox;
+
+// Diagnostic: Check if Buffer is accessible in the VM context
+if (process.env.MONGODB_BUNDLE_DEBUG) {
+  try {
+    const testScript = new vm.Script('typeof Buffer');
+    const bufferType = testScript.runInContext(sandbox);
+    debug(`In VM context, typeof Buffer = ${bufferType}`);
+  } catch (e) {
+    debug(`Error checking Buffer in context: ${(e as Error).message}`);
+  }
+}
 
 /**
  * Load the bundled MongoDB driver module in a VM context

--- a/test/tools/runner/vm_context_helper.ts
+++ b/test/tools/runner/vm_context_helper.ts
@@ -71,7 +71,6 @@ function createRestrictedRequire() {
     }
 
     const required = require(moduleName);
-    debug(`Loaded external module: ${moduleName}`);
     return required;
   } as NodeJS.Require;
 }

--- a/test/tools/runner/vm_context_helper.ts
+++ b/test/tools/runner/vm_context_helper.ts
@@ -5,6 +5,8 @@ import { isBuiltin } from 'node:module';
 import * as path from 'node:path';
 import * as vm from 'node:vm';
 
+import * as process from 'process';
+
 import { ALLOWED_DRIVER_REQUIRE_PROPERTY_NAME } from '../../mongodb_all';
 
 /**
@@ -12,7 +14,6 @@ import { ALLOWED_DRIVER_REQUIRE_PROPERTY_NAME } from '../../mongodb_all';
  */
 function debug(msg: unknown) {
   if (process.env.MONGODB_BUNDLE_DEBUG) {
-    // eslint-disable-next-line no-console
     console.log(`[BUNDLE_DEBUG] ${msg}`);
   }
 }
@@ -59,7 +60,7 @@ const exposedGlobals = new Set([
   'setImmediate',
   'setInterval',
   'setTimeout',
-  'queueMicrotask',
+  'queueMicrotask'
 ]);
 
 /**
@@ -98,7 +99,7 @@ const context = {
   TextDecoder: undefined,
 
   atob: undefined,
-  btoa: undefined,
+  btoa: undefined
 };
 
 // Expose allowed globals in the context

--- a/test/tools/runner/vm_context_helper.ts
+++ b/test/tools/runner/vm_context_helper.ts
@@ -81,13 +81,7 @@ const context = {
 
   // Needed for some modules
   global: undefined as any,
-  globalThis: undefined as any,
-
-  // These are needed for webByteUtils and are not available in the browser.
-  atob: undefined,
-  btoa: undefined,
-  TextEncoder: undefined,
-  TextDecoder: undefined
+  globalThis: undefined as any
 };
 
 // Expose allowed globals in the context
@@ -95,22 +89,6 @@ for (const globalName of exposedGlobals) {
   if (globalName in global) {
     context[globalName] = (global as any)[globalName];
   }
-}
-
-// Ensure TextEncoder/TextDecoder are always available (needed for webByteUtils)
-if (!context.TextEncoder && typeof TextEncoder !== 'undefined') {
-  context.TextEncoder = TextEncoder;
-}
-if (!context.TextDecoder && typeof TextDecoder !== 'undefined') {
-  context.TextDecoder = TextDecoder;
-}
-
-// Ensure btoa/atob are available (needed for webByteUtils base64 encoding)
-if (!context.btoa && typeof btoa !== 'undefined') {
-  context.btoa = btoa;
-}
-if (!context.atob && typeof atob !== 'undefined') {
-  context.atob = atob;
 }
 
 // Create a sandbox context with necessary globals

--- a/test/tools/unified-spec-runner/operations.ts
+++ b/test/tools/unified-spec-runner/operations.ts
@@ -3,6 +3,7 @@
 import { Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 
+import { ByteUtils } from 'bson';
 import { AssertionError, expect } from 'chai';
 import * as process from 'process';
 
@@ -30,7 +31,6 @@ import { EntitiesMap } from './entities';
 import { expectErrorCheck, resultCheck } from './match';
 import type { ExpectedEvent, OperationDescription } from './schema';
 import { getMatchingEventCount, translateOptions } from './unified-utils';
-import { ByteUtils } from 'bson';
 
 interface OperationFunctionParams {
   client: MongoClient;
@@ -126,7 +126,9 @@ operations.set('assertDifferentLsidOnLastTwoCommands', async ({ entities, operat
   expect(last.command).to.have.property('lsid');
   expect(secondLast.command).to.have.property('lsid');
 
-  expect(ByteUtils.compare(last.command.lsid.id.buffer, secondLast.command.lsid.id.buffer)).to.not.equal(0);
+  expect(
+    ByteUtils.compare(last.command.lsid.id.buffer, secondLast.command.lsid.id.buffer)
+  ).to.not.equal(0);
 });
 
 operations.set('assertSameLsidOnLastTwoCommands', async ({ entities, operation }) => {
@@ -145,7 +147,9 @@ operations.set('assertSameLsidOnLastTwoCommands', async ({ entities, operation }
   expect(last.command).to.have.property('lsid');
   expect(secondLast.command).to.have.property('lsid');
 
-  expect(ByteUtils.compare(last.command.lsid.id.buffer, secondLast.command.lsid.id.buffer)).to.equal(0);
+  expect(
+    ByteUtils.compare(last.command.lsid.id.buffer, secondLast.command.lsid.id.buffer)
+  ).to.equal(0);
 });
 
 operations.set('assertSessionDirty', async ({ operation }) => {

--- a/test/tools/unified-spec-runner/operations.ts
+++ b/test/tools/unified-spec-runner/operations.ts
@@ -30,6 +30,7 @@ import { EntitiesMap } from './entities';
 import { expectErrorCheck, resultCheck } from './match';
 import type { ExpectedEvent, OperationDescription } from './schema';
 import { getMatchingEventCount, translateOptions } from './unified-utils';
+import { ByteUtils } from 'bson';
 
 interface OperationFunctionParams {
   client: MongoClient;
@@ -125,7 +126,7 @@ operations.set('assertDifferentLsidOnLastTwoCommands', async ({ entities, operat
   expect(last.command).to.have.property('lsid');
   expect(secondLast.command).to.have.property('lsid');
 
-  expect(last.command.lsid.id.buffer.equals(secondLast.command.lsid.id.buffer)).to.be.false;
+  expect(ByteUtils.compare(last.command.lsid.id.buffer, secondLast.command.lsid.id.buffer)).to.not.equal(0);
 });
 
 operations.set('assertSameLsidOnLastTwoCommands', async ({ entities, operation }) => {
@@ -144,7 +145,7 @@ operations.set('assertSameLsidOnLastTwoCommands', async ({ entities, operation }
   expect(last.command).to.have.property('lsid');
   expect(secondLast.command).to.have.property('lsid');
 
-  expect(last.command.lsid.id.buffer.equals(secondLast.command.lsid.id.buffer)).to.be.true;
+  expect(ByteUtils.compare(last.command.lsid.id.buffer, secondLast.command.lsid.id.buffer)).to.equal(0);
 });
 
 operations.set('assertSessionDirty', async ({ operation }) => {

--- a/test/tools/utils.ts
+++ b/test/tools/utils.ts
@@ -21,6 +21,7 @@ import {
   OP_MSG,
   processTimeMS,
   resolveRuntimeAdapters,
+  runNodelessTests,
   type Runtime,
   type ServerApiVersion,
   Topology,
@@ -623,3 +624,18 @@ export function configureMongocryptdSpawnHooks(
  * A `Runtime` that resolves to entirely Nodejs modules, useful when tests must provide a default `runtime` object to an API.
  */
 export const runtime: Runtime = resolveRuntimeAdapters({});
+
+/**
+ * Metadata that can be used to skip tests in nodeless environments.
+ */
+export const runOnlyInNodeMetadata: MongoDBMetadataUI = {
+  requires: {
+    predicate: _test => {
+      if (runNodelessTests) {
+        return 'Test is not node specific and should be run in nodeless environments';
+      } else {
+        return true;
+      }
+    }
+  }
+};

--- a/test/tools/utils.ts
+++ b/test/tools/utils.ts
@@ -627,12 +627,13 @@ export const runtime: Runtime = resolveRuntimeAdapters({});
 
 /**
  * Metadata that can be used to skip tests in nodeless environments.
+ * Use this for tests that rely on Node.js-specific features and cannot be run in nodeless environments like Deno or the browser.
  */
 export const runOnlyInNodeMetadata: MongoDBMetadataUI = {
   requires: {
     predicate: _test => {
       if (runNodelessTests) {
-        return 'Test is not node specific and should be run in nodeless environments';
+        return 'Test is a node specific test and should be not be run in nodeless environments';
       } else {
         return true;
       }

--- a/test/unit/client-side-encryption/state_machine.test.ts
+++ b/test/unit/client-side-encryption/state_machine.test.ts
@@ -15,6 +15,7 @@ import {
   Db,
   type FindOptions,
   MongoClient,
+  runNodelessTests,
   squashError,
   StateMachine
 } from '../../mongodb';
@@ -60,6 +61,10 @@ describe('StateMachine', function () {
     let clientStub;
 
     beforeEach(function () {
+      if (runNodelessTests) {
+        // sinon doesn't work in nodeless tests
+        this.skip();
+      }
       this.sinon = sinon.createSandbox();
       runCommandStub = this.sinon.stub().resolves({});
       dbStub = this.sinon.createStubInstance(Db, {

--- a/test/unit/cmap/commands.test.ts
+++ b/test/unit/cmap/commands.test.ts
@@ -1,6 +1,7 @@
 import * as BSON from 'bson';
 import { expect } from 'chai';
 
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { readInt32LE } from '../../../src/bson';
 import { DocumentSequence, OpMsgRequest, OpReply } from '../../mongodb';
 

--- a/test/unit/cmap/commands.test.ts
+++ b/test/unit/cmap/commands.test.ts
@@ -1,7 +1,13 @@
 import * as BSON from 'bson';
 import { expect } from 'chai';
 
+import { readInt32LE } from '../../../src/bson';
 import { DocumentSequence, OpMsgRequest, OpReply } from '../../mongodb';
+
+// Helper to decode UTF-8 string from Uint8Array
+function utf8Slice(buffer: Uint8Array, start: number, end: number): string {
+  return BSON.ByteUtils.toUTF8(buffer, start, end, false);
+}
 
 describe('commands', function () {
   describe('OpMsgRequest', function () {
@@ -41,12 +47,12 @@ describe('commands', function () {
 
           it('sets the length of the document sequence', function () {
             // Bytes starting at index 1 is a 4 byte length.
-            expect(buffers[3].readInt32LE(1)).to.equal(25);
+            expect(readInt32LE(buffers[3], 1)).to.equal(25);
           });
 
           it('sets the name of the first field to be replaced', function () {
             // Bytes starting at index 5 is the field name.
-            expect(buffers[3].toString('utf8', 5, 10)).to.equal('field');
+            expect(utf8Slice(buffers[3], 5, 10)).to.equal('field');
           });
         });
 
@@ -81,12 +87,12 @@ describe('commands', function () {
 
           it('sets the length of the first document sequence', function () {
             // Bytes starting at index 1 is a 4 byte length.
-            expect(buffers[3].readInt32LE(1)).to.equal(28);
+            expect(readInt32LE(buffers[3], 1)).to.equal(28);
           });
 
           it('sets the name of the first field to be replaced', function () {
             // Bytes starting at index 5 is the field name.
-            expect(buffers[3].toString('utf8', 5, 13)).to.equal('fieldOne');
+            expect(utf8Slice(buffers[3], 5, 13)).to.equal('fieldOne');
           });
 
           it('sets the document sequence sections second type to 1', function () {
@@ -96,12 +102,12 @@ describe('commands', function () {
 
           it('sets the length of the second document sequence', function () {
             // Bytes starting at index 1 is a 4 byte length.
-            expect(buffers[3].readInt32LE(30)).to.equal(28);
+            expect(readInt32LE(buffers[3], 30)).to.equal(28);
           });
 
           it('sets the name of the second field to be replaced', function () {
             // Bytes starting at index 33 is the field name.
-            expect(buffers[3].toString('utf8', 34, 42)).to.equal('fieldTwo');
+            expect(utf8Slice(buffers[3], 34, 42)).to.equal('fieldTwo');
           });
         });
       });

--- a/test/unit/cmap/connect.test.ts
+++ b/test/unit/cmap/connect.test.ts
@@ -21,7 +21,8 @@ import {
   MongoClientAuthProviders,
   MongoCredentials,
   MongoNetworkError,
-  prepareHandshakeDocument
+  prepareHandshakeDocument,
+  runNodelessTests
 } from '../../mongodb';
 import { genClusterTime } from '../../tools/common';
 import * as mock from '../../tools/mongodb-mock/index';
@@ -467,6 +468,11 @@ describe('Connect Tests', function () {
     );
 
     before(function (done) {
+      if (runNodelessTests) {
+        // sinon doesn't work in nodeless tests
+        this.skip();
+      }
+
       // @SECLEVEL=0 allows the legacy test certificate (signed with SHA-1/1024-bit RSA)
       // to be accepted by OpenSSL 3.x, which rejects at the default security level.
       tlsServer = tls.createServer(

--- a/test/unit/cmap/wire_protocol/on_demand/document.test.ts
+++ b/test/unit/cmap/wire_protocol/on_demand/document.test.ts
@@ -1,7 +1,8 @@
 import { Binary, BSON, BSONError, BSONType, ObjectId, Timestamp } from 'bson';
 import { expect } from 'chai';
 
-import { OnDemandDocument } from '../../../../mongodb';
+import { OnDemandDocument, runNodelessTests } from '../../../../mongodb';
+import { ensureTypeByName } from '../../../../tools/utils';
 
 describe('class OnDemandDocument', () => {
   context('when given an empty BSON sequence', () => {
@@ -118,21 +119,37 @@ describe('class OnDemandDocument', () => {
     it('supports requesting multiple types', () => {
       expect(
         document.get('bool', BSONType.int) ??
-          document.get('bool', BSONType.long) ??
-          document.get('bool', BSONType.bool)
+        document.get('bool', BSONType.long) ??
+        document.get('bool', BSONType.bool)
       ).to.be.true;
     });
 
     it('throws if required is set to true and element name does not exist', () => {
-      expect(() => document.get('blah!', BSONType.bool, true)).to.throw(BSONError);
+      if (runNodelessTests) {
+        try {
+          document.get('blah!', BSONType.bool, true);
+        } catch (e) {
+          ensureTypeByName(e, 'BSONError');
+        }
+      } else {
+        expect(() => document.get('blah!', BSONType.bool, true)).to.throw(BSONError);
+      }
       expect(document).to.have.nested.property('cache.blah!', false);
     });
 
     it('throws if requested type is unsupported', () => {
-      expect(() => {
-        // @ts-expect-error: checking a bad BSON type
-        document.get('unsupportedType', BSONType.regex);
-      }).to.throw(BSONError, /unsupported/i);
+      if (runNodelessTests) {
+        try {          // @ts-expect-error: checking a bad BSON type
+          document.get('unsupportedType', BSONType.regex, true);
+        } catch (e) {
+          ensureTypeByName(e, 'BSONError');
+        }
+      } else {
+        expect(() => {
+          // @ts-expect-error: checking a bad BSON type
+          document.get('unsupportedType', BSONType.regex);
+        }).to.throw(BSONError, /unsupported/i);
+      }
     });
 
     it('caches the value', () => {
@@ -245,15 +262,31 @@ describe('class OnDemandDocument', () => {
     });
 
     it('throws if required is set to true and element name does not exist', () => {
-      expect(() => document.getNumber('blah!', true)).to.throw(BSONError);
+      if (runNodelessTests) {
+        try {
+          document.getNumber('blah!', true);
+        } catch (e) {
+          ensureTypeByName(e, 'BSONError');
+        }
+      } else {
+        expect(() => document.getNumber('blah!', true)).to.throw(BSONError);
+      }
     });
 
     it('throws if required is set to true and element is not numeric', () => {
       // just making sure this test does not fail for the non-exist reason
       expect(document.has('string')).to.be.true;
-      expect(() => {
-        document.getNumber('string', true);
-      }).to.throw(BSONError);
+      if (runNodelessTests) {
+        try {
+          document.getNumber('string', true);
+        } catch (e) {
+          ensureTypeByName(e, 'BSONError');
+        }
+      } else {
+        expect(() => {
+          document.getNumber('string', true);
+        }).to.throw();
+      }
     });
 
     it('returns null if required is set to false and element does not exist', () => {

--- a/test/unit/cmap/wire_protocol/on_demand/document.test.ts
+++ b/test/unit/cmap/wire_protocol/on_demand/document.test.ts
@@ -119,8 +119,8 @@ describe('class OnDemandDocument', () => {
     it('supports requesting multiple types', () => {
       expect(
         document.get('bool', BSONType.int) ??
-        document.get('bool', BSONType.long) ??
-        document.get('bool', BSONType.bool)
+          document.get('bool', BSONType.long) ??
+          document.get('bool', BSONType.bool)
       ).to.be.true;
     });
 
@@ -139,7 +139,8 @@ describe('class OnDemandDocument', () => {
 
     it('throws if requested type is unsupported', () => {
       if (runNodelessTests) {
-        try {          // @ts-expect-error: checking a bad BSON type
+        try {
+          // @ts-expect-error: checking a bad BSON type
           document.get('unsupportedType', BSONType.regex, true);
         } catch (e) {
           ensureTypeByName(e, 'BSONError');

--- a/test/unit/cmap/wire_protocol/on_demand/document.test.ts
+++ b/test/unit/cmap/wire_protocol/on_demand/document.test.ts
@@ -128,6 +128,7 @@ describe('class OnDemandDocument', () => {
       if (runNodelessTests) {
         try {
           document.get('blah!', BSONType.bool, true);
+          expect.fail('expected exception');
         } catch (e) {
           ensureTypeByName(e, 'BSONError');
         }
@@ -142,6 +143,7 @@ describe('class OnDemandDocument', () => {
         try {
           // @ts-expect-error: checking a bad BSON type
           document.get('unsupportedType', BSONType.regex, true);
+          expect.fail('expected exception');
         } catch (e) {
           ensureTypeByName(e, 'BSONError');
         }
@@ -266,6 +268,7 @@ describe('class OnDemandDocument', () => {
       if (runNodelessTests) {
         try {
           document.getNumber('blah!', true);
+          expect.fail('expected exception');
         } catch (e) {
           ensureTypeByName(e, 'BSONError');
         }
@@ -286,7 +289,7 @@ describe('class OnDemandDocument', () => {
       } else {
         expect(() => {
           document.getNumber('string', true);
-        }).to.throw();
+        }).to.throw(BSONError);
       }
     });
 

--- a/test/unit/commands.test.ts
+++ b/test/unit/commands.test.ts
@@ -3,6 +3,7 @@ import * as sinon from 'sinon';
 
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import * as compression from '../../src/cmap/wire_protocol/compression';
+import { readInt32LE, readUint8 } from '../../src/bson';
 import {
   compress,
   Compressor,
@@ -62,25 +63,25 @@ describe('class OpCompressedRequest', () => {
           const messageHeader = compressedCommand[0];
           expect(messageHeader.byteLength, 'message header is incorrect length').to.equal(16);
           expect(
-            messageHeader.readInt32LE(),
+            readInt32LE(messageHeader, 0),
             'message header reports incorrect message length'
           ).to.equal(16 + 9 + expectedCompressedCommand.length);
-          expect(messageHeader.readInt32LE(4), 'requestId incorrect').to.equal(1);
-          expect(messageHeader.readInt32LE(8), 'responseTo incorrect').to.equal(0);
-          expect(messageHeader.readInt32LE(12), 'opcode is not OP_COMPRESSED').to.equal(2012);
+          expect(readInt32LE(messageHeader, 4), 'requestId incorrect').to.equal(1);
+          expect(readInt32LE(messageHeader, 8), 'responseTo incorrect').to.equal(0);
+          expect(readInt32LE(messageHeader, 12), 'opcode is not OP_COMPRESSED').to.equal(2012);
         });
 
         it('constructs the compression details for the request', async () => {
           const compressionDetails = compressedCommand[1];
           expect(compressionDetails.byteLength, 'incorrect length').to.equal(9);
-          expect(compressionDetails.readInt32LE(), 'op code incorrect').to.equal(
+          expect(readInt32LE(compressionDetails, 0), 'op code incorrect').to.equal(
             protocol === OpMsgRequest ? OP_MSG : OP_QUERY
           );
           expect(
-            compressionDetails.readInt32LE(4),
+            readInt32LE(compressionDetails, 4),
             'uncompressed message length incorrect'
           ).to.equal(serializedFindCommand.length - 16);
-          expect(compressionDetails.readUint8(8), 'compressor incorrect').to.equal(
+          expect(readUint8(compressionDetails, 8), 'compressor incorrect').to.equal(
             Compressor['snappy']
           );
         });
@@ -106,7 +107,7 @@ describe('class OpCompressedRequest', () => {
               zlibCompressionLevel: 3
             }).toBin();
 
-            expect(messageHeader.readInt32LE(12), 'opcode is not OP_COMPRESSED').to.equal(2012);
+            expect(readInt32LE(messageHeader, 12), 'opcode is not OP_COMPRESSED').to.equal(2012);
 
             expect(spy).to.have.been.called;
 

--- a/test/unit/commands.test.ts
+++ b/test/unit/commands.test.ts
@@ -2,8 +2,9 @@ import { expect } from 'chai';
 import * as sinon from 'sinon';
 
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports
-import * as compression from '../../src/cmap/wire_protocol/compression';
 import { readInt32LE, readUint8 } from '../../src/bson';
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
+import * as compression from '../../src/cmap/wire_protocol/compression';
 import {
   compress,
   Compressor,

--- a/test/unit/nodeless.test.ts
+++ b/test/unit/nodeless.test.ts
@@ -12,7 +12,7 @@ describe('Nodeless tests', function () {
     expect(actualNodeless).to.equal(
       expectedNodeless,
       `runNodelessTests (${actualNodeless}) does not match MONGODB_BUNDLED env var (${nodelessEnv})` +
-      " run 'npm run build:runtime-barrel' to update the barrel file"
+        " run 'npm run build:runtime-barrel' to update the barrel file"
     );
   });
 

--- a/test/unit/nodeless.test.ts
+++ b/test/unit/nodeless.test.ts
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import { env } from 'process';
 
 import { runNodelessTests } from '../mongodb';
+import { sandbox } from '../tools/runner/vm_context_helper';
 
 describe('Nodeless tests', function () {
   it('runNodelessTests variable should match env vars', function () {
@@ -11,7 +12,13 @@ describe('Nodeless tests', function () {
     expect(actualNodeless).to.equal(
       expectedNodeless,
       `runNodelessTests (${actualNodeless}) does not match MONGODB_BUNDLED env var (${nodelessEnv})` +
-        " run 'npm run build:runtime-barrel' to update the barrel file"
+      " run 'npm run build:runtime-barrel' to update the barrel file"
     );
+  });
+
+  it('sandbox should not have node-specific properties', function () {
+    if (!runNodelessTests) this.skip();
+    expect(typeof (sandbox as any).process).to.equal('undefined');
+    expect(typeof (sandbox as any).Buffer).to.equal('undefined');
   });
 });

--- a/test/unit/sessions.test.ts
+++ b/test/unit/sessions.test.ts
@@ -9,11 +9,13 @@ import {
   MongoClient,
   MongoRuntimeError,
   processTimeMS,
+  runNodelessTests,
   ServerSession,
   ServerSessionPool
 } from '../mongodb';
 import { genClusterTime } from '../tools/common';
 import * as mock from '../tools/mongodb-mock/index';
+import { ensureTypeByName } from '../tools/utils';
 
 describe('Sessions - unit', function () {
   let client;
@@ -463,7 +465,11 @@ describe('Sessions - unit', function () {
 
         expect(result).to.not.exist;
         expect(command).to.have.property('lsid');
-        expect(command).to.have.property('txnNumber').instanceOf(Long);
+        if (runNodelessTests) {
+          ensureTypeByName(command.txnNumber, '_Long');
+        } else {
+          expect(command).to.have.property('txnNumber').instanceOf(Long);
+        }
         expect(command.txnNumber.toNumber()).to.equal(3);
         expect(session).to.have.property('_serverSession').that.is.instanceOf(ServerSession);
       });

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -956,8 +956,9 @@ describe('driver utils', function () {
         continue;
       }
 
-      const title = `comparing ${oid1} to ${oid2} returns ${result === 0 ? 'equal' : result === -1 ? 'less than' : 'greater than'
-        }`;
+      const title = `comparing ${oid1} to ${oid2} returns ${
+        result === 0 ? 'equal' : result === -1 ? 'less than' : 'greater than'
+      }`;
       // @ts-expect-error: not narrowed based on numeric result, but these values are correct
       it(title, () => expect(compareObjectId(oid1, oid2)).to.equal(result));
     }

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -23,6 +23,7 @@ import {
   MongoDBNamespace,
   MongoInvalidArgumentError,
   MongoRuntimeError,
+  runNodelessTests,
   shuffle
 } from '../mongodb';
 import { ensureTypeByName, sleep } from '../tools/utils';
@@ -940,15 +941,23 @@ describe('driver utils', function () {
 
     for (const { oid1, oid2, result } of table) {
       if (result === 'throws') {
-        it('passing non-objectId values throw', () =>
-          // @ts-expect-error: Passing bad values to ensure thrown error
-          expect(() => compareObjectId(oid1, oid2)).to.throw());
+        if (runNodelessTests) {
+          // web version of ByteUtils.compare doesn't throw on non-Buffer inputs, it just returns 0
+          it('passing non-objectId values returns 0', () => {
+            // @ts-expect-error: Passing bad values to ensure thrown error
+            expect(compareObjectId(oid1, oid2)).to.equal(0);
+          });
+        } else {
+          it('passing non-objectId values throw', () => {
+            // @ts-expect-error: Passing bad values to ensure thrown error
+            expect(() => compareObjectId(oid1, oid2)).to.throw();
+          });
+        }
         continue;
       }
 
-      const title = `comparing ${oid1} to ${oid2} returns ${
-        result === 0 ? 'equal' : result === -1 ? 'less than' : 'greater than'
-      }`;
+      const title = `comparing ${oid1} to ${oid2} returns ${result === 0 ? 'equal' : result === -1 ? 'less than' : 'greater than'
+        }`;
       // @ts-expect-error: not narrowed based on numeric result, but these values are correct
       it(title, () => expect(compareObjectId(oid1, oid2)).to.equal(result));
     }

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -943,6 +943,7 @@ describe('driver utils', function () {
       if (result === 'throws') {
         if (runNodelessTests) {
           // web version of ByteUtils.compare doesn't throw on non-Buffer inputs, it just returns 0
+          // TODO: NODE-7576 - compareObjectId has different behavior in web and node versions
           it('passing non-objectId values returns 0', () => {
             // @ts-expect-error: Passing bad values to ensure thrown error
             expect(compareObjectId(oid1, oid2)).to.equal(0);


### PR DESCRIPTION
### Description

#### Summary of Changes

This fixes the deno-specific issue where SCRAM is broken. The bug happens because we are invoking toString implicitly, and this results in a behavior change. The fix is to convert the bytes to string explicitly.

Part of the reason that this was not caught in testing is because we were still targeting node when creating the bundle.

Switching bundler to web exposed a few issues:
- removed last few Buffer.readInt32LE calls
- skipped more tests in nodeless where sinon can cause test failures
- supply globals that are not available in web (TextDecoder, TextEncoder, atob, btoa)
- export the created sandbox so our tests can verify that we aren't exporting things like Buffer
- update tests that verify error types
- update the bundle barrow file with missing exports

##### Notes for Reviewers

<!-- 
If there is any additional context on the changes in the PR that reviewers might find helpful, feel free to make notes in this section.

Otherwise, feel free to remove this section.
-->

#### What is the motivation for this change?

<!--
Remove this section if there is an associated Jira ticket explaining the motivation for this change. If there is not, please fill this section out with
information explaining why this change is valuable.
-->

Customer-created ticket. Driver is broken infor deno.

### Release Highlight

<!-- 
Contributors: please leave the release notes section for the Node driver team to fill in. The following instructions are for maintainers.

For user facing changes: please provide release notes. Feel free to browse previous releases for example release highlights.

If there are no user-facing changes in this PR, please delete the release highlight section from the PR description.
-->

<!-- RELEASE_HIGHLIGHT_START -->

### Fixed SCRAM authentication for non-Node.js runtimes (e.g., Deno)

SCRAM-based authentication (the default mechanism for username/password connections) was broken when using the driver in non-Node.js environments such as Deno. The root cause was an implicit `toString()` call on byte arrays that produced incorrect output outside of Node.js. This fix ensures explicit UTF-8 string conversion is used throughout the SCRAM implementation, restoring authentication in Deno and other web-compatible runtimes.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
