### PR TITLE
fix(NODE-7643): preserve $meta direction in [field, direction] sort pair

### DIFF
--- a/src/sort.ts
+++ b/src/sort.ts
@@ -81,7 +81,7 @@ function isReadonlyArray<T>(value: any): value is readonly T[] {
 
 /** @internal */
 function pairToMap(v: readonly [string, SortDirection]): SortForCmd {
-  return new Map([[`${v[0]}`, prepareDirection([v[1]])]]);
+  return new Map([[`${v[0]}`, prepareDirection(v[1])]]);
 }
 
 /** @internal */

--- a/test/unit/sort.test.ts
+++ b/test/unit/sort.test.ts
@@ -1,0 +1,21 @@
+import { expect } from 'chai';
+
+import { formatSort } from '../mongodb';
+
+describe('formatSort', function () {
+  context('when the sort is a [field, direction] pair', function () {
+    it('formats a numeric direction', function () {
+      expect(formatSort(['alpha', -1])).to.deep.equal(new Map([['alpha', -1]]));
+    });
+
+    it('formats a string direction', function () {
+      expect(formatSort(['alpha', 'asc'])).to.deep.equal(new Map([['alpha', 1]]));
+    });
+
+    it('preserves a $meta direction', function () {
+      expect(formatSort(['alpha', { $meta: 'textScore' }])).to.deep.equal(
+        new Map([['alpha', { $meta: 'textScore' }]])
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Description

Sorting by `$meta` is silently rejected in the `[field, direction]` pair form of `sort`. The documented, type-legal input

```js
cursor.sort(['score', { $meta: 'textScore' }])
```

which is the canonical way to sort full-text search results by relevance, throws:

```
MongoInvalidArgumentError: Invalid sort direction: [{"$meta":"textScore"}]
```

The equivalent object form `{ score: { $meta: 'textScore' } }` and the deep form `[['score', { $meta: 'textScore' }]]` both work, so the three shapes the API accepts behave inconsistently.

## Root cause

In `src/sort.ts`, `pairToMap` calls `prepareDirection([v[1]])`, wrapping the direction in an array, unlike every sibling converter which passes the raw value. A scalar direction coincidentally survives the array to string coercion (`[-1]` -> `"-1"`), but a `$meta` object does not (`isMeta` returns false for an array), so it is rejected.

This is a regression: `$meta`-in-pair support was added in #1808, and the #2573 sort refactor reintroduced the array wrapping.

## Fix

```diff
-  return new Map([[`${v[0]}`, prepareDirection([v[1]])]]);
+  return new Map([[`${v[0]}`, prepareDirection(v[1])]]);
```

## Test

Added `test/unit/sort.test.ts` (no `test/unit` file covered `formatSort` before). The `$meta` pair case fails unpatched with the error above and passes after; the scalar-direction pair cases pass throughout, showing the fix is scoped. Full `test/unit` suite stays green.
