### PR TITLE
chore(NODE-7759): pin bson-compat server

### DIFF
--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -1033,9 +1033,8 @@ tasks:
         params:
           updates:
             # Pinned on purpose, and paired with SOURCE_REV below -- see "switch source".
-            # 8.0.26 is the newest release the v7.0.0 tests pass against.
             # Bump this together with SOURCE_REV, not on its own.
-            - { key: VERSION, value: "8.0.26" }
+            - { key: VERSION, value: "v8.0-perf" }
             - { key: TOPOLOGY, value: server }
             - { key: AUTH, value: auth }
             - { key: SSL, value: nossl }
@@ -1059,9 +1058,8 @@ tasks:
         params:
           updates:
             # Pinned on purpose, and paired with SOURCE_REV below -- see "switch source".
-            # 8.0.26 is the newest release the v7.0.0 tests pass against.
             # Bump this together with SOURCE_REV, not on its own.
-            - { key: VERSION, value: "8.0.26" }
+            - { key: VERSION, value: "v8.0-perf" }
             - { key: TOPOLOGY, value: replica_set }
             - { key: AUTH, value: auth }
             - { key: SSL, value: nossl }
@@ -1085,9 +1083,8 @@ tasks:
         params:
           updates:
             # Pinned on purpose, and paired with SOURCE_REV below -- see "switch source".
-            # 8.0.26 is the newest release the v7.0.0 tests pass against.
             # Bump this together with SOURCE_REV, not on its own.
-            - { key: VERSION, value: "8.0.26" }
+            - { key: VERSION, value: "v8.0-perf" }
             - { key: TOPOLOGY, value: sharded_cluster }
             - { key: AUTH, value: auth }
             - { key: SSL, value: nossl }

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -51,7 +51,13 @@ functions:
         file: src/expansion.yml
 
   "switch source":
-    # Checkout the desired source revision if specified
+    # Checkout the desired source revision if specified.
+    #
+    # This resets the ENTIRE working tree to SOURCE_REV, test files included, so the tests that run
+    # are the ones that shipped in that release. A test quarantined on main afterwards is therefore
+    # not quarantined here. Callers pin a server version alongside SOURCE_REV to keep the only
+    # moving input the thing actually under test -- see the bson compatibility tasks below and
+    # "BSON Compatibility Variant" in test/readme.md.
     - command: shell.exec
       params:
         working_dir: src
@@ -1026,12 +1032,10 @@ tasks:
         type: setup
         params:
           updates:
-            # This variant pins its working tree to a released tag, so it runs that tag's test
-            # files and cannot pick up a test quarantined on main afterwards. SERVER-132246 is
-            # fixed in master but its v8.0 backport (BACKPORT-29016) is still staged, so 8.0.x
-            # fails the streaming-hello SDAM tests here on every run.
-            # TODO(NODE-7703): revisit once that backport ships and 8.0.x carries the fix.
-            - { key: VERSION, value: "latest" }
+            # Pinned on purpose, and paired with SOURCE_REV below -- see "switch source".
+            # 8.0.26 is the newest release the v7.0.0 tests pass against.
+            # Bump this together with SOURCE_REV, not on its own.
+            - { key: VERSION, value: "8.0.26" }
             - { key: TOPOLOGY, value: server }
             - { key: AUTH, value: auth }
             - { key: SSL, value: nossl }
@@ -1054,12 +1058,10 @@ tasks:
         type: setup
         params:
           updates:
-            # This variant pins its working tree to a released tag, so it runs that tag's test
-            # files and cannot pick up a test quarantined on main afterwards. SERVER-132246 is
-            # fixed in master but its v8.0 backport (BACKPORT-29016) is still staged, so 8.0.x
-            # fails the streaming-hello SDAM tests here on every run.
-            # TODO(NODE-7703): revisit once that backport ships and 8.0.x carries the fix.
-            - { key: VERSION, value: "latest" }
+            # Pinned on purpose, and paired with SOURCE_REV below -- see "switch source".
+            # 8.0.26 is the newest release the v7.0.0 tests pass against.
+            # Bump this together with SOURCE_REV, not on its own.
+            - { key: VERSION, value: "8.0.26" }
             - { key: TOPOLOGY, value: replica_set }
             - { key: AUTH, value: auth }
             - { key: SSL, value: nossl }
@@ -1082,12 +1084,10 @@ tasks:
         type: setup
         params:
           updates:
-            # This variant pins its working tree to a released tag, so it runs that tag's test
-            # files and cannot pick up a test quarantined on main afterwards. SERVER-132246 is
-            # fixed in master but its v8.0 backport (BACKPORT-29016) is still staged, so 8.0.x
-            # fails the streaming-hello SDAM tests here on every run.
-            # TODO(NODE-7703): revisit once that backport ships and 8.0.x carries the fix.
-            - { key: VERSION, value: "latest" }
+            # Pinned on purpose, and paired with SOURCE_REV below -- see "switch source".
+            # 8.0.26 is the newest release the v7.0.0 tests pass against.
+            # Bump this together with SOURCE_REV, not on its own.
+            - { key: VERSION, value: "8.0.26" }
             - { key: TOPOLOGY, value: sharded_cluster }
             - { key: AUTH, value: auth }
             - { key: SSL, value: nossl }

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -948,7 +948,7 @@ tasks:
         type: setup
         params:
           updates:
-            - {key: VERSION, value: latest}
+            - {key: VERSION, value: 8.0.26}
             - {key: TOPOLOGY, value: server}
             - {key: AUTH, value: auth}
             - {key: SSL, value: nossl}
