### PR TITLE
test(NODE-7171): capture resume token before resumeTokenChanged fires

### DIFF
--- a/test/integration/client-side-operations-timeout/node_csot.test.ts
+++ b/test/integration/client-side-operations-timeout/node_csot.test.ts
@@ -995,6 +995,11 @@ describe('CSOT driver tests', metadata, () => {
             .map(x => x.command);
           expect(aggregates).to.have.lengthOf(1);
 
+          // NODE-7171: capture the token before waiting for resumeTokenChanged — by the time the
+          // event fires, cs.resumeToken has already advanced to the post-batch token from the new
+          // aggregate, which differs from the token the resume aggregate was sent with.
+          const resumeToken = cs.resumeToken;
+
           await once(cs, 'resumeTokenChanged');
 
           aggregates = commandsStarted
@@ -1005,7 +1010,7 @@ describe('CSOT driver tests', metadata, () => {
 
           expect(aggregates[0].pipeline).to.deep.equal([{ $changeStream: {} }]);
           expect(aggregates[1].pipeline).to.deep.equal([
-            { $changeStream: { resumeAfter: cs.resumeToken } }
+            { $changeStream: { resumeAfter: resumeToken } }
           ]);
         });
       });

--- a/test/integration/client-side-operations-timeout/node_csot.test.ts
+++ b/test/integration/client-side-operations-timeout/node_csot.test.ts
@@ -995,9 +995,6 @@ describe('CSOT driver tests', metadata, () => {
             .map(x => x.command);
           expect(aggregates).to.have.lengthOf(1);
 
-          // NODE-7171: capture the token before waiting for resumeTokenChanged — by the time the
-          // event fires, cs.resumeToken has already advanced to the post-batch token from the new
-          // aggregate, which differs from the token the resume aggregate was sent with.
           const resumeToken = cs.resumeToken;
 
           await once(cs, 'resumeTokenChanged');


### PR DESCRIPTION
## Summary

Fixes a test that's been failing intermittently since September 2025 (NODE-7171, 9+ reports): `CSOT > Change Streams > when in stream mode > when the getMore times out > attempts to create a new change stream cursor`.

### Root cause

The test checks that after a getMore timeout the driver issues a resume aggregate with `resumeAfter` set to the token it held at the time of the error. The original code read `cs.resumeToken` after `await once(cs, 'resumeTokenChanged')`.

That's too late. `resumeTokenChanged` fires only after the resume aggregate has completed and the driver has updated `cs.resumeToken` to the post-batch resume token from the aggregate response. That token can differ from the one passed as `resumeAfter`, so the assertion compared the wrong value.

The test doesn't always fail because those two tokens are equal when the server's PBRT hasn't advanced during the resume. On a busy replica set with concurrent tests writing to the oplog, the PBRT almost always changes in the window between the getMore error and the aggregate response. On a quiet run it might not, which is why failures are intermittent.

### Fix

The fix captures `cs.resumeToken` before `await once(cs, 'resumeTokenChanged')`. In stream mode, `_processErrorStreamMode` runs the full resume sequence before emitting the error event: it closes the old cursor, calls `_resume()`, which constructs a new cursor with the previous token as `resumeAfter`. So when `errorIter.next()` resolves, `cs.resumeToken` already reflects what the next aggregate will use. The aggregate runs lazily when the cursor stream starts pulling, which requires a network round-trip that cannot complete before the synchronous token capture.