### PR TITLE
chore(NODE-7767): bson compat tests snappy fix

### DIFF
--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -74,7 +74,7 @@ functions:
       params:
         working_dir: src
         script: |
-          # Strip any `npm install snappy` from the test runner so it cannot clobber the pin above.
+          # Strip any `npm install snappy` from the test runner so it cannot clobber v7.3.3.
           sed -i 's/npm install snappy//' .evergreen/run-tests.sh
   "bootstrap mongo-orchestration":
     - command: subprocess.exec

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -76,6 +76,8 @@ functions:
         script: |
           source ${DRIVERS_TOOLS}/.evergreen/init-node-and-npm-env.sh
           npm install snappy@7.3.3
+          # Strip any `npm install snappy` from the test runner so it cannot clobber the pin above.
+          sed -i 's/npm install snappy//' .evergreen/run-tests.sh
   "bootstrap mongo-orchestration":
     - command: subprocess.exec
       params:

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -68,7 +68,14 @@ functions:
           git fetch origin "${SOURCE_REV}:${SOURCE_REV}"
           git checkout "${SOURCE_REV}"
           npm i
-
+  "NODE-7767 pin snappy":
+    # TODO: Remove this when snappy v7.4 is operational or there's a fix version which fixes require() breaks
+    - command: shell.exec
+      params:
+        working_dir: src
+        script: |
+          source ${DRIVERS_TOOLS}/.evergreen/init-node-and-npm-env.sh
+          npm install snappy@7.3.3
   "bootstrap mongo-orchestration":
     - command: subprocess.exec
       params:
@@ -1048,6 +1055,7 @@ tasks:
       - func: install package
         vars:
           PACKAGE: https://github.com/mongodb/js-bson#HEAD
+      - func: NODE-7767 pin snappy
       - func: log state
       - func: run tests
 
@@ -1073,6 +1081,7 @@ tasks:
       - func: install package
         vars:
           PACKAGE: https://github.com/mongodb/js-bson#HEAD
+      - func: NODE-7767 pin snappy
       - func: log state
       - func: run tests
 
@@ -1098,6 +1107,7 @@ tasks:
       - func: install package
         vars:
           PACKAGE: https://github.com/mongodb/js-bson#HEAD
+      - func: NODE-7767 pin snappy
       - func: log state
       - func: run tests
 

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -68,14 +68,12 @@ functions:
           git fetch origin "${SOURCE_REV}:${SOURCE_REV}"
           git checkout "${SOURCE_REV}"
           npm i
-  "NODE-7767 pin snappy":
+  "NODE-7767 strip snappy install from test runner":
     # TODO: Remove this when snappy v7.4 is operational or there's a fix version which fixes require() breaks
     - command: shell.exec
       params:
         working_dir: src
         script: |
-          source ${DRIVERS_TOOLS}/.evergreen/init-node-and-npm-env.sh
-          npm install snappy@7.3.3
           # Strip any `npm install snappy` from the test runner so it cannot clobber the pin above.
           sed -i 's/npm install snappy//' .evergreen/run-tests.sh
   "bootstrap mongo-orchestration":
@@ -1057,7 +1055,7 @@ tasks:
       - func: install package
         vars:
           PACKAGE: https://github.com/mongodb/js-bson#HEAD
-      - func: NODE-7767 pin snappy
+      - func: NODE-7767 strip snappy install from test runner
       - func: log state
       - func: run tests
 
@@ -1083,7 +1081,7 @@ tasks:
       - func: install package
         vars:
           PACKAGE: https://github.com/mongodb/js-bson#HEAD
-      - func: NODE-7767 pin snappy
+      - func: NODE-7767 strip snappy install from test runner
       - func: log state
       - func: run tests
 
@@ -1109,7 +1107,7 @@ tasks:
       - func: install package
         vars:
           PACKAGE: https://github.com/mongodb/js-bson#HEAD
