### PR TITLE
test(NODE-7509): add integration tests for Secure Frontend Processor

### DIFF
--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -695,6 +695,21 @@ functions:
         args:
           - ${PROJECT_DIRECTORY}/.evergreen/run-x509-tests.sh
 
+  "run sfp tests":
+    - command: subprocess.exec
+      type: test
+      params:
+        working_dir: "src"
+        include_expansions_in_env:
+          - AWS_ACCESS_KEY_ID
+          - AWS_SECRET_ACCESS_KEY
+          - AWS_SESSION_TOKEN
+          - PROJECT_DIRECTORY
+          - DRIVERS_TOOLS
+        binary: bash
+        args:
+          - ${PROJECT_DIRECTORY}/.evergreen/run-sfp-tests.sh
+
   install mongodb-client-encryption from source:
     - command: subprocess.exec
       type: setup

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1424,7 +1424,6 @@ tasks:
   - name: test-sfp
     tags:
       - latest
-      - auth
       - sfp
     commands:
       - func: install dependencies
@@ -3787,6 +3786,7 @@ buildvariants:
       - test-4.2-replica_set
       - test-4.2-sharded_cluster
       - test-latest-server-v1-api
+      - test-sfp
       - test-socks5
       - test-socks5-tls
       - test-snappy-compression
@@ -3831,6 +3831,7 @@ buildvariants:
       - test-4.2-replica_set
       - test-4.2-sharded_cluster
       - test-latest-server-v1-api
+      - test-sfp
       - test-socks5
       - test-socks5-tls
       - test-snappy-compression
@@ -3875,6 +3876,7 @@ buildvariants:
       - test-4.2-replica_set
       - test-4.2-sharded_cluster
       - test-latest-server-v1-api
+      - test-sfp
       - test-socks5
       - test-socks5-tls
       - test-snappy-compression
@@ -3919,6 +3921,7 @@ buildvariants:
       - test-4.2-replica_set
       - test-4.2-sharded_cluster
       - test-latest-server-v1-api
+      - test-sfp
       - test-socks5-tls
       - test-snappy-compression
       - test-zstd-compression
@@ -4103,7 +4106,6 @@ buildvariants:
       - test-rapid-sharded_cluster
       - test-latest-server-v1-api
       - test-x509-authentication
-      - test-sfp
       - test-atlas-connectivity
       - test-auth-ldap
       - test-socks5-csfle
@@ -4130,7 +4132,6 @@ buildvariants:
       - test-rapid-sharded_cluster
       - test-latest-server-v1-api
       - test-x509-authentication
-      - test-sfp
       - test-atlas-connectivity
       - test-auth-ldap
       - test-socks5-csfle

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -629,6 +629,20 @@ functions:
         binary: bash
         args:
           - ${PROJECT_DIRECTORY}/.evergreen/run-x509-tests.sh
+  run sfp tests:
+    - command: subprocess.exec
+      type: test
+      params:
+        working_dir: src
+        include_expansions_in_env:
+          - AWS_ACCESS_KEY_ID
+          - AWS_SECRET_ACCESS_KEY
+          - AWS_SESSION_TOKEN
+          - PROJECT_DIRECTORY
+          - DRIVERS_TOOLS
+        binary: bash
+        args:
+          - ${PROJECT_DIRECTORY}/.evergreen/run-sfp-tests.sh
   install mongodb-client-encryption from source:
     - command: subprocess.exec
       type: setup
@@ -1407,6 +1421,15 @@ tasks:
       - func: install dependencies
       - func: assume secrets manager role
       - func: run x509 auth tests
+  - name: test-sfp
+    tags:
+      - latest
+      - auth
+      - sfp
+    commands:
+      - func: install dependencies
+      - func: assume secrets manager role
+      - func: run sfp tests
   - name: test-atlas-connectivity
     tags:
       - atlas-connect
@@ -3542,6 +3565,7 @@ buildvariants:
       - test-4.2-sharded_cluster
       - test-latest-server-v1-api
       - test-x509-authentication
+      - test-sfp
       - test-atlas-connectivity
       - test-5.0-load-balanced
       - test-6.0-load-balanced
@@ -3597,6 +3621,7 @@ buildvariants:
       - test-4.2-sharded_cluster
       - test-latest-server-v1-api
       - test-x509-authentication
+      - test-sfp
       - test-atlas-connectivity
       - test-5.0-load-balanced
       - test-6.0-load-balanced
@@ -3652,6 +3677,7 @@ buildvariants:
       - test-4.2-sharded_cluster
       - test-latest-server-v1-api
       - test-x509-authentication
+      - test-sfp
       - test-atlas-connectivity
       - test-5.0-load-balanced
       - test-6.0-load-balanced
