### PR TITLE
chore: run bson compat tests against latest server

### DIFF
--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -1026,7 +1026,12 @@ tasks:
         type: setup
         params:
           updates:
-            - { key: VERSION, value: "8.0" }
+            # This variant pins its working tree to a released tag, so it runs that tag's test
+            # files and cannot pick up a test quarantined on main afterwards. SERVER-132246 is
+            # fixed in master but its v8.0 backport (BACKPORT-29016) is still staged, so 8.0.x
+            # fails the streaming-hello SDAM tests here on every run.
+            # TODO(NODE-7703): revisit once that backport ships and 8.0.x carries the fix.
+            - { key: VERSION, value: "latest" }
             - { key: TOPOLOGY, value: server }
             - { key: AUTH, value: auth }
             - { key: SSL, value: nossl }
@@ -1049,7 +1054,12 @@ tasks:
         type: setup
         params:
           updates:
-            - { key: VERSION, value: "8.0" }
+            # This variant pins its working tree to a released tag, so it runs that tag's test
+            # files and cannot pick up a test quarantined on main afterwards. SERVER-132246 is
+            # fixed in master but its v8.0 backport (BACKPORT-29016) is still staged, so 8.0.x
+            # fails the streaming-hello SDAM tests here on every run.
+            # TODO(NODE-7703): revisit once that backport ships and 8.0.x carries the fix.
+            - { key: VERSION, value: "latest" }
             - { key: TOPOLOGY, value: replica_set }
             - { key: AUTH, value: auth }
             - { key: SSL, value: nossl }
@@ -1072,7 +1082,12 @@ tasks:
         type: setup
         params:
           updates:
-            - { key: VERSION, value: "8.0" }
+            # This variant pins its working tree to a released tag, so it runs that tag's test
+            # files and cannot pick up a test quarantined on main afterwards. SERVER-132246 is
+            # fixed in master but its v8.0 backport (BACKPORT-29016) is still staged, so 8.0.x
+            # fails the streaming-hello SDAM tests here on every run.
+            # TODO(NODE-7703): revisit once that backport ships and 8.0.x carries the fix.
+            - { key: VERSION, value: "latest" }
             - { key: TOPOLOGY, value: sharded_cluster }
             - { key: AUTH, value: auth }
             - { key: SSL, value: nossl }

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -948,7 +948,7 @@ tasks:
         type: setup
         params:
           updates:
-            - {key: VERSION, value: '8.0'}
+            - {key: VERSION, value: latest}
             - {key: TOPOLOGY, value: server}
             - {key: AUTH, value: auth}
             - {key: SSL, value: nossl}
@@ -970,7 +970,7 @@ tasks:
         type: setup
         params:
           updates:
-            - {key: VERSION, value: '8.0'}
+            - {key: VERSION, value: latest}
             - {key: TOPOLOGY, value: replica_set}
             - {key: AUTH, value: auth}
             - {key: SSL, value: nossl}
@@ -992,7 +992,7 @@ tasks:
         type: setup
         params:
           updates:
-            - {key: VERSION, value: '8.0'}
+            - {key: VERSION, value: latest}
             - {key: TOPOLOGY, value: sharded_cluster}
             - {key: AUTH, value: auth}
             - {key: SSL, value: nossl}


### PR DESCRIPTION
### Description

#### Summary of Changes

BSON compat tests are failing when running against 8.0 server.
This issue is fixed in latest server (SERVER-132246), but the fix has not been ported to latest 8 (BACKPORT-29016).
This PR changes it so BSON compat tests run against `latest` instead of the unpatched 8.0 server.

The broken SDAM tests are going to be reinstated in NODE-7703 , at which point we can revert this change to use server 8 once again.

#### What is the motivation for this change?

Broken BSON compat SDAM tests.

### Double check the following

- [x] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
