### PR TITLE
chore(NODE-7694): Successful lint tasks can precede integration tests as a dependency

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -713,6 +713,10 @@ tasks:
           add_expansions_to_env: true
           args:
             - src/.evergreen/run-deployed-gcp-kms-tests.sh
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-gcpkms-fail-task
     commands:
       - command: expansions.update
@@ -734,6 +738,10 @@ tasks:
             NODE_LTS_VERSION: ${NODE_LTS_VERSION}
           args:
             - src/.evergreen/run-gcp-kms-tests.sh
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-azurekms-task
     commands:
       - command: expansions.update
@@ -750,6 +758,10 @@ tasks:
           add_expansions_to_env: true
           args:
             - src/.evergreen/run-deployed-azure-kms-tests.sh
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-azurekms-fail-task
     commands:
       - command: expansions.update
@@ -771,6 +783,10 @@ tasks:
             NODE_LTS_VERSION: ${NODE_LTS_VERSION}
           args:
             - src/.evergreen/run-azure-kms-tests.sh
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: oidc-auth-test-k8s-latest-eks
     commands:
       - func: install dependencies
@@ -791,6 +807,10 @@ tasks:
             - AWS_SESSION_TOKEN
           args:
             - .evergreen/run-oidc-tests-k8s.sh
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: oidc-auth-test-k8s-latest-gke
     commands:
       - func: install dependencies
@@ -811,6 +831,10 @@ tasks:
             - AWS_SESSION_TOKEN
           args:
             - .evergreen/run-oidc-tests-k8s.sh
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: oidc-auth-test-k8s-latest-aks
     commands:
       - func: install dependencies
@@ -831,6 +855,10 @@ tasks:
             - AWS_SESSION_TOKEN
           args:
             - .evergreen/run-oidc-tests-k8s.sh
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: oidc-auth-test-azure-latest
     commands:
       - func: install dependencies
@@ -858,6 +886,10 @@ tasks:
             SCRIPT: run-oidc-unified-tests.sh
           args:
             - .evergreen/run-oidc-tests-azure.sh
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: oidc-auth-test-test-latest
     commands:
       - func: install dependencies
@@ -885,6 +917,10 @@ tasks:
             SCRIPT: run-oidc-unified-tests.sh
           args:
             - .evergreen/run-oidc-tests-test.sh
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: oidc-auth-test-gcp-latest
     commands:
       - func: install dependencies
@@ -900,6 +936,10 @@ tasks:
             SCRIPT: run-oidc-prose-tests.sh
           args:
             - .evergreen/run-oidc-tests-gcp.sh
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-aws-lambda-deployed
     commands:
       - command: expansions.update
@@ -923,6 +963,10 @@ tasks:
             AWS_REGION: us-east-1
           args:
             - ${DRIVERS_TOOLS}/.evergreen/aws_lambda/run-deployed-lambda-aws-tests.sh
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-search-index-helpers
     commands:
       - command: expansions.update
@@ -939,6 +983,10 @@ tasks:
           add_expansions_to_env: true
           args:
             - .evergreen/run-search-index-management-tests.sh
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-bson-latest-driver-7.0.0-unit-tests
     commands:
       - command: expansions.update
@@ -955,6 +1003,10 @@ tasks:
           PACKAGE: https://github.com/mongodb/js-bson#HEAD
       - func: log state
       - func: run unit tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-bson-latest-driver-7.0.0-server-tests
     commands:
       - command: expansions.update
@@ -978,6 +1030,10 @@ tasks:
       - func: strip snappy install from test runner
       - func: log state
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-bson-latest-driver-7.0.0-replica_set-tests
     commands:
       - command: expansions.update
@@ -1001,6 +1057,10 @@ tasks:
       - func: strip snappy install from test runner
       - func: log state
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-bson-latest-driver-7.0.0-sharded_cluster-tests
     commands:
       - command: expansions.update
@@ -1024,6 +1084,10 @@ tasks:
       - func: strip snappy install from test runner
       - func: log state
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-latest-server
     tags:
       - latest
