### PR TITLE
test(NODE-6820): test on Graviton processor

### DIFF
--- a/.evergreen/ci_matrix_constants.js
+++ b/.evergreen/ci_matrix_constants.js
@@ -20,6 +20,7 @@ const UBUNTU_OS = 'ubuntu1804-large';
 const UBUNTU_20_OS = 'ubuntu2004-small';
 const UBUNTU_22_OS = 'ubuntu2204-large';
 const DEBIAN_OS = 'debian11-small';
+const GRAVITON_OS = 'amazon2023-arm64-latest-large-m8g';
 
 module.exports = {
   MONGODB_VERSIONS,
@@ -37,5 +38,6 @@ module.exports = {
   UBUNTU_OS,
   UBUNTU_20_OS,
   UBUNTU_22_OS,
-  DEBIAN_OS
+  DEBIAN_OS,
+  GRAVITON_OS
 };

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -4079,3 +4079,16 @@ buildvariants:
       NODE_LTS_VERSION: 24
       CLIENT_ENCRYPTION: true
       MONGODB_BUNDLED: true
+  - name: amazon-linux-2023-arm64-graviton4
+    display_name: Graviton4 AL2023 Node24
+    run_on: amazon2023-arm64-latest-large-m8g
+    expansions:
+      NODE_LTS_VERSION: 24
+      CLIENT_ENCRYPTION: true
+    tasks:
+      - test-latest-server
+      - test-latest-replica_set
+      - test-latest-sharded_cluster
+      - test-latest-server-v1-api
+      - test-zstd-compression
+      - test-snappy-compression

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -4085,6 +4085,7 @@ buildvariants:
     expansions:
       NODE_LTS_VERSION: 24
       CLIENT_ENCRYPTION: true
+      TEST_CSFLE: true
     tasks:
       - test-latest-server
       - test-latest-replica_set

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -17,7 +17,8 @@ const {
   MACOS_OS,
   UBUNTU_20_OS,
   DEBIAN_OS,
-  UBUNTU_22_OS
+  UBUNTU_22_OS,
+  GRAVITON_OS
 } = require('./ci_matrix_constants');
 
 // TODO(NODE-7499): unpin npm version once Node 22 ships a bundled npm that can upgrade itself
@@ -873,6 +874,26 @@ BUILD_VARIANTS.push({
   run_on: WINDOWS_OS,
   tasks: commonNodelessTasks,
   expansions: nodelessExpansions
+});
+
+const gravitonTasks = [
+  'test-latest-server',
+  'test-latest-replica_set',
+  'test-latest-sharded_cluster',
+  'test-latest-server-v1-api',
+  'test-zstd-compression',
+  'test-snappy-compression',
+];
+
+BUILD_VARIANTS.push({
+  name: 'amazon-linux-2023-arm64-graviton4',
+  display_name: `Graviton4 AL2023 Node${LATEST_LTS}`,
+  run_on: GRAVITON_OS,
+  expansions: {
+    NODE_LTS_VERSION: LATEST_LTS,
+    CLIENT_ENCRYPTION: true,
+  },
+  tasks: gravitonTasks,
 });
 
 // TODO(NODE-4897): Debug socks5 tests on node latest

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -882,7 +882,7 @@ const gravitonTasks = [
   'test-latest-sharded_cluster',
   'test-latest-server-v1-api',
   'test-zstd-compression',
-  'test-snappy-compression',
+  'test-snappy-compression'
 ];
 
 BUILD_VARIANTS.push({
@@ -891,9 +891,9 @@ BUILD_VARIANTS.push({
   run_on: GRAVITON_OS,
   expansions: {
     NODE_LTS_VERSION: LATEST_LTS,
-    CLIENT_ENCRYPTION: true,
+    CLIENT_ENCRYPTION: true
   },
-  tasks: gravitonTasks,
+  tasks: gravitonTasks
 });
 
 // TODO(NODE-4897): Debug socks5 tests on node latest

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -891,7 +891,8 @@ BUILD_VARIANTS.push({
   run_on: GRAVITON_OS,
   expansions: {
     NODE_LTS_VERSION: LATEST_LTS,
-    CLIENT_ENCRYPTION: true
+    CLIENT_ENCRYPTION: true,
+    TEST_CSFLE: true
   },
   tasks: gravitonTasks
 });


### PR DESCRIPTION
### Description

#### Summary of Changes

Adds a new Evergreen build variant (`amazon-linux-2023-arm64-graviton4`) that runs the driver test suite on AWS Graviton 4 (arm64) hardware using the `amazon2023-arm64-latest-large-m8g` distro.

Tests included:
- All three topologies: standalone, replica set, sharded cluster (latest server)
- Native modules: zstd compression, snappy compression, mongo-client-encryption (CSFLE)

Kerberos testing is out of scope for this PR per NODE-6820.

<!-- Please describe the changes in this PR in a high-level overview. -->

##### Notes for Reviewers

The distro `amazon2023-arm64-latest-large-m8g` was identified in DRIVERS-2436 as the recommended Graviton 4 distro for integration testing (Graviton 4, AL2023).

The new `Graviton4 AL2023 Node24` build variant is visible in Evergreen.

#### What is the motivation for this change?

ARM processors have known behavioral differences from x86 that can cause subtle bugs in native code - most notably, `char` is unsigned by default on ARM (vs. signed on x86), and floating-point contraction behavior may differ between gcc and clang. MongoDB servers on Graviton are increasingly common in Atlas, making it important to validate that our native driver modules (kerberos, snappy, zstd, CSFLE) behave correctly on this architecture.

### Double check the following

- [x] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
