### PR TITLE
chore(NODE-7765): add default timeouts

### DIFF
--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -129,12 +129,12 @@ functions:
     - <<: *assume_secrets_manager_role
     - command: subprocess.exec
       type: test
+      timeout_secs: 300
       params:
         env:
           TEST_CSFLE: "true"
         add_expansions_to_env: true
         working_dir: "src"
-        timeout_secs: 300
         binary: bash
         args:
           - .evergreen/run-tests.sh
@@ -178,21 +178,21 @@ functions:
   "run-lb-tests":
     - command: subprocess.exec
       type: test
+      timeout_secs: 300
       params:
         add_expansions_to_env: true
         binary: bash
         working_dir: src
-        timeout_secs: 300
         args:
           - .evergreen/run-tests.sh
 
   "run-compression-tests":
     - command: subprocess.exec
       type: test
+      timeout_secs: 300
       params:
         binary: bash
         working_dir: src
-        timeout_secs: 300
         add_expansions_to_env: true
         args:
           - .evergreen/run-tests.sh
@@ -208,9 +208,9 @@ functions:
   "run lint checks":
     - command: subprocess.exec
       type: test
+      timeout_secs: 60
       params:
         working_dir: "src"
-        timeout_secs: 60
         env:
           PROJECT_DIRECTORY: ${PROJECT_DIRECTORY}
           DRIVERS_TOOLS: ${DRIVERS_TOOLS}
@@ -221,9 +221,9 @@ functions:
   "run unit tests":
     - command: subprocess.exec
       type: test
+      timeout_secs: 60
       params:
         working_dir: "src"
-        timeout_secs: 60
         env:
           PROJECT_DIRECTORY: ${PROJECT_DIRECTORY}
           DRIVERS_TOOLS: ${DRIVERS_TOOLS}
@@ -234,9 +234,9 @@ functions:
   "check types":
     - command: subprocess.exec
       type: test
+      timeout_secs: 60
       params:
         working_dir: "src"
-        timeout_secs: 60
         env:
           PROJECT_DIRECTORY: ${PROJECT_DIRECTORY}
           DRIVERS_TOOLS: ${DRIVERS_TOOLS}
@@ -250,9 +250,9 @@ functions:
   "check resource management":
     - command: subprocess.exec
       type: test
+      timeout_secs: 60
       params:
         working_dir: "src"
-        timeout_secs: 60
         env:
           PROJECT_DIRECTORY: ${PROJECT_DIRECTORY}
           DRIVERS_TOOLS: ${DRIVERS_TOOLS}
@@ -263,9 +263,9 @@ functions:
   "check resource management feature integration":
     - command: subprocess.exec
       type: test
+      timeout_secs: 60
       params:
         working_dir: "src"
-        timeout_secs: 60
         env:
           PROJECT_DIRECTORY: ${PROJECT_DIRECTORY}
           DRIVERS_TOOLS: ${DRIVERS_TOOLS}
@@ -277,9 +277,9 @@ functions:
   "compile driver":
     - command: subprocess.exec
       type: test
+      timeout_secs: 60
       params:
         working_dir: "src"
-        timeout_secs: 60
         env:
           PROJECT_DIRECTORY: ${PROJECT_DIRECTORY}
           DRIVERS_TOOLS: ${DRIVERS_TOOLS}
@@ -578,9 +578,9 @@ functions:
 
   "run lambda handler example tests":
     - command: subprocess.exec
+      timeout_secs: 60
       params:
         working_dir: "src"
-        timeout_secs: 60
         env:
           MONGODB_URI: ${MONGODB_URI}
           PROJECT_DIRECTORY: ${PROJECT_DIRECTORY}

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -13,13 +13,28 @@ command_type: system
 # That roughly accounts for variable system performance for various buildvariants
 exec_timeout_secs: 7200
 
+# Default idle timeout for every command that does not set its own `timeout_secs`.
+# Commands that need something tighter set `timeout_secs` next to `command:`, which wins.
+timeout_secs: 300
+
 # What to do when evergreen hits the timeout (`post:` tasks are run automatically)
