### PR TITLE
chore: skip csot tests on latest

### DIFF
--- a/test/integration/client-side-operations-timeout/client_side_operations_timeout.prose.test.ts
+++ b/test/integration/client-side-operations-timeout/client_side_operations_timeout.prose.test.ts
@@ -46,6 +46,7 @@ describe('CSOT spec prose tests', function () {
 
   before(function () {
     if (semver.satisfies(this.configuration.version, '>=9.0')) {
+      this.skipReason = 'TODO(NODE-7418): CSOT tests fail on server >=9.0, tracked in NODE-7418';
       this.skip();
     }
   });

--- a/test/integration/client-side-operations-timeout/client_side_operations_timeout.prose.test.ts
+++ b/test/integration/client-side-operations-timeout/client_side_operations_timeout.prose.test.ts
@@ -44,6 +44,12 @@ describe('CSOT spec prose tests', function () {
     await client?.close();
   });
 
+  before(function () {
+    if (semver.satisfies(this.configuration.version, '>=9.0')) {
+      this.skip();
+    }
+  });
+
   describe('1. Multi-batch writes', { requires: { topology: 'single', mongodb: '>=4.4' } }, () => {
     /**
      * This test MUST only run against standalones on server versions 4.4 and higher.

--- a/test/integration/client-side-operations-timeout/client_side_operations_timeout.spec.test.ts
+++ b/test/integration/client-side-operations-timeout/client_side_operations_timeout.spec.test.ts
@@ -52,12 +52,13 @@ describe('CSOT spec tests', function () {
     ) {
       return '4.4 replicaset fail point does not blockConnection for requested time';
     }
-    // TODO(NODE-7418): on sharded clusters the initial $changeStream aggregate blocks server-side
-    // for the full maxTimeMS because mongos propagates maxTimeMS to each shard as maxAwaitTimeMS.
-    // The legacy-timeout retryability tests also fail because socketTimeoutMS=100 is too tight for
-    // SSL connection establishment on a sharded+SSL Evergreen host.
+    // TODO(NODE-7418): on latest server (>=9.0) sharded clusters, the initial $changeStream
+    // aggregate blocks server-side for the full maxTimeMS because mongos propagates maxTimeMS to
+    // each shard as maxAwaitTimeMS. The legacy-timeout retryability tests also fail because
+    // socketTimeoutMS=100 is too tight for SSL connection establishment on a sharded+SSL host.
     if (
       configuration.topologyType === 'Sharded' &&
+      semver.satisfies(configuration.version, '>=9.0') &&
       csotChangeStreamShardedSkips.has(test.description)
     ) {
       return 'TODO(NODE-7418): CSOT createChangeStream tests hang on sharded clusters, fixed by NODE-7418';
@@ -66,12 +67,12 @@ describe('CSOT spec tests', function () {
   });
 });
 
-// Descriptions of CSOT change stream tests that fail specifically on sharded topologies.
-// On sharded clusters, mongos propagates maxTimeMS to each shard as maxAwaitTimeMS on the
-// initial $changeStream aggregate, causing the server to block for the full budget.
-// The legacy timeout tests additionally fail because socketTimeoutMS=100 is too tight
-// for SSL connection establishment overhead on sharded+SSL CI hosts.
-// Tracked in NODE-7418 / DRIVERS-3018.
+// Descriptions of CSOT change stream tests that fail specifically on sharded topologies
+// running against the latest server (>=9.0). On sharded clusters, mongos propagates maxTimeMS
+// to each shard as maxAwaitTimeMS on the initial $changeStream aggregate, causing the server to
+// block for the full budget. The legacy timeout tests additionally fail because socketTimeoutMS=100
+// is too tight for SSL connection establishment overhead on sharded+SSL CI hosts.
+// Tracked in NODE-7418 / DRIVERS-3018 / SERVER-129623.
 const csotChangeStreamShardedSkips = new Set([
   'change stream can be iterated again if previous iteration times out',
   'timeoutMS can be configured on a MongoCollection - createChangeStream on collection',
@@ -96,6 +97,7 @@ describe('CSOT modified spec tests', function () {
     // TODO(NODE-7418): same root cause as csotChangeStreamShardedSkips above.
     if (
       configuration.topologyType === 'Sharded' &&
+      semver.satisfies(configuration.version, '>=9.0') &&
       test.description === 'timeoutMS is refreshed for getMore if maxAwaitTimeMS is set'
     ) {
       return 'TODO(NODE-7418): CSOT createChangeStream tests hang on sharded clusters, fixed by NODE-7418';

--- a/test/integration/client-side-operations-timeout/client_side_operations_timeout.spec.test.ts
+++ b/test/integration/client-side-operations-timeout/client_side_operations_timeout.spec.test.ts
@@ -52,13 +52,54 @@ describe('CSOT spec tests', function () {
     ) {
       return '4.4 replicaset fail point does not blockConnection for requested time';
     }
+    // TODO(NODE-7418): on sharded clusters the initial $changeStream aggregate blocks server-side
+    // for the full maxTimeMS because mongos propagates maxTimeMS to each shard as maxAwaitTimeMS.
+    // The legacy-timeout retryability tests also fail because socketTimeoutMS=100 is too tight for
+    // SSL connection establishment on a sharded+SSL Evergreen host.
+    if (
+      configuration.topologyType === 'Sharded' &&
+      csotChangeStreamShardedSkips.has(test.description)
+    ) {
+      return 'TODO(NODE-7418): CSOT createChangeStream tests hang on sharded clusters, fixed by NODE-7418';
+    }
     return false;
   });
 });
+
+// Descriptions of CSOT change stream tests that fail specifically on sharded topologies.
+// On sharded clusters, mongos propagates maxTimeMS to each shard as maxAwaitTimeMS on the
+// initial $changeStream aggregate, causing the server to block for the full budget.
+// The legacy timeout tests additionally fail because socketTimeoutMS=100 is too tight
+// for SSL connection establishment overhead on sharded+SSL CI hosts.
+// Tracked in NODE-7418 / DRIVERS-3018.
+const csotChangeStreamShardedSkips = new Set([
+  'change stream can be iterated again if previous iteration times out',
+  'timeoutMS can be configured on a MongoCollection - createChangeStream on collection',
+  'timeoutMS can be configured on a MongoDatabase - createChangeStream on database',
+  'timeoutMS can be configured on a MongoDatabase - createChangeStream on collection',
+  'timeoutMS can be configured for an operation - createChangeStream on client',
+  'timeoutMS can be configured for an operation - createChangeStream on database',
+  'timeoutMS can be configured for an operation - createChangeStream on collection',
+  'operation succeeds after one socket timeout - createChangeStream on client',
+  'operation succeeds after one socket timeout - createChangeStream on database',
+  'operation succeeds after one socket timeout - createChangeStream on collection',
+  'operation is retried multiple times for non-zero timeoutMS - createChangeStream on client',
+  'operation is retried multiple times for non-zero timeoutMS - createChangeStream on database',
+  'operation is retried multiple times for non-zero timeoutMS - createChangeStream on collection'
+]);
 
 describe('CSOT modified spec tests', function () {
   const specs = loadSpecTests(
     join('..', 'integration', 'client-side-operations-timeout', 'unified-csot-node-specs')
   );
-  runUnifiedSuite(specs);
+  runUnifiedSuite(specs, (test, configuration) => {
+    // TODO(NODE-7418): same root cause as csotChangeStreamShardedSkips above.
+    if (
+      configuration.topologyType === 'Sharded' &&
+      test.description === 'timeoutMS is refreshed for getMore if maxAwaitTimeMS is set'
+    ) {
+      return 'TODO(NODE-7418): CSOT createChangeStream tests hang on sharded clusters, fixed by NODE-7418';
+    }
+    return false;
+  });
 });

--- a/test/integration/client-side-operations-timeout/client_side_operations_timeout.spec.test.ts
+++ b/test/integration/client-side-operations-timeout/client_side_operations_timeout.spec.test.ts
@@ -38,6 +38,9 @@ describe('CSOT spec tests', function () {
   }
 
   runUnifiedSuite(specs, (test, configuration) => {
+    if (semver.satisfies(configuration.version, '>=9.0')) {
+      return 'TODO(NODE-7418): CSOT tests fail on server >=9.0, tracked in NODE-7418';
+    }
     const sessionCSOTTests = ['timeoutMS applied to withTransaction'];
     if (
       configuration.topologyType === 'LoadBalanced' &&
@@ -52,55 +55,17 @@ describe('CSOT spec tests', function () {
     ) {
       return '4.4 replicaset fail point does not blockConnection for requested time';
     }
-    // TODO(NODE-7418): on latest server (>=9.0) sharded clusters, the initial $changeStream
-    // aggregate blocks server-side for the full maxTimeMS because mongos propagates maxTimeMS to
-    // each shard as maxAwaitTimeMS. The legacy-timeout retryability tests also fail because
-    // socketTimeoutMS=100 is too tight for SSL connection establishment on a sharded+SSL host.
-    if (
-      configuration.topologyType === 'Sharded' &&
-      semver.satisfies(configuration.version, '>=9.0') &&
-      csotChangeStreamShardedSkips.has(test.description)
-    ) {
-      return 'TODO(NODE-7418): CSOT createChangeStream tests hang on sharded clusters, tracked in NODE-7418';
-    }
     return false;
   });
 });
-
-// Descriptions of CSOT change stream tests that fail specifically on sharded topologies
-// running against the latest server (>=9.0). On sharded clusters, mongos propagates maxTimeMS
-// to each shard as maxAwaitTimeMS on the initial $changeStream aggregate, causing the server to
-// block for the full budget. The legacy timeout tests additionally fail because socketTimeoutMS=100
-// is too tight for SSL connection establishment overhead on sharded+SSL CI hosts.
-// Tracked in NODE-7418 / DRIVERS-3018 / SERVER-129623.
-const csotChangeStreamShardedSkips = new Set([
-  'change stream can be iterated again if previous iteration times out',
-  'timeoutMS can be configured on a MongoCollection - createChangeStream on collection',
-  'timeoutMS can be configured on a MongoDatabase - createChangeStream on database',
-  'timeoutMS can be configured on a MongoDatabase - createChangeStream on collection',
-  'timeoutMS can be configured for an operation - createChangeStream on client',
-  'timeoutMS can be configured for an operation - createChangeStream on database',
-  'timeoutMS can be configured for an operation - createChangeStream on collection',
-  'operation succeeds after one socket timeout - createChangeStream on client',
-  'operation succeeds after one socket timeout - createChangeStream on database',
-  'operation succeeds after one socket timeout - createChangeStream on collection',
-  'operation is retried multiple times for non-zero timeoutMS - createChangeStream on client',
-  'operation is retried multiple times for non-zero timeoutMS - createChangeStream on database',
-  'operation is retried multiple times for non-zero timeoutMS - createChangeStream on collection'
-]);
 
 describe('CSOT modified spec tests', function () {
   const specs = loadSpecTests(
     join('..', 'integration', 'client-side-operations-timeout', 'unified-csot-node-specs')
   );
   runUnifiedSuite(specs, (test, configuration) => {
-    // TODO(NODE-7418): same root cause as csotChangeStreamShardedSkips above.
-    if (
-      configuration.topologyType === 'Sharded' &&
-      semver.satisfies(configuration.version, '>=9.0') &&
-      test.description === 'timeoutMS is refreshed for getMore if maxAwaitTimeMS is set'
-    ) {
-      return 'TODO(NODE-7418): CSOT createChangeStream tests hang on sharded clusters, tracked in NODE-7418';
+    if (semver.satisfies(configuration.version, '>=9.0')) {
+      return 'TODO(NODE-7418): CSOT tests fail on server >=9.0, tracked in NODE-7418';
     }
     return false;
   });

--- a/test/integration/client-side-operations-timeout/client_side_operations_timeout.spec.test.ts
+++ b/test/integration/client-side-operations-timeout/client_side_operations_timeout.spec.test.ts
@@ -61,7 +61,7 @@ describe('CSOT spec tests', function () {
       semver.satisfies(configuration.version, '>=9.0') &&
       csotChangeStreamShardedSkips.has(test.description)
     ) {
-      return 'TODO(NODE-7418): CSOT createChangeStream tests hang on sharded clusters, fixed by NODE-7418';
+      return 'TODO(NODE-7418): CSOT createChangeStream tests hang on sharded clusters, tracked in NODE-7418';
     }
     return false;
   });
@@ -100,7 +100,7 @@ describe('CSOT modified spec tests', function () {
       semver.satisfies(configuration.version, '>=9.0') &&
       test.description === 'timeoutMS is refreshed for getMore if maxAwaitTimeMS is set'
     ) {
-      return 'TODO(NODE-7418): CSOT createChangeStream tests hang on sharded clusters, fixed by NODE-7418';
+      return 'TODO(NODE-7418): CSOT createChangeStream tests hang on sharded clusters, tracked in NODE-7418';
     }
     return false;
   });

--- a/test/integration/client-side-operations-timeout/node_csot.test.ts
+++ b/test/integration/client-side-operations-timeout/node_csot.test.ts
@@ -38,6 +38,7 @@ const metadata = { requires: { mongodb: '>=4.4' } };
 describe('CSOT driver tests', metadata, () => {
   before(function () {
     if (semver.satisfies(this.configuration.version, '>=9.0')) {
+      this.skipReason = 'TODO(NODE-7418): CSOT tests fail on server >=9.0, tracked in NODE-7418';
       this.skip();
     }
   });

--- a/test/integration/client-side-operations-timeout/node_csot.test.ts
+++ b/test/integration/client-side-operations-timeout/node_csot.test.ts
@@ -36,6 +36,12 @@ import { type FailCommandFailPoint, type FailPoint, waitUntilPoolsFilled } from 
 const metadata = { requires: { mongodb: '>=4.4' } };
 
 describe('CSOT driver tests', metadata, () => {
+  before(function () {
+    if (semver.satisfies(this.configuration.version, '>=9.0')) {
+      this.skip();
+    }
+  });
+
   // NOTE: minPoolSize here is set to ensure that connections are available when testing timeout
   // behaviour. This reduces flakiness in our tests since operations will not spend time
   // establishing connections, more closely mirroring long-running application behaviour

--- a/test/integration/crud/client_bulk_write.test.ts
+++ b/test/integration/crud/client_bulk_write.test.ts
@@ -93,6 +93,7 @@ describe('Client Bulk Write', function () {
   describe('CSOT enabled', function () {
     before(function () {
       if (semver.satisfies(this.configuration.version, '>=9.0')) {
+        this.skipReason = 'TODO(NODE-7418): CSOT tests fail on server >=9.0, tracked in NODE-7418';
         this.skip();
       }
     });

--- a/test/integration/crud/client_bulk_write.test.ts
+++ b/test/integration/crud/client_bulk_write.test.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import * as semver from 'semver';
 import { setTimeout } from 'timers/promises';
 
 import {
@@ -90,6 +91,12 @@ describe('Client Bulk Write', function () {
   });
 
   describe('CSOT enabled', function () {
+    before(function () {
+      if (semver.satisfies(this.configuration.version, '>=9.0')) {
+        this.skip();
+      }
+    });
+
     describe('when timeoutMS is set on the client', function () {
       beforeEach(async function () {
         client = this.configuration.newClient({}, { timeoutMS: 300 });


### PR DESCRIPTION
### Description

#### Summary of Changes

Skips CSOT tests that consistently fail on latest.
[SERVER-129623](https://jira.mongodb.org/browse/SERVER-129623)

The proper fix is tracked in [NODE-7418](https://jira.mongodb.org/browse/NODE-7418) and is in progress in #4872.

### Double check the following

- [x] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
- [x] New TODOs have a related JIRA ticket