### PR TITLE
chore: use bson@7.3.2 on CI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4201,9 +4201,9 @@
       }
     },
     "node_modules/bson": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-7.3.1.tgz",
-      "integrity": "sha512-h/C0qe6857pQhcSJHLfsR1uYGj98Ge3wKAD3Ed9KqH3wcVh+BM4Jq4xISD7vs9OPuT07n+q3QQVjslJ286j6ag==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-7.3.2.tgz",
+      "integrity": "sha512-1w0ra+ho1cuE+w8jzwgzTFIimFtCfZeCoOsvIPQg6uyFCsp8M29U7bNNf5GrFh88TXbYg1g3TyKUGpd6O7q6zA==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20.19.0"


### PR DESCRIPTION
### Description

#### Summary of Changes

Use latest `bson` in CI for correctness (compatibility) and performance tests.

### Double check the following

- [x] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
