### PR TITLE
test(NODE-7656): Skip time-sensitive CSOT tests opening change streams on 9.0+ sharded clusters

### DIFF
--- a/test/integration/client-side-operations-timeout/client_side_operations_timeout.spec.test.ts
+++ b/test/integration/client-side-operations-timeout/client_side_operations_timeout.spec.test.ts
@@ -38,9 +38,6 @@ describe('CSOT spec tests', function () {
   }
 
   runUnifiedSuite(specs, (test, configuration) => {
-    if (semver.satisfies(configuration.version, '>=9.0')) {
-      return 'TODO(NODE-7418): CSOT tests fail on server >=9.0, tracked in NODE-7418';
-    }
     const sessionCSOTTests = ['timeoutMS applied to withTransaction'];
     if (
       configuration.topologyType === 'LoadBalanced' &&
@@ -63,10 +60,5 @@ describe('CSOT modified spec tests', function () {
   const specs = loadSpecTests(
     join('..', 'integration', 'client-side-operations-timeout', 'unified-csot-node-specs')
   );
-  runUnifiedSuite(specs, (test, configuration) => {
-    if (semver.satisfies(configuration.version, '>=9.0')) {
-      return 'TODO(NODE-7418): CSOT tests fail on server >=9.0, tracked in NODE-7418';
-    }
-    return false;
-  });
+  runUnifiedSuite(specs, () => false);
 });

--- a/test/integration/client-side-operations-timeout/unified-csot-node-specs/change-streams.json
+++ b/test/integration/client-side-operations-timeout/unified-csot-node-specs/change-streams.json
@@ -54,6 +54,21 @@
   "tests": [
     {
       "description": "timeoutMS is refreshed for getMore if maxAwaitTimeMS is set",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.4",
+          "topologies": [
+            "replicaset"
+          ]
+        },
+        {
+          "minServerVersion": "4.4",
+          "maxServerVersion": "8.99",
+          "topologies": [
+            "sharded"
+          ]
+        }
+      ],
       "operations": [
         {
           "name": "failPoint",

--- a/test/spec/client-side-operations-timeout/change-streams.json
+++ b/test/spec/client-side-operations-timeout/change-streams.json
@@ -405,6 +405,21 @@
     },
     {
       "description": "change stream can be iterated again if previous iteration times out",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.4",
+          "topologies": [
+            "replicaset"
+          ]
+        },
+        {
+          "minServerVersion": "4.4",
+          "maxServerVersion": "8.99",
+          "topologies": [
+            "sharded"
+          ]
+        }
+      ],
       "operations": [
         {
           "name": "createChangeStream",

--- a/test/spec/client-side-operations-timeout/change-streams.yml
+++ b/test/spec/client-side-operations-timeout/change-streams.yml
@@ -226,6 +226,13 @@ tests:
                 maxTimeMS: { $$type: ["int", "long"] }
 
   - description: "change stream can be iterated again if previous iteration times out"
+    runOnRequirements:
+      - minServerVersion: "4.4"
+        topologies: ["replicaset"]
+      - minServerVersion: "4.4"
+        maxServerVersion: "8.99" # Skip sharded 9.0+ due to reasons noted in DRIVERS-3556.
+        # Removing the skip may be desired in the future if this test migrates from timeoutMS to maxTimeMS. See DRIVERS-3556 for a suggested approach: add a unified test runner option to advance the config server's cluster time immediately before opening a change stream. Otherwise, existing tests using maxTimeMS < periodicNoopIntervalSecs on 9.0+ sharded clusters may unexpectedly fail with server timeouts.
+        topologies: ["sharded"]
     operations:
       - name: createChangeStream
         object: *collection

--- a/test/spec/client-side-operations-timeout/override-collection-timeoutMS.json
+++ b/test/spec/client-side-operations-timeout/override-collection-timeoutMS.json
@@ -1303,6 +1303,21 @@
     },
     {
       "description": "timeoutMS can be configured on a MongoCollection - createChangeStream on collection",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.4",
+          "topologies": [
+            "replicaset"
+          ]
+        },
+        {
+          "minServerVersion": "4.4",
+          "maxServerVersion": "8.99",
+          "topologies": [
+            "sharded"
+          ]
+        }
+      ],
       "operations": [
         {
           "name": "createEntities",

--- a/test/spec/client-side-operations-timeout/override-collection-timeoutMS.yml
+++ b/test/spec/client-side-operations-timeout/override-collection-timeoutMS.yml
@@ -717,6 +717,13 @@ tests:
                 listIndexes: *collectionName
                 maxTimeMS: { $$exists: false }
   - description: "timeoutMS can be configured on a MongoCollection - createChangeStream on collection"
+    runOnRequirements:
+    - minServerVersion: "4.4"
+      topologies: ["replicaset"]
+    - minServerVersion: "4.4"
+      maxServerVersion: "8.99" # Skip sharded 9.0+ due to reasons noted in DRIVERS-3556.
+      # Removing the skip may be desired in the future if this test migrates from timeoutMS to maxTimeMS. See DRIVERS-3556 for a suggested approach: add a unified test runner option to advance the config server's cluster time immediately before opening a change stream. Otherwise, existing tests using maxTimeMS < periodicNoopIntervalSecs on 9.0+ sharded clusters may unexpectedly fail with server timeouts.
+      topologies: ["sharded"]
     operations:
       - name: createEntities
         object: testRunner

--- a/test/spec/client-side-operations-timeout/override-database-timeoutMS.json
+++ b/test/spec/client-side-operations-timeout/override-database-timeoutMS.json
@@ -683,6 +683,21 @@
     },
     {
       "description": "timeoutMS can be configured on a MongoDatabase - createChangeStream on database",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.4",
+          "topologies": [
+            "replicaset"
+          ]
+        },
+        {
+          "minServerVersion": "4.4",
+          "maxServerVersion": "8.99",
+          "topologies": [
+            "sharded"
+          ]
+        }
+      ],
       "operations": [
         {
           "name": "createEntities",
@@ -2217,6 +2232,21 @@
     },
     {
       "description": "timeoutMS can be configured on a MongoDatabase - createChangeStream on collection",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.4",
+          "topologies": [
+            "replicaset"
+          ]
+        },
+        {
+          "minServerVersion": "4.4",
+          "maxServerVersion": "8.99",
+          "topologies": [
+            "sharded"
+          ]
+        }
+      ],
       "operations": [
         {
           "name": "createEntities",

--- a/test/spec/client-side-operations-timeout/override-database-timeoutMS.yml
+++ b/test/spec/client-side-operations-timeout/override-database-timeoutMS.yml
@@ -377,6 +377,13 @@ tests:
                 ping: 1
                 maxTimeMS: { $$exists: false }
   - description: "timeoutMS can be configured on a MongoDatabase - createChangeStream on database"
+    runOnRequirements:
+    - minServerVersion: "4.4"
+      topologies: ["replicaset"]
+    - minServerVersion: "4.4"
+      maxServerVersion: "8.99" # Skip sharded 9.0+ due to reasons noted in DRIVERS-3556.
+      # Removing the skip may be desired in the future if this test migrates from timeoutMS to maxTimeMS. See DRIVERS-3556 for a suggested approach: add a unified test runner option to advance the config server's cluster time immediately before opening a change stream. Otherwise, existing tests using maxTimeMS < periodicNoopIntervalSecs on 9.0+ sharded clusters may unexpectedly fail with server timeouts.
+      topologies: ["sharded"]
     operations:
       - name: createEntities
         object: testRunner
@@ -1207,6 +1214,13 @@ tests:
                 listIndexes: *collectionName
                 maxTimeMS: { $$exists: false }
   - description: "timeoutMS can be configured on a MongoDatabase - createChangeStream on collection"
+    runOnRequirements:
+    - minServerVersion: "4.4"
+      topologies: ["replicaset"]
+    - minServerVersion: "4.4"
+      maxServerVersion: "8.99" # Skip sharded 9.0+ due to reasons noted in DRIVERS-3556.
+      # Removing the skip may be desired in the future if this test migrates from timeoutMS to maxTimeMS. See DRIVERS-3556 for a suggested approach: add a unified test runner option to advance the config server's cluster time immediately before opening a change stream. Otherwise, existing tests using maxTimeMS < periodicNoopIntervalSecs on 9.0+ sharded clusters may unexpectedly fail with server timeouts.
+      topologies: ["sharded"]
     operations:
       - name: createEntities
         object: testRunner

--- a/test/spec/client-side-operations-timeout/override-operation-timeoutMS.json
+++ b/test/spec/client-side-operations-timeout/override-operation-timeoutMS.json
@@ -269,6 +269,21 @@
     },
     {
       "description": "timeoutMS can be configured for an operation - createChangeStream on client",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.4",
+          "topologies": [
+            "replicaset"
+          ]
+        },
+        {
+          "minServerVersion": "4.4",
+          "maxServerVersion": "8.99",
+          "topologies": [
+            "sharded"
+          ]
+        }
+      ],
       "operations": [
         {
           "name": "failPoint",
@@ -824,6 +839,21 @@
     },
     {
       "description": "timeoutMS can be configured for an operation - createChangeStream on database",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.4",
+          "topologies": [
+            "replicaset"
+          ]
+        },
+        {
+          "minServerVersion": "4.4",
+          "maxServerVersion": "8.99",
+          "topologies": [
+            "sharded"
+          ]
+        }
+      ],
       "operations": [
         {
           "name": "failPoint",
@@ -1890,6 +1920,21 @@
     },
     {
       "description": "timeoutMS can be configured for an operation - createChangeStream on collection",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.4",
+          "topologies": [
+            "replicaset"
+          ]
+        },
+        {
+          "minServerVersion": "4.4",
+          "maxServerVersion": "8.99",
+          "topologies": [
+            "sharded"
+          ]
+        }
+      ],
       "operations": [
         {
           "name": "failPoint",

--- a/test/spec/client-side-operations-timeout/override-operation-timeoutMS.yml
+++ b/test/spec/client-side-operations-timeout/override-operation-timeoutMS.yml
@@ -160,6 +160,13 @@ tests:
                 listDatabases: 1
                 maxTimeMS: { $$exists: false }
   - description: "timeoutMS can be configured for an operation - createChangeStream on client"
+    runOnRequirements:
+    - minServerVersion: "4.4"
+      topologies: ["replicaset"]
+    - minServerVersion: "4.4"
+      maxServerVersion: "8.99" # Skip sharded 9.0+ due to reasons noted in DRIVERS-3556.
+      # Removing the skip may be desired in the future if this test migrates from timeoutMS to maxTimeMS. See DRIVERS-3556 for a suggested approach: add a unified test runner option to advance the config server's cluster time immediately before opening a change stream. Otherwise, existing tests using maxTimeMS < periodicNoopIntervalSecs on 9.0+ sharded clusters may unexpectedly fail with server timeouts.
+      topologies: ["sharded"]
     operations:
       - name: failPoint
         object: testRunner
@@ -452,6 +459,13 @@ tests:
                 ping: 1
                 maxTimeMS: { $$exists: false }
   - description: "timeoutMS can be configured for an operation - createChangeStream on database"
+    runOnRequirements:
+    - minServerVersion: "4.4"
+      topologies: ["replicaset"]
+    - minServerVersion: "4.4"
+      maxServerVersion: "8.99" # Skip sharded 9.0+ due to reasons noted in DRIVERS-3556.
+      # Removing the skip may be desired in the future if this test migrates from timeoutMS to maxTimeMS. See DRIVERS-3556 for a suggested approach: add a unified test runner option to advance the config server's cluster time immediately before opening a change stream. Otherwise, existing tests using maxTimeMS < periodicNoopIntervalSecs on 9.0+ sharded clusters may unexpectedly fail with server timeouts.
+      topologies: ["sharded"]
     operations:
       - name: failPoint
         object: testRunner
@@ -1028,6 +1042,13 @@ tests:
                 listIndexes: *collectionName
                 maxTimeMS: { $$exists: false }
   - description: "timeoutMS can be configured for an operation - createChangeStream on collection"
+    runOnRequirements:
+    - minServerVersion: "4.4"
+      topologies: ["replicaset"]
+    - minServerVersion: "4.4"
+      maxServerVersion: "8.99" # Skip sharded 9.0+ due to reasons noted in DRIVERS-3556.
+      # Removing the skip may be desired in the future if this test migrates from timeoutMS to maxTimeMS. See DRIVERS-3556 for a suggested approach: add a unified test runner option to advance the config server's cluster time immediately before opening a change stream. Otherwise, existing tests using maxTimeMS < periodicNoopIntervalSecs on 9.0+ sharded clusters may unexpectedly fail with server timeouts.
+      topologies: ["sharded"]
     operations:
       - name: failPoint
         object: testRunner

--- a/test/spec/client-side-operations-timeout/retryability-legacy-timeouts.json
+++ b/test/spec/client-side-operations-timeout/retryability-legacy-timeouts.json
@@ -1398,6 +1398,21 @@
     },
     {
       "description": "operation succeeds after one socket timeout - createChangeStream on client",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.4",
+          "topologies": [
+            "replicaset"
+          ]
+        },
+        {
+          "minServerVersion": "4.4",
+          "maxServerVersion": "8.99",
+          "topologies": [
+            "sharded"
+          ]
+        }
+      ],
       "operations": [
         {
           "name": "failPoint",
@@ -1880,6 +1895,21 @@
     },
     {
       "description": "operation succeeds after one socket timeout - createChangeStream on database",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.4",
+          "topologies": [
+            "replicaset"
+          ]
+        },
+        {
+          "minServerVersion": "4.4",
+          "maxServerVersion": "8.99",
+          "topologies": [
+            "sharded"
+          ]
+        }
+      ],
       "operations": [
         {
           "name": "failPoint",
@@ -2923,6 +2953,21 @@
     },
     {
       "description": "operation succeeds after one socket timeout - createChangeStream on collection",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.4",
+          "topologies": [
+            "replicaset"
+          ]
+        },
+        {
+          "minServerVersion": "4.4",
+          "maxServerVersion": "8.99",
+          "topologies": [
+            "sharded"
+          ]
+        }
+      ],
       "operations": [
         {
           "name": "failPoint",

--- a/test/spec/client-side-operations-timeout/retryability-legacy-timeouts.yml
+++ b/test/spec/client-side-operations-timeout/retryability-legacy-timeouts.yml
@@ -770,6 +770,13 @@ tests:
               command:
                 listDatabases: 1
   - description: "operation succeeds after one socket timeout - createChangeStream on client"
+    runOnRequirements:
+      - minServerVersion: "4.4"
+        topologies: ["replicaset"]
+      - minServerVersion: "4.4"
+        maxServerVersion: "8.99" # Skip sharded 9.0+ due to reasons noted in DRIVERS-3556.
+        # Removing the skip may be desired in the future if this test migrates from timeoutMS to maxTimeMS. See DRIVERS-3556 for a suggested approach: add a unified test runner option to advance the config server's cluster time immediately before opening a change stream. Otherwise, existing tests using maxTimeMS < periodicNoopIntervalSecs on 9.0+ sharded clusters may unexpectedly fail with server timeouts.
+        topologies: ["sharded"]
     operations:
       - name: failPoint
         object: testRunner
@@ -1030,6 +1037,13 @@ tests:
               command:
                 listCollections: 1
   - description: "operation succeeds after one socket timeout - createChangeStream on database"
+    runOnRequirements:
+      - minServerVersion: "4.4"
+        topologies: ["replicaset"]
+      - minServerVersion: "4.4"
+        maxServerVersion: "8.99" # Skip sharded 9.0+ due to reasons noted in DRIVERS-3556.
+        # Removing the skip may be desired in the future if this test migrates from timeoutMS to maxTimeMS. See DRIVERS-3556 for a suggested approach: add a unified test runner option to advance the config server's cluster time immediately before opening a change stream. Otherwise, existing tests using maxTimeMS < periodicNoopIntervalSecs on 9.0+ sharded clusters may unexpectedly fail with server timeouts.
+        topologies: ["sharded"]
     operations:
       - name: failPoint
         object: testRunner
@@ -1609,6 +1623,13 @@ tests:
               command:
                 listIndexes: *collectionName
   - description: "operation succeeds after one socket timeout - createChangeStream on collection"
+    runOnRequirements:
+      - minServerVersion: "4.4"
+        topologies: ["replicaset"]
+      - minServerVersion: "4.4"
+        maxServerVersion: "8.99" # Skip sharded 9.0+ due to reasons noted in DRIVERS-3556.
+        # Removing the skip may be desired in the future if this test migrates from timeoutMS to maxTimeMS. See DRIVERS-3556 for a suggested approach: add a unified test runner option to advance the config server's cluster time immediately before opening a change stream. Otherwise, existing tests using maxTimeMS < periodicNoopIntervalSecs on 9.0+ sharded clusters may unexpectedly fail with server timeouts.
+        topologies: ["sharded"]
     operations:
       - name: failPoint
         object: testRunner

--- a/test/spec/client-side-operations-timeout/retryability-timeoutMS.json
+++ b/test/spec/client-side-operations-timeout/retryability-timeoutMS.json
@@ -2626,7 +2626,17 @@
       "description": "operation is retried multiple times for non-zero timeoutMS - createChangeStream on client",
       "runOnRequirements": [
         {
-          "minServerVersion": "4.3.1"
+          "minServerVersion": "4.3.1",
+          "topologies": [
+            "replicaset"
+          ]
+        },
+        {
+          "minServerVersion": "4.3.1",
+          "maxServerVersion": "8.99",
+          "topologies": [
+            "sharded"
+          ]
         }
       ],
       "operations": [
@@ -3531,7 +3541,17 @@
       "description": "operation is retried multiple times for non-zero timeoutMS - createChangeStream on database",
       "runOnRequirements": [
         {
-          "minServerVersion": "4.3.1"
+          "minServerVersion": "4.3.1",
+          "topologies": [
+            "replicaset"
+          ]
+        },
+        {
+          "minServerVersion": "4.3.1",
+          "maxServerVersion": "8.99",
+          "topologies": [
+            "sharded"
+          ]
         }
       ],
       "operations": [
@@ -5513,7 +5533,17 @@
       "description": "operation is retried multiple times for non-zero timeoutMS - createChangeStream on collection",
       "runOnRequirements": [
         {
-          "minServerVersion": "4.3.1"
+          "minServerVersion": "4.3.1",
+          "topologies": [
+            "replicaset"
+          ]
+        },
+        {
+          "minServerVersion": "4.3.1",
+          "maxServerVersion": "8.99",
+          "topologies": [
+            "sharded"
+          ]
         }
       ],
       "operations": [

--- a/test/spec/client-side-operations-timeout/retryability-timeoutMS.yml
+++ b/test/spec/client-side-operations-timeout/retryability-timeoutMS.yml
@@ -1315,6 +1315,11 @@ tests:
   - description: "operation is retried multiple times for non-zero timeoutMS - createChangeStream on client"
     runOnRequirements:
       - minServerVersion: "4.3.1" # failCommand errorLabels option
+        topologies: ["replicaset"]
+      - minServerVersion: "4.3.1" # failCommand errorLabels option
+        maxServerVersion: "8.99" # Skip sharded 9.0+ due to reasons noted in DRIVERS-3556.
+        # Removing the skip may be desired in the future if this test migrates from timeoutMS to maxTimeMS. See DRIVERS-3556 for a suggested approach: add a unified test runner option to advance the config server's cluster time immediately before opening a change stream. Otherwise, existing tests using maxTimeMS < periodicNoopIntervalSecs on 9.0+ sharded clusters may unexpectedly fail with server timeouts.
+        topologies: ["sharded"]
     operations:
       - name: failPoint
         object: testRunner
@@ -1755,6 +1760,11 @@ tests:
   - description: "operation is retried multiple times for non-zero timeoutMS - createChangeStream on database"
     runOnRequirements:
       - minServerVersion: "4.3.1" # failCommand errorLabels option
+        topologies: ["replicaset"]
+      - minServerVersion: "4.3.1" # failCommand errorLabels option
+        maxServerVersion: "8.99" # Skip sharded 9.0+ due to reasons noted in DRIVERS-3556.
+        # Removing the skip may be desired in the future if this test migrates from timeoutMS to maxTimeMS. See DRIVERS-3556 for a suggested approach: add a unified test runner option to advance the config server's cluster time immediately before opening a change stream. Otherwise, existing tests using maxTimeMS < periodicNoopIntervalSecs on 9.0+ sharded clusters may unexpectedly fail with server timeouts.
+        topologies: ["sharded"]
     operations:
       - name: failPoint
         object: testRunner
@@ -2740,6 +2750,11 @@ tests:
   - description: "operation is retried multiple times for non-zero timeoutMS - createChangeStream on collection"
     runOnRequirements:
       - minServerVersion: "4.3.1" # failCommand errorLabels option
+        topologies: ["replicaset"]
+      - minServerVersion: "4.3.1" # failCommand errorLabels option
+        maxServerVersion: "8.99" # Skip sharded 9.0+ due to reasons noted in DRIVERS-3556.
+        # Removing the skip may be desired in the future if this test migrates from timeoutMS to maxTimeMS. See DRIVERS-3556 for a suggested approach: add a unified test runner option to advance the config server's cluster time immediately before opening a change stream. Otherwise, existing tests using maxTimeMS < periodicNoopIntervalSecs on 9.0+ sharded clusters may unexpectedly fail with server timeouts.
+        topologies: ["sharded"]
     operations:
       - name: failPoint
         object: testRunner


### PR DESCRIPTION
### Description

#### Summary of Changes

Skip CSOT tests against 9.0+ server.

### Double check the following

- [ ] Lint is passing (`npm run check:lint`)
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
