### PR TITLE
chore(NODE-7573): remove DISPATCH_WORKFLOW_REF parameter from publish workflow

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -29,7 +29,6 @@ jobs:
         name: Dispatch npm-publish workflow
         env:
           GH_TOKEN: ${{ github.token }}
-          DISPATCH_WORKFLOW_REF: ${{ github.sha }}
         run: |
           node ./.github/scripts/dispatch-and-wait.mjs npm-publish.yml \
             tag=nightly \


### PR DESCRIPTION
### Description

#### Summary of Changes

The first nightly run after #4930 was merged [failed](https://github.com/mongodb/node-mongodb-native/actions/runs/25410073390/job/74529623570) immediately with:

```
could not create workflow dispatch event: HTTP 422: No ref found for: 5cc96e7fb16040505d4c8e779d0ab5980988fe7a
```

Root cause: `DISPATCH_WORKFLOW_REF: ${{ github.sha }}` was set based on a reviewer suggestion to pin the workflow file to the exact commit being published. However, the GitHub Actions dispatch API (`POST /actions/workflows/{id}/dispatches`) requires a branch or tag name as ref - bare commit SHAs are not accepted.

Fix: Remove `DISPATCH_WORKFLOW_REF`. The script (`dispatch-and-wait.mjs`) already defaults to `main`, which is correct: `npm-publish.yml` is taken from `main`.

The underlying concern (provenance diverging from published source) is already addressed by the separate `ref="${{github.sha }}"` input passed to `npm-publish.yml`, which pins the checkout - and therefore the provenance attestation - to the exact commit being published. `DISPATCH_WORKFLOW_REF` only controls which branch the workflow definition is loaded from, not what source is built.

### Double check the following

- [x] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