@@ -1040,6 +1104,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-latest-replica_set
     tags:
       - latest
@@ -1056,6 +1124,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-latest-sharded_cluster
     tags:
       - latest
@@ -1072,6 +1144,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-rapid-server
     tags:
       - rapid
@@ -1088,6 +1164,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-rapid-replica_set
     tags:
       - rapid
@@ -1104,6 +1184,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-rapid-sharded_cluster
     tags:
       - rapid
@@ -1120,6 +1204,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-9.0-server
     tags:
       - '9.0'
@@ -1136,6 +1224,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-9.0-replica_set
     tags:
       - '9.0'
@@ -1152,6 +1244,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-9.0-sharded_cluster
     tags:
       - '9.0'
@@ -1168,6 +1264,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-8.0-server
     tags:
       - '8.0'
@@ -1184,6 +1284,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-8.0-replica_set
     tags:
       - '8.0'
@@ -1200,6 +1304,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-8.0-sharded_cluster
     tags:
       - '8.0'
@@ -1216,6 +1324,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-7.0-server
     tags:
       - '7.0'
@@ -1232,6 +1344,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-7.0-replica_set
     tags:
       - '7.0'
@@ -1248,6 +1364,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-7.0-sharded_cluster
     tags:
       - '7.0'
@@ -1264,6 +1384,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-6.0-server
     tags:
       - '6.0'
@@ -1280,6 +1404,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-6.0-replica_set
     tags:
       - '6.0'
@@ -1296,6 +1424,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-6.0-sharded_cluster
     tags:
       - '6.0'
@@ -1312,6 +1444,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-5.0-server
     tags:
       - '5.0'
@@ -1328,6 +1464,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-5.0-replica_set
     tags:
       - '5.0'
@@ -1344,6 +1484,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-5.0-sharded_cluster
     tags:
       - '5.0'
@@ -1360,6 +1504,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-4.4-server
     tags:
       - '4.4'
@@ -1376,6 +1524,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-4.4-replica_set
     tags:
       - '4.4'
@@ -1392,6 +1544,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-4.4-sharded_cluster
     tags:
       - '4.4'
@@ -1408,6 +1564,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-latest-server-v1-api
     tags:
       - latest
@@ -1428,6 +1588,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-x509-authentication
     tags:
       - latest
@@ -1437,6 +1601,10 @@ tasks:
       - func: install dependencies
       - func: assume secrets manager role
       - func: run x509 auth tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-sfp
     tags:
       - latest
@@ -1445,12 +1613,20 @@ tasks:
       - func: install dependencies
       - func: assume secrets manager role
       - func: run sfp tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-atlas-connectivity
     tags:
       - atlas-connect
     commands:
       - func: install dependencies
       - func: run atlas tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-5.0-load-balanced
     tags:
       - latest
@@ -1472,6 +1648,10 @@ tasks:
       - func: start-load-balancer
       - func: run-lb-tests
       - func: stop-load-balancer
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-6.0-load-balanced
     tags:
       - latest
@@ -1493,6 +1673,10 @@ tasks:
       - func: start-load-balancer
       - func: run-lb-tests
       - func: stop-load-balancer
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-7.0-load-balanced
     tags:
       - latest
@@ -1514,6 +1698,10 @@ tasks:
       - func: start-load-balancer
       - func: run-lb-tests
       - func: stop-load-balancer
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-8.0-load-balanced
     tags:
       - latest
@@ -1535,6 +1723,10 @@ tasks:
       - func: start-load-balancer
       - func: run-lb-tests
       - func: stop-load-balancer
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-9.0-load-balanced
     tags:
       - latest
@@ -1556,6 +1748,10 @@ tasks:
       - func: start-load-balancer
       - func: run-lb-tests
       - func: stop-load-balancer
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-rapid-load-balanced
     tags:
       - latest
