### PR TITLE
ci: use toolchain python in windows

### DIFF
--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -21,7 +21,7 @@ if [ "${OS:-}" = "Windows_NT" ] && [ -n "${NODE_ARTIFACTS_PATH:-}" ]; then
 fi
 _INSTALL_DEPS_NODE_ARTIFACTS_PATH="${NODE_ARTIFACTS_PATH:-}"
 
-if [ "$NATIVE" = "true" ]; then
+if [ "$NATIVE" = "true" ] || [ "${OS:-}" = "Windows_NT" ]; then
   # https://github.com/nodejs/node-gyp#configuring-python-dependency
   . $DRIVERS_TOOLS/.evergreen/find-python3.sh
   NODE_GYP_FORCE_PYTHON=$(find_python3)


### PR DESCRIPTION
### Description

#### Summary of Changes

For Windows, use installed Python.

#### What is the motivation for this change?

<!--
Remove this section if there is an associated Jira ticket explaining the motivation for this change. If there is not, please fill this section out with
information explaining why this change is valuable.
-->

We are seeing sporadic Python failures where the wrong Python is used and results in errors like this:
> ModuleNotFoundError: No module named '_ctypes'

Guidance from dbx-devs is to use the toolchain Python for Windows.

### Double check the following

- [ ] Lint is passing (`npm run check:lint`)
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
