### PR TITLE
chore(NODE-7794): use correct ldap test target

### DIFF
--- a/.evergreen/run-kerberos-tests.sh
+++ b/.evergreen/run-kerberos-tests.sh
@@ -14,17 +14,17 @@ echo "Writing keytab"
 # DON'T PRINT KEYTAB TO STDOUT
 set +o verbose
 if [[ "$OSTYPE" == "darwin"* ]]; then
-    echo ${KEYTAB_BASE64_BUILD} | base64 -D >"$(pwd)/.evergreen/drivers.keytab"
+    echo ${KEYTAB_BASE64} | base64 -D >"$(pwd)/.evergreen/drivers.keytab"
 else
-    echo ${KEYTAB_BASE64_BUILD} | base64 -d >"$(pwd)/.evergreen/drivers.keytab"
+    echo ${KEYTAB_BASE64} | base64 -d >"$(pwd)/.evergreen/drivers.keytab"
 fi
 echo "Running kdestroy"
 kdestroy -A
 echo "Running kinit"
-kinit -k -t "$(pwd)/.evergreen/drivers.keytab" -p ${PRINCIPAL_BUILD}
+kinit -k -t "$(pwd)/.evergreen/drivers.keytab" -p ${PRINCIPAL}
 
-USER=$(node -p "encodeURIComponent(process.env.PRINCIPAL_BUILD)")
-export MONGODB_URI="mongodb://${USER}@${SASL_HOST_BUILD}/${GSSAPI_DB}?authMechanism=GSSAPI"
+USER=$(node -p "encodeURIComponent(process.env.PRINCIPAL)")
+export MONGODB_URI="mongodb://${USER}@${SASL_HOST}/${GSSAPI_DB}?authMechanism=GSSAPI"
 
 set -o xtrace
 

--- a/test/manual/kerberos.test.ts
+++ b/test/manual/kerberos.test.ts
@@ -41,10 +41,10 @@ describe('Kerberos', function () {
   });
 
   const krb5Uri = process.env.MONGODB_URI;
-  const host = process.env.SASL_HOST_BUILD;
+  const host = process.env.SASL_HOST;
 
-  if (!process.env.PRINCIPAL_BUILD) {
-    console.error('skipping Kerberos tests, PRINCIPAL_BUILD environment variable is not defined');
+  if (!process.env.PRINCIPAL) {
+    console.error('skipping Kerberos tests, PRINCIPAL environment variable is not defined');
     return;
   }
 
@@ -219,7 +219,7 @@ describe('Kerberos', function () {
       it('authenticates', async function () {
         client = new MongoClient(`${krb5Uri}&maxPoolSize=1`, {
           authMechanismProperties: {
-            SERVICE_HOST: 'ldaptest.build.10gen.cc'
+            SERVICE_HOST: 'ldaptest.10gen.cc'
           }
         });
 
@@ -256,7 +256,7 @@ describe('Kerberos', function () {
 
   it('should fail to authenticate with bad credentials', async function () {
     client = new MongoClient(
-      krb5Uri.replace(encodeURIComponent(process.env.PRINCIPAL_BUILD), 'bad%40creds.cc')
+      krb5Uri.replace(encodeURIComponent(process.env.PRINCIPAL), 'bad%40creds.cc')
     );
     const err = await client.connect().catch(e => e);
     expect(err.message).to.match(/Authentication failed/);

--- a/test/manual/kerberos.test.ts
+++ b/test/manual/kerberos.test.ts
@@ -219,7 +219,7 @@ describe('Kerberos', function () {
       it('authenticates', async function () {
         client = new MongoClient(`${krb5Uri}&maxPoolSize=1`, {
           authMechanismProperties: {
-            SERVICE_HOST: 'ldaptest.10gen.cc'
+            SERVICE_HOST: 'ldaptest.build.10gen.cc'
           }
         });
 

--- a/test/manual/kerberos.test.ts
+++ b/test/manual/kerberos.test.ts
@@ -219,7 +219,7 @@ describe('Kerberos', function () {
       it('authenticates', async function () {
         client = new MongoClient(`${krb5Uri}&maxPoolSize=1`, {
           authMechanismProperties: {
-            SERVICE_HOST: 'ldaptest.build.10gen.cc'
+            SERVICE_HOST: host
           }
         });
 

--- a/test/manual/ldap.test.ts
+++ b/test/manual/ldap.test.ts
@@ -4,9 +4,9 @@ import * as process from 'process';
 import { MongoClient } from '../mongodb';
 
 describe('LDAP', function () {
-  const { SASL_USER, SASL_PASS, SASL_HOST_BUILD } = process.env;
+  const { SASL_USER, SASL_PASS, SASL_HOST } = process.env;
 
-  const MONGODB_URI = `mongodb://${SASL_USER}:${SASL_PASS}@${SASL_HOST_BUILD}?authMechanism=plain&authSource=$external`;
+  const MONGODB_URI = `mongodb://${SASL_USER}:${SASL_PASS}@${SASL_HOST}?authMechanism=plain&authSource=$external`;
 
   it('Should correctly authenticate against ldap', async function () {
     const client = new MongoClient(MONGODB_URI);

--- a/test/manual/ldap.test.ts
+++ b/test/manual/ldap.test.ts
@@ -11,14 +11,10 @@ describe('LDAP', function () {
   it('Should correctly authenticate against ldap', async function () {
     const client = new MongoClient(MONGODB_URI);
 
-    let thrown;
-    try {
-      await client.connect();
-    } catch (error) {
-      thrown = error;
-    }
+    await client.connect();
 
-    expect(thrown).to.not.exist;
+    const doc = await client.db('ldap').collection('test').findOne();
+    expect(doc).property('ldap').to.equal(true);
 
     await client.close();
   });


### PR DESCRIPTION
### Description

#### Summary of Changes

The backing values for _BUILD-suffixed enterprise auth environment variables have been zeroed out. Now that the original values are compatible with the driver again, we should move back. This unblocks CI.

##### Notes for Reviewers

<!-- 
If there is any additional context on the changes in the PR that reviewers might find helpful, feel free to make notes in this section.

Otherwise, feel free to remove this section.
-->

#### What is the motivation for this change?

<!--
Remove this section if there is an associated Jira ticket explaining the motivation for this change. If there is not, please fill this section out with
information explaining why this change is valuable.
-->

### Release Highlight

<!-- 
Contributors: please leave the release notes section for the Node driver team to fill in. The following instructions are for maintainers.

For user facing changes: please provide release notes. Feel free to browse previous releases for example release highlights.

If there are no user-facing changes in this PR, please delete the release highlight section from the PR description.
-->

<!-- RELEASE_HIGHLIGHT_START -->

### Release notes highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Lint is passing (`npm run check:lint`)
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
