### PR TITLE
chore(NODE-7771): align tags to match their versions on evergreen tasks

### DIFF
--- a/.evergreen/config.in.yml
+++ b/.evergreen/config.in.yml
@@ -802,6 +802,9 @@ tasks:
             - src/.evergreen/run-deployed-gcp-kms-tests.sh
 
   - name: "test-gcpkms-fail-task"
+    tags:
+      - latest
+      - server
     # test-gcpkms-fail-task runs in a non-GCE environment.
     # It is expected to fail to obtain GCE credentials.
     commands:
@@ -843,6 +846,9 @@ tasks:
             - src/.evergreen/run-deployed-azure-kms-tests.sh
 
   - name: "test-azurekms-fail-task"
+    tags:
+      - latest
+      - server
     commands:
       - command: expansions.update
         type: setup
@@ -1052,6 +1058,9 @@ tasks:
       - func: run unit tests
 
   - name: test-bson-latest-driver-7.0.0-server-tests
+    tags:
+      - "v8.0-perf"
+      - server
     commands:
       - command: expansions.update
         type: setup
@@ -1078,6 +1087,9 @@ tasks:
       - func: run tests
 
   - name: test-bson-latest-driver-7.0.0-replica_set-tests
+    tags:
+      - "v8.0-perf"
+      - replica_set
     commands:
       - command: expansions.update
         type: setup
@@ -1104,6 +1116,9 @@ tasks:
       - func: run tests
 
   - name: test-bson-latest-driver-7.0.0-sharded_cluster-tests
+    tags:
+      - "v8.0-perf"
+      - sharded_cluster
     commands:
       - command: expansions.update
         type: setup

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -714,6 +714,9 @@ tasks:
           args:
             - src/.evergreen/run-deployed-gcp-kms-tests.sh
   - name: test-gcpkms-fail-task
+    tags:
+      - latest
+      - server
     commands:
       - command: expansions.update
         type: setup
@@ -751,6 +754,9 @@ tasks:
           args:
             - src/.evergreen/run-deployed-azure-kms-tests.sh
   - name: test-azurekms-fail-task
+    tags:
+      - latest
+      - server
     commands:
       - command: expansions.update
         type: setup
@@ -956,6 +962,9 @@ tasks:
       - func: log state
       - func: run unit tests
   - name: test-bson-latest-driver-7.0.0-server-tests
+    tags:
+      - v8.0-perf
+      - server
     commands:
       - command: expansions.update
         type: setup
@@ -979,6 +988,9 @@ tasks:
       - func: log state
       - func: run tests
   - name: test-bson-latest-driver-7.0.0-replica_set-tests
+    tags:
+      - v8.0-perf
+      - replica_set
     commands:
       - command: expansions.update
         type: setup
@@ -1002,6 +1014,9 @@ tasks:
       - func: log state
       - func: run tests
   - name: test-bson-latest-driver-7.0.0-sharded_cluster-tests
+    tags:
+      - v8.0-perf
+      - sharded_cluster
     commands:
       - command: expansions.update
         type: setup
@@ -1430,7 +1445,6 @@ tasks:
       - func: run tests
   - name: test-x509-authentication
     tags:
-      - latest
       - auth
       - x509
     commands:
@@ -1439,7 +1453,6 @@ tasks:
       - func: run x509 auth tests
   - name: test-sfp
     tags:
-      - latest
       - sfp
     commands:
       - func: install dependencies
@@ -1453,7 +1466,7 @@ tasks:
       - func: run atlas tests
   - name: test-5.0-load-balanced
     tags:
-      - latest
+      - '5.0'
       - sharded_cluster
       - load_balancer
     commands:
@@ -1474,7 +1487,7 @@ tasks:
       - func: stop-load-balancer
   - name: test-6.0-load-balanced
     tags:
-      - latest
+      - '6.0'
       - sharded_cluster
       - load_balancer
     commands:
@@ -1495,7 +1508,7 @@ tasks:
       - func: stop-load-balancer
   - name: test-7.0-load-balanced
     tags:
-      - latest
+      - '7.0'
       - sharded_cluster
       - load_balancer
     commands:
@@ -1516,7 +1529,7 @@ tasks:
       - func: stop-load-balancer
   - name: test-8.0-load-balanced
     tags:
-      - latest
+      - '8.0'
       - sharded_cluster
       - load_balancer
     commands:
@@ -1537,7 +1550,7 @@ tasks:
       - func: stop-load-balancer
   - name: test-9.0-load-balanced
     tags:
-      - latest
+      - '9.0'
       - sharded_cluster
       - load_balancer
     commands:
@@ -1558,7 +1571,7 @@ tasks:
       - func: stop-load-balancer
   - name: test-rapid-load-balanced
     tags:
