### PR TITLE
chore: disable bson compat tests in prs

### DIFF
--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -1367,14 +1367,7 @@ buildvariants:
   - name: BSON compatibility tests
     display_name: BSON compatibility tests
     run_on: rhel80-large
-    allowed_requesters: [
-      "patch",
-      "github_tag",
-      "commit",
-      "trigger",
-      "ad_hoc",
-      "github_merge_queue"
-    ]
+    tags: ["bson-compat"]
     tasks:
       - test-bson-latest-driver-7.0.0-unit-tests
       - test-bson-latest-driver-7.0.0-server-tests

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -1367,7 +1367,14 @@ buildvariants:
   - name: BSON compatibility tests
     display_name: BSON compatibility tests
     run_on: rhel80-large
-    patchable: false
+    allowed_requesters: [
+      "patch",
+      "github_tag",
+      "commit",
+      "trigger",
+      "ad_hoc",
+      "github_merge_queue"
+    ]
     tasks:
       - test-bson-latest-driver-7.0.0-unit-tests
       - test-bson-latest-driver-7.0.0-server-tests

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -1367,6 +1367,7 @@ buildvariants:
   - name: BSON compatibility tests
     display_name: BSON compatibility tests
     run_on: rhel80-large
+    patchable: false
     tasks:
       - test-bson-latest-driver-7.0.0-unit-tests
       - test-bson-latest-driver-7.0.0-server-tests

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -3511,7 +3511,13 @@ buildvariants:
   - name: BSON compatibility tests
     display_name: BSON compatibility tests
     run_on: rhel80-large
-    patchable: false
+    allowed_requesters:
+      - patch
+      - github_tag
+      - commit
+      - trigger
+      - ad_hoc
+      - github_merge_queue
     tasks:
       - test-bson-latest-driver-7.0.0-unit-tests
       - test-bson-latest-driver-7.0.0-server-tests

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -3511,13 +3511,8 @@ buildvariants:
   - name: BSON compatibility tests
     display_name: BSON compatibility tests
     run_on: rhel80-large
-    allowed_requesters:
-      - patch
-      - github_tag
-      - commit
-      - trigger
-      - ad_hoc
-      - github_merge_queue
+    tags:
+      - bson-compat
     tasks:
       - test-bson-latest-driver-7.0.0-unit-tests
       - test-bson-latest-driver-7.0.0-server-tests

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -3511,6 +3511,7 @@ buildvariants:
   - name: BSON compatibility tests
     display_name: BSON compatibility tests
     run_on: rhel80-large
+    patchable: false
     tasks:
       - test-bson-latest-driver-7.0.0-unit-tests
       - test-bson-latest-driver-7.0.0-server-tests


### PR DESCRIPTION
## Summary
- Adds `bson-compat` tag to the "BSON compatibility tests" build variant in `.evergreen/config.in.yml`
- Regenerates `.evergreen/config.yml`
- The `!bson-compat` exclusion is configured in Evergreen project settings (GitHub Patch Definitions), so this variant no longer runs on PRs

## Test plan
- Verify that the "BSON compatibility tests" variant does not appear when this PR triggers CI