### PR TITLE
chore: disable bson compat tests in prs

### DIFF
--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -1367,14 +1367,7 @@ buildvariants:
   - name: BSON compatibility tests
     display_name: BSON compatibility tests
     run_on: rhel80-large
-    allowed_requesters: [
-      "patch",
-      "github_tag",
-      "commit",
-      "trigger",
-      "ad_hoc",
-      "github_merge_queue"
-    ]
+    tags: ["bson-compat"]
     tasks:
       - test-bson-latest-driver-7.0.0-unit-tests
       - test-bson-latest-driver-7.0.0-server-tests

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -1367,7 +1367,14 @@ buildvariants:
   - name: BSON compatibility tests
     display_name: BSON compatibility tests
     run_on: rhel80-large
-    patchable: false
+    allowed_requesters: [
+      "patch",
+      "github_tag",
+      "commit",
+      "trigger",
+      "ad_hoc",
+      "github_merge_queue"
+    ]
     tasks:
       - test-bson-latest-driver-7.0.0-unit-tests
       - test-bson-latest-driver-7.0.0-server-tests

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -1367,6 +1367,7 @@ buildvariants:
   - name: BSON compatibility tests
     display_name: BSON compatibility tests
     run_on: rhel80-large
+    patchable: false
     tasks:
       - test-bson-latest-driver-7.0.0-unit-tests
       - test-bson-latest-driver-7.0.0-server-tests

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -3511,7 +3511,13 @@ buildvariants:
   - name: BSON compatibility tests
     display_name: BSON compatibility tests
     run_on: rhel80-large
-    patchable: false
+    allowed_requesters:
+      - patch
+      - github_tag
+      - commit
+      - trigger
+      - ad_hoc
+      - github_merge_queue
     tasks:
       - test-bson-latest-driver-7.0.0-unit-tests
       - test-bson-latest-driver-7.0.0-server-tests

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -3511,13 +3511,8 @@ buildvariants:
   - name: BSON compatibility tests
     display_name: BSON compatibility tests
     run_on: rhel80-large
-    allowed_requesters:
-      - patch
-      - github_tag
-      - commit
-      - trigger
-      - ad_hoc
-      - github_merge_queue
+    tags:
+      - bson-compat
     tasks:
       - test-bson-latest-driver-7.0.0-unit-tests
       - test-bson-latest-driver-7.0.0-server-tests

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -3511,6 +3511,7 @@ buildvariants:
   - name: BSON compatibility tests
     display_name: BSON compatibility tests
     run_on: rhel80-large
+    patchable: false
     tasks:
       - test-bson-latest-driver-7.0.0-unit-tests
       - test-bson-latest-driver-7.0.0-server-tests


### PR DESCRIPTION
### Description

#### Summary of Changes

Disable execution of BSON compat tests in PRs.

This PR adds the tag `bson-compat`, which is going to be acted on by the project's GitHub settings, where we will filter that tag with regex `!bson-compat`.

<img width="1481" height="990" alt="Screenshot 2026-06-02 at 1 17 44 PM" src="https://github.com/user-attachments/assets/b398edb3-fdc8-4a6f-b4cc-eb4dc6f2f05b" />

#### What is the motivation for this change?

BSON compat tests are only ever running against driver 7.0, and this is not impacted by any changes in the PR, so there's zero reason to run it.

### Double check the following

- [ ] Lint is passing (`npm run check:lint`)
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