-      - func: NODE-7767 pin snappy
+      - func: NODE-7767 strip snappy install from test runner
       - func: log state
       - func: run tests
 

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -68,8 +68,8 @@ functions:
           git fetch origin "${SOURCE_REV}:${SOURCE_REV}"
           git checkout "${SOURCE_REV}"
           npm i
-  "NODE-7767 strip snappy install from test runner":
-    # TODO: Remove this when snappy v7.4 is operational or there's a fix version which fixes require() breaks
+  "strip snappy install from test runner":
+    # TODO: NODE-7766 Remove this when snappy v7.4 is operational or there's a fix version which fixes require() breaks
     - command: shell.exec
       params:
         working_dir: src
@@ -1055,7 +1055,7 @@ tasks:
       - func: install package
         vars:
           PACKAGE: https://github.com/mongodb/js-bson#HEAD
-      - func: NODE-7767 strip snappy install from test runner
+      - func: strip snappy install from test runner
       - func: log state
       - func: run tests
 
@@ -1081,7 +1081,7 @@ tasks:
       - func: install package
         vars:
           PACKAGE: https://github.com/mongodb/js-bson#HEAD
-      - func: NODE-7767 strip snappy install from test runner
+      - func: strip snappy install from test runner
       - func: log state
       - func: run tests
 
@@ -1107,7 +1107,7 @@ tasks:
       - func: install package
         vars:
           PACKAGE: https://github.com/mongodb/js-bson#HEAD
-      - func: NODE-7767 strip snappy install from test runner
+      - func: strip snappy install from test runner
       - func: log state
       - func: run tests
 

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -40,7 +40,7 @@ functions:
           git fetch origin "${SOURCE_REV}:${SOURCE_REV}"
           git checkout "${SOURCE_REV}"
           npm i
-  NODE-7767 strip snappy install from test runner:
+  strip snappy install from test runner:
     - command: shell.exec
       params:
         working_dir: src
@@ -969,7 +969,7 @@ tasks:
       - func: install package
         vars:
           PACKAGE: https://github.com/mongodb/js-bson#HEAD
-      - func: NODE-7767 strip snappy install from test runner
+      - func: strip snappy install from test runner
       - func: log state
       - func: run tests
   - name: test-bson-latest-driver-7.0.0-replica_set-tests
@@ -992,7 +992,7 @@ tasks:
       - func: install package
         vars:
           PACKAGE: https://github.com/mongodb/js-bson#HEAD
-      - func: NODE-7767 strip snappy install from test runner
+      - func: strip snappy install from test runner
       - func: log state
       - func: run tests
   - name: test-bson-latest-driver-7.0.0-sharded_cluster-tests
@@ -1015,7 +1015,7 @@ tasks:
       - func: install package
         vars:
           PACKAGE: https://github.com/mongodb/js-bson#HEAD
-      - func: NODE-7767 strip snappy install from test runner
+      - func: strip snappy install from test runner
       - func: log state
       - func: run tests
   - name: test-latest-server

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -47,6 +47,8 @@ functions:
         script: |
           source ${DRIVERS_TOOLS}/.evergreen/init-node-and-npm-env.sh
           npm install snappy@7.3.3
+          # Strip any `npm install snappy` from the test runner so it cannot clobber the pin above.
+          sed -i 's/npm install snappy//' .evergreen/run-tests.sh
   bootstrap mongo-orchestration:
     - command: subprocess.exec
       params:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -40,6 +40,13 @@ functions:
           git fetch origin "${SOURCE_REV}:${SOURCE_REV}"
           git checkout "${SOURCE_REV}"
           npm i
+  NODE-7767 pin snappy:
+    - command: shell.exec
+      params:
+        working_dir: src
+        script: |
+          source ${DRIVERS_TOOLS}/.evergreen/init-node-and-npm-env.sh
+          npm install snappy@7.3.3
   bootstrap mongo-orchestration:
     - command: subprocess.exec
       params:
@@ -962,6 +969,7 @@ tasks:
       - func: install package
         vars:
           PACKAGE: https://github.com/mongodb/js-bson#HEAD
