### PR TITLE
chore(NODE-7767): snappy 7.4 is incompatible in CI

### DIFF
--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -61,7 +61,7 @@ fi
 
 npm install @mongodb-js/zstd
 
-# // TODO: NODE-7766 remove this pin when snappy is fixed
+# TODO: NODE-7766 remove this pin when snappy is fixed
 npm install snappy@7.3.3
 
 export AUTH=$AUTH

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -60,7 +60,7 @@ if [ "$COMPRESSOR" != "" ]; then
 fi
 
 npm install @mongodb-js/zstd
-npm install snappy
+npm install snappy@7.3.3
 
 export AUTH=$AUTH
 export SINGLE_MONGOS_LB_URI=${SINGLE_MONGOS_LB_URI}

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -60,6 +60,8 @@ if [ "$COMPRESSOR" != "" ]; then
 fi
 
 npm install @mongodb-js/zstd
+
+# // TODO: NODE-7766 remove this pin when snappy is fixed
 npm install snappy@7.3.3
 
 export AUTH=$AUTH

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -61,9 +61,6 @@ fi
 
 npm install @mongodb-js/zstd
 
-# TODO: NODE-7766 remove this pin when snappy is fixed
-npm install snappy@7.3.3
-
 export AUTH=$AUTH
 export SINGLE_MONGOS_LB_URI=${SINGLE_MONGOS_LB_URI}
 export MULTI_MONGOS_LB_URI=${MULTI_MONGOS_LB_URI}

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "semver": "^7.7.2",
         "sinon": "^18.0.1",
         "sinon-chai": "^4.0.1",
-        "snappy": "^7.3.2",
+        "snappy": "7.3.3",
         "socks": "^2.8.7",
         "source-map-support": "^0.5.21",
         "ts-node": "^10.9.2",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "semver": "^7.7.2",
     "sinon": "^18.0.1",
     "sinon-chai": "^4.0.1",
-    "snappy": "^7.3.2",
+    "snappy": "7.3.3",
     "socks": "^2.8.7",
     "source-map-support": "^0.5.21",
     "ts-node": "^10.9.2",

--- a/test/action/dependency.test.ts
+++ b/test/action/dependency.test.ts
@@ -66,9 +66,14 @@ describe('package.json', function () {
     )) {
       // If a dependency specifies `alpha|beta`, the major version will fail to install because
       // an alpha < the major of that version (ex: mongodb-client-encryption@7.0.0-alpha < mongodb-client-encryption@7.0.0)
-      const depInstallSpecifier = /alpha|beta/.test(depVersion)
+      let depInstallSpecifier = /alpha|beta/.test(depVersion)
         ? depVersion
         : depVersion.split('.')[0];
+
+      // TODO: NODE-7766 remove this pin when snappy is fixed
+      if (depName === 'snappy') {
+        depInstallSpecifier = '7.3.3';
+      }
 
       context(`when ${depName} is NOT installed`, () => {
         beforeEach(async () => {


### PR DESCRIPTION
### Description

#### Summary of Changes

Snappy@7.4.0 is incompatible with the driver and is breaking our CI. These changes will pin snappy to a compatible version explicitly in our CI, and include a callout to remove the pin at a later date.

##### Notes for Reviewers

<!-- 
If there is any additional context on the changes in the PR that reviewers might find helpful, feel free to make notes in this section.

Otherwise, feel free to remove this section.
-->

#### What is the motivation for this change?

<!--
Remove this section if there is an associated Jira ticket explaining the motivation for this change. If there is not, please fill this section out with
information explaining why this change is valuable.
-->

### Release Highlight

<!-- 
Contributors: please leave the release notes section for the Node driver team to fill in. The following instructions are for maintainers.

For user facing changes: please provide release notes. Feel free to browse previous releases for example release highlights.

If there are no user-facing changes in this PR, please delete the release highlight section from the PR description.
-->

<!-- RELEASE_HIGHLIGHT_START -->

### Release notes highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Lint is passing (`npm run check:lint`)
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
