### PR TITLE
chore(NODE-7599): tighten build workflow permissions and update release docs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,9 +4,7 @@ on:
 name: Build
 
 permissions:
-  contents: write
-  pull-requests: write
-  id-token: write
+  contents: read
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The official [MongoDB](https://www.mongodb.com/) driver for Node.js.
 
 ### Release Integrity
 
-Releases are created automatically and signed using the [Node team's GPG key](https://pgp.mongodb.com/node-driver.asc). This applies to the git tag as well as all release packages provided as part of a GitHub release. To verify the provided packages, download the key and import it using gpg:
+Releases are created automatically and signed using the [Node team's GPG key](https://pgp.mongodb.com/node-driver.asc). All release packages provided as part of a GitHub release are signed. To verify the provided packages, download the key and import it using gpg:
 
 ```shell
 gpg --import node-driver.asc
@@ -46,7 +46,13 @@ gpg --verify mongodb-X.Y.Z.tgz.sig mongodb-X.Y.Z.tgz
 ```
 
 > [!Note]
-> No verification is done when using npm to install the package. The contents of the Github tarball and npm's tarball are identical.
+> No GPG verification is done when using npm to install the package. The contents of the Github tarball and npm's tarball are identical.
+
+Releases published to the npm registry also include a [provenance attestation](https://docs.npmjs.com/generating-provenance-statements), which cryptographically links the package to its source repository and build workflow. To verify provenance:
+
+```shell
+npm audit signatures
+```
 
 The MongoDB Node.js driver follows [semantic versioning](https://semver.org/) for its releases.
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ gpg --verify mongodb-X.Y.Z.tgz.sig mongodb-X.Y.Z.tgz
 ```
 
 > [!Note]
-> No GPG verification is done when using npm to install the package. The contents of the Github tarball and npm's tarball are identical.
+> No GPG verification is done when using npm to install the package. The contents of the GitHub tarball and npm's tarball are identical.
 
 Releases published to the npm registry also include a [provenance attestation](https://docs.npmjs.com/generating-provenance-statements), which cryptographically links the package to its source repository and build workflow. To verify provenance:
 

--- a/etc/notes/releasing.md
+++ b/etc/notes/releasing.md
@@ -120,7 +120,7 @@ It may take some time for the building and uploading to finish, but no more than
 
 To configure a repo for a prerelease:
 
-1. Update the release Github action's `npm publish` step to publish an alpha by specifying `--tag alpha`:
+1. Update the release GitHub action's publish step to dispatch `npm-publish.yml` with `--tag alpha`:
 
 ```yaml
       - name: Dispatch npm-publish workflow

--- a/etc/notes/releasing.md
+++ b/etc/notes/releasing.md
@@ -100,15 +100,9 @@ The MongoDB driver can now generate a cup of joe.
 
 ### Authentication
 
-The github action is able to publish with the repository secret `NPM_TOKEN`.
-This is a granular API key that is unique to each package and has to be rotated on a regular basis.
-The `dbx-node@mongodb.com` npm account is the author of the automated release.
+The GitHub Actions release workflow publishes to npm using [npm Trusted Publishing](https://docs.npmjs.com/trusted-publishers) (OIDC). A short-lived OIDC token is issued by GitHub Actions at publish time — no long-lived `NPM_TOKEN` secret is required on the `main` branch. The `mongodb` package's trusted publisher entry on npmjs.com points at `npm-publish.yml`, which is dispatched by `release.yml` via `dispatch-and-wait.mjs`.
 
-The nightly release flow is an exception: `release-nightly.yml` dispatches
-`.github/workflows/npm-publish.yml`, which authenticates to the npm registry
-via [npm Trusted Publishing](https://docs.npmjs.com/trusted-publishers) (OIDC)
-rather than `NPM_TOKEN`. The `mongodb` package's trusted publisher entry on
-npmjs.com points at `npm-publish.yml`.
+The `5.x` and `6.x` backport branches still publish using the legacy `NPM_TOKEN` secret. These branches are only used when a backport release is actually needed — the migration to trusted publishers will be done at that point, not proactively.
 
 ### Prebuilds
 
@@ -129,10 +123,14 @@ To configure a repo for a prerelease:
 1. Update the release Github action's `npm publish` step to publish an alpha by specifying `--tag alpha`:
 
 ```yaml
-      - run: npm publish --provenance --tag alpha
-        if: ${{ needs.release_please.outputs.release_created }}
+      - name: Dispatch npm-publish workflow
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          node ./.github/scripts/dispatch-and-wait.mjs npm-publish.yml \
+            tag=alpha \
+            version="${{ inputs.alphaVersion }}" \
+            ref="${{ github.sha }}"
 ```
 
 2. Update the release please configuration file with the following parameters:


### PR DESCRIPTION
### Description

#### Summary of Changes

<!-- Please describe the changes in this PR in a high-level overview. -->

Three related maintenance changes following the migration of the main branch to npm Trusted Publishing (OIDC):

1. Tighten permissions from `contents: write, pull-requests: write, id-token: write` to `contents: read`. This is a reusable workflow placeholder (`echo "nothing to do."`) - it never needed write access. The overly broad permissions were carried over from when the workflow was templated but never trimmed.

2. `README.md`: Fix an incorrect claim in the Release Integrity section, git tags are lightweight (not annotated/signed), so GPG signing applies only to the npm package. Also adds a note on verifying npm provenance attestations via npm audit signatures, which is available now that we publish with `--provenance`.
 
3. `etc/notes/releasing.md`: Rewrite the Authentication section to reflect the current state: main branch uses OIDC trusted publishers (no `NPM_TOKEN` needed); 5.x and 6.x backport branches still use NPM_TOKEN and will be migrated only when a backport release is actually needed. Also updates the alpha release YAML example from the old `NODE_AUTH_TOKEN` pattern to the current `dispatch-and-wait.mjs` dispatch approach.

#### What is the motivation for this change?

<!--
Remove this section if there is an associated Jira ticket explaining the motivation for this change. If there is not, please fill this section out with
information explaining why this change is valuable.
-->

The main branch was migrated to npm Trusted Publishers in NODE-7562, but several docs and the `build.yml` workflow were not updated to match. This PR closes that gap.

### Double check the following

- [x] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