@@ -970,7 +970,7 @@ tasks:
         type: setup
         params:
           updates:
-            - {key: VERSION, value: latest}
+            - {key: VERSION, value: 8.0.26}
             - {key: TOPOLOGY, value: replica_set}
             - {key: AUTH, value: auth}
             - {key: SSL, value: nossl}
@@ -992,7 +992,7 @@ tasks:
         type: setup
         params:
           updates:
-            - {key: VERSION, value: latest}
+            - {key: VERSION, value: 8.0.26}
             - {key: TOPOLOGY, value: sharded_cluster}
             - {key: AUTH, value: auth}
             - {key: SSL, value: nossl}

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -948,7 +948,7 @@ tasks:
         type: setup
         params:
           updates:
-            - {key: VERSION, value: 8.0.26}
+            - {key: VERSION, value: v8.0-perf}
             - {key: TOPOLOGY, value: server}
             - {key: AUTH, value: auth}
             - {key: SSL, value: nossl}
@@ -970,7 +970,7 @@ tasks:
         type: setup
         params:
           updates:
-            - {key: VERSION, value: 8.0.26}
+            - {key: VERSION, value: v8.0-perf}
             - {key: TOPOLOGY, value: replica_set}
             - {key: AUTH, value: auth}
             - {key: SSL, value: nossl}
@@ -992,7 +992,7 @@ tasks:
         type: setup
         params:
           updates:
-            - {key: VERSION, value: 8.0.26}
+            - {key: VERSION, value: v8.0-perf}
             - {key: TOPOLOGY, value: sharded_cluster}
             - {key: AUTH, value: auth}
             - {key: SSL, value: nossl}

--- a/test/readme.md
+++ b/test/readme.md
@@ -268,11 +268,10 @@ This variant pins two concepts for the app, and they need to be updated together
 - `VERSION` pins the MongoDB server that the tests run against
   - NOTE: value of "8.0" is not a pin, since it will resolve "8.0.x", and will be different depending on what versions are available. Use a full version like "8.0.26" or "v8.0-perf" to pin the server.
 
-The "BSON compatibility tests" variant DOES NOT run on pull requests. If you are making changes to the variant, they need to be tested with a manual patch:
+The "BSON compatibility tests" variant DOES NOT run on pull requests by default. If you are making changes to the variant, they need to be tested by explicitly running them in Evergreen or with a manual patch:
 ```sh
 evergreen patch -u -y -f --browse -d "NODE-XXXX: <what changed>" -v "BSON compatibility tests" -t all
 ```
-Link the patch in your PR, so a reviewer is able to verify that your changes are not breaking.
 
 ## Manually Testing the Driver
 

--- a/test/readme.md
+++ b/test/readme.md
@@ -266,7 +266,7 @@ We have a variant called "BSON compatibility tests", which checks out a released
 This variant pins two concepts for the app, and they need to be updated together:
 - `SOURCE_REV` pins the driver + test source
 - `VERSION` pins the MongoDB server that the tests run against
-  - NOTE: value of "8.0" is not a pin, since it will resolve "8.0.x", and will be different depending on what versions are available. Use a full version like "8.0.26" to pin the server.
+  - NOTE: value of "8.0" is not a pin, since it will resolve "8.0.x", and will be different depending on what versions are available. Use a full version like "8.0.26" or "v8.0-perf" to pin the server.
 
 The "BSON compatibility tests" variant DOES NOT run on pull requests. If you are making changes to the variant, they need to be tested with a manual patch:
 ```sh

--- a/test/readme.md
+++ b/test/readme.md
@@ -20,6 +20,7 @@ about the types of tests and how to run them.
         - [Setup](#setup)
         - [Running the Build](#running-the-build)
   - [Using a Pre-Release Version of a Dependent Library](#using-a-pre-release-version-of-a-dependent-library)
+    - [BSON Compatibility Variant](#bson-compatibility-variant)
   - [Manually Testing the Driver](#manually-testing-the-driver)
   - [Writing Tests](#writing-tests)
     - [Framework](#framework)
@@ -257,6 +258,21 @@ Follow the steps below to do so.
 
 Now you can run the automated tests, run manual tests, or kick off an Evergreen build from your local
 repository.
+
+### BSON Compatibility Variant
+
+We have a variant called "BSON compatibility tests", which checks out a released driver tag, installs `bson` from the tip of `js-bson`, then runs that tag's test suite. This is done to verify that the latest `bson` releases continue to work with an existing application, which in this case is Node Driver + Tests + MongoDB Server.
+
+This variant pins two concepts for the app, and they need to be updated together:
+- `SOURCE_REV` pins the driver + test source
+- `VERSION` pins the MongoDB server that the tests run against
+  - NOTE: value of "8.0" is not a pin, since it will resolve "8.0.x", and will be different depending on what versions are available. Use a full version like "8.0.26" to pin the server.
+
+The "BSON compatibility tests" variant DOES NOT run on pull requests. If you are making changes to the variant, they need to be tested with a manual patch:
+```sh
+evergreen patch -u -y -f --browse -d "NODE-XXXX: <what changed>" -v "BSON compatibility tests" -t all
+```
+Link the patch in your PR, so a reviewer is able to verify that your changes are not breaking.
 
 ## Manually Testing the Driver
 


### PR DESCRIPTION
### Description

#### Summary of Changes

Pin server to a known working version, and add documentation around this variant.

#### What is the motivation for this change?

Pin the server being used for BSON compat tests, so we are only testing one variable: the latest BSON library.

### Double check the following

- [x] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
