### PR TITLE
chore(NODE-7770): add server 9.0 to the test matrix

### DIFF
--- a/.evergreen/ci_matrix_constants.js
+++ b/.evergreen/ci_matrix_constants.js
@@ -1,4 +1,4 @@
-const MONGODB_VERSIONS = ['latest', 'rapid', '8.0', '7.0', '6.0', '5.0', '4.4'];
+const MONGODB_VERSIONS = ['latest', 'rapid', '9.0', '8.0', '7.0', '6.0', '5.0', '4.4'];
 const versions = [
   { codeName: 'iron', versionNumber: '20.19.0' },
   { codeName: 'jod', versionNumber: 22 },

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1104,6 +1104,54 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+  - name: test-9.0-server
+    tags:
+      - '9.0'
+      - server
+    commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '9.0'}
+            - {key: TOPOLOGY, value: server}
+            - {key: SSL, value: nossl}
+            - {key: AUTH, value: auth}
+      - func: install dependencies
+      - func: bootstrap mongo-orchestration
+      - func: run tests
+  - name: test-9.0-replica_set
+    tags:
+      - '9.0'
+      - replica_set
+    commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '9.0'}
+            - {key: TOPOLOGY, value: replica_set}
+            - {key: SSL, value: nossl}
+            - {key: AUTH, value: auth}
+      - func: install dependencies
+      - func: bootstrap mongo-orchestration
+      - func: run tests
+  - name: test-9.0-sharded_cluster
+    tags:
+      - '9.0'
+      - sharded_cluster
+    commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '9.0'}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: SSL, value: nossl}
+            - {key: AUTH, value: auth}
+      - func: install dependencies
+      - func: bootstrap mongo-orchestration
+      - func: run tests
   - name: test-8.0-server
     tags:
       - '8.0'
@@ -1471,6 +1519,27 @@ tasks:
       - func: start-load-balancer
       - func: run-lb-tests
       - func: stop-load-balancer
+  - name: test-9.0-load-balanced
+    tags:
+      - latest
+      - sharded_cluster
+      - load_balancer
+    commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '9.0'}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: AUTH, value: auth}
+            - {key: LOAD_BALANCER, value: 'true'}
+            - {key: CLIENT_ENCRYPTION, value: 'false'}
+            - {key: TEST_CSFLE, value: 'false'}
+      - func: install dependencies
+      - func: bootstrap mongo-orchestration
+      - func: start-load-balancer
+      - func: run-lb-tests
+      - func: stop-load-balancer
   - name: test-rapid-load-balanced
     tags:
       - latest
@@ -1621,6 +1690,22 @@ tasks:
         params:
           updates:
             - {key: VERSION, value: latest}
+            - {key: SSL, value: ssl}
+            - {key: TOPOLOGY, value: server}
+            - {key: AUTH, value: auth}
+      - func: install dependencies
+      - func: bootstrap mongo-orchestration
+      - func: run tls tests
+  - name: test-tls-support-9.0
+    tags:
+      - tls-support
+      - tls-support-9.0
+    commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '9.0'}
             - {key: SSL, value: ssl}
             - {key: TOPOLOGY, value: server}
             - {key: AUTH, value: auth}
@@ -2223,6 +2308,60 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+  - name: test-9.0-server-noauth
+    tags:
+      - '9.0'
+      - server
+      - noauth
+    commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '9.0'}
+            - {key: TOPOLOGY, value: server}
+            - {key: AUTH, value: noauth}
+            - {key: SSL, value: nossl}
+            - {key: NODE_LTS_VERSION, value: 20.19.0}
+      - func: install dependencies
+      - func: bootstrap mongo-orchestration
+      - func: run tests
+  - name: test-9.0-replica_set-noauth
+    tags:
+      - '9.0'
+      - replica_set
+      - noauth
+    commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '9.0'}
+            - {key: TOPOLOGY, value: replica_set}
+            - {key: AUTH, value: noauth}
+            - {key: SSL, value: nossl}
+            - {key: NODE_LTS_VERSION, value: 20.19.0}
+      - func: install dependencies
+      - func: bootstrap mongo-orchestration
+      - func: run tests
+  - name: test-9.0-sharded_cluster-noauth
+    tags:
+      - '9.0'
+      - sharded_cluster
+      - noauth
+    commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '9.0'}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: AUTH, value: noauth}
+            - {key: SSL, value: nossl}
+            - {key: NODE_LTS_VERSION, value: 20.19.0}
+      - func: install dependencies
+      - func: bootstrap mongo-orchestration
+      - func: run tests
   - name: test-8.0-server-noauth
     tags:
       - '8.0'