+      - func: NODE-7767 pin snappy
       - func: log state
       - func: run tests
   - name: test-bson-latest-driver-7.0.0-replica_set-tests
@@ -984,6 +992,7 @@ tasks:
       - func: install package
         vars:
           PACKAGE: https://github.com/mongodb/js-bson#HEAD
+      - func: NODE-7767 pin snappy
       - func: log state
       - func: run tests
   - name: test-bson-latest-driver-7.0.0-sharded_cluster-tests
@@ -1006,6 +1015,7 @@ tasks:
       - func: install package
         vars:
           PACKAGE: https://github.com/mongodb/js-bson#HEAD
+      - func: NODE-7767 pin snappy
       - func: log state
       - func: run tests
   - name: test-latest-server

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -45,7 +45,7 @@ functions:
       params:
         working_dir: src
         script: |
-          # Strip any `npm install snappy` from the test runner so it cannot clobber the pin above.
+          # Strip any `npm install snappy` from the test runner so it cannot clobber v7.3.3.
           sed -i 's/npm install snappy//' .evergreen/run-tests.sh
   bootstrap mongo-orchestration:
     - command: subprocess.exec

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -40,13 +40,11 @@ functions:
           git fetch origin "${SOURCE_REV}:${SOURCE_REV}"
           git checkout "${SOURCE_REV}"
           npm i
-  NODE-7767 pin snappy:
+  NODE-7767 strip snappy install from test runner:
     - command: shell.exec
       params:
         working_dir: src
         script: |
-          source ${DRIVERS_TOOLS}/.evergreen/init-node-and-npm-env.sh
-          npm install snappy@7.3.3
           # Strip any `npm install snappy` from the test runner so it cannot clobber the pin above.
           sed -i 's/npm install snappy//' .evergreen/run-tests.sh
   bootstrap mongo-orchestration:
@@ -971,7 +969,7 @@ tasks:
       - func: install package
         vars:
           PACKAGE: https://github.com/mongodb/js-bson#HEAD
-      - func: NODE-7767 pin snappy
+      - func: NODE-7767 strip snappy install from test runner
       - func: log state
       - func: run tests
   - name: test-bson-latest-driver-7.0.0-replica_set-tests
@@ -994,7 +992,7 @@ tasks:
       - func: install package
         vars:
           PACKAGE: https://github.com/mongodb/js-bson#HEAD
-      - func: NODE-7767 pin snappy
+      - func: NODE-7767 strip snappy install from test runner
       - func: log state
       - func: run tests
   - name: test-bson-latest-driver-7.0.0-sharded_cluster-tests
@@ -1017,7 +1015,7 @@ tasks:
       - func: install package
         vars:
           PACKAGE: https://github.com/mongodb/js-bson#HEAD
-      - func: NODE-7767 pin snappy
+      - func: NODE-7767 strip snappy install from test runner
       - func: log state
       - func: run tests
   - name: test-latest-server


### PR DESCRIPTION
### Description

#### Summary of Changes

Snappy's default installed developer deps via install-dependencies.sh are clobbered via the intaked script run-tests.sh which comes from v7.0.0 of the driver in our bson compat tests runner. This change will forcibly strip out the offending instruction from the script.

##### Notes for Reviewers

<!-- 
If there is any additional context on the changes in the PR that reviewers might find helpful, feel free to make notes in this section.

Otherwise, feel free to remove this section.
-->

#### What is the motivation for this change?

<!--
Remove this section if there is an associated Jira ticket explaining the motivation for this change. If there is not, please fill this section out with
information explaining why this change is valuable.
-->

### Release Highlight

<!-- 
Contributors: please leave the release notes section for the Node driver team to fill in. The following instructions are for maintainers.

For user facing changes: please provide release notes. Feel free to browse previous releases for example release highlights.

If there are no user-facing changes in this PR, please delete the release highlight section from the PR description.
-->

<!-- RELEASE_HIGHLIGHT_START -->

### Release notes highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Lint is passing (`npm run check:lint`)
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
