### PR TITLE
feat(NODE-7634): remove experimental tag from async dispose methods

### DIFF
--- a/src/change_stream.ts
+++ b/src/change_stream.ts
@@ -573,7 +573,6 @@ export class ChangeStream<
   implements AsyncDisposable
 {
   /**
-   * @experimental
    * An alias for {@link ChangeStream.close|ChangeStream.close()}.
    */
   async [Symbol.asyncDispose]() {

--- a/src/cursor/abstract_cursor.ts
+++ b/src/cursor/abstract_cursor.ts
@@ -430,7 +430,6 @@ export abstract class AbstractCursor<
   }
 
   /**
-   * @experimental
    * An alias for {@link AbstractCursor.close|AbstractCursor.close()}.
    */
   async [Symbol.asyncDispose]() {

--- a/src/mongo_client.ts
+++ b/src/mongo_client.ts
@@ -482,7 +482,6 @@ export class MongoClient extends TypedEventEmitter<MongoClientEvents> implements
   }
 
   /**
-   * @experimental
    * An alias for {@link MongoClient.close|MongoClient.close()}.
    */
   async [Symbol.asyncDispose]() {

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -290,7 +290,6 @@ export class ClientSession
     }
   }
   /**
-   * @experimental
    * An alias for {@link ClientSession.endSession|ClientSession.endSession()}.
    */
   async [Symbol.asyncDispose]() {


### PR DESCRIPTION
### Description

#### Summary of Changes

Removes the `@experimental` tag from the four `Symbol.asyncDispose` methods on `MongoClient`, `AbstractCursor`, `ChangeStream`, and `ClientSession`. These power explicit resource management (`await using`), introduced in v6.9.0 (NODE-5614) and stable since. Documentation/metadata only, no behavior or signature changes.

### Release Highlight

<!-- 
Contributors: please leave the release notes section for the Node driver team to fill in. The following instructions are for maintainers.

For user facing changes: please provide release notes. Feel free to browse previous releases for example release highlights.

If there are no user-facing changes in this PR, please delete the release highlight section from the PR description.
-->

<!-- RELEASE_HIGHLIGHT_START -->

### Explicit resource management is now stable

The `Symbol.asyncDispose` methods on `MongoClient`, `ClientSession`, `ChangeStream`, and cursors enable `await using` for automatic cleanup. These methods were introduced as experimental in v6.9.0. Since then, TC39 Explicit Resource Management proposal reached Stage 4 in 2025, and Node.js enabled explicit resource management as a stable feature in Node.js 24, so the experimental flags have been removed from our APIs and the APIs are now officially supported.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