@@ -2558,6 +2697,22 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+  - name: test-9.0-csfle-mongocryptd
+    tags:
+      - '9.0'
+      - sharded_cluster
+    commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '9.0'}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: AUTH, value: auth}
+            - {key: NODE_LTS_VERSION, value: '24'}
+      - func: install dependencies
+      - func: bootstrap mongo-orchestration
+      - func: run tests
   - name: test-8.0-csfle-mongocryptd
     tags:
       - '8.0'
@@ -2749,6 +2904,66 @@ tasks:
         params:
           updates:
             - {key: VERSION, value: rapid}
+            - {key: TOPOLOGY, value: sharded_cluster}
+            - {key: AUTH, value: auth}
+            - {key: SSL, value: ssl}
+            - {key: NODE_LTS_VERSION, value: '24'}
+            - {key: CLIENT_ENCRYPTION, value: 'true'}
+            - {key: TEST_CSFLE, value: 'true'}
+      - func: install dependencies
+      - func: bootstrap mongo-orchestration
+      - func: run tests
+  - name: test-9.0-server-ssl
+    tags:
+      - '9.0'
+      - server
+      - ssl
+    commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '9.0'}
+            - {key: TOPOLOGY, value: server}
+            - {key: AUTH, value: auth}
+            - {key: SSL, value: ssl}
+            - {key: NODE_LTS_VERSION, value: '24'}
+            - {key: CLIENT_ENCRYPTION, value: 'true'}
+            - {key: TEST_CSFLE, value: 'true'}
+      - func: install dependencies
+      - func: bootstrap mongo-orchestration
+      - func: run tests
+  - name: test-9.0-replica_set-ssl
+    tags:
+      - '9.0'
+      - replica_set
+      - ssl
+    commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '9.0'}
+            - {key: TOPOLOGY, value: replica_set}
+            - {key: AUTH, value: auth}
+            - {key: SSL, value: ssl}
+            - {key: NODE_LTS_VERSION, value: '24'}
+            - {key: CLIENT_ENCRYPTION, value: 'true'}
+            - {key: TEST_CSFLE, value: 'true'}
+      - func: install dependencies
+      - func: bootstrap mongo-orchestration
+      - func: run tests
+  - name: test-9.0-sharded_cluster-ssl
+    tags:
+      - '9.0'
+      - sharded_cluster
+      - ssl
+    commands:
+      - command: expansions.update
+        type: setup
+        params:
+          updates:
+            - {key: VERSION, value: '9.0'}
             - {key: TOPOLOGY, value: sharded_cluster}
             - {key: AUTH, value: auth}
             - {key: SSL, value: ssl}
@@ -3350,6 +3565,9 @@ buildvariants:
       - test-rapid-server
       - test-rapid-replica_set
       - test-rapid-sharded_cluster
+      - test-9.0-server
+      - test-9.0-replica_set
+      - test-9.0-sharded_cluster
       - test-8.0-server
       - test-8.0-replica_set
       - test-8.0-sharded_cluster
@@ -3373,6 +3591,7 @@ buildvariants:
       - test-6.0-load-balanced
       - test-7.0-load-balanced
       - test-8.0-load-balanced
+      - test-9.0-load-balanced
       - test-rapid-load-balanced
       - test-latest-load-balanced
       - test-auth-kerberos
@@ -3383,6 +3602,7 @@ buildvariants:
       - test-snappy-compression
       - test-zstd-compression
       - test-tls-support-latest
+      - test-tls-support-9.0
       - test-tls-support-8.0
       - test-tls-support-7.0
       - test-tls-support-6.0
