### PR TITLE
chore: skip csfle tests and fix related broken tests

### DIFF
--- a/test/integration/client-side-encryption/client_side_encryption.prose.22.range_explicit_encryption.test.ts
+++ b/test/integration/client-side-encryption/client_side_encryption.prose.22.range_explicit_encryption.test.ts
@@ -270,8 +270,8 @@ describe('Range Explicit Encryption', function () {
       it('Case 2: can find encrypted range and return the maximum', metaData, async function () {
         const query = {
           $and: [
-            { 'encrypted<Type>': { $gte: factory(6) } },
-            { 'encrypted<Type>': { $lte: factory(200) } }
+            { [`encrypted${dataType}`]: { $gte: factory(6) } },
+            { [`encrypted${dataType}`]: { $lte: factory(200) } }
           ]
         };
 
@@ -322,8 +322,8 @@ describe('Range Explicit Encryption', function () {
       it('Case 3: can find encrypted range and return the minimum', metaData, async function () {
         const query = {
           $and: [
-            { 'encrypted<Type>': { $gte: factory(0) } },
-            { 'encrypted<Type>': { $lte: factory(6) } }
+            { [`encrypted${dataType}`]: { $gte: factory(0) } },
+            { [`encrypted${dataType}`]: { $lte: factory(6) } }
           ]
         };
 
@@ -369,7 +369,7 @@ describe('Range Explicit Encryption', function () {
 
       it('Case 4: can find encrypted range with an open range query', metaData, async function () {
         const query = {
-          $and: [{ 'encrypted<Type>': { $gt: factory(30) } }]
+          $and: [{ [`encrypted${dataType}`]: { $gt: factory(30) } }]
         };
 
         const findPayload = await clientEncryption.encryptExpression(query, {
@@ -398,7 +398,7 @@ describe('Range Explicit Encryption', function () {
       });
 
       it('Case 5: can run an aggregation expression inside $expr', metaData, async function () {
-        const query = { $and: [{ $lt: ['$encrypted<Type>', factory(30)] }] };
+        const query = { $and: [{ $lt: [`$encrypted${dataType}`, factory(30)] }] };
 
         const findPayload = await clientEncryption.encryptExpression(query, {
           keyId,

--- a/test/integration/client-side-encryption/client_side_encryption.prose.27.text_queries.test.ts
+++ b/test/integration/client-side-encryption/client_side_encryption.prose.27.text_queries.test.ts
@@ -7,16 +7,17 @@ import * as semver from 'semver';
 
 import { getCSFLEKMSProviders } from '../../csfle-kms-providers';
 import { ClientEncryption, type MongoClient, MongoDBCollectionNamespace } from '../../mongodb';
-const metadata: MongoDBMetadataUI = {
+// # Server 9.0.0-rc0 removes support for "prefixPreview" and "suffixPreview": SERVER-123416
+const metadataWithoutPreview: MongoDBMetadataUI = {
   requires: {
     clientSideEncryption: '>=6.4.0',
-    mongodb: '>=8.2.0',
+    mongodb: '>=8.2.0 <9.0.0',
     topology: '!single',
     libmongocrypt: '>=1.15.1'
   }
 };
-// # Server 9.0.0-rc0 removes support for "prefixPreview" and "suffixPreview": SERVER-123416
-const metadataWithoutPreview: MongoDBMetadataUI = {
+// TODO(NODE-7628): substringPreview contention validation broken on MongoDB 9.0+ (SERVER-91887).
+const metadataWithoutSubstringPreview: MongoDBMetadataUI = {
   requires: {
     clientSideEncryption: '>=6.4.0',
     mongodb: '>=8.2.0 <9.0.0',
@@ -418,7 +419,7 @@ describe('27. Text Explicit Encryption', function () {
     expect(result).to.be.null;
   });
 
-  it('Case 5: can find a document by substring', metadata, async function () {
+  it('Case 5: can find a document by substring', metadataWithoutSubstringPreview, async function () {
     // Use clientEncryption.encrypt() to encrypt the string "bar" with the following EncryptOpts:
     // class EncryptOpts {
     //    keyId : <key1ID>,
@@ -468,7 +469,7 @@ describe('27. Text Explicit Encryption', function () {
     expect(result).to.deep.equal({ _id: 0, encryptedText: 'foobarbaz' });
   });
 
-  it('Case 6: assert no document found by substring', metadata, async function () {
+  it('Case 6: assert no document found by substring', metadataWithoutSubstringPreview, async function () {
     // Use clientEncryption.encrypt() to encrypt the string "bar" with the following EncryptOpts:
     // class EncryptOpts {
     //    keyId : <key1ID>,

--- a/test/integration/client-side-encryption/client_side_encryption.prose.27.text_queries.test.ts
+++ b/test/integration/client-side-encryption/client_side_encryption.prose.27.text_queries.test.ts
@@ -419,105 +419,113 @@ describe('27. Text Explicit Encryption', function () {
     expect(result).to.be.null;
   });
 
-  it('Case 5: can find a document by substring', metadataWithoutSubstringPreview, async function () {
-    // Use clientEncryption.encrypt() to encrypt the string "bar" with the following EncryptOpts:
-    // class EncryptOpts {
-    //    keyId : <key1ID>,
-    //    algorithm: "TextPreview",
-    //    queryType: "substringPreview",
-    //    contentionFactor: 0,
-    //    textOpts: TextOpts {
-    //       caseSensitive: true,
-    //       diacriticSensitive: true,
-    //       substring: SubstringOpts {
-    //        strMaxLength: 10,
-    //        strMaxQueryLength: 10,
-    //        strMinQueryLength: 2,
-    //       }
-    //    },
-    // }
-    const encryptedFoo = await clientEncryption.encrypt('bar', {
-      keyId: keyId1,
-      algorithm: 'TextPreview',
-      queryType: 'substringPreview',
-      contentionFactor: 0,
-      textOptions: {
-        caseSensitive: true,
-        diacriticSensitive: true,
-        substring: {
-          strMaxLength: 10,
-          strMaxQueryLength: 10,
-          strMinQueryLength: 2
+  it(
+    'Case 5: can find a document by substring',
+    metadataWithoutSubstringPreview,
+    async function () {
+      // Use clientEncryption.encrypt() to encrypt the string "bar" with the following EncryptOpts:
+      // class EncryptOpts {
+      //    keyId : <key1ID>,
+      //    algorithm: "TextPreview",
+      //    queryType: "substringPreview",
+      //    contentionFactor: 0,
+      //    textOpts: TextOpts {
+      //       caseSensitive: true,
+      //       diacriticSensitive: true,
+      //       substring: SubstringOpts {
+      //        strMaxLength: 10,
+      //        strMaxQueryLength: 10,
+      //        strMinQueryLength: 2,
+      //       }
+      //    },
+      // }
+      const encryptedFoo = await clientEncryption.encrypt('bar', {
+        keyId: keyId1,
+        algorithm: 'TextPreview',
+        queryType: 'substringPreview',
+        contentionFactor: 0,
+        textOptions: {
+          caseSensitive: true,
+          diacriticSensitive: true,
+          substring: {
+            strMaxLength: 10,
+            strMaxQueryLength: 10,
+            strMinQueryLength: 2
+          }
         }
-      }
-    });
+      });
 
-    // Use encryptedClient to run a "find" operation on the db.substring collection with the following filter:
-    // { $expr: { $encStrContains: {input: '$encryptedText', substring: <encrypted 'bar'>} } }
-    const filter = {
-      $expr: { $encStrContains: { input: '$encryptedText', substring: encryptedFoo } }
-    };
+      // Use encryptedClient to run a "find" operation on the db.substring collection with the following filter:
+      // { $expr: { $encStrContains: {input: '$encryptedText', substring: <encrypted 'bar'>} } }
+      const filter = {
+        $expr: { $encStrContains: { input: '$encryptedText', substring: encryptedFoo } }
+      };
 
-    const { __safeContent__, ...result } = await encryptedClient
-      .db('db')
-      .collection<{
-        _id: number;
-        encryptedText: Binary;
-        __safeContent__: any;
-      }>('substring')
-      .findOne(filter);
-    expect(result).to.deep.equal({ _id: 0, encryptedText: 'foobarbaz' });
-  });
+      const { __safeContent__, ...result } = await encryptedClient
+        .db('db')
+        .collection<{
+          _id: number;
+          encryptedText: Binary;
+          __safeContent__: any;
+        }>('substring')
+        .findOne(filter);
+      expect(result).to.deep.equal({ _id: 0, encryptedText: 'foobarbaz' });
+    }
+  );
 
-  it('Case 6: assert no document found by substring', metadataWithoutSubstringPreview, async function () {
-    // Use clientEncryption.encrypt() to encrypt the string "bar" with the following EncryptOpts:
-    // class EncryptOpts {
-    //    keyId : <key1ID>,
-    //    algorithm: "TextPreview",
-    //    queryType: "substringPreview",
-    //    contentionFactor: 0,
-    //    textOpts: TextOpts {
-    //       caseSensitive: true,
-    //       diacriticSensitive: true,
-    //       substring: SubstringOpts {
-    //        strMaxLength: 10,
-    //        strMaxQueryLength: 10,
-    //        strMinQueryLength: 2,
-    //       }
-    //    },
-    // }
-    const encryptedQux = await clientEncryption.encrypt('qux', {
-      keyId: keyId1,
-      algorithm: 'TextPreview',
-      queryType: 'substringPreview',
-      contentionFactor: 0,
-      textOptions: {
-        caseSensitive: true,
-        diacriticSensitive: true,
-        substring: {
-          strMaxLength: 10,
-          strMaxQueryLength: 10,
-          strMinQueryLength: 2
+  it(
+    'Case 6: assert no document found by substring',
+    metadataWithoutSubstringPreview,
+    async function () {
+      // Use clientEncryption.encrypt() to encrypt the string "bar" with the following EncryptOpts:
+      // class EncryptOpts {
+      //    keyId : <key1ID>,
+      //    algorithm: "TextPreview",
+      //    queryType: "substringPreview",
+      //    contentionFactor: 0,
+      //    textOpts: TextOpts {
+      //       caseSensitive: true,
+      //       diacriticSensitive: true,
+      //       substring: SubstringOpts {
+      //        strMaxLength: 10,
+      //        strMaxQueryLength: 10,
+      //        strMinQueryLength: 2,
+      //       }
+      //    },
+      // }
+      const encryptedQux = await clientEncryption.encrypt('qux', {
+        keyId: keyId1,
+        algorithm: 'TextPreview',
+        queryType: 'substringPreview',
+        contentionFactor: 0,
+        textOptions: {
+          caseSensitive: true,
+          diacriticSensitive: true,
+          substring: {
+            strMaxLength: 10,
+            strMaxQueryLength: 10,
+            strMinQueryLength: 2
+          }
         }
-      }
-    });
+      });
 
-    // Use encryptedClient to run a "find" operation on the db.substring collection with the following filter:
-    // { $expr: { $encStrContains: {input: '$encryptedText', substring: <encrypted 'bar'>} } }
-    const filter = {
-      $expr: { $encStrContains: { input: '$encryptedText', substring: encryptedQux } }
-    };
+      // Use encryptedClient to run a "find" operation on the db.substring collection with the following filter:
+      // { $expr: { $encStrContains: {input: '$encryptedText', substring: <encrypted 'bar'>} } }
+      const filter = {
+        $expr: { $encStrContains: { input: '$encryptedText', substring: encryptedQux } }
+      };
 
-    const result = await encryptedClient
-      .db('db')
-      .collection<{
-        _id: number;
-        encryptedText: Binary;
-        __safeContent__: any;
-      }>('substring')
-      .findOne(filter);
-    expect(result).to.be.null;
-  });
+      const result = await encryptedClient
+        .db('db')
+        .collection<{
+          _id: number;
+          encryptedText: Binary;
+          __safeContent__: any;
+        }>('substring')
+        .findOne(filter);
+      expect(result).to.be.null;
+    }
+  );
 
   it('Case 7: assert contentionFactor is required', metadataWithoutPreview, async function () {
     // Skip this test case if testing MongoDB server 9.0.0+.

--- a/test/integration/client-side-encryption/client_side_encryption.prose.27.text_queries.test.ts
+++ b/test/integration/client-side-encryption/client_side_encryption.prose.27.text_queries.test.ts
@@ -16,7 +16,7 @@ const metadataWithoutPreview: MongoDBMetadataUI = {
     libmongocrypt: '>=1.15.1'
   }
 };
-// TODO(NODE-7628): substringPreview contention validation broken on MongoDB 9.0+ (SERVER-91887).
+// TODO(NODE-7623): substringPreview contention validation broken on MongoDB 9.0+ (SERVER-91887).
 const metadataWithoutSubstringPreview: MongoDBMetadataUI = {
   requires: {
     clientSideEncryption: '>=6.4.0',

--- a/test/integration/client-side-encryption/client_side_encryption.prose.test.ts
+++ b/test/integration/client-side-encryption/client_side_encryption.prose.test.ts
@@ -65,6 +65,16 @@ const eeMetadata: MongoDBMetadataUI = {
   }
 };
 
+// TODO(NODE-7628): Case 2 explicitly inserts with contentionFactor:10 into a collection
+// configured with contention:0; SERVER-91887 now rejects this mismatch on 9.0+.
+const eeMetadataPre90: MongoDBMetadataUI = {
+  requires: {
+    clientSideEncryption: true,
+    mongodb: '>=7.0.0 <9.0.0',
+    topology: ['replicaset', 'sharded']
+  }
+};
+
 async function loadExternal(file) {
   return EJSON.parse(
     await fs.readFile(
@@ -2063,7 +2073,7 @@ describe('Client Side Encryption Prose Tests', metadata, function () {
 
     context(
       'Case 2: can insert encrypted indexed and find with non-zero contention',
-      eeMetadata,
+      eeMetadataPre90,
       function () {
         let findPayload;
         let findPayload2;

--- a/test/integration/client-side-encryption/client_side_encryption.prose.test.ts
+++ b/test/integration/client-side-encryption/client_side_encryption.prose.test.ts
@@ -65,7 +65,7 @@ const eeMetadata: MongoDBMetadataUI = {
   }
 };
 
-// TODO(NODE-7628): Case 2 explicitly inserts with contentionFactor:10 into a collection
+// TODO(NODE-7623): Case 2 explicitly inserts with contentionFactor:10 into a collection
 // configured with contention:0; SERVER-91887 now rejects this mismatch on 9.0+.
 const eeMetadataPre90: MongoDBMetadataUI = {
   requires: {

--- a/test/integration/client-side-encryption/client_side_encryption.spec.test.ts
+++ b/test/integration/client-side-encryption/client_side_encryption.spec.test.ts
@@ -60,16 +60,16 @@ describe('Client Side Encryption (Legacy)', function () {
       if (typeof result === 'string') return result;
     }
 
-    // TODO(NODE-7628): fle2v2-BypassQueryAnalysis hardcoded payload has contentionFactor that
+    // TODO(NODE-7623): fle2v2-BypassQueryAnalysis hardcoded payload has contentionFactor that
     // exceeds the collection's configured contention; SERVER-91887 now validates this on 9.0+.
     if (
       description === 'BypassQueryAnalysis decrypts' &&
       semver.satisfies(configuration.version, '>=9.0.0')
     ) {
-      return 'TODO(NODE-7628): fle2v2-BypassQueryAnalysis hardcoded payload contentionFactor exceeds configured contention (SERVER-91887)';
+      return 'TODO(NODE-7623): fle2v2-BypassQueryAnalysis hardcoded payload contentionFactor exceeds configured contention (SERVER-91887)';
     }
 
-    // TODO(NODE-7628): fle2v2 equality spec tests insert with auto-encryption against a field
+    // TODO(NODE-7623): fle2v2 equality spec tests insert with auto-encryption against a field
     // configured with contention:0, but libmongocrypt generates random contentionFactor values.
     // SERVER-91887 now rejects payloads whose contentionFactor exceeds configured contention on 9.0+.
     if (
@@ -85,7 +85,7 @@ describe('Client Side Encryption (Legacy)', function () {
         'encryptedFields is preferred over jsonSchema'
       ].includes(description)
     ) {
-      return 'TODO(NODE-7628): fle2v2 equality auto-encryption generates contentionFactor that exceeds contention:0 (SERVER-91887)';
+      return 'TODO(NODE-7623): fle2v2 equality auto-encryption generates contentionFactor that exceeds contention:0 (SERVER-91887)';
     }
 
     return true;
@@ -135,22 +135,22 @@ describe('Client Side Encryption (Unified)', function () {
         if (typeof shouldSkip === 'string') return shouldSkip;
       }
 
-      // TODO(NODE-7628): fle2v2-BypassQueryAnalysis hardcoded payload has contentionFactor that
+      // TODO(NODE-7623): fle2v2-BypassQueryAnalysis hardcoded payload has contentionFactor that
       // exceeds the collection's configured contention; SERVER-91887 now validates this on 9.0+.
       if (
         description === 'BypassQueryAnalysis decrypts' &&
         semver.satisfies(configuration.version, '>=9.0.0')
       ) {
-        return 'TODO(NODE-7628): fle2v2-BypassQueryAnalysis hardcoded payload contentionFactor exceeds configured contention (SERVER-91887)';
+        return 'TODO(NODE-7623): fle2v2-BypassQueryAnalysis hardcoded payload contentionFactor exceeds configured contention (SERVER-91887)';
       }
 
-      // TODO(NODE-7628): same as legacy runner — auto-encryption generates random contentionFactor
+      // TODO(NODE-7623): same as legacy runner — auto-encryption generates random contentionFactor
       // that exceeds contention:0 on 9.0+ (SERVER-91887).
       if (
         description === 'encryptedFieldsMap is preferred over remote encryptedFields' &&
         semver.satisfies(configuration.version, '>=9.0.0')
       ) {
-        return 'TODO(NODE-7628): fle2v2 equality auto-encryption generates contentionFactor that exceeds contention:0 (SERVER-91887)';
+        return 'TODO(NODE-7623): fle2v2 equality auto-encryption generates contentionFactor that exceeds contention:0 (SERVER-91887)';
       }
 
       return false;

--- a/test/integration/client-side-encryption/client_side_encryption.spec.test.ts
+++ b/test/integration/client-side-encryption/client_side_encryption.spec.test.ts
@@ -1,4 +1,5 @@
 import * as path from 'path';
+import * as semver from 'semver';
 
 import { loadSpecTests } from '../../spec';
 import {
@@ -58,6 +59,35 @@ describe('Client Side Encryption (Legacy)', function () {
 
       if (typeof result === 'string') return result;
     }
+
+    // TODO(NODE-7628): fle2v2-BypassQueryAnalysis hardcoded payload has contentionFactor that
+    // exceeds the collection's configured contention; SERVER-91887 now validates this on 9.0+.
+    if (
+      description === 'BypassQueryAnalysis decrypts' &&
+      semver.satisfies(configuration.version, '>=9.0.0')
+    ) {
+      return 'TODO(NODE-7628): fle2v2-BypassQueryAnalysis hardcoded payload contentionFactor exceeds configured contention (SERVER-91887)';
+    }
+
+    // TODO(NODE-7628): fle2v2 equality spec tests insert with auto-encryption against a field
+    // configured with contention:0, but libmongocrypt generates random contentionFactor values.
+    // SERVER-91887 now rejects payloads whose contentionFactor exceeds configured contention on 9.0+.
+    if (
+      semver.satisfies(configuration.version, '>=9.0.0') &&
+      [
+        'Insert and find FLE2 indexed field',
+        'Delete can query an FLE2 indexed field',
+        'Update can query an FLE2 indexed field',
+        'Update can modify an FLE2 indexed field',
+        'findOneAndUpdate can query an FLE2 indexed field',
+        'findOneAndUpdate can modify an FLE2 indexed field',
+        'encryptedFieldsMap is preferred over remote encryptedFields',
+        'encryptedFields is preferred over jsonSchema'
+      ].includes(description)
+    ) {
+      return 'TODO(NODE-7628): fle2v2 equality auto-encryption generates contentionFactor that exceeds contention:0 (SERVER-91887)';
+    }
+
     return true;
   });
 });
@@ -103,6 +133,24 @@ describe('Client Side Encryption (Unified)', function () {
           metadata: { requires: { clientSideEncryption: '>=6.4.0' } }
         });
         if (typeof shouldSkip === 'string') return shouldSkip;
+      }
+
+      // TODO(NODE-7628): fle2v2-BypassQueryAnalysis hardcoded payload has contentionFactor that
+      // exceeds the collection's configured contention; SERVER-91887 now validates this on 9.0+.
+      if (
+        description === 'BypassQueryAnalysis decrypts' &&
+        semver.satisfies(configuration.version, '>=9.0.0')
+      ) {
+        return 'TODO(NODE-7628): fle2v2-BypassQueryAnalysis hardcoded payload contentionFactor exceeds configured contention (SERVER-91887)';
+      }
+
+      // TODO(NODE-7628): same as legacy runner — auto-encryption generates random contentionFactor
+      // that exceeds contention:0 on 9.0+ (SERVER-91887).
+      if (
+        description === 'encryptedFieldsMap is preferred over remote encryptedFields' &&
+        semver.satisfies(configuration.version, '>=9.0.0')
+      ) {
+        return 'TODO(NODE-7628): fle2v2 equality auto-encryption generates contentionFactor that exceeds contention:0 (SERVER-91887)';
       }
 
       return false;


### PR DESCRIPTION
### Description

#### Summary of Changes

This skips some CSFLE tests against 9.0+, which are currently failing due to https://jira.mongodb.org/browse/SERVER-91887 and https://jira.mongodb.org/browse/DRIVERS-3547 

#### What is the motivation for this change?

Failing tests, caused by a 9.0 server change.

### Double check the following

- [x] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