-      - latest
+      - rapid
       - sharded_cluster
       - load_balancer
     commands:
@@ -1621,6 +1634,7 @@ tasks:
       - func: run ldap tests
   - name: test-socks5
     tags:
+      - latest
       - socks5
     commands:
       - command: expansions.update
@@ -1634,6 +1648,7 @@ tasks:
       - func: run socks5 tests
   - name: test-socks5-csfle
     tags:
+      - latest
       - socks5-csfle
     commands:
       - command: expansions.update
@@ -1648,6 +1663,7 @@ tasks:
       - func: run socks5 tests
   - name: test-socks5-tls
     tags:
+      - latest
       - socks5-tls
     commands:
       - command: expansions.update
@@ -1698,6 +1714,7 @@ tasks:
       - func: run-compression-tests
   - name: test-tls-support-latest
     tags:
+      - latest
       - tls-support
       - tls-support-latest
     commands:
@@ -1714,6 +1731,7 @@ tasks:
       - func: run tls tests
   - name: test-tls-support-9.0
     tags:
+      - '9.0'
       - tls-support
       - tls-support-9.0
     commands:
@@ -1730,6 +1748,7 @@ tasks:
       - func: run tls tests
   - name: test-tls-support-8.0
     tags:
+      - '8.0'
       - tls-support
       - tls-support-8.0
     commands:
@@ -1746,6 +1765,7 @@ tasks:
       - func: run tls tests
   - name: test-tls-support-7.0
     tags:
+      - '7.0'
       - tls-support
       - tls-support-7.0
     commands:
@@ -1762,6 +1782,7 @@ tasks:
       - func: run tls tests
   - name: test-tls-support-6.0
     tags:
+      - '6.0'
       - tls-support
       - tls-support-6.0
     commands:
@@ -1778,6 +1799,7 @@ tasks:
       - func: run tls tests
   - name: test-tls-support-5.0
     tags:
+      - '5.0'
       - tls-support
       - tls-support-5.0
     commands:
@@ -1794,6 +1816,7 @@ tasks:
       - func: run tls tests
   - name: test-tls-support-4.4
     tags:
+      - '4.4'
       - tls-support
       - tls-support-4.4
     commands:
@@ -1809,6 +1832,8 @@ tasks:
       - func: bootstrap mongo-orchestration
       - func: run tls tests
   - name: aws-latest-auth-test-run-aws-auth-test-with-regular-aws-credentials
+    tags:
+      - latest
     commands:
       - command: expansions.update
         type: setup
@@ -1824,6 +1849,8 @@ tasks:
       - func: assume secrets manager role
       - func: run aws auth test with regular aws credentials
   - name: aws-latest-auth-test-run-aws-auth-test-with-assume-role-credentials
+    tags:
+      - latest
     commands:
       - command: expansions.update
         type: setup
@@ -1839,6 +1866,8 @@ tasks:
       - func: assume secrets manager role
       - func: run aws auth test with assume role credentials
   - name: aws-latest-auth-test-run-aws-auth-test-with-aws-EC2-credentials
+    tags:
+      - latest
     commands:
       - command: expansions.update
         type: setup
@@ -1854,6 +1883,8 @@ tasks:
       - func: assume secrets manager role
       - func: run aws auth test with aws EC2 credentials
   - name: aws-latest-auth-test-run-aws-auth-test-with-aws-credentials-as-environment-variables
+    tags:
+      - latest
     commands:
       - command: expansions.update
         type: setup
@@ -1869,6 +1900,8 @@ tasks:
       - func: assume secrets manager role
       - func: run aws auth test with aws credentials as environment variables
   - name: aws-latest-auth-test-run-aws-auth-test-with-aws-credentials-and-session-token-as-environment-variables
+    tags:
+      - latest
     commands:
       - command: expansions.update
         type: setup
@@ -1884,6 +1917,8 @@ tasks:
       - func: assume secrets manager role
       - func: run aws auth test with aws credentials and session token as environment variables
   - name: aws-latest-auth-test-run-aws-ECS-auth-test
+    tags:
+      - latest
     commands:
       - command: expansions.update
         type: setup
@@ -1899,6 +1934,8 @@ tasks:
       - func: assume secrets manager role
       - func: run aws ECS auth test
   - name: aws-latest-auth-test-run-aws-auth-test-AssumeRoleWithWebIdentity-with-AWS_ROLE_SESSION_NAME-unset
+    tags:
+      - latest
     commands:
       - command: expansions.update
         type: setup
@@ -1914,6 +1951,8 @@ tasks:
       - func: assume secrets manager role
       - func: run aws auth test AssumeRoleWithWebIdentity with AWS_ROLE_SESSION_NAME unset
   - name: aws-latest-auth-test-run-aws-auth-test-AssumeRoleWithWebIdentity-with-AWS_ROLE_SESSION_NAME-set
