### PR TITLE
feat(NODE-7624): support baseBackoffMS and update client backpressure backoff

### DIFF
--- a/src/cmap/connect.ts
+++ b/src/cmap/connect.ts
@@ -224,7 +224,7 @@ export interface HandshakeDocument extends Document {
   compression: string[];
   saslSupportedMechs?: string;
   loadBalanced?: boolean;
-  backpressure: true;
+  backpressure: '2';
 }
 
 /**
@@ -242,7 +242,7 @@ export async function prepareHandshakeDocument(
 
   const handshakeDoc: HandshakeDocument = {
     [serverApi?.version || options.loadBalanced === true ? 'hello' : LEGACY_HELLO_COMMAND]: 1,
-    backpressure: true,
+    backpressure: '2',
     helloOk: true,
     client: clientMetadata,
     compression: compressors

--- a/src/operations/execute_operation.ts
+++ b/src/operations/execute_operation.ts
@@ -185,11 +185,13 @@ const MAX_BACKOFF_MS = 10_000;
 export function calculateBaseBackoffMS(error: MongoError): number {
   if (!(error instanceof MongoServerError)) return BASE_BACKOFF_MS;
 
-  // The server sends baseBackoffMS as an int64, so it arrives as a Long rather than a number when
-  // the client is configured with `promoteLongs: false`. Coerce rather than check for `number`.
+  // The server sends baseBackoffMS as an int64, so its runtime type depends on the client's BSON
+  // options: a number by default, a Long under `promoteLongs: false`, a bigint under
+  // `useBigInt64: true`. `Number()` handles all three, so coerce rather than check for `number`.
   // `errorResponse` is indexed as `any`; narrow to `unknown` so the checks below are real.
   const raw: unknown = error.errorResponse.baseBackoffMS;
-  const baseBackoffMS = typeof raw === 'number' || typeof raw === 'object' ? Number(raw) : NaN;
+  const isNumeric = typeof raw === 'number' || typeof raw === 'bigint' || typeof raw === 'object';
+  const baseBackoffMS = isNumeric ? Number(raw) : NaN;
   const useServerValue = Number.isFinite(baseBackoffMS) && baseBackoffMS > 0;
   const result = useServerValue ? baseBackoffMS : BASE_BACKOFF_MS;
   return result;

--- a/src/operations/execute_operation.ts
+++ b/src/operations/execute_operation.ts
@@ -170,9 +170,30 @@ type RetryOptions = {
   timeoutContext: TimeoutContext;
 };
 /** @internal The base backoff duration in milliseconds */
-const BASE_BACKOFF_MS = 100;
+export const BASE_BACKOFF_MS = 100;
 /** @internal The maximum backoff duration in milliseconds */
 const MAX_BACKOFF_MS = 10_000;