@@ -1577,6 +1773,10 @@ tasks:
       - func: start-load-balancer
       - func: run-lb-tests
       - func: stop-load-balancer
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-latest-load-balanced
     tags:
       - latest
@@ -1598,6 +1798,10 @@ tasks:
       - func: start-load-balancer
       - func: run-lb-tests
       - func: stop-load-balancer
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-auth-kerberos
     tags:
       - auth
@@ -1611,6 +1815,10 @@ tasks:
       - func: install dependencies
       - func: assume secrets manager role
       - func: run kerberos tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-auth-ldap
     tags:
       - auth
@@ -1619,6 +1827,10 @@ tasks:
       - func: install dependencies
       - func: assume secrets manager role
       - func: run ldap tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-socks5
     tags:
       - socks5
@@ -1632,6 +1844,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run socks5 tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-socks5-csfle
     tags:
       - socks5-csfle
@@ -1646,6 +1862,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run socks5 tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-socks5-tls
     tags:
       - socks5-tls
@@ -1660,6 +1880,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run socks5 tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-snappy-compression
     tags:
       - latest
@@ -1678,6 +1902,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run-compression-tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-zstd-compression
     tags:
       - latest
@@ -1696,6 +1924,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run-compression-tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-tls-support-latest
     tags:
       - tls-support
@@ -1712,6 +1944,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tls tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-tls-support-9.0
     tags:
       - tls-support
@@ -1728,6 +1964,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tls tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-tls-support-8.0
     tags:
       - tls-support
@@ -1744,6 +1984,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tls tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-tls-support-7.0
     tags:
       - tls-support
@@ -1760,6 +2004,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tls tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-tls-support-6.0
     tags:
       - tls-support
@@ -1776,6 +2024,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tls tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-tls-support-5.0
     tags:
       - tls-support
@@ -1792,6 +2044,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tls tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-tls-support-4.4
     tags:
       - tls-support
@@ -1808,6 +2064,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tls tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: aws-latest-auth-test-run-aws-auth-test-with-regular-aws-credentials
     commands:
       - command: expansions.update
@@ -1823,6 +2083,10 @@ tasks:
       - func: bootstrap mongo-orchestration
       - func: assume secrets manager role
       - func: run aws auth test with regular aws credentials
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: aws-latest-auth-test-run-aws-auth-test-with-assume-role-credentials
     commands:
       - command: expansions.update
@@ -1838,6 +2102,10 @@ tasks:
       - func: bootstrap mongo-orchestration
       - func: assume secrets manager role
       - func: run aws auth test with assume role credentials
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: aws-latest-auth-test-run-aws-auth-test-with-aws-EC2-credentials
     commands:
       - command: expansions.update
@@ -1853,6 +2121,10 @@ tasks:
       - func: bootstrap mongo-orchestration
       - func: assume secrets manager role
       - func: run aws auth test with aws EC2 credentials
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: aws-latest-auth-test-run-aws-auth-test-with-aws-credentials-as-environment-variables
     commands:
       - command: expansions.update
@@ -1868,6 +2140,10 @@ tasks:
       - func: bootstrap mongo-orchestration
       - func: assume secrets manager role
       - func: run aws auth test with aws credentials as environment variables
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: aws-latest-auth-test-run-aws-auth-test-with-aws-credentials-and-session-token-as-environment-variables
     commands:
       - command: expansions.update
@@ -1883,6 +2159,10 @@ tasks:
       - func: bootstrap mongo-orchestration
       - func: assume secrets manager role
       - func: run aws auth test with aws credentials and session token as environment variables
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: aws-latest-auth-test-run-aws-ECS-auth-test
     commands:
       - command: expansions.update
@@ -1898,6 +2178,10 @@ tasks:
       - func: bootstrap mongo-orchestration
       - func: assume secrets manager role
       - func: run aws ECS auth test
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: aws-latest-auth-test-run-aws-auth-test-AssumeRoleWithWebIdentity-with-AWS_ROLE_SESSION_NAME-unset
     commands:
       - command: expansions.update
