### PR TITLE
test(NODE-5517): display installed deps in CI

### DIFF
--- a/.mocharc.js
+++ b/.mocharc.js
@@ -5,6 +5,7 @@ const [major] = process.versions.node.split('.');
 /** @type {import("mocha").MochaOptions} */
 module.exports = {
   require: [
+    'test/mocha_root_hooks.ts',
     'source-map-support/register',
     'ts-node/register',
     'test/tools/runner/throw_rejections.cjs',

--- a/test/explicit-resource-management/.mocharc.json
+++ b/test/explicit-resource-management/.mocharc.json
@@ -1,5 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/mocharc.json",
+  "require": [
+    "../mocha_root_hooks.ts"
+  ],
   "extension": [
     "js"
   ],

--- a/test/manual/mocharc.js
+++ b/test/manual/mocharc.js
@@ -6,10 +6,10 @@ const [major] = process.versions.node.split('.');
 /** @type {import("mocha").MochaOptions} */
 module.exports = {
   require: [
+    'test/mocha_root_hooks.ts',
     'ts-node/register',
     'test/tools/runner/throw_rejections.cjs',
-    'test/tools/runner/chai_addons.ts',
-    'test/mocha_root_hooks.ts'
+    'test/tools/runner/chai_addons.ts'
   ],
   reporter: 'test/tools/reporter/mongodb_reporter.js',
   failZero: true,

--- a/test/manual/mocharc.js
+++ b/test/manual/mocharc.js
@@ -8,7 +8,8 @@ module.exports = {
   require: [
     'ts-node/register',
     'test/tools/runner/throw_rejections.cjs',
-    'test/tools/runner/chai_addons.ts'
+    'test/tools/runner/chai_addons.ts',
+    'test/mocha_root_hooks.ts'
   ],
   reporter: 'test/tools/reporter/mongodb_reporter.js',
   failZero: true,

--- a/test/mocha_lambda.js
+++ b/test/mocha_lambda.js
@@ -6,6 +6,7 @@ const [major] = process.versions.node.split('.');
 /** @type {import("mocha").MochaOptions} */
 module.exports = {
   require: [
+    'test/mocha_root_hooks.ts',
     'test/tools/runner/throw_rejections.cjs',
     'test/integration/node-specific/examples/setup.js'
   ],

--- a/test/mocha_mongodb.js
+++ b/test/mocha_mongodb.js
@@ -6,14 +6,14 @@ const [major] = process.versions.node.split('.');
 /** @type {import("mocha").MochaOptions} */
 module.exports = {
   require: [
+    'test/mocha_root_hooks.ts',
     'source-map-support/register',
     'ts-node/register',
     'test/tools/runner/throw_rejections.cjs',
     'test/tools/runner/chai_addons.ts',
     'test/tools/runner/ee_checker.ts',
     'test/tools/runner/hooks/configuration.ts',
-    'test/tools/runner/hooks/leak_checker.ts',
-    'test/mocha_root_hooks.ts'
+    'test/tools/runner/hooks/leak_checker.ts'
   ],
   extension: ['js', 'ts'],
   ui: 'test/tools/runner/metadata_ui.js',

--- a/test/mocha_mongodb.js
+++ b/test/mocha_mongodb.js
@@ -12,7 +12,8 @@ module.exports = {
     'test/tools/runner/chai_addons.ts',
     'test/tools/runner/ee_checker.ts',
     'test/tools/runner/hooks/configuration.ts',
-    'test/tools/runner/hooks/leak_checker.ts'
+    'test/tools/runner/hooks/leak_checker.ts',
+    'test/mocha_root_hooks.ts'
   ],
   extension: ['js', 'ts'],
   ui: 'test/tools/runner/metadata_ui.js',

--- a/test/mocha_root_hooks.ts
+++ b/test/mocha_root_hooks.ts
@@ -1,0 +1,7 @@
+import { execSync } from 'child_process';
+
+export const mochaHooks = {
+  beforeAll() {
+    console.log(`Installed dependencies:\n${execSync('npm ls').toString()}`);
+  }
+};


### PR DESCRIPTION
### Description

#### Summary of Changes

Adds a prefire test hook to mocha which is called whenever a mocha test is invoked. The hook simply logs all installed dependencies via `npm ls`. This solves an issue described in NODE-5517 which highlights that, even though we already do dependency logging in our install scripts, we may have steps between installs & test runs which surface new dependencies we should have visibility of in CI logs.

This should cover gaps without necessitating changing many ci scripts.

##### Notes for Reviewers

<!-- 
If there is any additional context on the changes in the PR that reviewers might find helpful, feel free to make notes in this section.

Otherwise, feel free to remove this section.
-->

#### What is the motivation for this change?

<!--
Remove this section if there is an associated Jira ticket explaining the motivation for this change. If there is not, please fill this section out with
information explaining why this change is valuable.
-->

### Release Highlight

<!-- 
Contributors: please leave the release notes section for the Node driver team to fill in. The following instructions are for maintainers.

For user facing changes: please provide release notes. Feel free to browse previous releases for example release highlights.

If there are no user-facing changes in this PR, please delete the release highlight section from the PR description.
-->

<!-- RELEASE_HIGHLIGHT_START -->

CI tests updated to always print installed dependencies in logs.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Lint is passing (`npm run check:lint`)
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
