### PR TITLE
chore(NODE-7805): restrict release_notes to PRs from this repository

### DIFF
--- a/.github/workflows/release_notes.yml
+++ b/.github/workflows/release_notes.yml
@@ -38,6 +38,23 @@ jobs:
             echo "$COMMENTER not permitted to trigger notes" && exit 1
           fi
 
+      # Release PRs are always branches in this repository, so refuse to check
+      # out and run code from a fork
+      - name: check if the PR comes from this repository
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event_name == 'issue_comment' && github.event.issue.number || inputs.releasePr }}
+          REPOSITORY: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -o pipefail
+          HEAD_REPOSITORY=$(gh api "/repos/$REPOSITORY/pulls/$PR_NUMBER" --jq ".head.repo.full_name")
+          if [ "$HEAD_REPOSITORY" = "$REPOSITORY" ]; then
+            echo "PR #$PR_NUMBER is from $REPOSITORY!" && exit 0
+          else
+            echo "PR #$PR_NUMBER is from $HEAD_REPOSITORY, not $REPOSITORY" && exit 1
+          fi
+
       # checkout the HEAD ref from prNumber
       - uses: actions/checkout@v7
         with:


### PR DESCRIPTION
### Description

#### Summary of Changes

Add a step to the `release_notes` workflow that checks the target PR's head branch lives in this repository, so the workflow refuses to check out and run code from a fork.

### Double check the following

- [x] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