@@ -3707,6 +3733,7 @@ buildvariants:
       - test-4.2-sharded_cluster
       - test-latest-server-v1-api
       - test-x509-authentication
+      - test-sfp
       - test-atlas-connectivity
       - test-5.0-load-balanced
       - test-6.0-load-balanced
@@ -4076,6 +4103,7 @@ buildvariants:
       - test-rapid-sharded_cluster
       - test-latest-server-v1-api
       - test-x509-authentication
+      - test-sfp
       - test-atlas-connectivity
       - test-auth-ldap
       - test-socks5-csfle
@@ -4102,6 +4130,7 @@ buildvariants:
       - test-rapid-sharded_cluster
       - test-latest-server-v1-api
       - test-x509-authentication
+      - test-sfp
       - test-atlas-connectivity
       - test-auth-ldap
       - test-socks5-csfle

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -149,6 +149,16 @@ BASE_TASKS.push({
   ]
 });
 
+BASE_TASKS.push({
+  name: `test-sfp`,
+  tags: ['latest', 'auth', 'sfp'],
+  commands: [
+    { func: 'install dependencies' },
+    { func: 'assume secrets manager role' },
+    { func: 'run sfp tests' }
+  ]
+});
+
 // manually added tasks
 TASKS.push(
   ...[
@@ -824,6 +834,7 @@ const commonNodelessTasks = [
   'test-rapid-sharded_cluster',
   'test-latest-server-v1-api',
   'test-x509-authentication',
+  'test-sfp',
   'test-atlas-connectivity',
   'test-auth-ldap',
   'test-socks5-csfle',

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -150,8 +150,10 @@ BASE_TASKS.push({
 });
 
 BASE_TASKS.push({
+  // No `auth` tag: that tag would exclude this task from the Windows variants (WINDOWS_SKIP_TAGS),
+  // but SFP is a transparent proxy we want to exercise on Windows too.
   name: `test-sfp`,
-  tags: ['latest', 'auth', 'sfp'],
+  tags: ['latest', 'sfp'],
   commands: [
     { func: 'install dependencies' },
     { func: 'assume secrets manager role' },
@@ -834,7 +836,6 @@ const commonNodelessTasks = [
   'test-rapid-sharded_cluster',
   'test-latest-server-v1-api',
   'test-x509-authentication',
-  'test-sfp',
   'test-atlas-connectivity',
   'test-auth-ldap',
   'test-socks5-csfle',

--- a/.evergreen/run-sfp-tests.sh
+++ b/.evergreen/run-sfp-tests.sh
@@ -8,12 +8,10 @@ set -o errexit
 bash ${DRIVERS_TOOLS}/.evergreen/secrets_handling/setup-secrets.sh drivers/sfp
 source secrets-export.sh
 
-# The X.509 client certificate is stored base64-encoded; decode it to a PEM file and point
-# SFP_ATLAS_X509_CERT at that path (the tests read the path from this variable).
-if [ -n "${SFP_ATLAS_X509_CERT_BASE64:-}" ]; then
-  echo "${SFP_ATLAS_X509_CERT_BASE64}" | base64 --decode >sfp-x509-cert.pem
-  export SFP_ATLAS_X509_CERT="$PWD/sfp-x509-cert.pem"
-fi
+# The X.509 client certificate is stored base64-encoded as SFP_ATLAS_X509_BASE64; decode it to a
+# PEM file and point SFP_ATLAS_X509_CERT at that path (the tests read the path from this variable).
+echo "${SFP_ATLAS_X509_BASE64}" | base64 --decode >sfp-x509-cert.pem
+export SFP_ATLAS_X509_CERT="$PWD/sfp-x509-cert.pem"
 
 export SFP_ATLAS_URI
 export SFP_ATLAS_USER

--- a/.evergreen/run-sfp-tests.sh
+++ b/.evergreen/run-sfp-tests.sh
@@ -10,8 +10,10 @@ source secrets-export.sh
 
 # The X.509 client certificate is stored base64-encoded as SFP_ATLAS_X509_BASE64; decode it to a
 # PEM file and point SFP_ATLAS_X509_CERT at that path (the tests read the path from this variable).
+# Use a relative path: a cygwin-style absolute $PWD (/cygdrive/c/...) is not resolvable by native
+# Windows Node, whereas a relative path resolves against the process cwd (src) on all platforms.
 echo "${SFP_ATLAS_X509_BASE64}" | base64 --decode >sfp-x509-cert.pem
-export SFP_ATLAS_X509_CERT="$PWD/sfp-x509-cert.pem"
+export SFP_ATLAS_X509_CERT="sfp-x509-cert.pem"
 
 export SFP_ATLAS_URI
 export SFP_ATLAS_USER

--- a/.evergreen/run-sfp-tests.sh
+++ b/.evergreen/run-sfp-tests.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+source $DRIVERS_TOOLS/.evergreen/init-node-and-npm-env.sh
+
+set -o errexit
+
+# Pull the SFP connection URIs and credentials from AWS Secrets Manager (drivers/sfp).
+bash ${DRIVERS_TOOLS}/.evergreen/secrets_handling/setup-secrets.sh drivers/sfp
+source secrets-export.sh
+
+# The X.509 client certificate is stored base64-encoded; decode it to a PEM file and point
+# SFP_ATLAS_X509_CERT at that path (the tests read the path from this variable).
+if [ -n "${SFP_ATLAS_X509_CERT_BASE64:-}" ]; then
+  echo "${SFP_ATLAS_X509_CERT_BASE64}" | base64 --decode >sfp-x509-cert.pem
+  export SFP_ATLAS_X509_CERT="$PWD/sfp-x509-cert.pem"
+fi
+
+export SFP_ATLAS_URI
+export SFP_ATLAS_USER
+export SFP_ATLAS_PASSWORD
+export SFP_ATLAS_X509_URI
+export SFP_ATLAS_X509_CERT
+
+npm run check:sfp

--- a/package.json
+++ b/package.json
@@ -157,6 +157,7 @@
     "check:csfle": "npm run build:bundle && nyc mocha --config test/mocha_mongodb.js test/integration/client-side-encryption",
     "check:snappy": "npm run build:bundle && nyc mocha test/unit/assorted/snappy.test.js",
     "check:x509": "npm run build:bundle && nyc mocha test/manual/x509_auth.test.ts",
+    "check:sfp": "npm run build:bundle && nyc mocha test/manual/sfp.test.ts",
     "mocha:debug": "npm run build:bundle && node --inspect --enable-source-maps --no-experimental-strip-types ./node_modules/mocha/bin/mocha.js",
     "build:bundle": "npm run bundle:driver && npm run bundle:types && npm run build:runtime-barrel",
     "build:runtime-barrel": "node etc/build-runtime-barrel.mjs",

--- a/test/manual/sfp.test.ts
+++ b/test/manual/sfp.test.ts
@@ -126,7 +126,7 @@ describe('Atlas Secure Frontend Processor (SFP)', function () {
       authMechanism: 'SCRAM-SHA-256'
     });
     try {
-      await cleanup.db('test').collection(collectionName).drop();
+      await cleanup.db('db').collection(collectionName).drop();
     } finally {
       await cleanup.close();
     }

--- a/test/manual/sfp.test.ts
+++ b/test/manual/sfp.test.ts
@@ -121,14 +121,22 @@ describe('Atlas Secure Frontend Processor (SFP)', function () {
   });
 
   after(async function () {
-    const cleanup = new MongoClient(required('SFP_ATLAS_URI'), {
+    // Both auth flows write to the same collection name, but the SCRAM and X.509 tests connect
+    // through different SFP endpoints, so drop the collection against each of them.
+    const scram = new MongoClient(required('SFP_ATLAS_URI'), {
       auth: { username: required('SFP_ATLAS_USER'), password: required('SFP_ATLAS_PASSWORD') },
       authMechanism: 'SCRAM-SHA-256'
     });
+    const x509 = new MongoClient(required('SFP_ATLAS_X509_URI'), {
+      tlsCertificateKeyFile: required('SFP_ATLAS_X509_CERT'),
+      authMechanism: 'MONGODB-X509'
+    });
     try {
-      await cleanup.db('db').collection(collectionName).drop();
+      await scram.db('db').collection(collectionName).drop();
+      await x509.db('db').collection(collectionName).drop();
     } finally {
-      await cleanup.close();
+      await scram.close();
+      await x509.close();
     }
   });
 });

--- a/test/manual/sfp.test.ts
+++ b/test/manual/sfp.test.ts
@@ -1,0 +1,134 @@
+import { expect } from 'chai';
+import * as process from 'process';
+
+import {
+  MongoClient,
+  type MongoClient as MongoClientType,
+  type MongoClientOptions,
+  ObjectId
+} from '../mongodb';
+
+/**
+ * Atlas Secure Frontend Processor (SFP) testing.
+ *
+ * See specifications/source/atlas-sfp-testing/atlas-sfp-testing.md.
+ *
+ * The SFP is a transparent proxy that sits in front of preconfigured Atlas clusters.  These tests
+ * verify connectivity and authentication (unauthenticated, SCRAM-SHA-256, X.509) through the proxy.
+ * Connection URIs and credentials are provided via environment variables.
+ */
+
+function required(name: string): string {
+  const value = process.env[name];
+  if (value == null || value === '') {
+    throw new Error(`Missing required environment variable ${name}`);
+  }
+  return value;
+}
+
+describe('Atlas Secure Frontend Processor (SFP)', function () {
+  // A unique collection name per test run, dropped in the after hook (spec: Test Isolation).
+  const collectionName = `sfp_test_${new ObjectId().toString()}`;
+  let client: MongoClient;
+
+  this.timeout(60000);
+
+  afterEach(async function () {
+    await client?.close();
+  });
+
+  async function assertPing(client: MongoClientType) {
+    const result = await client.db('admin').command({ ping: 1 });
+    expect(result).to.have.property('ok', 1);
+  }
+
+  async function assertConnectionStatus(
+    client: MongoClientType,
+    { authenticated }: { authenticated: boolean }
+  ) {
+    const result = await client.db('admin').command({ connectionStatus: 1 });
+    expect(result).to.have.property('ok', 1);
+    const authenticatedUsers = result.authInfo?.authenticatedUsers ?? [];
+    if (authenticated) {
+      expect(authenticatedUsers).to.have.length.of.at.least(1);
+    } else {
+      expect(authenticatedUsers).to.have.lengthOf(0);
+    }
+  }
+
+  async function assertCRUD(client: MongoClientType) {
+    const collection = client.db('db').collection(collectionName);
+    const _id = new ObjectId();
+    const { insertedId } = await collection.insertOne({ _id });
+    expect(insertedId).to.deep.equal(_id);
+
+    const found = await collection.findOne({ _id });
+    expect(found).to.deep.equal({ _id });
+  }
+
+  context('when unauthenticated', function () {
+    it('pings and reports no authenticated users', async function () {
+      client = new MongoClient(required('SFP_ATLAS_URI'));
+      await client.connect();
+
+      await assertPing(client);
+      await assertConnectionStatus(client, { authenticated: false });
+    });
+  });
+
+  // Each authenticated test runs under three variations: baseline, with a compressor, and with
+  // Server API version 1.
+  const variations: Array<{ name: string; options: MongoClientOptions }> = [
+    { name: 'baseline', options: {} },
+    // zlib is built into Node, so it needs no optional native addon (unlike zstd/snappy).
+    { name: 'with zlib compression', options: { compressors: ['zlib'] } },
+    { name: 'with Server API v1', options: { serverApi: { version: '1' } } }
+  ];
+
+  context('when authenticating with SCRAM-SHA-256', function () {
+    for (const { name, options } of variations) {
+      it(`succeeds ${name}`, async function () {
+        const uri = required('SFP_ATLAS_URI');
+        client = new MongoClient(uri, {
+          auth: { username: required('SFP_ATLAS_USER'), password: required('SFP_ATLAS_PASSWORD') },
+          authMechanism: 'SCRAM-SHA-256',
+          ...options
+        });
+        await client.connect();
+
+        await assertPing(client);
+        await assertConnectionStatus(client, { authenticated: true });
+        await assertCRUD(client);
+      });
+    }
+  });
+
+  context('when authenticating with X.509', function () {
+    for (const { name, options } of variations) {
+      it(`succeeds ${name}`, async function () {
+        client = new MongoClient(required('SFP_ATLAS_X509_URI'), {
+          tlsCertificateKeyFile: required('SFP_ATLAS_X509_CERT'),
+          authMechanism: 'MONGODB-X509',
+          ...options
+        });
+        await client.connect();
+
+        await assertPing(client);
+        await assertConnectionStatus(client, { authenticated: true });
+        await assertCRUD(client);
+      });
+    }
+  });
+
+  after(async function () {
+    const cleanup = new MongoClient(required('SFP_ATLAS_URI'), {
+      auth: { username: required('SFP_ATLAS_USER'), password: required('SFP_ATLAS_PASSWORD') },
+      authMechanism: 'SCRAM-SHA-256'
+    });
+    try {
+      await cleanup.db('test').collection(collectionName).drop();
+    } finally {
+      await cleanup.close();
+    }
+  });
+});


### PR DESCRIPTION
### Description

Adds integration tests that verify the Node driver connects and authenticates correctly through an Atlas Secure Frontend Processor (SFP / monguard), per the [SFP testing spec](https://github.com/mongodb/specifications/blob/master/source/atlas-sfp-testing/atlas-sfp-testing.md).

Covers unauthenticated, SCRAM-SHA-256, and X.509 auth, each asserting `ping`, `connectionStatus`, and CRUD - with the authenticated cases also run under a compressor (zlib) and Server API v1. Credentials come from AWS Secrets Manager (`drivers/sfp`).

Wired up as a new `test-sfp` Evergreen task (`test/manual/sfp.test.ts` + `.evergreen/run-sfp-tests.sh`, `check:sfp`), running on the rhel8 and Windows variants.

<img width="1180" height="571" alt="image" src="https://github.com/user-attachments/assets/7019b063-3e9b-4b47-aed4-46e9b510206f" />


### Double check the following

- [x] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