+# A stalled task is usually a leaked child process still holding the command's
+# stdout open, so dump the process tables before the host is reclaimed. On Windows
+# `ps` only lists cygwin processes, hence `tasklist` for native ones. Every command
+# is guarded so the handler cannot itself fail or hang.
 timeout:
-  - command: subprocess.exec
+  - command: shell.exec
     params:
-      binary: ls
-      args:
-        - "-la"
+      shell: bash
+      script: |
+        echo "--- task directory ---"
+        ls -la || true
+        echo "--- unix/cygwin process table ---"
+        ps -ef || true
+        echo "--- windows process table ---"
+        tasklist //V || true
+        echo "--- listening sockets ---"
+        netstat -an || ss -tuna || true
 
 functions:
   "assume secrets manager role": &assume_secrets_manager_role
@@ -129,7 +144,6 @@ functions:
     - <<: *assume_secrets_manager_role
     - command: subprocess.exec
       type: test
-      timeout_secs: 300
       params:
         env:
           TEST_CSFLE: "true"
@@ -178,7 +192,6 @@ functions:
   "run-lb-tests":
     - command: subprocess.exec
       type: test
-      timeout_secs: 300
       params:
         add_expansions_to_env: true
         binary: bash
@@ -189,7 +202,6 @@ functions:
   "run-compression-tests":
     - command: subprocess.exec
       type: test
-      timeout_secs: 300
       params:
         binary: bash
         working_dir: src
@@ -682,6 +694,11 @@ functions:
   "run spec driver benchmarks":
     - command: subprocess.exec
       type: test
+      # The benchmark runner prints one line per benchmark, only once that benchmark
+      # finishes, and each one runs until it accumulates 5 minutes of task time or
+      # 100 iterations (test/benchmarks/driver_bench/src/runner.mts). So a single
+      # benchmark is legitimately silent for longer than the project-wide default.
+      timeout_secs: 600
       params:
         working_dir: "src"
         env:

--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -21,7 +21,8 @@ timeout_secs: 300
 # A stalled task is usually a leaked child process still holding the command's
 # stdout open, so dump the process tables before the host is reclaimed. On Windows
 # `ps` only lists cygwin processes, hence `tasklist` for native ones. Every command
-# is guarded so the handler cannot itself fail or hang.
+# is `|| true` so a missing tool does not fail the handler; evergreen bounds the block
+# as a whole with its 15 minute callback timeout.
 timeout:
   - command: shell.exec
     params:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1,12 +1,20 @@
 stepback: true
 command_type: system
 exec_timeout_secs: 7200
+timeout_secs: 300
 timeout:
-  - command: subprocess.exec
+  - command: shell.exec
     params:
-      binary: ls
-      args:
-        - '-la'
+      shell: bash
+      script: |
+        echo "--- task directory ---"
+        ls -la || true
+        echo "--- unix/cygwin process table ---"
+        ps -ef || true
+        echo "--- windows process table ---"
+        tasklist //V || true
+        echo "--- listening sockets ---"
+        netstat -an || ss -tuna || true
 functions:
   assume secrets manager role:
     - command: ec2.assume_role
@@ -97,7 +105,6 @@ functions:
         role_arn: ${DRIVERS_SECRETS_ARN}
     - command: subprocess.exec
       type: test
-      timeout_secs: 300
       params:
         env:
           TEST_CSFLE: 'true'
@@ -141,7 +148,6 @@ functions:
   run-lb-tests:
     - command: subprocess.exec
       type: test
-      timeout_secs: 300
       params:
         add_expansions_to_env: true
         binary: bash
@@ -151,7 +157,6 @@ functions:
   run-compression-tests:
     - command: subprocess.exec
       type: test
-      timeout_secs: 300
       params:
         binary: bash
         working_dir: src
@@ -612,6 +617,7 @@ functions:
   run spec driver benchmarks:
     - command: subprocess.exec
       type: test
+      timeout_secs: 600
       params:
         working_dir: src
         env:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -97,12 +97,12 @@ functions:
         role_arn: ${DRIVERS_SECRETS_ARN}
     - command: subprocess.exec
       type: test