@@ -1913,6 +2197,10 @@ tasks:
       - func: bootstrap mongo-orchestration
       - func: assume secrets manager role
       - func: run aws auth test AssumeRoleWithWebIdentity with AWS_ROLE_SESSION_NAME unset
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: aws-latest-auth-test-run-aws-auth-test-AssumeRoleWithWebIdentity-with-AWS_ROLE_SESSION_NAME-set
     commands:
       - command: expansions.update
@@ -1928,6 +2216,10 @@ tasks:
       - func: bootstrap mongo-orchestration
       - func: assume secrets manager role
       - func: run aws auth test AssumeRoleWithWebIdentity with AWS_ROLE_SESSION_NAME set
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: run-spec-benchmark-tests-node-server
     tags:
       - run-spec-benchmark-tests
@@ -1947,6 +2239,10 @@ tasks:
       - func: bootstrap mongo-orchestration
       - func: run spec driver benchmarks
       - func: perf send
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: run-spec-benchmark-tests-node-server-timeoutMS-120000
     tags:
       - run-spec-benchmark-tests
@@ -1966,6 +2262,10 @@ tasks:
       - func: bootstrap mongo-orchestration
       - func: run spec driver benchmarks
       - func: perf send
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: run-spec-benchmark-tests-node-server-timeoutMS-0
     tags:
       - run-spec-benchmark-tests
@@ -1985,6 +2285,10 @@ tasks:
       - func: bootstrap mongo-orchestration
       - func: run spec driver benchmarks
       - func: perf send
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: run-spec-benchmark-tests-node-server-monitorCommands-true
     tags:
       - run-spec-benchmark-tests
@@ -2004,6 +2308,10 @@ tasks:
       - func: bootstrap mongo-orchestration
       - func: run spec driver benchmarks
       - func: perf send
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: run-spec-benchmark-tests-node-server-logging
     tags:
       - run-spec-benchmark-tests
@@ -2023,6 +2331,10 @@ tasks:
       - func: bootstrap mongo-orchestration
       - func: run spec driver benchmarks
       - func: perf send
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: run-unit-tests-node-20.19.0
     tags:
       - unit-tests
@@ -2034,6 +2346,10 @@ tasks:
             - {key: NODE_LTS_VERSION, value: 20.19.0}
       - func: install dependencies
       - func: run unit tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: run-unit-tests-node-22
     tags:
       - unit-tests
@@ -2045,6 +2361,10 @@ tasks:
             - {key: NODE_LTS_VERSION, value: '22'}
       - func: install dependencies
       - func: run unit tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: run-unit-tests-node-24
     tags:
       - unit-tests
@@ -2056,6 +2376,10 @@ tasks:
             - {key: NODE_LTS_VERSION, value: '24'}
       - func: install dependencies
       - func: run unit tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: run-lint-checks
     tags:
       - lint-checks
@@ -2081,6 +2405,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: check resource management feature integration
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: check-types-typescript-current
     tags:
       - check-types-typescript-current
@@ -2094,6 +2422,10 @@ tasks:
             - {key: TS_VERSION, value: current}
       - func: install dependencies
       - func: check types
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: check-types-typescript-5.6
     tags:
       - check-types-typescript-5.6
@@ -2107,6 +2439,10 @@ tasks:
             - {key: TS_VERSION, value: '5.6'}
       - func: install dependencies
       - func: check types
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: compile-driver-typescript-current
     tags:
       - compile-driver-typescript-current
@@ -2120,6 +2456,10 @@ tasks:
             - {key: TS_VERSION, value: current}
       - func: install dependencies
       - func: compile driver
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: download-and-merge-coverage
     tags: []
     commands:
@@ -2128,6 +2468,9 @@ tasks:
       - name: '*'
         variant: '* !performance-tests'
         status: '*'
+        patch_optional: true
+      - name: run-lint-checks
+        variant: lint
         patch_optional: true
   - name: run-custom-csfle-tests-5.0
     tags:
@@ -2146,6 +2489,10 @@ tasks:
       - func: install mongodb-client-encryption from source
       - func: assume secrets manager role
       - func: run custom csfle tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: run-custom-csfle-tests-rapid
     tags:
       - run-custom-dependency-tests
@@ -2163,6 +2510,10 @@ tasks:
       - func: install mongodb-client-encryption from source
       - func: assume secrets manager role
       - func: run custom csfle tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: run-custom-csfle-tests-latest
     tags:
       - run-custom-dependency-tests
@@ -2180,6 +2531,10 @@ tasks:
       - func: install mongodb-client-encryption from source
       - func: assume secrets manager role
       - func: run custom csfle tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-latest-driver-mongodb-client-encryption-7.0.0
     tags:
       - run-custom-dependency-tests
@@ -2198,6 +2553,10 @@ tasks:
         vars:
           PACKAGE: mongodb-client-encryption@7.0.0
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-alpine-fle
     tags:
       - alpine-fle
@@ -2216,6 +2575,10 @@ tasks:
       - func: bootstrap mongo-orchestration
       - func: assume secrets manager role
       - func: build and test alpine FLE
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-latest-server-noauth
     tags:
       - latest
@@ -2234,6 +2597,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-latest-replica_set-noauth
     tags:
       - latest
@@ -2252,6 +2619,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-latest-sharded_cluster-noauth
     tags:
       - latest
@@ -2270,6 +2641,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-rapid-server-noauth
     tags:
       - rapid
@@ -2288,6 +2663,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-rapid-replica_set-noauth
     tags:
       - rapid
@@ -2306,6 +2685,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-rapid-sharded_cluster-noauth
     tags:
       - rapid
@@ -2324,6 +2707,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-9.0-server-noauth
     tags:
       - '9.0'
@@ -2342,6 +2729,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-9.0-replica_set-noauth
     tags:
       - '9.0'
@@ -2360,6 +2751,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-9.0-sharded_cluster-noauth
     tags:
       - '9.0'
@@ -2378,6 +2773,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-8.0-server-noauth
     tags:
       - '8.0'
@@ -2396,6 +2795,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-8.0-replica_set-noauth
     tags:
       - '8.0'
@@ -2414,6 +2817,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-8.0-sharded_cluster-noauth
     tags:
       - '8.0'
@@ -2432,6 +2839,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-7.0-server-noauth
     tags:
       - '7.0'
@@ -2450,6 +2861,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-7.0-replica_set-noauth
     tags:
       - '7.0'
@@ -2468,6 +2883,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-7.0-sharded_cluster-noauth
     tags:
       - '7.0'
@@ -2486,6 +2905,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-6.0-server-noauth
     tags:
       - '6.0'
@@ -2504,6 +2927,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-6.0-replica_set-noauth
     tags:
       - '6.0'
@@ -2522,6 +2949,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-6.0-sharded_cluster-noauth
     tags:
       - '6.0'
@@ -2540,6 +2971,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-5.0-server-noauth
     tags:
       - '5.0'
@@ -2558,6 +2993,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-5.0-replica_set-noauth
     tags:
       - '5.0'
@@ -2576,6 +3015,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-5.0-sharded_cluster-noauth
     tags:
       - '5.0'
@@ -2594,6 +3037,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-4.4-server-noauth
     tags:
       - '4.4'
@@ -2612,6 +3059,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-4.4-replica_set-noauth
     tags:
       - '4.4'
@@ -2630,6 +3081,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-4.4-sharded_cluster-noauth
     tags:
       - '4.4'
@@ -2648,6 +3103,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-lambda-example
     tags:
       - latest
@@ -2663,6 +3122,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run lambda handler example tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-lambda-aws-auth-example
     tags:
       - latest
@@ -2681,6 +3144,10 @@ tasks:
       - func: bootstrap mongo-orchestration
       - func: assume secrets manager role
       - func: run lambda handler example tests with aws auth
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-latest-csfle-mongocryptd
     tags:
       - latest
