### PR TITLE
fix(NODE-7659): key unordered bulk insertedIds by originating operation index

### DIFF
--- a/src/bulk/unordered.ts
+++ b/src/bulk/unordered.ts
@@ -97,7 +97,7 @@ export class UnorderedBulkOperation extends BulkOperationBase {
     if (batchType === BatchType.INSERT) {
       this.s.currentInsertBatch = this.s.currentBatch;
       this.s.bulkResult.insertedIds.push({
-        index: this.s.bulkResult.insertedIds.length,
+        index: this.s.currentIndex - 1,
         _id: (document as Document)._id
       });
     } else if (batchType === BatchType.UPDATE) {

--- a/test/unit/bulk.test.ts
+++ b/test/unit/bulk.test.ts
@@ -1,0 +1,63 @@
+import { expect } from 'chai';
+
+import {
+  DEFAULT_PK_FACTORY,
+  MongoDBCollectionNamespace,
+  OrderedBulkOperation,
+  UnorderedBulkOperation
+} from '../mongodb';
+
+describe('Bulk Operation insertedIds', function () {
+  function makeFakeCollection() {
+    const topology = {
+      lastHello() {
+        return { maxBsonObjectSize: 16 * 1024 * 1024, maxWriteBatchSize: 1000 };
+      },
+      s: { options: {} }
+    };
+    const collection: any = {
+      client: { topology },
+      topology,
+      db: { options: {} },
+      bsonOptions: {},
+      s: {
+        namespace: new MongoDBCollectionNamespace('test', 'coll'),
+        pkFactory: DEFAULT_PK_FACTORY,
+        bsonOptions: {},
+        collection: undefined
+      }
+    };
+    collection.s.collection = collection;
+    return collection;
+  }
+
+  function addMixedOperations(bulk: OrderedBulkOperation | UnorderedBulkOperation) {
+    bulk.raw({ insertOne: { document: { _id: 'a', x: 1 } } });
+    bulk.raw({ updateOne: { filter: { x: 1 }, update: { $set: { y: 2 } } } });
+    bulk.raw({ insertOne: { document: { _id: 'b', x: 3 } } });
+    bulk.raw({ deleteOne: { filter: { x: 3 } } });
+    bulk.raw({ insertOne: { document: { _id: 'c', x: 5 } } });
+  }
+
+  it('ordered bulk keys insertedIds by the originating operation index', function () {
+    const bulk = new OrderedBulkOperation(makeFakeCollection(), { ordered: true } as any);
+    addMixedOperations(bulk);
+    const insertedIds = (bulk as any).s.bulkResult.insertedIds;
+    expect(insertedIds).to.deep.equal([
+      { index: 0, _id: 'a' },
+      { index: 2, _id: 'b' },
+      { index: 4, _id: 'c' }
+    ]);
+  });
+
+  it('unordered bulk keys insertedIds by the originating operation index', function () {
+    const bulk = new UnorderedBulkOperation(makeFakeCollection(), { ordered: false } as any);
+    addMixedOperations(bulk);
+    const insertedIds = (bulk as any).s.bulkResult.insertedIds;
+    expect(insertedIds).to.deep.equal([
+      { index: 0, _id: 'a' },
+      { index: 2, _id: 'b' },
+      { index: 4, _id: 'c' }
+    ]);
+  });
+});


### PR DESCRIPTION
When a bulk write runs with `{ ordered: false }` and inserts are interleaved with
update or delete operations, `BulkWriteResult.insertedIds` used the wrong keys. The
unordered path recorded each inserted id at `index: insertedIds.length` (a count of
inserts seen so far) instead of the index of the originating operation in the user
supplied operations list.

The public property is documented as "hash key is the index of the originating
operation", and the ordered path already behaves that way. Write errors and upserts
in the same code path are also remapped to the original operation index, so the
unordered `insertedIds` index was the only place using a different index space.

Example: `bulkWrite([insert, update, insert, delete, insert], { ordered: false })`
returned insertedIds keyed 0, 1, 2 for the three inserts. The inserts originate at
operation positions 0, 2, 4, which is what the ordered path returns and what this
change now returns for unordered as well.

This also fixes `getSuccessfullyInsertedIds` for unordered results: it filters inserts
by comparing `insertedId.index` to `writeError.index`, and `writeError.index` is the
original operation index, so the two now live in the same index space.

Fix: record the id at `this.s.currentIndex - 1` (currentIndex is incremented before the
insert bookkeeping in the unordered path).

Adds a unit test that builds ordered and unordered bulk operations with a mixed
operation sequence and asserts both key insertedIds by the originating operation index.
No database required.
