### PR TITLE
test(NODE-7574): use mapping refspec when fetching tag in switch source

### DIFF
--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -59,7 +59,7 @@ functions:
         script: |
           set -euxo pipefail
           git reset --hard HEAD
-          git fetch origin "${SOURCE_REV}"
+          git fetch origin "${SOURCE_REV}:${SOURCE_REV}"
           git checkout "${SOURCE_REV}"
           npm i
 

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -37,7 +37,7 @@ functions:
         script: |
           set -euxo pipefail
           git reset --hard HEAD
-          git fetch origin "${SOURCE_REV}"
+          git fetch origin "${SOURCE_REV}:${SOURCE_REV}"
           git checkout "${SOURCE_REV}"
           npm i
   bootstrap mongo-orchestration:


### PR DESCRIPTION
### Description

#### Summary of Changes

The switch source Evergreen function was broken for tag-based SOURCE_REV values (e.g. refs/tags/v7.0.0), causing all four `test-bson-latest-driver-7.0.0-*` tasks to fail:
```
git fetch origin refs/tags/v7.0.0
* tag  v7.0.0 -> FETCH_HEAD
git checkout refs/tags/v7.0.0
error: pathspec 'refs/tags/v7.0.0' did not match any file(s) known to git
```

Root cause: `git fetch origin <refspec>` without a destination stores the result in FETCH_HEAD only - it does not create a local ref at refs/tags/v7.0.0. The subsequent git checkout refs/tags/v7.0.0 then fails because that local ref doesn't exist.

This previously worked because the Evergreen initial clone included all remote tags, so refs/tags/v7.0.0 already existed locally before the fetch ran. A change in the runner/agent setup (shallower clone without --tags) removed that implicit dependency.

### Double check the following

- [x] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