+      timeout_secs: 300
       params:
         env:
           TEST_CSFLE: 'true'
         add_expansions_to_env: true
         working_dir: src
-        timeout_secs: 300
         binary: bash
         args:
           - .evergreen/run-tests.sh
@@ -141,20 +141,20 @@ functions:
   run-lb-tests:
     - command: subprocess.exec
       type: test
+      timeout_secs: 300
       params:
         add_expansions_to_env: true
         binary: bash
         working_dir: src
-        timeout_secs: 300
         args:
           - .evergreen/run-tests.sh
   run-compression-tests:
     - command: subprocess.exec
       type: test
+      timeout_secs: 300
       params:
         binary: bash
         working_dir: src
-        timeout_secs: 300
         add_expansions_to_env: true
         args:
           - .evergreen/run-tests.sh
@@ -168,9 +168,9 @@ functions:
   run lint checks:
     - command: subprocess.exec
       type: test
+      timeout_secs: 60
       params:
         working_dir: src
-        timeout_secs: 60
         env:
           PROJECT_DIRECTORY: ${PROJECT_DIRECTORY}
           DRIVERS_TOOLS: ${DRIVERS_TOOLS}
@@ -180,9 +180,9 @@ functions:
   run unit tests:
     - command: subprocess.exec
       type: test
+      timeout_secs: 60
       params:
         working_dir: src
-        timeout_secs: 60
         env:
           PROJECT_DIRECTORY: ${PROJECT_DIRECTORY}
           DRIVERS_TOOLS: ${DRIVERS_TOOLS}
@@ -192,9 +192,9 @@ functions:
   check types:
     - command: subprocess.exec
       type: test
+      timeout_secs: 60
       params:
         working_dir: src
-        timeout_secs: 60
         env:
           PROJECT_DIRECTORY: ${PROJECT_DIRECTORY}
           DRIVERS_TOOLS: ${DRIVERS_TOOLS}
@@ -207,9 +207,9 @@ functions:
   check resource management:
     - command: subprocess.exec
       type: test
+      timeout_secs: 60
       params:
         working_dir: src
-        timeout_secs: 60
         env:
           PROJECT_DIRECTORY: ${PROJECT_DIRECTORY}
           DRIVERS_TOOLS: ${DRIVERS_TOOLS}
@@ -219,9 +219,9 @@ functions:
   check resource management feature integration:
     - command: subprocess.exec
       type: test
+      timeout_secs: 60
       params:
         working_dir: src
-        timeout_secs: 60
         env:
           PROJECT_DIRECTORY: ${PROJECT_DIRECTORY}
           DRIVERS_TOOLS: ${DRIVERS_TOOLS}
@@ -232,9 +232,9 @@ functions:
   compile driver:
     - command: subprocess.exec
       type: test
+      timeout_secs: 60
       params:
         working_dir: src
-        timeout_secs: 60
         env:
           PROJECT_DIRECTORY: ${PROJECT_DIRECTORY}
           DRIVERS_TOOLS: ${DRIVERS_TOOLS}
@@ -517,9 +517,9 @@ functions:
           - .evergreen/run-custom-csfle-tests.sh
   run lambda handler example tests:
     - command: subprocess.exec
+      timeout_secs: 60
       params:
         working_dir: src
-        timeout_secs: 60
         env:
           MONGODB_URI: ${MONGODB_URI}
           PROJECT_DIRECTORY: ${PROJECT_DIRECTORY}


### PR DESCRIPTION
### Description

#### Summary of Changes

This PR adds a default `timeout_secs: 300` to all tasks, which means that if the task produces no stdout/stderr output for 5 minutes, the task will be killed.

##### Notes for Reviewers

Changes:
- set a global 5 minute timeout
- remove existing 5 minute timeouts
- set timeout to be 10 minutes for benchmarks
- when timeout is triggered, log diagnostics data, so we can identify what caused the timeout

#### What is the motivation for this change?

Timeouts weren't correctly set in evergreen config, so tasks only timed out after 2 hours (default timeout value).

### Double check the following

- [ ] Lint is passing (`npm run check:lint`)
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