+    tags:
+      - latest
     commands:
       - command: expansions.update
         type: setup
@@ -1930,6 +1969,7 @@ tasks:
       - func: run aws auth test AssumeRoleWithWebIdentity with AWS_ROLE_SESSION_NAME set
   - name: run-spec-benchmark-tests-node-server
     tags:
+      - v6.0-perf
       - run-spec-benchmark-tests
       - performance
     exec_timeout_secs: 7200
@@ -1949,6 +1989,7 @@ tasks:
       - func: perf send
   - name: run-spec-benchmark-tests-node-server-monitorCommands-true
     tags:
+      - v6.0-perf
       - run-spec-benchmark-tests
       - performance
     exec_timeout_secs: 7200
@@ -1968,6 +2009,7 @@ tasks:
       - func: perf send
   - name: run-spec-benchmark-tests-node-server-logging
     tags:
+      - v6.0-perf
       - run-spec-benchmark-tests
       - performance
     exec_timeout_secs: 7200
@@ -2031,6 +2073,7 @@ tasks:
       - func: run lint checks
   - name: test-explicit-resource-management-feature-integration
     tags:
+      - latest
       - resource-management
     commands:
       - command: expansions.update
@@ -2093,6 +2136,7 @@ tasks:
         patch_optional: true
   - name: run-custom-csfle-tests-5.0
     tags:
+      - '5.0'
       - run-custom-dependency-tests
     commands:
       - command: expansions.update
@@ -2110,6 +2154,7 @@ tasks:
       - func: run custom csfle tests
   - name: run-custom-csfle-tests-rapid
     tags:
+      - rapid
       - run-custom-dependency-tests
     commands:
       - command: expansions.update
@@ -2127,6 +2172,7 @@ tasks:
       - func: run custom csfle tests
   - name: run-custom-csfle-tests-latest
     tags:
+      - latest
       - run-custom-dependency-tests
     commands:
       - command: expansions.update
@@ -2144,6 +2190,7 @@ tasks:
       - func: run custom csfle tests
   - name: test-latest-driver-mongodb-client-encryption-7.0.0
     tags:
+      - '7.0'
       - run-custom-dependency-tests
     commands:
       - command: expansions.update
@@ -2162,6 +2209,7 @@ tasks:
       - func: run tests
   - name: test-alpine-fle
     tags:
+      - latest
       - alpine-fle
     commands:
       - command: expansions.update
@@ -2612,7 +2660,7 @@ tasks:
       - func: run tests
   - name: test-lambda-example
     tags:
-      - latest
+      - rapid
       - lambda
     commands:
       - command: expansions.update
@@ -2627,7 +2675,7 @@ tasks:
       - func: run lambda handler example tests
   - name: test-lambda-aws-auth-example
     tags:
-      - latest
+      - rapid
       - lambda
     commands:
       - command: expansions.update

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -141,7 +141,7 @@ BASE_TASKS.push({
 
 BASE_TASKS.push({
   name: `test-x509-authentication`,
-  tags: ['latest', 'auth', 'x509'],
+  tags: ['auth', 'x509'],
   commands: [
     { func: 'install dependencies' },
     { func: 'assume secrets manager role' },
@@ -153,7 +153,7 @@ BASE_TASKS.push({
   // No `auth` tag: that tag would exclude this task from the Windows variants (WINDOWS_SKIP_TAGS),
   // but SFP is a transparent proxy we want to exercise on Windows too.
   name: `test-sfp`,
-  tags: ['latest', 'sfp'],
+  tags: ['sfp'],
   commands: [
     { func: 'install dependencies' },
     { func: 'assume secrets manager role' },
@@ -171,7 +171,7 @@ TASKS.push(
     },
     ...LB_VERSIONS.map(ver => ({
       name: `test-${ver}-load-balanced`,
-      tags: ['latest', 'sharded_cluster', 'load_balancer'],
+      tags: [ver, 'sharded_cluster', 'load_balancer'],
       commands: [
         updateExpansions({
           VERSION: ver,
@@ -211,7 +211,7 @@ TASKS.push(
     },
     {
       name: 'test-socks5',
-      tags: ['socks5'],
+      tags: ['latest', 'socks5'],
       commands: [
         updateExpansions({
           VERSION: 'latest',
@@ -224,7 +224,7 @@ TASKS.push(
     },
     {
       name: 'test-socks5-csfle',
-      tags: ['socks5-csfle'],
+      tags: ['latest', 'socks5-csfle'],
       commands: [
         updateExpansions({
           VERSION: 'latest',
@@ -238,7 +238,7 @@ TASKS.push(
     },
     {
       name: 'test-socks5-tls',
-      tags: ['socks5-tls'],
+      tags: ['latest', 'socks5-tls'],
       commands: [
         updateExpansions({
           SSL: 'ssl',
@@ -293,7 +293,7 @@ const AWS_LAMBDA_HANDLER_TASKS = [];
 // Add task for testing lambda example without aws auth.
 AWS_LAMBDA_HANDLER_TASKS.push({
   name: 'test-lambda-example',
-  tags: ['latest', 'lambda'],
+  tags: ['rapid', 'lambda'],
   commands: [
     updateExpansions({
       NODE_LTS_VERSION: LOWEST_LTS,
@@ -309,7 +309,7 @@ AWS_LAMBDA_HANDLER_TASKS.push({
 // Add task for testing lambda example with aws auth.
 AWS_LAMBDA_HANDLER_TASKS.push({
   name: 'test-lambda-aws-auth-example',
-  tags: ['latest', 'lambda'],
+  tags: ['rapid', 'lambda'],
   commands: [
     updateExpansions({
       NODE_LTS_VERSION: LOWEST_LTS,
@@ -328,7 +328,7 @@ AWS_LAMBDA_HANDLER_TASKS.push({
 for (const VERSION of TLS_VERSIONS) {
   TASKS.push({
     name: `test-tls-support-${VERSION}`,
-    tags: ['tls-support', `tls-support-${VERSION}`],
+    tags: [VERSION, 'tls-support', `tls-support-${VERSION}`],
     commands: [
       updateExpansions({
         VERSION,
@@ -360,6 +360,7 @@ for (const VERSION of AWS_AUTH_VERSIONS) {
 
   const awsTasks = awsFuncs.map(fn => ({
     name: name(fn.func),
+    tags: [VERSION],
     commands: [
       updateExpansions({
         VERSION,
@@ -528,7 +529,7 @@ SINGLETON_TASKS.push(
     },
     {
       name: 'test-explicit-resource-management-feature-integration',
-      tags: ['resource-management'],
+      tags: ['latest', 'resource-management'],
       commands: [
         updateExpansions({
           VERSION: 'latest',
@@ -612,7 +613,7 @@ const customDependencyTests = [];
 for (const serverVersion of ['5.0', 'rapid', 'latest']) {
   customDependencyTests.push({
     name: `run-custom-csfle-tests-${serverVersion}`,
-    tags: ['run-custom-dependency-tests'],
+    tags: [serverVersion, 'run-custom-dependency-tests'],
     commands: [
       updateExpansions({
         NODE_LTS_VERSION: LOWEST_LTS,
@@ -631,7 +632,7 @@ for (const serverVersion of ['5.0', 'rapid', 'latest']) {
 
 customDependencyTests.push({
   name: `test-latest-driver-mongodb-client-encryption-7.0.0`,
-  tags: ['run-custom-dependency-tests'],
+  tags: ['7.0', 'run-custom-dependency-tests'],
   commands: [
     updateExpansions({
       NODE_LTS_VERSION: LOWEST_LTS,
@@ -674,7 +675,7 @@ SINGLETON_TASKS.push(...customDependencyTests);
 
 SINGLETON_TASKS.push({
   name: `test-alpine-fle`,
-  tags: ['alpine-fle'],
+  tags: ['latest', 'alpine-fle'],
   commands: [
     updateExpansions({
       NODE_LTS_VERSION: LOWEST_LTS,
@@ -694,7 +695,7 @@ SINGLETON_TASKS.push({
 function addPerformanceTasks() {
   const makePerfTask = (name, MONGODB_CLIENT_OPTIONS) => ({
     name,
-    tags: ['run-spec-benchmark-tests', 'performance'],
+    tags: ['v6.0-perf', 'run-spec-benchmark-tests', 'performance'],
     exec_timeout_secs: 7200,
     commands: [
       updateExpansions({


### PR DESCRIPTION
### Description

#### Summary of Changes

Many of the evergreen tasks are missing or have incorrect tags which reflect the targeted mongo server version. This PR removes incorrect tags, and appends the correct server version tag to each task.

##### Notes for Reviewers

<!-- 
If there is any additional context on the changes in the PR that reviewers might find helpful, feel free to make notes in this section.

Otherwise, feel free to remove this section.
-->

#### What is the motivation for this change?

<!--
Remove this section if there is an associated Jira ticket explaining the motivation for this change. If there is not, please fill this section out with
information explaining why this change is valuable.
-->

### Release Highlight

<!-- 
Contributors: please leave the release notes section for the Node driver team to fill in. The following instructions are for maintainers.

For user facing changes: please provide release notes. Feel free to browse previous releases for example release highlights.

If there are no user-facing changes in this PR, please delete the release highlight section from the PR description.
-->

<!-- RELEASE_HIGHLIGHT_START -->

### Release notes highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Lint is passing (`npm run check:lint`)
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