@@ -2697,6 +3164,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-rapid-csfle-mongocryptd
     tags:
       - rapid
@@ -2713,6 +3184,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-9.0-csfle-mongocryptd
     tags:
       - '9.0'
@@ -2729,6 +3204,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-8.0-csfle-mongocryptd
     tags:
       - '8.0'
@@ -2745,6 +3224,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-7.0-csfle-mongocryptd
     tags:
       - '7.0'
@@ -2761,6 +3244,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-6.0-csfle-mongocryptd
     tags:
       - '6.0'
@@ -2777,6 +3264,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-5.0-csfle-mongocryptd
     tags:
       - '5.0'
@@ -2793,6 +3284,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-4.4-csfle-mongocryptd
     tags:
       - '4.4'
@@ -2809,6 +3304,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-latest-server-ssl
     tags:
       - latest
@@ -2829,6 +3328,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-latest-replica_set-ssl
     tags:
       - latest
@@ -2849,6 +3352,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-latest-sharded_cluster-ssl
     tags:
       - latest
@@ -2869,6 +3376,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-rapid-server-ssl
     tags:
       - rapid
@@ -2889,6 +3400,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-rapid-replica_set-ssl
     tags:
       - rapid
@@ -2909,6 +3424,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-rapid-sharded_cluster-ssl
     tags:
       - rapid
@@ -2929,6 +3448,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-9.0-server-ssl
     tags:
       - '9.0'
@@ -2949,6 +3472,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-9.0-replica_set-ssl
     tags:
       - '9.0'
@@ -2969,6 +3496,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-9.0-sharded_cluster-ssl
     tags:
       - '9.0'
@@ -2989,6 +3520,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-8.0-server-ssl
     tags:
       - '8.0'
@@ -3009,6 +3544,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-8.0-replica_set-ssl
     tags:
       - '8.0'
@@ -3029,6 +3568,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-8.0-sharded_cluster-ssl
     tags:
       - '8.0'
@@ -3049,6 +3592,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-7.0-server-ssl
     tags:
       - '7.0'
@@ -3069,6 +3616,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-7.0-replica_set-ssl
     tags:
       - '7.0'
@@ -3089,6 +3640,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-7.0-sharded_cluster-ssl
     tags:
       - '7.0'
@@ -3109,6 +3664,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-6.0-server-ssl
     tags:
       - '6.0'
@@ -3129,6 +3688,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-6.0-replica_set-ssl
     tags:
       - '6.0'
@@ -3149,6 +3712,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-6.0-sharded_cluster-ssl
     tags:
       - '6.0'
@@ -3169,6 +3736,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-5.0-server-ssl
     tags:
       - '5.0'
@@ -3189,6 +3760,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-5.0-replica_set-ssl
     tags:
       - '5.0'
@@ -3209,6 +3784,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-5.0-sharded_cluster-ssl
     tags:
       - '5.0'
@@ -3229,6 +3808,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-4.4-server-ssl
     tags:
       - '4.4'
@@ -3249,6 +3832,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-4.4-replica_set-ssl
     tags:
       - '4.4'
@@ -3269,6 +3856,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
   - name: test-4.4-sharded_cluster-ssl
     tags:
       - '4.4'
@@ -3289,6 +3880,10 @@ tasks:
       - func: install dependencies
       - func: bootstrap mongo-orchestration
       - func: run tests
