### PR TITLE
chore(NODE-7563): migrate 5.x release workflows to npm trusted publishers

### DIFF
--- a/.github/scripts/dispatch-and-wait.mjs
+++ b/.github/scripts/dispatch-and-wait.mjs
@@ -1,0 +1,73 @@
+// @ts-check
+// TODO(NODE-7570): replace with workflow_call once GitHub/npm resolve the OIDC
+// workflow_ref mismatch (https://github.com/npm/documentation/issues/1755).
+//
+// Dispatch a workflow_dispatch-triggered GitHub Actions workflow and wait for
+// the resulting run to complete (propagating its exit status).
+//
+// `gh workflow run` prints the created workflow run URL on stdout when the
+// server returns it (current github.com API version does); we parse the run
+// id out of the URL and pass it to `gh run watch`.
+//
+// Usage:
+//   node dispatch-and-wait.mjs <workflow.yml> [key=value ...]
+//
+//   For npm-publish.yml specifically:
+//   node dispatch-and-wait.mjs npm-publish.yml tag=<tag> version=<v> ref=<sha>
+//
+// Arguments:
+//   <workflow.yml>    Filename of the target workflow under .github/workflows/
+//                     in the same repo. Must declare `on: workflow_dispatch:`.
+//   key=value ...     Inputs forwarded to the dispatched workflow. Valid keys
+//                     and which of them are required are determined by the
+//                     target workflow's `on.workflow_dispatch.inputs`; the
+//                     dispatch fails if any required input is missing or any
+//                     unknown input is passed. For `npm-publish.yml`, all of
+//                     `tag`, `version`, and `ref` are required.
+//                     Example: tag=nightly version=1.2.3 ref=abc1234
+//
+// Environment:
+//   GH_TOKEN              (required) used by the gh CLI; in a workflow set
+//                         this to ${{ github.token }}.
+//   DISPATCH_WORKFLOW_REF (optional, default `main`) git ref the target
+//                         workflow file is loaded from. Hardcoded to main by
+//                         default so callers on backport branches don't have
+//                         to keep a copy of the target workflow on their
+//                         branch.
+import * as child_process from 'node:child_process';
+import * as process from 'node:process';
+
+const [, , workflow, ...inputArgs] = process.argv;
+if (!workflow) {
+  console.error('usage: dispatch-and-wait.mjs <workflow.yml> [key=value ...]');
+  process.exit(2);
+}
+
+const dispatchRef = process.env.DISPATCH_WORKFLOW_REF || 'main';
+
+const ghArgs = [
+  'workflow', 'run', workflow,
+  '--ref', dispatchRef,
+  ...inputArgs.flatMap(kv => ['-f', kv])
+];
+console.log(`Dispatching ${workflow} from ref ${dispatchRef}`);
+
+const dispatch = child_process.spawnSync('gh', ghArgs, {
+  encoding: 'utf8',
+  stdio: ['inherit', 'pipe', 'inherit']
+});
+if (dispatch.status !== 0) process.exit(dispatch.status ?? 1);
+
+// gh prints e.g. "https://github.com/owner/repo/actions/runs/<id>"
+const match = dispatch.stdout.match(/\/actions\/runs\/(\d+)/);
+if (!match) {
+  console.error('Could not extract run id from gh workflow run output:', dispatch.stdout);
+  process.exit(1);
+}
+const runId = match[1];
+console.log(`Dispatched run ${runId}`);
+
+const watch = child_process.spawnSync('gh', ['run', 'watch', runId, '--exit-status'], {
+  stdio: 'inherit'
+});
+process.exit(watch.status ?? 1);

--- a/.github/workflows/release-5.x.yml
+++ b/.github/workflows/release-5.x.yml
@@ -6,7 +6,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  id-token: write
+  actions: write
 
 name: release-5x
 
@@ -23,9 +23,11 @@ jobs:
       - if: ${{ steps.release.outputs.release_created }}
         uses: actions/checkout@v4
       - if: ${{ steps.release.outputs.release_created }}
