### PR TITLE
docs: clarify release notes verification steps

### DIFF
--- a/etc/notes/releasing.md
+++ b/etc/notes/releasing.md
@@ -81,8 +81,8 @@ The MongoDB driver can now generate a cup of joe.
     - Double check the result looks logically organized and complete
         - As a rule of thumb, every `feat` and `fix` should have a corresponding release note
         - Cross-reference the list of tickets in the corresponding jira release for consistency
-    - You may edit the PR body for any quick edits or re-orderings.
-    - If there are a number of changes, edit the original PRs and post a new `run` comment
+    - You may modify the release PR body directly for any quick edits or re-orderings.
+    - If there are any non-cosmetic changes, edit the original PRs and post a new `run release_notes` comment
 1. Merge the release PR
     - If this is a release to a previous major, navigate to the new release and reset "latest" to our latest release in our _current_ major.
 1. If this is a new driver minor release, generate the new documentation

--- a/etc/notes/releasing.md
+++ b/etc/notes/releasing.md
@@ -78,7 +78,9 @@ The MongoDB driver can now generate a cup of joe.
     - You may skip this step if you are releasing a package other than the driver.
 1. Comment "`run release_notes`" on the release PR.
     - This will kick off the action that reads the notes from each PR going into the release.
-    - Double check the result looks logically organized
+    - Double check the result looks logically organized and complete
+        - As a rule of thumb, every `feat` and `fix` should have a corresponding release note
+        - Cross-reference the list of tickets in the corresponding jira release for consistency
     - You may edit the PR body for any quick edits or re-orderings.
     - If there are a number of changes, edit the original PRs and post a new `run` comment
 1. Merge the release PR

--- a/etc/notes/releasing.md
+++ b/etc/notes/releasing.md
@@ -80,7 +80,7 @@ The MongoDB driver can now generate a cup of joe.
     - This will kick off the action that reads the notes from each PR going into the release.
     - Double check the result looks logically organized and complete
         - As a rule of thumb, every `feat` and `fix` should have a corresponding release note
-        - Cross-reference the list of tickets in the corresponding jira release for consistency
+        - Cross-reference the list of tickets in the corresponding JIRA release for consistency
     - You may modify the release PR body directly for any quick edits or re-orderings.
     - If there are any non-cosmetic changes, edit the original PRs and post a new `run release_notes` comment
 1. Merge the release PR


### PR DESCRIPTION
### Description

#### Summary of Changes

Clarified release instructions around release note verification.

#### What is the motivation for this change?

Process clarity.


### Double check the following

- [ ] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [N/A] Changes are covered by tests
- [N/A] New TODOs have a related JIRA ticket