@@ -3402,6 +3622,9 @@ buildvariants:
       - test-rapid-server
       - test-rapid-replica_set
       - test-rapid-sharded_cluster
+      - test-9.0-server
+      - test-9.0-replica_set
+      - test-9.0-sharded_cluster
       - test-8.0-server
       - test-8.0-replica_set
       - test-8.0-sharded_cluster
@@ -3425,6 +3648,7 @@ buildvariants:
       - test-6.0-load-balanced
       - test-7.0-load-balanced
       - test-8.0-load-balanced
+      - test-9.0-load-balanced
       - test-rapid-load-balanced
       - test-latest-load-balanced
       - test-auth-kerberos
@@ -3435,6 +3659,7 @@ buildvariants:
       - test-snappy-compression
       - test-zstd-compression
       - test-tls-support-latest
+      - test-tls-support-9.0
       - test-tls-support-8.0
       - test-tls-support-7.0
       - test-tls-support-6.0
@@ -3454,6 +3679,9 @@ buildvariants:
       - test-rapid-server
       - test-rapid-replica_set
       - test-rapid-sharded_cluster
+      - test-9.0-server
+      - test-9.0-replica_set
+      - test-9.0-sharded_cluster
       - test-8.0-server
       - test-8.0-replica_set
       - test-8.0-sharded_cluster
@@ -3477,6 +3705,7 @@ buildvariants:
       - test-6.0-load-balanced
       - test-7.0-load-balanced
       - test-8.0-load-balanced
+      - test-9.0-load-balanced
       - test-rapid-load-balanced
       - test-latest-load-balanced
       - test-auth-kerberos
@@ -3487,6 +3716,7 @@ buildvariants:
       - test-snappy-compression
       - test-zstd-compression
       - test-tls-support-latest
+      - test-tls-support-9.0
       - test-tls-support-8.0
       - test-tls-support-7.0
       - test-tls-support-6.0
@@ -3506,6 +3736,9 @@ buildvariants:
       - test-rapid-server
       - test-rapid-replica_set
       - test-rapid-sharded_cluster
+      - test-9.0-server
+      - test-9.0-replica_set
+      - test-9.0-sharded_cluster
       - test-8.0-server
       - test-8.0-replica_set
       - test-8.0-sharded_cluster
@@ -3529,6 +3762,7 @@ buildvariants:
       - test-6.0-load-balanced
       - test-7.0-load-balanced
       - test-8.0-load-balanced
+      - test-9.0-load-balanced
       - test-rapid-load-balanced
       - test-latest-load-balanced
       - test-auth-kerberos
@@ -3538,6 +3772,7 @@ buildvariants:
       - test-snappy-compression
       - test-zstd-compression
       - test-tls-support-latest
+      - test-tls-support-9.0
       - test-tls-support-8.0
       - test-tls-support-7.0
       - test-tls-support-6.0
@@ -3557,6 +3792,9 @@ buildvariants:
       - test-rapid-server
       - test-rapid-replica_set
       - test-rapid-sharded_cluster
+      - test-9.0-server
+      - test-9.0-replica_set
+      - test-9.0-sharded_cluster
       - test-8.0-server
       - test-8.0-replica_set
       - test-8.0-sharded_cluster
@@ -3579,6 +3817,7 @@ buildvariants:
       - test-snappy-compression
       - test-zstd-compression
       - test-tls-support-latest
+      - test-tls-support-9.0
       - test-tls-support-8.0
       - test-tls-support-7.0
       - test-tls-support-6.0
@@ -3598,6 +3837,9 @@ buildvariants:
       - test-rapid-server
       - test-rapid-replica_set
       - test-rapid-sharded_cluster
+      - test-9.0-server
+      - test-9.0-replica_set
+      - test-9.0-sharded_cluster
       - test-8.0-server
       - test-8.0-replica_set
       - test-8.0-sharded_cluster
@@ -3620,6 +3862,7 @@ buildvariants:
       - test-snappy-compression
       - test-zstd-compression
       - test-tls-support-latest
+      - test-tls-support-9.0
       - test-tls-support-8.0
       - test-tls-support-7.0
       - test-tls-support-6.0