+    depends_on:
+      - name: run-lint-checks
+        variant: lint
+        patch_optional: true
 task_groups:
   - name: test_gcpkms_task_group
     setup_group_can_fail_task: true

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -915,6 +915,17 @@ fileData.tasks = [
 
 fileData.buildvariants = [...(fileData.buildvariants ?? []), ...BUILD_VARIANTS];
 
+// gate everything on lint
+const LINT_GATE_TASK = 'run-lint-checks';
+const LINT_GATE = { name: LINT_GATE_TASK, variant: 'lint', patch_optional: true };
+for (const task of fileData.tasks) {
+  if (task.name === LINT_GATE_TASK) continue;
+  // Appended, not assigned: download-and-merge-coverage fans in on `status: '*'`, which is
+  // satisfied by blocked tasks, so without its own gate it gets dispatched and fails with
+  // nothing to merge. Keep its fan-in and let the gate block it too.
+  task.depends_on = [...(task.depends_on ?? []), LINT_GATE];
+}
+
 fs.writeFileSync(
   `${__dirname}/config.yml`,
   yaml.dump(fileData, { lineWidth: 120, noRefs: true, flowLevel: 7, condenseFlow: false }),

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -916,7 +916,7 @@ fileData.tasks = [
 fileData.buildvariants = [...(fileData.buildvariants ?? []), ...BUILD_VARIANTS];
 
 // gate everything on lint
-const LINT_GATE_TASK = 'run-lint-checks';
+const    LINT_GATE_TASK    =    'run-lint-checks';
 const LINT_GATE = { name: LINT_GATE_TASK, variant: 'lint', patch_optional: true };
 for (const task of fileData.tasks) {
   if (task.name === LINT_GATE_TASK) continue;

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -916,7 +916,7 @@ fileData.tasks = [
 fileData.buildvariants = [...(fileData.buildvariants ?? []), ...BUILD_VARIANTS];
 
 // gate everything on lint
-const    LINT_GATE_TASK    =    'run-lint-checks';
+const LINT_GATE_TASK = 'run-lint-checks';
 const LINT_GATE = { name: LINT_GATE_TASK, variant: 'lint', patch_optional: true };
 for (const task of fileData.tasks) {
   if (task.name === LINT_GATE_TASK) continue;

--- a/.evergreen/generate_evergreen_tasks.js
+++ b/.evergreen/generate_evergreen_tasks.js
@@ -920,9 +920,6 @@ const    LINT_GATE_TASK    =    'run-lint-checks';
 const LINT_GATE = { name: LINT_GATE_TASK, variant: 'lint', patch_optional: true };
 for (const task of fileData.tasks) {
   if (task.name === LINT_GATE_TASK) continue;
-  // Appended, not assigned: download-and-merge-coverage fans in on `status: '*'`, which is
-  // satisfied by blocked tasks, so without its own gate it gets dispatched and fails with
-  // nothing to merge. Keep its fan-in and let the gate block it too.
   task.depends_on = [...(task.depends_on ?? []), LINT_GATE];
 }
 

--- a/src/cmap/wire_protocol/constants.ts
+++ b/src/cmap/wire_protocol/constants.ts
@@ -14,4 +14,4 @@ export const OP_INSERT = 2002;
 export const OP_QUERY = 2004;
 export const OP_DELETE = 2006;
 export const OP_COMPRESSED = 2012;
-export const OP_MSG = 2013;
+export const    OP_MSG    =    2013;

--- a/src/cmap/wire_protocol/constants.ts
+++ b/src/cmap/wire_protocol/constants.ts
@@ -14,4 +14,4 @@ export const OP_INSERT = 2002;
 export const OP_QUERY = 2004;
 export const OP_DELETE = 2006;
 export const OP_COMPRESSED = 2012;
-export const    OP_MSG    =    2013;
+export const OP_MSG = 2013;


### PR DESCRIPTION
### Description

#### Summary of Changes

Gate all Evergreen tasks on the lint task, so source with lint errors never runs tests.

##### Notes for Reviewers

This PR has a commit that introduces a lint error. The build for that version failed quickly:

<img width="828" height="353" alt="Screenshot 2026-09-04 at 12 56 35 PM" src="https://github.com/user-attachments/assets/83f57281-8b32-4ba6-8a3a-112fb609870a" />

The lint error will be fixed and the full suite of tests will run. This PR is part of the testing of this task.

#### What is the motivation for this change?

Lint errors should prevent expensive tests from running unnecessarily.

### Double check the following

- [ ] Lint is passing (`npm run check:lint`)
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