-        name: actions/setup
-        uses: ./.github/actions/setup
-      - if: ${{ steps.release.outputs.release_created }}
-        run: npm publish --provenance --tag=5x
+        name: Dispatch npm-publish workflow
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          node ./.github/scripts/dispatch-and-wait.mjs npm-publish.yml \
+            tag=5x \
+            version="$(node -p "require('./package.json').version")" \
+            ref="${{ github.sha }}"

--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -19,10 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - shell: bash
+        env:
+          ALPHA_VERSION: ${{ inputs.alphaVersion }}
         run: |
           ALPHA_SEMVER_REGEXP="-alpha(\.([0-9]|[1-9][0-9]+))?$"
 
-          if ! [[ "${{ inputs.alphaVersion }}" =~ $ALPHA_SEMVER_REGEXP ]]; then
+          if ! [[ "$ALPHA_VERSION" =~ $ALPHA_SEMVER_REGEXP ]]; then
             echo "Invalid alphaVersion string"
             exit 1
           fi
@@ -30,8 +32,9 @@ jobs:
       - name: Dispatch npm-publish workflow
         env:
           GH_TOKEN: ${{ github.token }}
+          ALPHA_VERSION: ${{ inputs.alphaVersion }}
         run: |
           node ./.github/scripts/dispatch-and-wait.mjs npm-publish.yml \
             tag=alpha \
-            version="${{ inputs.alphaVersion }}" \
+            version="$ALPHA_VERSION" \
             ref="${{ github.sha }}"

--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -9,7 +9,8 @@ on:
         type: string
 
 permissions:
-  id-token: write
+  actions: write
+  contents: read
 
 name: release-alpha
 
@@ -26,9 +27,11 @@ jobs:
             exit 1
           fi
       - uses: actions/checkout@v4
-      - name: actions/setup
-        uses: ./.github/actions/setup
-      - run: npm version "${{ inputs.alphaVersion }}" --git-tag-version=false
-      - run: npm publish --provenance --tag=alpha
+      - name: Dispatch npm-publish workflow
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          node ./.github/scripts/dispatch-and-wait.mjs npm-publish.yml \
+            tag=alpha \
+            version="${{ inputs.alphaVersion }}" \
+            ref="${{ github.sha }}"

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -11,7 +11,8 @@ on:
   workflow_dispatch: {}
 
 permissions:
-  id-token: write
+  actions: write
+  contents: read
 
 name: release-nightly
 
@@ -25,6 +26,11 @@ jobs:
       - id: build_nightly
         run: npm run build:nightly
       - if: ${{ steps.build_nightly.outputs.publish == 'yes' }}
-        run: npm publish --provenance --tag=nightly
+        name: Dispatch npm-publish workflow
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          node ./.github/scripts/dispatch-and-wait.mjs npm-publish.yml \
+            tag=nightly \
+            version="$(node -p "require('./package.json').version")" \
+            ref="${{ github.sha }}"


### PR DESCRIPTION
### Description

#### Summary of Changes

Migrates `release-5.x.yml`, `release-alpha.yml`, and `release-nightly.yml` on the `5.x` branch to [npm Trusted Publishing](https://docs.npmjs.com/generating-provenance-statements#using-third-party-package-publishing-tools) by dispatching to the centralized `npm-publish.yml` workflow (lives on `main`, introduced in #4930). Adds `dispatch-and-wait.mjs` helper script — required because GitHub Actions loads workflow files from the triggering branch, but the script defaults to loading `npm-publish.yml` from `main`.

##### Notes for Reviewers

The `5.x` branch uses an older single-job workflow structure with a local `.github/actions/setup` composite action instead of `drivers-github-tools`. The dispatch pattern is identical to main; only the surrounding YAML structure differs.

Main PR: #4941 — 6.x PR: #4943

### Double check the following

- [x] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket