### PR TITLE
docs: Add preliminary checks to release instructions

### DIFF
--- a/etc/notes/releasing.md
+++ b/etc/notes/releasing.md
@@ -74,6 +74,10 @@ The MongoDB driver can now generate a cup of joe.
 
 ## Release Instructions
 
+1. Verify that the release is ready.
+    - Check the Jira release to make sure all worked tagged for this release has been completed.
+    - Check CI for failures.
+    - Check the performance metrics to make sure there are no regressions.
 1. On slack notify `#node-driver-docs`, `#nodejs-devtools`, and `#mongoose` that we intend to publish a release.
     - You may skip this step if you are releasing a package other than the driver.
 1. **If there are new or changed experimental features**, update `EXPERIMENTAL_FEATURES.md`

--- a/etc/notes/releasing.md
+++ b/etc/notes/releasing.md
@@ -75,7 +75,7 @@ The MongoDB driver can now generate a cup of joe.
 ## Release Instructions
 
 1. Verify that the release is ready.
-    - Check the Jira release to make sure all worked tagged for this release has been completed.
+    - Check the JIRA release to make sure all work tagged for this release has been completed.
     - Check CI for failures.
     - Check the performance metrics to make sure there are no regressions.
 1. On slack notify `#node-driver-docs`, `#nodejs-devtools`, and `#mongoose` that we intend to publish a release.


### PR DESCRIPTION
Added a first step to verify release readiness.

### Description

#### Summary of Changes

New first step for the release instructions to verify the release for readiness.

#### What is the motivation for this change?

More reliable releases

### Double check the following

- [ ] Lint is passing (`npm run check:lint`)
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [N/A] Changes are covered by tests
- [N/A] New TODOs have a related JIRA ticket