@@ -3639,6 +3882,9 @@ buildvariants:
       - test-rapid-server
       - test-rapid-replica_set
       - test-rapid-sharded_cluster
+      - test-9.0-server
+      - test-9.0-replica_set
+      - test-9.0-sharded_cluster
       - test-8.0-server
       - test-8.0-replica_set
       - test-8.0-sharded_cluster
@@ -3661,6 +3907,7 @@ buildvariants:
       - test-snappy-compression
       - test-zstd-compression
       - test-tls-support-latest
+      - test-tls-support-9.0
       - test-tls-support-8.0
       - test-tls-support-7.0
       - test-tls-support-6.0
@@ -3680,6 +3927,9 @@ buildvariants:
       - test-rapid-server
       - test-rapid-replica_set
       - test-rapid-sharded_cluster
+      - test-9.0-server
+      - test-9.0-replica_set
+      - test-9.0-sharded_cluster
       - test-8.0-server
       - test-8.0-replica_set
       - test-8.0-sharded_cluster
@@ -3701,6 +3951,7 @@ buildvariants:
       - test-snappy-compression
       - test-zstd-compression
       - test-tls-support-latest
+      - test-tls-support-9.0
       - test-tls-support-8.0
       - test-tls-support-7.0
       - test-tls-support-6.0
@@ -3716,6 +3967,7 @@ buildvariants:
     tasks:
       - test-latest-csfle-mongocryptd
       - test-rapid-csfle-mongocryptd
+      - test-9.0-csfle-mongocryptd
       - test-8.0-csfle-mongocryptd
       - test-7.0-csfle-mongocryptd
       - test-6.0-csfle-mongocryptd
@@ -3731,6 +3983,7 @@ buildvariants:
     tasks:
       - test-latest-csfle-mongocryptd
       - test-rapid-csfle-mongocryptd
+      - test-9.0-csfle-mongocryptd
       - test-8.0-csfle-mongocryptd
       - test-7.0-csfle-mongocryptd
       - test-6.0-csfle-mongocryptd
@@ -3827,6 +4080,9 @@ buildvariants:
       - test-rapid-server-noauth
       - test-rapid-replica_set-noauth
       - test-rapid-sharded_cluster-noauth
+      - test-9.0-server-noauth
+      - test-9.0-replica_set-noauth
+      - test-9.0-sharded_cluster-noauth
       - test-8.0-server-noauth
       - test-8.0-replica_set-noauth
       - test-8.0-sharded_cluster-noauth

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -3979,7 +3979,7 @@ buildvariants:
     expansions:
       CLIENT_ENCRYPTION: true
       RUN_WITH_MONGOCRYPTD: true
-      NODE_LTS_VERSION: 20.19.0
+      NODE_LTS_VERSION: 24
     tasks:
       - test-latest-csfle-mongocryptd
       - test-rapid-csfle-mongocryptd

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -465,7 +465,7 @@ for (const nodeVersion of [LOWEST_LTS, LATEST_LTS]) {
     expansions: {
       CLIENT_ENCRYPTION: true,
       RUN_WITH_MONGOCRYPTD: true,
-      NODE_LTS_VERSION: LOWEST_LTS
+      NODE_LTS_VERSION: nodeVersion
     },
     tasks: MONGOCRYPTD_CSFLE_TASKS.map(task => task.name)
   });


### PR DESCRIPTION
### Description

#### Summary of Changes

From DRIVERS-3610:

> In server, v9.0 branched off of master on July 13, 2026, so latest is no longer testing what will become 9.0.0.
> 
> 9.0.0 release candidates are not in full.json, so the most expedient thing to do is to temporarily point "9.0" to the latest build of the v9.0 branch, just like latest is the latest build of the master branch.
> 
> Each driver should then add 9.0 to the test matrix.

We need to bump the submodule (drivers-evergreen-tools) to latest to pick up required changes.
We also need to update MONGODB_VERSIONS in .evergreen/ci_matrix_constants.js and regen the evergreen config, so the new tasks fan out automatically.
No cleanup will be needed on our side when 9.0 GAs: UNPUBLISHED_VERSIONS entry will be removed in drivers-evergreen-tools.

### Double check the following

- [x] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