+
+/**
+ * @internal
+ * The server-supplied base backoff duration in milliseconds, if the error carries a usable one.
+ *
+ * The server may attach `baseBackoffMS` to an overload error to indicate how long clients should
+ * back off in place of the driver's default. Only a positive value is honoured: the server disables
+ * the behaviour by reporting `0`, in which case we fall back to `BASE_BACKOFF_MS`.
+ */
+export function calculateBaseBackoffMS(error: MongoError): number {
+  if (!(error instanceof MongoServerError)) return BASE_BACKOFF_MS;
+
+  // The server sends baseBackoffMS as an int64, so it arrives as a Long rather than a number when
+  // the client is configured with `promoteLongs: false`. Coerce rather than check for `number`.
+  // `errorResponse` is indexed as `any`; narrow to `unknown` so the checks below are real.
+  const raw: unknown = error.errorResponse.baseBackoffMS;
+  const baseBackoffMS = typeof raw === 'number' || typeof raw === 'object' ? Number(raw) : NaN;
+  const useServerValue = Number.isFinite(baseBackoffMS) && baseBackoffMS > 0;
+  const result = useServerValue ? baseBackoffMS : BASE_BACKOFF_MS;
+  return result;
+}
 
 /**
  * Executes an operation and retries as appropriate
@@ -327,7 +348,11 @@ async function executeOperationWithRetries<
       }
 
       if (operationError.hasErrorLabel(MongoErrorLabel.SystemOverloadedError)) {
-        const backoffMS = Math.random() * Math.min(MAX_BACKOFF_MS, BASE_BACKOFF_MS * 2 ** attempt);
+        const baseBackoffMS = calculateBaseBackoffMS(operationError);
+        // The spec numbers the first retry as attempt 1, while `attempt` here is the zero-based
+        // index of the attempt that just failed -- hence the `+ 1`.
+        const backoffMS =
+          Math.random() * Math.min(MAX_BACKOFF_MS, baseBackoffMS * 2 ** (attempt + 1));
 
         // if the backoff would exhaust the CSOT timeout, short-circuit.
         if (timeoutContext.csotEnabled() && backoffMS > timeoutContext.remainingTimeMS) {

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -771,7 +771,7 @@ export class ClientSession
       ) {
         // 2. If `transactionAttempt` > 0:
         if (isRetry) {
-          // 2.1 Calculate backoffMS to be jitter * min(BACKOFF_INITIAL * 1.5 ** (transactionAttempt - 1), BACKOFF_MAX).
+          // 2.1 Calculate backoffMS to be jitter * min(BACKOFF_INITIAL * 1.5 ** (transactionAttempt), BACKOFF_MAX).
           //  If elapsed time + backoffMS > TIMEOUT_MS, then propagate the previously encountered error to the caller of
           //  withTransaction as per timeout error propagation and return immediately. Otherwise, sleep for backoffMS.
           //  2.1.1 jitter is a random float between [0, 1), optionally including 1, depending on what is most natural
@@ -785,10 +785,7 @@ export class ClientSession
           const jitter = Math.random();
           const backoffMS =
             jitter *
-            Math.min(
-              BACKOFF_INITIAL_MS * BACKOFF_GROWTH ** (transactionAttempt - 1),
-              BACKOFF_MAX_MS
-            );
+            Math.min(BACKOFF_INITIAL_MS * BACKOFF_GROWTH ** transactionAttempt, BACKOFF_MAX_MS);
 
           if (processTimeMS() + backoffMS >= deadline) {
             throw makeTimeoutError(

--- a/test/integration/client-backpressure/client-backpressure.prose.test.ts
+++ b/test/integration/client-backpressure/client-backpressure.prose.test.ts
@@ -53,7 +53,7 @@ describe('Client Backpressure (Prose)', function () {
       });
 
       //    iv. Configure the random number generator used for jitter to always return a number as close as possible to `1`.
-      stub.returns(0.99);
+      stub.returns(1);
 
       //    v. Execute step iii again.
       const { duration: durationBackoff } = await measureDuration(async () => {
@@ -62,8 +62,8 @@ describe('Client Backpressure (Prose)', function () {
       });
 
       //    vi. Compare the time between the two runs.
-      //        The sum of 2 backoffs is 0.3 seconds. There is a 0.3-second window to account for potential variance.
-      expect(durationBackoff - durationNoBackoff).to.be.within(300 - 300, 300 + 300);
+      //        The sum of 2 backoffs is 0.6 seconds. There is a 0.6-second window to account for potential variance.
+      expect(durationBackoff - durationNoBackoff).to.be.within(600 - 600, 600 + 600);
     }
   );
 
@@ -151,6 +151,74 @@ describe('Client Backpressure (Prose)', function () {
 
       // 6. Assert that the total number of started commands is `maxAdaptiveRetries` + 1 (2).
       expect(commandsStarted).to.have.length(2);
+    }
+  );
+
+  it(
+    'Test 5: Overload Errors with baseBackoffMS override base backoff',
+    {
+      requires: {
+        mongodb: '>=9.0'
+      }
+    },
+    async function () {
+      // 1. Let `client` be a `MongoClient`.
+      client = this.configuration.newClient();
+      await client.connect();
+
+      // 2. Let `coll` be a collection.
+      const collection = client.db('foo').collection('bar');
+      const admin = client.db('admin');
+
+      // 3. Configure the random number generator used for exponential backoff jitter to always
+      //    return a number as close as possible to `1`.
+      //    Note: the assertions in step 10 are lower bounds on the sum of the backoffs, so we pin
+      //    jitter to exactly 1 rather than to a value just below it.
+      sinon.stub(Math, 'random').returns(1);
+
+      // 4. Configure the following failPoint:
+      await configureFailPoint(this.configuration, {
+        configureFailPoint: 'failCommand',
+        mode: 'alwaysOn',
+        data: {
+          failCommands: ['insert'],
+          errorCode: 462, // IngressRequestRateLimitExceeded
+          errorLabels: ['SystemOverloadedError', 'RetryableError']
+        }
+      });
+
+      // 5. Insert the document `{ a: 1 }`. Expect that the command errors. Measure the duration of
+      //    the command execution.
+      const { duration: exponentialBackoffTime, result: defaultBackoffError } =
+        await measureDuration(() => collection.insertOne({ a: 1 }));
+      expect(defaultBackoffError).to.be.instanceof(MongoServerError);
+
+      let withBaseBackoffMSTime: number;
+      let baseBackoffError: unknown;
+      try {
+        // 6. Run the following command to set up `baseBackoffMS` on overload errors.
+        await admin.command({ setParameter: 1, externalClientBaseBackoffMS: 50 });
+
+        // 7. Execute step 5 again.
+        ({ duration: withBaseBackoffMSTime, result: baseBackoffError } = await measureDuration(() =>
+          collection.insertOne({ a: 1 })
+        ));
+      } finally {
+        // 9. Run the following command to disable `baseBackoffMS` on overload errors.
+        await admin.command({ setParameter: 1, externalClientBaseBackoffMS: 0 });
+      }
+
+      // 8. Assert that the server attached `baseBackoffMS` to the error and that the driver parsed it.
+      expect(baseBackoffError).to.be.instanceof(MongoServerError);
+      expect(baseBackoffError).to.have.nested.property('errorResponse.baseBackoffMS', 50);
+
+      // 10. Assert absolute bounds on each run's duration.
+      //     A run can never be faster than the sum of its backoffs. With jitter pinned to 1, the
+      //     default backoffs are `0.2 + 0.4 = 0.6s` and the `baseBackoffMS=50` backoffs are
+      //     `0.1 + 0.2 = 0.3s`.
+      expect(exponentialBackoffTime).to.be.at.least(600);
+      expect(withBaseBackoffMSTime).to.be.at.least(300);
+      expect(withBaseBackoffMSTime).to.be.lessThan(600);
     }
   );
 });

--- a/test/integration/client-backpressure/client-backpressure.prose.test.ts
+++ b/test/integration/client-backpressure/client-backpressure.prose.test.ts
@@ -203,14 +203,14 @@ describe('Client Backpressure (Prose)', function () {
         ({ duration: withBaseBackoffMSTime, result: baseBackoffError } = await measureDuration(() =>
           collection.insertOne({ a: 1 })
         ));
+
+        // 8. Assert that the server attached `baseBackoffMS` to the error and that the driver parsed it.
+        expect(baseBackoffError).to.be.instanceof(MongoServerError);
+        expect(baseBackoffError).to.have.nested.property('errorResponse.baseBackoffMS', 50);
       } finally {
         // 9. Run the following command to disable `baseBackoffMS` on overload errors.
         await admin.command({ setParameter: 1, externalClientBaseBackoffMS: 0 });
       }
-
-      // 8. Assert that the server attached `baseBackoffMS` to the error and that the driver parsed it.
-      expect(baseBackoffError).to.be.instanceof(MongoServerError);
-      expect(baseBackoffError).to.have.nested.property('errorResponse.baseBackoffMS', 50);
 
       // 10. Assert absolute bounds on each run's duration.
       //     A run can never be faster than the sum of its backoffs. With jitter pinned to 1, the

--- a/test/integration/mongodb-handshake/mongodb-handshake.prose.test.ts
+++ b/test/integration/mongodb-handshake/mongodb-handshake.prose.test.ts
@@ -972,7 +972,7 @@ describe('Backpressure Metadata', function () {
     await client?.close();
   });
 
-  it('includes backpressure in the handshake document', function () {
+  it(`includes backpressure: '2' in the handshake document`, function () {
     const isHello = (cmd: Document): cmd is HandshakeDocument =>
       `hello` in cmd || LEGACY_HELLO_COMMAND in cmd;
 
@@ -981,8 +981,8 @@ describe('Backpressure Metadata', function () {
     expect(hellos.length).to.be.greaterThan(0);
 
     expect(
-      hellos.every(hello => hello.backpressure === true),
-      `some handshake documents did not specify backpressure: true`
-    );
+      hellos.every(hello => hello.backpressure === '2'),
+      `some handshake documents did not specify backpressure: '2'`
+    ).to.be.true;
   });
 });

--- a/test/integration/transactions-convenient-api/transactions-convenient-api.prose.test.ts
+++ b/test/integration/transactions-convenient-api/transactions-convenient-api.prose.test.ts
@@ -328,11 +328,11 @@ describe('Retry Backoff is Enforced', function () {
       });
 
       // 5. Compare the durations of the two runs.
-      //    The sum of 13 backoffs is roughly 1.8 seconds. There is a half-second window to
+      //    The sum of 13 backoffs is roughly 2.3 seconds. There is a half-second window to
       //    account for potential variance between the two runs.
       expect(fullBackoffDuration).to.be.within(
-        noBackoffTime + 1800 - 500,
-        noBackoffTime + 1800 + 500
+        noBackoffTime + 2300 - 500,
+        noBackoffTime + 2300 + 500
       );
     }
   );

--- a/test/spec/client-backpressure/README.md
+++ b/test/spec/client-backpressure/README.md
@@ -53,11 +53,13 @@ executed against a MongoDB 4.4+ server that has enabled the `configureFailPoint`
     6. Compare the time between the two runs.
 
         ```python
-        assertTrue(absolute_value(with_backoff_time - (no_backoff_time + 0.3 seconds)) < 0.3 seconds)
+        assertTrue(absolute_value(with_backoff_time - (no_backoff_time + 0.6 seconds)) < 0.6 seconds)
         ```
 
-        The sum of 2 backoffs is 0.3 seconds. There is a 0.3-second window to account for potential variance between the
+        The sum of 2 backoffs is 0.6 seconds. There is a 0.6-second window to account for potential variance between the
         two runs.
+
+#### Test 2: REMOVED
 
 #### Test 3: Overload Errors are Retried a Maximum of MAX_RETRIES times
 
@@ -117,3 +119,66 @@ option.
 5. Assert that the raised error contains both the `RetryableError` and `SystemOverloadedError` error labels.
 
 6. Assert that the total number of started commands is `maxAdaptiveRetries` + 1 (2).
+
+#### Test 5: Overload Errors with baseBackoffMS override base backoff
+
+Drivers SHOULD test that overload errors with `baseBackoffMS` override the default backoff duration. This test MUST be
+executed against a MongoDB 9.0+ server that has enabled the `configureFailPoint` command with the `errorLabels` option.
+
+1. Let `client` be a `MongoClient`.
+
+2. Let `coll` be a collection.
+
+3. Configure the random number generator used for exponential backoff jitter to always return a number as close as
+    possible to `1`.
+
+4. Configure the following failPoint:
+
+    ```javascript
+        {
+            configureFailPoint: 'failCommand',
+            mode: 'alwaysOn',
+            data: {
+                failCommands: ['insert'],
+                errorCode: 462, // IngressRequestRateLimitExceeded
+                errorLabels: ['SystemOverloadedError', 'RetryableError']
+            }
+        }
+    ```
+
+5. Insert the document `{ a: 1 }`. Expect that the command errors. Measure the duration of the command execution.
+
+    ```javascript
+       const start = performance.now();
+       expect(
+        await coll.insertOne({ a: 1 }).catch(e => e)
+       ).to.be.an.instanceof(MongoServerError);
+       const end = performance.now();
+    ```
+
+6. Run the following command to set up `baseBackoffMS` on overload errors.
+
+    ```python
+    client.admin.command("setParameter", 1, externalClientBaseBackoffMS=50)
+    ```
+
+7. Execute step 5 again.
+
+8. Assert that the server attached `baseBackoffMS` to the error and that the driver parsed it.
+
+9. Run the following command to disable `baseBackoffMS` on overload errors.
+
+    ```python
+    client.admin.command("setParameter", 1, externalClientBaseBackoffMS=0)
+    ```
+
+10. Assert absolute bounds on each run's duration.
+
+    ```python
+    assertGreaterEqual(exponential_backoff_time, 0.6)
+    assertGreaterEqual(with_base_backoff_ms_time, 0.3)
+    assertLess(with_base_backoff_ms_time, 0.6)
+    ```
+
+    A run can never be faster than the sum of its backoffs. With jitter pinned to 1, the default backoffs are
+    `0.2 + 0.4 = 0.6s` and the `baseBackoffMS=50` backoffs are `0.1 + 0.2 = 0.3s`.

--- a/test/unit/operations/execute_operation.test.ts
+++ b/test/unit/operations/execute_operation.test.ts
@@ -23,6 +23,10 @@ describe('executeOperation() backoff', function () {
           50
         );
       });
+
+      it('uses it when the int64 was deserialized as a bigint (useBigInt64)', function () {
+        expect(calculateBaseBackoffMS(makeError({ baseBackoffMS: 50n }))).to.equal(50);
+      });
     });
 
     context('when the error does not carry a usable baseBackoffMS', function () {

--- a/test/unit/operations/execute_operation.test.ts
+++ b/test/unit/operations/execute_operation.test.ts
@@ -1,0 +1,57 @@
+import { expect } from 'chai';
+
+import {
+  BASE_BACKOFF_MS,
+  calculateBaseBackoffMS,
+  Long,
+  MongoNetworkError,
+  MongoServerError
+} from '../../mongodb';
+
+describe('executeOperation() backoff', function () {
+  describe('calculateBaseBackoffMS()', function () {
+    const makeError = (response: Record<string, unknown>) =>
+      new MongoServerError({ message: 'overloaded', ...response });
+
+    context('when the error carries a positive baseBackoffMS', function () {
+      it('uses the server-supplied value', function () {
+        expect(calculateBaseBackoffMS(makeError({ baseBackoffMS: 50 }))).to.equal(50);
+      });
+
+      it('uses it when the server sent an int64 that was not promoted', function () {
+        expect(calculateBaseBackoffMS(makeError({ baseBackoffMS: Long.fromNumber(50) }))).to.equal(
+          50
+        );
+      });
+    });
+
+    context('when the error does not carry a usable baseBackoffMS', function () {
+      it('falls back to the default when absent', function () {
+        expect(calculateBaseBackoffMS(makeError({}))).to.equal(BASE_BACKOFF_MS);
+      });
+
+      it('falls back to the default when 0, which is how the server disables the behaviour', function () {
+        expect(calculateBaseBackoffMS(makeError({ baseBackoffMS: 0 }))).to.equal(BASE_BACKOFF_MS);
+      });
+
+      it('falls back to the default when negative', function () {
+        expect(calculateBaseBackoffMS(makeError({ baseBackoffMS: -1 }))).to.equal(BASE_BACKOFF_MS);
+      });
+
+      it('falls back to the default when not a number', function () {
+        expect(calculateBaseBackoffMS(makeError({ baseBackoffMS: 'soon' }))).to.equal(
+          BASE_BACKOFF_MS
+        );
+      });
+    });
+
+    context('when the error is not a server error', function () {
+      it('falls back to the default', function () {
+        // Overload errors raised during connection establishment carry the labels but no reply.
+        expect(calculateBaseBackoffMS(new MongoNetworkError('connection reset'))).to.equal(
+          BASE_BACKOFF_MS
+        );
+      });
+    });
+  });
+});


### PR DESCRIPTION
### Description

#### Summary of Changes

Add support for baseBackoffMS to existing client backpressure drivers.
This change also alters how backoffs are calculated and changes the backpressure wire representation.

### Release Highlight

<!-- 
Contributors: please leave the release notes section for the Node driver team to fill in. The following instructions are for maintainers.

For user facing changes: please provide release notes. Feel free to browse previous releases for example release highlights.

If there are no user-facing changes in this PR, please delete the release highlight section from the PR description.
-->

<!-- RELEASE_HIGHLIGHT_START -->

### Improved  Intelligent Workload Management

Improved performance for MongoDB 9.0's Intelligent Workload Management (IWM) by only retrying overload errors when doing so is expected to not worsen server conditions

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Lint is passing (`npm run check:lint`)
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
