### PR TITLE
test(NODE-7559): remove timeseries change stream test

### DIFF
--- a/test/spec/change-streams/unified/change-streams-nsType.json
+++ b/test/spec/change-streams/unified/change-streams-nsType.json
@@ -64,47 +64,6 @@
       ]
     },
     {
-      "description": "nsType is present when creating timeseries",
-      "operations": [
-        {
-          "name": "dropCollection",
-          "object": "database0",
-          "arguments": {
-            "collection": "foo"
-          }
-        },
-        {
-          "name": "createChangeStream",
-          "object": "database0",
-          "arguments": {
-            "pipeline": [],
-            "showExpandedEvents": true
-          },
-          "saveResultAsEntity": "changeStream0"
-        },
-        {
-          "name": "createCollection",
-          "object": "database0",
-          "arguments": {
-            "collection": "foo",
-            "timeseries": {
-              "timeField": "time",
-              "metaField": "meta",
-              "granularity": "minutes"
-            }
-          }
-        },
-        {
-          "name": "iterateUntilDocumentOrError",
-          "object": "changeStream0",
-          "expectResult": {
-            "operationType": "create",
-            "nsType": "timeseries"
-          }
-        }
-      ]
-    },
-    {
       "description": "nsType is present when creating views",
       "operations": [
         {

--- a/test/spec/change-streams/unified/change-streams-nsType.yml
+++ b/test/spec/change-streams/unified/change-streams-nsType.yml
@@ -36,32 +36,6 @@ tests:
           operationType: create
           nsType: collection
 
-  - description: "nsType is present when creating timeseries"
-    operations:
-      - name: dropCollection
-        object: *database0
-        arguments:
-          collection: &collection0 foo
-      - name: createChangeStream
-        object: *database0
-        arguments:
-          pipeline: []
-          showExpandedEvents: true
-        saveResultAsEntity: &changeStream0 changeStream0
-      - name: createCollection
-        object: *database0
-        arguments:
-          collection: *collection0
-          timeseries:
-            timeField: "time"
-            metaField: "meta"
-            granularity: "minutes"
-      - name: iterateUntilDocumentOrError
-        object: *changeStream0
-        expectResult:
-          operationType: create
-          nsType: timeseries
-
   - description: "nsType is present when creating views"
     operations:
       - name: dropCollection


### PR DESCRIPTION
### Description

#### Summary of Changes

2nd implementer for DRIVERS ticket.

Change stream events are not emitted for timeseries as of 9.0, removing related spec tests.

### Double check the following

- [x] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
