### PR TITLE
test(NODE-7028): fix flaky AbortSignal timing assertions

### DIFF
--- a/test/integration/node-specific/abort_signal.test.ts
+++ b/test/integration/node-specific/abort_signal.test.ts
@@ -514,6 +514,7 @@ describe('AbortSignal support', () => {
 
             const result = await willBeResultBlocked;
             const end = performance.now();
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             expect(end - abortedAt!).to.be.lessThan(10); // shouldn't wait for the blocked connection
 
             expect(result).to.be.instanceOf(DOMException);
@@ -952,6 +953,7 @@ describe('AbortSignal support', () => {
 
       const result = await collection.findOne({}, { signal }).catch(error => error);
       const end = performance.now();
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       expect(end - abortedAt!).to.be.lessThan(10); // shouldn't wait for the blocked connection
 
       expect(result).to.be.instanceOf(DOMException);
@@ -997,6 +999,7 @@ describe('AbortSignal support', () => {
 
       const result = await db.command({ ping: 1 }, { signal }).catch(error => error);
       const end = performance.now();
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       expect(end - abortedAt!).to.be.lessThan(10); // shouldn't wait for the blocked connection
 
       expect(result).to.be.instanceOf(DOMException);

--- a/test/integration/node-specific/abort_signal.test.ts
+++ b/test/integration/node-specific/abort_signal.test.ts
@@ -504,8 +504,8 @@ describe('AbortSignal support', () => {
             let abortedAt: number;
             client.on('commandStarted', e => {
               if (e.commandName === cursorName) {
-                controller.abort();
                 abortedAt = performance.now();
+                controller.abort();
               }
             });
             let commandFailed = false;

--- a/test/integration/node-specific/abort_signal.test.ts
+++ b/test/integration/node-specific/abort_signal.test.ts
@@ -501,15 +501,20 @@ describe('AbortSignal support', () => {
               }
             }
 
-            client.on('commandStarted', e => e.commandName === cursorName && controller.abort());
+            let abortedAt: number;
+            client.on('commandStarted', e => {
+              if (e.commandName === cursorName) {
+                controller.abort();
+                abortedAt = performance.now();
+              }
+            });
             let commandFailed = false;
             client.on('commandFailed', e => e.commandName === cursorName && (commandFailed = true));
             const willBeResultBlocked = iterateUntilDocumentOrError(cursor, cursorAPI, args);
 
-            const start = performance.now();
             const result = await willBeResultBlocked;
             const end = performance.now();
-            expect(end - start).to.be.lessThan(10); // shouldn't wait for the blocked connection
+            expect(end - abortedAt!).to.be.lessThan(10); // shouldn't wait for the blocked connection
 
             expect(result).to.be.instanceOf(DOMException);
 
@@ -933,17 +938,21 @@ describe('AbortSignal support', () => {
     });
 
     it(`rejects findOne`, async () => {
+      let abortedAt: number;
       client.on(
         'commandStarted',
         // Abort a bit after find has started:
-        ev => ev.commandName === 'find' && sleep(1).then(() => controller.abort())
+        ev =>
+          ev.commandName === 'find' &&
+          sleep(1).then(() => {
+            abortedAt = performance.now();
+            controller.abort();
+          })
       );
 
-      const start = performance.now();
       const result = await collection.findOne({}, { signal }).catch(error => error);
       const end = performance.now();
-      // TODO(NODE-6833): This duration was bumped from 10 to 40 to reduce flakiness, if this fails again investigate it.
-      expect(end - start).to.be.lessThan(40); // shouldn't wait for the blocked connection
+      expect(end - abortedAt!).to.be.lessThan(10); // shouldn't wait for the blocked connection
 
       expect(result).to.be.instanceOf(DOMException);
     });
@@ -974,16 +983,21 @@ describe('AbortSignal support', () => {
     });
 
     it(`rejects command`, async () => {
+      let abortedAt: number;
       client.on(
         'commandStarted',
         // Abort a bit after ping has started:
-        ev => ev.commandName === 'ping' && sleep(1).then(() => controller.abort())
+        ev =>
+          ev.commandName === 'ping' &&
+          sleep(1).then(() => {
+            abortedAt = performance.now();
+            controller.abort();
+          })
       );
 
-      const start = performance.now();
       const result = await db.command({ ping: 1 }, { signal }).catch(error => error);
       const end = performance.now();
-      expect(end - start).to.be.lessThan(10); // shouldn't wait for the blocked connection
+      expect(end - abortedAt!).to.be.lessThan(10); // shouldn't wait for the blocked connection
 
       expect(result).to.be.instanceOf(DOMException);
     });

--- a/test/integration/node-specific/abort_signal.test.ts
+++ b/test/integration/node-specific/abort_signal.test.ts
@@ -501,7 +501,7 @@ describe('AbortSignal support', () => {
               }
             }
 
-            let abortedAt: number;
+            let abortedAt = 0;
             client.on('commandStarted', e => {
               if (e.commandName === cursorName) {
                 abortedAt = performance.now();
@@ -514,8 +514,8 @@ describe('AbortSignal support', () => {
 
             const result = await willBeResultBlocked;
             const end = performance.now();
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            expect(end - abortedAt!).to.be.lessThan(10); // shouldn't wait for the blocked connection
+            expect(abortedAt, 'commandStarted handler did not fire').to.be.greaterThan(0);
+            expect(end - abortedAt).to.be.lessThan(10); // shouldn't wait for the blocked connection
 
             expect(result).to.be.instanceOf(DOMException);
 
@@ -939,7 +939,7 @@ describe('AbortSignal support', () => {
     });
 
     it(`rejects findOne`, async () => {
-      let abortedAt: number;
+      let abortedAt = 0;
       client.on(
         'commandStarted',
         // Abort a bit after find has started:
@@ -953,8 +953,8 @@ describe('AbortSignal support', () => {
 
       const result = await collection.findOne({}, { signal }).catch(error => error);
       const end = performance.now();
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      expect(end - abortedAt!).to.be.lessThan(10); // shouldn't wait for the blocked connection
+      expect(abortedAt, 'commandStarted handler did not fire').to.be.greaterThan(0);
+      expect(end - abortedAt).to.be.lessThan(10); // shouldn't wait for the blocked connection
 
       expect(result).to.be.instanceOf(DOMException);
     });
@@ -985,7 +985,7 @@ describe('AbortSignal support', () => {
     });
 
     it(`rejects command`, async () => {
-      let abortedAt: number;
+      let abortedAt = 0;
       client.on(
         'commandStarted',
         // Abort a bit after ping has started:
@@ -999,8 +999,8 @@ describe('AbortSignal support', () => {
 
       const result = await db.command({ ping: 1 }, { signal }).catch(error => error);
       const end = performance.now();
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      expect(end - abortedAt!).to.be.lessThan(10); // shouldn't wait for the blocked connection
+      expect(abortedAt, 'commandStarted handler did not fire').to.be.greaterThan(0);
+      expect(end - abortedAt).to.be.lessThan(10); // shouldn't wait for the blocked connection
 
       expect(result).to.be.instanceOf(DOMException);
     });


### PR DESCRIPTION
### Description

#### Summary of Changes

Fixes flaky `AbortSignal support` integration tests by measuring abort propagation latency instead of total operation time.

The assertions were checking `end - start` where `start` was captured before the operation began. Since `controller.abort()` only fires after `commandStarted` (which comes after server selection, connection checkout, and BSON encoding), the pre-abort overhead alone could exceed the timing threshold on a loaded CI machine.

Fix: capture `abortedAt = performance.now()` at the moment `controller.abort()` is called and assert `end - abortedAt < 10ms` - measuring only how fast the abort propagates, which is the property the tests actually verify.

Affected tests:
- `rejects findOne` (NODE-6833) - removes the 40ms workaround threshold, restores 10ms
- `rejects command` - same fix
- cursor "during connection read" `rejects <api>` (NODE-7028) - `find`, `listCollections`, `aggregate`

### Double check the following

- [x] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket