### PR TITLE
chore(NODE-7826): test connect() which includes auth, purely

### DIFF
--- a/test/manual/ldap.test.ts
+++ b/test/manual/ldap.test.ts
@@ -11,11 +11,14 @@ describe('LDAP', function () {
   it('Should correctly authenticate against ldap', async function () {
     const client = new MongoClient(MONGODB_URI);
 
-    await client.connect();
+    let thrown: Error;
+    try {
+      await client.connect();
+    } catch (error) {
+      thrown = error;
+    }
 
-    const doc = await client.db('ldap').collection('test').findOne();
-    expect(doc).property('ldap').to.equal(true);
-
+    expect(thrown).to.not.exist;
     await client.close();
   });
 });

--- a/test/manual/ldap.test.ts
+++ b/test/manual/ldap.test.ts
@@ -11,7 +11,7 @@ describe('LDAP', function () {
   it('Should correctly authenticate against ldap', async function () {
     const client = new MongoClient(MONGODB_URI);
 
-    let thrown: Error;
+    let thrown: Error | undefined;
     try {
       await client.connect();
     } catch (error) {


### PR DESCRIPTION
### Description

#### Summary of Changes

There is no data in the shared enterprise auth DB used in evergreen tests. This data is checked in our LDAP auth tests, but checking auth does not necessitate data checks, so we should remove this anyway.

Reverts: https://github.com/mongodb/node-mongodb-native/pull/5038/changes/2b3fc6fce1fa7d140d78fb2f2013175905d284eb which fixes the CI.

##### Notes for Reviewers

<!-- 
If there is any additional context on the changes in the PR that reviewers might find helpful, feel free to make notes in this section.

Otherwise, feel free to remove this section.
-->

#### What is the motivation for this change?

<!--
Remove this section if there is an associated Jira ticket explaining the motivation for this change. If there is not, please fill this section out with
information explaining why this change is valuable.
-->

### Release Highlight

<!-- 
Contributors: please leave the release notes section for the Node driver team to fill in. The following instructions are for maintainers.

For user facing changes: please provide release notes. Feel free to browse previous releases for example release highlights.

If there are no user-facing changes in this PR, please delete the release highlight section from the PR description.
-->

<!-- RELEASE_HIGHLIGHT_START -->

### Release notes highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Lint is passing (`npm run check:lint`)
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
