### PR TITLE
docs: update agent instructions about commit naming in prs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,7 +117,9 @@ Public API (MongoClient, Db, Collection, Cursors)
 
 ## Commit Messages
 
-Follow [Conventional Commits](https://www.conventionalcommits.org/): `<type>(NODE-XXXX): <subject>`
+PRs are **squash-merged**. The PR title becomes the single commit message on `main`, so only the PR title needs to follow the format below. Individual commits within a branch don't need to match (though it's good practice and helps reviewers).
+
+PR title format follows [Conventional Commits](https://www.conventionalcommits.org/): `<type>(NODE-XXXX): <subject>`
 
 Types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`
 


### PR DESCRIPTION
### Description

#### Summary of Changes

Update agent instructions for naming convention, specifically the names of PR commits. This update ensures that agents don't complain about naming "issues" in PRs, since we squash commits.

#### What is the motivation for this change?

Agents complain about things that don't matter: commit messages in PRs.

### Double check the following

- [x] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
