### PR TITLE
test(NODE-7831): widen duration bounds in flaky timing assertions

### DIFF
--- a/test/integration/client-backpressure/client-backpressure.prose.test.ts
+++ b/test/integration/client-backpressure/client-backpressure.prose.test.ts
@@ -213,11 +213,14 @@ describe('Client Backpressure (Prose)', function () {
       }
 
       // 10. Assert absolute bounds on each run's duration.
-      //     A run can never be faster than the sum of its backoffs. With jitter pinned to 1, the
-      //     default backoffs are `0.2 + 0.4 = 0.6s` and the `baseBackoffMS=50` backoffs are
-      //     `0.1 + 0.2 = 0.3s`.
-      expect(exponentialBackoffTime).to.be.at.least(600);
-      expect(withBaseBackoffMSTime).to.be.at.least(300);
+      //     A run cannot be meaningfully faster than the sum of its backoffs. With jitter pinned
+      //     to 1, the default backoffs are `0.2 + 0.4 = 0.6s` and the `baseBackoffMS=50` backoffs
+      //     are `0.1 + 0.2 = 0.3s`. The lower bounds include a small tolerance because sleep
+      //     timers run on a millisecond-granularity clock, so a sleep can complete marginally
+      //     earlier than the requested duration when measured with a higher-resolution clock.
+      const TOLERANCE_MS = 5;
+      expect(exponentialBackoffTime).to.be.at.least(600 - TOLERANCE_MS);
+      expect(withBaseBackoffMSTime).to.be.at.least(300 - TOLERANCE_MS);
       expect(withBaseBackoffMSTime).to.be.lessThan(600);
     }
   );

--- a/test/integration/client-side-encryption/driver.test.ts
+++ b/test/integration/client-side-encryption/driver.test.ts
@@ -436,7 +436,10 @@ describe('Client Side Encryption Functional', function () {
         } else {
           expect(error).to.be.instanceOf(MongoOperationTimeoutError);
         }
-        expect(end - start).to.be.within(498, 1000);
+        // timeoutMS is 500, but the driver's CSOT bookkeeping truncates timestamps to whole
+        // milliseconds and timers run on a millisecond-granularity clock, so the timeout can fire
+        // a few milliseconds early when measured with performance.now().
+        expect(end - start).to.be.within(495, 1000);
       };
     }
 


### PR DESCRIPTION
### Description

Adds small timing tolerances to two flaky duration assertions (sleep timers run on a millisecond-granularity clock and can complete marginally early when measured with `performance.now()`).

### Double check the following

- [x] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
