### PR TITLE
chore(NODE-7691): add optional section into PR template for bug fixes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,6 +19,22 @@ Remove this section if there is an associated Jira ticket explaining the motivat
 information explaining why this change is valuable.
 -->
 
+#### For bug fixes
+
+<!-- Delete this section if this PR is not a bug fix. -->
+
+**Current (incorrect) behaviour:**
+
+**Expected behaviour:**
+
+**How to reproduce:**
+
+<!-- Minimal code sample or the failing test, plus any relevant configuration. -->
+
+**Affected versions:**
+
+<!-- Driver version(s) where the bug appears, plus Node.js and MongoDB server versions and topology if they matter. -->
+
 ### Release Highlight
 
 <!-- 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,9 +23,9 @@ information explaining why this change is valuable.
 
 <!-- Remove this section if this PR is not a bug fix. -->
 
-**Current (incorrect) behaviour:**
+**Current (incorrect) behavior:**
 
-**Expected behaviour:**
+**Expected behavior:**
 
 **How to reproduce:**
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,7 +21,7 @@ information explaining why this change is valuable.
 
 #### For bug fixes
 
-<!-- Delete this section if this PR is not a bug fix. -->
+<!-- Remove this section if this PR is not a bug fix. -->
 
 **Current (incorrect) behaviour:**
 


### PR DESCRIPTION
### Description

#### Summary of Changes

Change the PR template adding one more (optional) section for bug fixes requesting additional information: expected-vs-actual, versions, repro steps.

### Double check the following

- [x] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
